### PR TITLE
fix: always use the changelog subject in table state stores

### DIFF
--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingDeserializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingDeserializer.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.logging.processing;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -41,11 +42,26 @@ public final class LoggingDeserializer<T> implements Deserializer<T> {
 
   @Override
   public T deserialize(final String topic, final byte[] bytes) {
+    return tryDeserialize(topic, bytes).get();
+  }
+
+  /**
+   * Similar to {@link #deserialize(String, byte[])}, but allows the erroneous case
+   * to delay the log-and-throw behavior until {@link DelayedResult#get()} is called.
+   *
+   * <p>This can be used in the scenarios when an error is expected, such as if a retry
+   * will likely solve the problem, to avoid spamming the processing logger with messages
+   * that are not helpful to the end user.</p>
+   */
+  public DelayedResult<T> tryDeserialize(final String topic, final byte[] bytes) {
     try {
-      return delegate.deserialize(topic, bytes);
+      return new DelayedResult<T>(delegate.deserialize(topic, bytes));
     } catch (final RuntimeException e) {
-      processingLogger.error(new DeserializationError(e, Optional.ofNullable(bytes), topic));
-      throw e;
+      return new DelayedResult<T>(
+          e,
+          new DeserializationError(e, Optional.ofNullable(bytes), topic),
+          processingLogger
+      );
     }
   }
 
@@ -53,4 +69,51 @@ public final class LoggingDeserializer<T> implements Deserializer<T> {
   public void close() {
     delegate.close();
   }
+
+  public static class DelayedResult<T> {
+
+    private final T result;
+    private final RuntimeException error;
+    private final ProcessingLogger processingLogger;
+    private final DeserializationError deserializationError;
+
+    public DelayedResult(
+        final RuntimeException error,
+        final DeserializationError deserializationError,
+        final ProcessingLogger processingLogger
+    ) {
+      this.result = null;
+      this.error = error;
+      this.deserializationError = requireNonNull(deserializationError, "deserializationError");
+      this.processingLogger = requireNonNull(processingLogger, "processingLogger");
+    }
+
+    public DelayedResult(final T result) {
+      this.result = result;
+      this.error = null;
+      this.deserializationError = null;
+      this.processingLogger = null;
+    }
+
+    public boolean isError() {
+      return error != null;
+    }
+
+    @VisibleForTesting
+    RuntimeException getError() {
+      return error;
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public T get() {
+      if (isError()) {
+        processingLogger.error(deserializationError);
+        throw error;
+      }
+
+      return result;
+    }
+
+  }
+
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/StaticTopicSerde.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/StaticTopicSerde.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.logging.processing.LoggingDeserializer;
+import io.confluent.ksql.logging.processing.LoggingDeserializer.DelayedResult;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * The {@code StaticTopicSerde} hard codes the topic name that is passed
+ * to the delegate Serde, regardless to what the caller passes in as the
+ * topic. The only exception is that if a deserialization attempt fails,
+ * the deserializer will attempt one more time using the topic that was
+ * passed to the Serde (instead of the hard coded value). In this situation,
+ * the {@code onFailure} callback is called so that the user of this class
+ * can remedy the issue (i.e. register an extra schema under the hard coded
+ * topic). The callback will not be called if both serialization attempts fail.
+ *
+ * <p>This class is intended as a workaround for the issues described in
+ * both KAFKA-10179 and KSQL-5673; specifically, it allows a materialized
+ * state store to use a different topic name than that which Kafka Streams
+ * passes in to the Serde.</p>
+ *
+ * <p><b>Think carefully before reusing this class! It's inteded use case is
+ * very narrow.</b></p>
+ */
+public final class StaticTopicSerde<T> implements Serde<T> {
+
+  public interface Callback {
+
+    /**
+     * This method is called when the {@link Serde#deserializer()}'s produced by
+     * this class' {@link Deserializer#deserialize(String, byte[])} method fails
+     * using the static topic but succeeds using the source topic.
+     *
+     * @param sourceTopic the original topic that was passed in to the deserializer
+     * @param staticTopic the hard coded topic that was passed into the {@code StaticTopicSerde}
+     * @param data        the data that failed deserialization
+     */
+    void onDeserializationFailure(String sourceTopic, String staticTopic, byte[] data);
+  }
+
+  private final Serde<T> delegate;
+  private final String topic;
+  private final Callback onFailure;
+
+  /**
+   * @param topic     the topic to hardcode
+   * @param serde     the delegate serde
+   * @param onFailure a callback to call on failure
+   *
+   * @return a serde which delegates to {@code serde} but passes along {@code topic}
+   *         in place of whatever the actual topic is
+   */
+  public static <S> Serde<S> wrap(
+      final String topic,
+      final Serde<S> serde,
+      final Callback onFailure
+  ) {
+    return new StaticTopicSerde<>(topic, serde, onFailure);
+  }
+
+  private StaticTopicSerde(
+      final String topic,
+      final Serde<T> delegate,
+      final Callback onFailure
+  ) {
+    this.topic = Objects.requireNonNull(topic, "topic");
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.onFailure = Objects.requireNonNull(onFailure, "onFailure");
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    delegate.configure(configs, isKey);
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public Serializer<T> serializer() {
+    final Serializer<T> serializer = delegate.serializer();
+    return (topic, data) -> serializer.serialize(this.topic, data);
+  }
+
+  @Override
+  public Deserializer<T> deserializer() {
+    final Deserializer<T> deserializer = delegate.deserializer();
+
+    if (deserializer instanceof LoggingDeserializer<?>) {
+      final LoggingDeserializer<T> loggingDeserializer = (LoggingDeserializer<T>) deserializer;
+
+      return (topic, data) -> {
+        final DelayedResult<T> staticResult = loggingDeserializer.tryDeserialize(this.topic, data);
+        if (!staticResult.isError()) {
+          return staticResult.get();
+        }
+
+        // if both attempts error, then staticResult.get() will log the error to
+        // the processing log and throw - do not call the callback in this case
+        final DelayedResult<T> sourceResult = loggingDeserializer.tryDeserialize(topic, data);
+        if (sourceResult.isError()) {
+          return staticResult.get();
+        }
+
+        onFailure.onDeserializationFailure(topic, this.topic, data);
+        return sourceResult.get();
+      };
+    }
+
+    return (topic, data) -> {
+      try {
+        return deserializer.deserialize(this.topic, data);
+      } catch (final Exception e) {
+        final T object = deserializer.deserialize(topic, data);
+        onFailure.onDeserializationFailure(topic, this.topic, data);
+        return object;
+      }
+    };
+  }
+
+  @VisibleForTesting
+  public String getTopic() {
+    return topic;
+  }
+
+  @VisibleForTesting
+  public Callback getOnFailure() {
+    return onFailure;
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingDeserializerTest.java
@@ -16,7 +16,10 @@
 package io.confluent.ksql.logging.processing;
 
 import static io.confluent.ksql.GenericRow.genericRow;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,12 +27,14 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.NullPointerTester;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.logging.processing.LoggingDeserializer.DelayedResult;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,6 +104,20 @@ public class LoggingDeserializerTest {
     verify(delegate).deserialize("some topic", SOME_BYTES);
   }
 
+  @Test
+  public void shouldTryDeserializeWithDelegate() {
+    // Given:
+    when(delegate.deserialize(any(), any())).thenReturn(SOME_ROW);
+
+    // When:
+    final DelayedResult<GenericRow> result = deserializer.tryDeserialize("some topic", SOME_BYTES);
+
+    // Then:
+    verify(delegate).deserialize("some topic", SOME_BYTES);
+    assertThat(result.isError(), is(false));
+    assertThat(result.get(), is(SOME_ROW));
+  }
+
   @Test(expected = ArithmeticException.class)
   public void shouldThrowIfDelegateThrows() {
     // Given:
@@ -125,5 +144,22 @@ public class LoggingDeserializerTest {
 
     // Then:
     verify(processingLogger).error(new DeserializationError(e, Optional.of(SOME_BYTES), "t"));
+  }
+
+  @Test
+  public void shouldDelayLogOnException() {
+    // Given:
+    when(delegate.deserialize(any(), any()))
+        .thenThrow(new RuntimeException("outer",
+            new RuntimeException("inner", new RuntimeException("cause"))));
+
+    // When:
+    final DelayedResult<GenericRow> result = deserializer.tryDeserialize("t", SOME_BYTES);
+
+    // Then:
+    assertTrue(result.isError());
+    assertThrows(RuntimeException.class, result::get);
+    verify(processingLogger)
+        .error(new DeserializationError(result.getError(), Optional.of(SOME_BYTES), "t"));
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/StaticTopicSerdeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/StaticTopicSerdeTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.logging.processing.DeserializationError;
+import io.confluent.ksql.logging.processing.LoggingDeserializer;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.serde.StaticTopicSerde.Callback;
+import java.util.Optional;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes.WrapperSerde;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StaticTopicSerdeTest {
+
+  private static final byte[] SOME_BYTES = new byte[]{1, 2, 3};
+  private static final Object SOME_OBJECT = 1;
+  private static final String STATIC_TOPIC = "static";
+  private static final String SOURCE_TOPIC = "source";
+
+  @Mock
+  private Serializer<Object> delegateS;
+  @Mock
+  private Deserializer<Object> delegateD;
+  @Mock
+  private Callback callback;
+
+  private Serde<Object> staticSerde;
+
+  @Before
+  public void setUp() {
+    final Serde<Object> delegate = new WrapperSerde<>(delegateS, delegateD);
+
+    when(delegateS.serialize(Mockito.any(), Mockito.any())).thenReturn(SOME_BYTES);
+    when(delegateD.deserialize(Mockito.any(), Mockito.any())).thenReturn(SOME_OBJECT);
+
+    staticSerde = StaticTopicSerde.wrap(STATIC_TOPIC, delegate, callback);
+  }
+
+  @Test
+  public void shouldUseDelegateSerializerWithStaticTopic() {
+    // When:
+    final byte[] serialized = staticSerde.serializer().serialize(SOURCE_TOPIC, SOME_OBJECT);
+
+    // Then:
+    verify(delegateS).serialize(STATIC_TOPIC, SOME_OBJECT);
+    assertThat(serialized, is(SOME_BYTES));
+    verifyZeroInteractions(callback);
+  }
+
+  @Test
+  public void shouldUseDelegateDeserializerWithStaticTopic() {
+    // When:
+    final Object deserialized = staticSerde.deserializer().deserialize(SOURCE_TOPIC, SOME_BYTES);
+
+    // Then:
+    verify(delegateD).deserialize(STATIC_TOPIC, SOME_BYTES);
+    assertThat(deserialized, is(SOME_OBJECT));
+    verifyZeroInteractions(callback);
+  }
+
+  @Test
+  public void shouldUseDelegateLoggingDeserializerWithStaticTopic() {
+    // Given:
+    final ProcessingLogger logger = mock(ProcessingLogger.class);
+    final LoggingDeserializer<Object> loggingDelegate = new LoggingDeserializer<>(delegateD, logger);
+    final Serde<Object> delegate = new WrapperSerde<>(delegateS, loggingDelegate);
+
+    staticSerde = StaticTopicSerde.wrap(STATIC_TOPIC, delegate, callback);
+
+    // When:
+    final Object deserialized = staticSerde.deserializer().deserialize(SOURCE_TOPIC, SOME_BYTES);
+
+    // Then:
+    verify(delegateD).deserialize(STATIC_TOPIC, SOME_BYTES);
+    assertThat(deserialized, is(SOME_OBJECT));
+    verifyZeroInteractions(callback);
+    verifyZeroInteractions(logger);
+  }
+
+  @Test
+  public void shouldTrySourceTopicAndCallCallbackOnDeserializationFailure() {
+    // Given:
+    when(delegateD.deserialize(Mockito.eq(STATIC_TOPIC), Mockito.any())).thenThrow(new RuntimeException());
+
+    // When:
+    final Object deserialized = staticSerde.deserializer().deserialize(SOURCE_TOPIC, SOME_BYTES);
+
+    // Then:
+    verify(delegateD).deserialize(STATIC_TOPIC, SOME_BYTES);
+    verify(delegateD).deserialize(SOURCE_TOPIC, SOME_BYTES);
+    verify(callback).onDeserializationFailure(SOURCE_TOPIC, STATIC_TOPIC, SOME_BYTES);
+    assertThat(deserialized, is(SOME_OBJECT));
+  }
+
+  @Test
+  public void shouldTrySourceTopicAndCallCallbackOnDeserializationFailureWithLoggingDeserializer() {
+    // Given:
+    when(delegateD.deserialize(Mockito.eq(STATIC_TOPIC), Mockito.any())).thenThrow(new RuntimeException());
+
+    final ProcessingLogger logger = mock(ProcessingLogger.class);
+    final LoggingDeserializer<Object> loggingDelegate = new LoggingDeserializer<>(delegateD, logger);
+    final Serde<Object> delegate = new WrapperSerde<>(delegateS, loggingDelegate);
+
+    staticSerde = StaticTopicSerde.wrap(STATIC_TOPIC, delegate, callback);
+
+    // When:
+    final Object deserialized = staticSerde.deserializer().deserialize(SOURCE_TOPIC, SOME_BYTES);
+
+    // Then:
+    verifyZeroInteractions(logger);
+    verify(callback).onDeserializationFailure(SOURCE_TOPIC, STATIC_TOPIC, SOME_BYTES);
+    assertThat(deserialized, is(SOME_OBJECT));
+  }
+
+  @Test
+  public void shouldLogOriginalFailureIfBothFail() {
+    // Given:
+    when(delegateD.deserialize(Mockito.any(), Mockito.any())).thenThrow(new RuntimeException());
+
+    final ProcessingLogger logger = mock(ProcessingLogger.class);
+    final LoggingDeserializer<Object> loggingDelegate = new LoggingDeserializer<>(delegateD, logger);
+    final Serde<Object> delegate = new WrapperSerde<>(delegateS, loggingDelegate);
+
+    staticSerde = StaticTopicSerde.wrap(STATIC_TOPIC, delegate, callback);
+
+    // When:
+    final RuntimeException err = assertThrows(
+        RuntimeException.class,
+        () -> staticSerde.deserializer().deserialize(SOURCE_TOPIC, SOME_BYTES));
+
+    // Then:
+    verify(logger).error(new DeserializationError(err, Optional.of(SOME_BYTES), STATIC_TOPIC));
+    verifyZeroInteractions(callback);
+  }
+
+}

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/RegisterSchemaCallback.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/RegisterSchemaCallback.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.ksql.serde.StaticTopicSerde;
+import io.confluent.ksql.util.KsqlConstants;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class RegisterSchemaCallback implements StaticTopicSerde.Callback {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RegisterSchemaCallback.class);
+  private final SchemaRegistryClient srClient;
+
+  RegisterSchemaCallback(final SchemaRegistryClient srClient) {
+    this.srClient = Objects.requireNonNull(srClient, "srClient");
+  }
+
+  @Override
+  public void onDeserializationFailure(
+      final String source,
+      final String changelog,
+      final byte[] data
+  ) {
+    final String sourceSubject = source + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
+    final String changelogSubject = changelog + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
+    try {
+      // all schema registry events start with a magic byte 0x0 and then four bytes
+      // indicating the schema id - we extract that schema id from the data that failed
+      // to deserialize and then register it into the changelog subject
+      final int id = ByteBuffer.wrap(data, 1, Integer.BYTES).getInt();
+
+      LOG.info("Trying to fetch & register schema id {} under subject {}", id, changelogSubject);
+      final ParsedSchema schema = srClient.getSchemaBySubjectAndId(sourceSubject, id);
+      srClient.register(changelogSubject, schema);
+    } catch (IOException | RestClientException e) {
+      LOG.warn("Failed during deserialization callback for topic " + source, e);
+    }
+  }
+
+}

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/RegisterSchemaCallbackTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/RegisterSchemaCallbackTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.ksql.util.KsqlConstants;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RegisterSchemaCallbackTest {
+
+  private static final String SUFFIX = KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
+  private static final String SOURCE = "s1";
+  private static final String CHANGELOG = "s2";
+  private static final int ID = 1;
+  private static final byte[] SOME_DATA = new byte[]{0x0, 0x0, 0x0, 0x0, 0x1};
+
+  @Mock
+  private SchemaRegistryClient srClient;
+  @Mock
+  private ParsedSchema schema;
+  
+  @Test
+  public void shouldRegisterIdFromData() throws IOException, RestClientException {
+    // Given:
+    when(srClient.getSchemaBySubjectAndId(SOURCE + SUFFIX, ID)).thenReturn(schema);
+    final RegisterSchemaCallback call = new RegisterSchemaCallback(srClient);
+
+    // When:
+    call.onDeserializationFailure(SOURCE, CHANGELOG, SOME_DATA);
+
+    // Then:
+    verify(srClient).register(CHANGELOG + SUFFIX, schema);
+  }
+
+}


### PR DESCRIPTION
fixes #5673 
replaces #5812 

### Description 
This commit takes a different approach to fixing the issue described in the two links above; we will hardcode the serializer for source tables to use the changelog topic, and we allow the deserializer to fallback to the source topic if it fails to deserialize using the changelog topic.

This fixes the issue by obviating https://github.com/apache/kafka/pull/8902/ - all queries that were created before #5781 was merged will always pass in the changelog topic to their state store serde. This means that:

1. we will never register a schema to the user's subject unless they use `INSERT INTO`
2. we will be able to deserialize events in the state store if the schema ID for the event is in either subject
3. if we ever encounter an event we could not serialize using the changelog subject, we will register that schema into the changelog subject

### Review Guide

- The entrypoint for this change is in `SourceBuilder`, where we pass into the `Consumed` instance a custom Serde that spoofs the topic to always use the changelog topic
- The spoofed serde is `StaticTopicSerde`
- That serde accepts a callback `RegisterSchemaCallback` to help optimize repeated failed deserialization attempts
- In order to prevent false positive logging to the processing logger, the `LoggingDeserializer` is extended to support delaying the exceptional case

### Testing done 

- Unit tests
- Manual testing to cover the case in #5673 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

