### PR TITLE
chore: add validation to the metastore for create or replace

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -258,7 +258,8 @@ public final class QueryExecutor {
         overrides,
         queryCloseCallback,
         ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG),
-        classifier);
+        classifier
+    );
   }
 
   private TransientQueryQueue buildTransientQueryQueue(

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/KsqlTopic.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/KsqlTopic.java
@@ -68,4 +68,12 @@ public class KsqlTopic {
   public int hashCode() {
     return Objects.hash(kafkaTopicName, keyFormat, valueFormat);
   }
+
+  @Override
+  public String toString() {
+    return "KsqlTopic{" + "kafkaTopicName='" + kafkaTopicName + '\''
+        + ", keyFormat=" + keyFormat
+        + ", valueFormat=" + valueFormat
+        + '}';
+  }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/timestamp/TimestampColumn.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/timestamp/TimestampColumn.java
@@ -61,4 +61,11 @@ public final class TimestampColumn {
   public int hashCode() {
     return Objects.hash(column, format);
   }
+
+  @Override
+  public String toString() {
+    return "TimestampColumn{" + "column=" + column
+        + ", format=" + format
+        + '}';
+  }
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -87,6 +87,10 @@ public final class MetaStoreImpl implements MutableMetaStore {
       throw new KsqlException(String.format(
           "Cannot add %s '%s': A %s with the same name already exists",
           newType, name.text(), existingType));
+    } else if (existing != null) {
+      existing.source.canUpgradeTo(dataSource).ifPresent(msg -> {
+        throw new KsqlException("Cannot REPLACE data source: " + msg);
+      });
     }
 
     dataSources.put(dataSource.getName(), new SourceInfo(dataSource));

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
@@ -102,4 +102,11 @@ public interface DataSource {
    * @return returns whether this stream/table was created by a C(T|S)AS
    */
   boolean isCasTarget();
+
+  /**
+   * @param other the other data source
+   * @return an optional, empty if compatible or an explanation if incompatible
+   */
+  Optional<String> canUpgradeTo(DataSource other);
+
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -17,7 +17,11 @@ package io.confluent.ksql.metastore.model;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
@@ -27,8 +31,10 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.serde.SerdeOption;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Immutable
@@ -42,6 +48,16 @@ abstract class StructuredDataSource<K> implements DataSource {
   private final String sqlExpression;
   private final ImmutableSet<SerdeOption> serdeOptions;
   private final boolean casTarget;
+
+  private static final ImmutableList<Property<?>> PROPERTIES = ImmutableList.of(
+      new Property<>("name", DataSource::getName),
+      new Property<>("type", DataSource::getDataSourceType),
+      new Property<>("topic", DataSource::getKsqlTopic),
+      new Property<>("serdeOptions", DataSource::getSerdeOptions),
+      new Property<>("timestampColumn", DataSource::getTimestampColumn)
+  );
+  private static final Property<LogicalSchema> SCHEMA_PROP =
+      new Property<>("schema", DataSource::getSchema);
 
   StructuredDataSource(
       final String sqlExpression,
@@ -122,5 +138,67 @@ abstract class StructuredDataSource<K> implements DataSource {
   @Override
   public String toString() {
     return getClass().getSimpleName() + " name:" + getName();
+  }
+
+  @Override
+  public Optional<String> canUpgradeTo(final DataSource other) {
+    final List<String> issues = PROPERTIES.stream()
+        .filter(prop -> !prop.isCompatible(this, other))
+        .map(prop -> getCompatMessage(other, prop))
+        .collect(Collectors.toList());
+
+    checkSchemas(getSchema(), other.getSchema())
+        .map(s -> getCompatMessage(other, SCHEMA_PROP) + "(" + s + ")")
+        .ifPresent(issues::add);
+
+    final String err = String.join("\n\tAND ", issues);
+    return err.isEmpty() ? Optional.empty() : Optional.of(err);
+  }
+
+  private String getCompatMessage(
+      final DataSource other,
+      final Property<?> prop
+  ) {
+    return String.format(
+        "DataSource '%s' has %s = %s which is not upgradeable to %s",
+        getName(),
+        prop.name,
+        prop.getter.apply(this).toString(),
+        prop.getter.apply(other).toString()
+    );
+  }
+
+  @VisibleForTesting
+  static Optional<String> checkSchemas(
+      final LogicalSchema schema,
+      final LogicalSchema other
+  ) {
+    if (!schema.key().equals(other.key())) {
+      return Optional.of("Key columns must be identical.");
+    }
+
+    final ImmutableSet<Column> colA = ImmutableSet.copyOf(schema.columns());
+    final ImmutableSet<Column> colB = ImmutableSet.copyOf(other.columns());
+
+    final SetView<Column> difference = Sets.difference(colA, colB);
+    if (!difference.isEmpty()) {
+      return Optional.of("The following columns are changed or missing: " + difference);
+    }
+
+    return Optional.empty();
+  }
+
+  private static class Property<T> {
+    final String name;
+    final Function<DataSource, T> getter;
+
+    Property(final String name, final Function<DataSource, T> getter) {
+      this.name = requireNonNull(name, "name");
+      this.getter = requireNonNull(getter, "getter");
+    }
+
+    public boolean isCompatible(final DataSource source, final DataSource other) {
+      return getter.apply(source).equals(getter.apply(other));
+    }
   }
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.testing.EffectivelyImmutable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -188,8 +189,11 @@ abstract class StructuredDataSource<K> implements DataSource {
     return Optional.empty();
   }
 
+  @Immutable
   private static class Property<T> {
+
     final String name;
+    @EffectivelyImmutable
     final Function<DataSource, T> getter;
 
     Property(final String name, final Function<DataSource, T> getter) {


### PR DESCRIPTION
### Description 

The next step in the `CREATE OR REPLACE` saga, this validates that the upgrades are compatible from a schema perspective. It does not yet implement the physical plan check to make sure that we allow the topology evolution.

### Testing done 

More unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

