### PR TITLE
chore: revert "remove confluent-hub from ksqlDB image"

### DIFF
--- a/ksqldb-docker/Dockerfile
+++ b/ksqldb-docker/Dockerfile
@@ -16,6 +16,11 @@ ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksqldb/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 
+RUN echo "===> Installing confluent-hub..." \
+    && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
+    && tar xf confluent-hub-client-latest.tar.gz \
+    && rm confluent-hub-client-latest.tar.gz
+
 RUN chmod +x /usr/bin/docker/configure
 RUN chmod +x /usr/bin/docker/run
 


### PR DESCRIPTION
### Description 

The PR reverts https://github.com/confluentinc/ksql/pull/5829, as we've decided to leave confluent-hub in both the standalone and CP images.

### Testing done 

Image builds.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

