### PR TITLE
feat: new array_remove udf

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -276,6 +276,22 @@ Array entries are compared according to their natural sort order, which sorts th
 
 If the array field is NULL, or contains only NULLs, then NULL is returned.
 
+### `ARRAY_REMOVE`
+
+```sql
+ARRAY_REMOVE(array, element)
+```
+
+Removes all elements from the input array equal to `element`.
+
+Examples:
+```sql
+- array_remove([1, 2, 3, 2, 1], 2) -> [1, 3, 1]
+- array_remove([false, NULL, true, true], false) -> [NULL, true, true]
+- array_remove(['Foo', 'Bar', NULL, 'baz'], null) -> ['Foo', 'Bar', 'baz']
+```
+If the array field is NULL then NULL is returned.
+
 ### `ARRAY_SORT`
 
 ```sql

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayRemove.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/array/ArrayRemove.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@UdfDescription(
+    name = "array_remove",
+    category = FunctionCategory.ARRAY,
+    description = "Removes all the elements equal to a specific value from an array."
+        + " Returns NULL if the input array is NULL.")
+public class ArrayRemove {
+
+  @Udf
+  public <T> List<T> remove(
+      @UdfParameter(description = "Array of values") final List<T> array,
+      @UdfParameter(description = "Value to remove") final T victim) {
+    if (array == null) {
+      return null;
+    }
+
+    final List<T> result = array.stream()
+        .filter(el -> !Objects.equals(el, victim))
+        .collect(Collectors.toList());
+    return result;
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayRemoveTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/array/ArrayRemoveTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class ArrayRemoveTest {
+  private final ArrayRemove udf = new ArrayRemove();
+
+  @Test
+  public void shouldRemoveAllMatchingElements() {
+    final List<String> input1 = Arrays.asList("foo", " ", "foo", "bar");
+    final String input2 = "foo";
+    final List<String> result = udf.remove(input1, input2);
+    assertThat(result, is(Arrays.asList(" ", "bar")));
+  }
+
+  @Test
+  public void shouldRemoveIntegers() {
+    final List<Integer> input1 = Arrays.asList(1, 2, 3, 2, 1);
+    final Integer input2 = 2;
+    final List<Integer> result = udf.remove(input1, input2);
+    assertThat(result, contains(1, 3, 1));
+  }
+
+  @Test
+  public void shouldRemoveDoubles() {
+    final List<Double> input1 = Arrays.asList(1.1, 2.99, 1.1, 3.0);
+    final Double input2 = 1.1;
+    final List<Double> result = udf.remove(input1, input2);
+    assertThat(result, contains(2.99, 3.0));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldRemoveMap() {
+    final Map<String, Integer> map1 = ImmutableMap.of("foo", 1, "bar", 2, "baz", 3);
+    final Map<String, Integer> map2 = ImmutableMap.of("foo", 10, "baz", 3);
+    final Map<String, Integer> map3 = ImmutableMap.of("foo", 1, "bar", 2, "baz", 3);
+    final List<Map<String, Integer>> input1 = Arrays.asList(map1, map2, map3);
+    final Map<String, Integer> input2 = map3;
+    final List<Map<String, Integer>> result = udf.remove(input1, input2);
+    assertThat(result, contains(map2));
+  }
+
+  @Test
+  public void shouldReturnAllElementsIfNoNull() {
+    final List<String> input1 = Arrays.asList("foo");
+    final String input2 = null;
+    final List<String> result = udf.remove(input1, input2);
+    assertThat(result, contains("foo"));
+  }
+
+  @Test
+  public void shouldReturnAllElementsIfNoMatches() {
+    final List<String> input1 = Arrays.asList("foo");
+    final String input2 = "bar";
+    final List<String> result = udf.remove(input1, input2);
+    assertThat(result, contains("foo"));
+  }
+
+  @Test
+  public void shouldReturnNullForNullInputArray() {
+    final List<String> input1 = null;
+    final String input2 = "foo";
+    final List<String> result = udf.remove(input1, input2);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullInputs() {
+    final List<Long> input1 = null;
+    final Long input2 = null;
+    final List<Long> result = udf.remove(input1, input2);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldRetainNulls() {
+    final List<String> input1 = Arrays.asList(null, "foo");
+    final String input2 = "foo";
+    final List<String> result = udf.remove(input1, input2);
+    assertThat(result, contains((String) null));
+  }
+
+  @Test
+  public void shouldRemoveNullsWhenRequested() {
+    final List<String> input1 = Arrays.asList(null, "foo", "bar");
+    final String input2 = null;
+    final List<String> result = udf.remove(input1, input2);
+    assertThat(result, contains("foo", "bar"));
+  }
+
+  @Test
+  public void shouldReturnEmptyForArraysOfOnlyNulls() {
+    final List<String> input1 = Arrays.asList(null, null);
+    final String input2 = null;
+    final List<String> result = udf.remove(input1, input2);
+    assertThat(result, hasSize(0));
+  }
+
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_all_primitive_types/6.1.0_1594957049270/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_all_primitive_types/6.1.0_1594957049270/plan.json
@@ -1,0 +1,130 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, BOOLS ARRAY<BOOLEAN>, BAD_BOOL BOOLEAN, INTS ARRAY<INTEGER>, BAD_INT INTEGER, BIGINTS ARRAY<BIGINT>, BAD_BIGINT BIGINT, DOUBLES ARRAY<DOUBLE>, BAD_DOUBLE DOUBLE, STRINGS ARRAY<STRING>, BAD_STRING STRING, DECIMALS ARRAY<DECIMAL(2, 1)>, BAD_DECIMAL DECIMAL(2, 1)) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `BOOLS` ARRAY<BOOLEAN>, `BAD_BOOL` BOOLEAN, `INTS` ARRAY<INTEGER>, `BAD_INT` INTEGER, `BIGINTS` ARRAY<BIGINT>, `BAD_BIGINT` BIGINT, `DOUBLES` ARRAY<DOUBLE>, `BAD_DOUBLE` DOUBLE, `STRINGS` ARRAY<STRING>, `BAD_STRING` STRING, `DECIMALS` ARRAY<DECIMAL(2, 1)>, `BAD_DECIMAL` DECIMAL(2, 1)",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_REMOVE(INPUT.BOOLS, INPUT.BAD_BOOL) BOOLS,\n  ARRAY_REMOVE(INPUT.INTS, INPUT.BAD_INT) INTS,\n  ARRAY_REMOVE(INPUT.BIGINTS, INPUT.BAD_BIGINT) BIGINTS,\n  ARRAY_REMOVE(INPUT.DOUBLES, INPUT.BAD_DOUBLE) DOUBLES,\n  ARRAY_REMOVE(INPUT.STRINGS, INPUT.BAD_STRING) STRINGS,\n  ARRAY_REMOVE(INPUT.DECIMALS, INPUT.BAD_DECIMAL) DECIMALS\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `BOOLS` ARRAY<BOOLEAN>, `INTS` ARRAY<INTEGER>, `BIGINTS` ARRAY<BIGINT>, `DOUBLES` ARRAY<DOUBLE>, `STRINGS` ARRAY<STRING>, `DECIMALS` ARRAY<DECIMAL(2, 1)>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `BOOLS` ARRAY<BOOLEAN>, `BAD_BOOL` BOOLEAN, `INTS` ARRAY<INTEGER>, `BAD_INT` INTEGER, `BIGINTS` ARRAY<BIGINT>, `BAD_BIGINT` BIGINT, `DOUBLES` ARRAY<DOUBLE>, `BAD_DOUBLE` DOUBLE, `STRINGS` ARRAY<STRING>, `BAD_STRING` STRING, `DECIMALS` ARRAY<DECIMAL(2, 1)>, `BAD_DECIMAL` DECIMAL(2, 1)"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_REMOVE(BOOLS, BAD_BOOL) AS BOOLS", "ARRAY_REMOVE(INTS, BAD_INT) AS INTS", "ARRAY_REMOVE(BIGINTS, BAD_BIGINT) AS BIGINTS", "ARRAY_REMOVE(DOUBLES, BAD_DOUBLE) AS DOUBLES", "ARRAY_REMOVE(STRINGS, BAD_STRING) AS STRINGS", "ARRAY_REMOVE(DECIMALS, BAD_DECIMAL) AS DECIMALS" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_all_primitive_types/6.1.0_1594957049270/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_all_primitive_types/6.1.0_1594957049270/spec.json
@@ -1,0 +1,191 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1594957049270,
+  "path" : "query-validation-tests\\array-remove.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<BOOLS ARRAY<BOOLEAN>, BAD_BOOL BOOLEAN, INTS ARRAY<INT>, BAD_INT INT, BIGINTS ARRAY<BIGINT>, BAD_BIGINT BIGINT, DOUBLES ARRAY<DOUBLE>, BAD_DOUBLE DOUBLE, STRINGS ARRAY<VARCHAR>, BAD_STRING VARCHAR, DECIMALS ARRAY<DECIMAL(2, 1)>, BAD_DECIMAL DECIMAL(2, 1)> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<BOOLS ARRAY<BOOLEAN>, INTS ARRAY<INT>, BIGINTS ARRAY<BIGINT>, DOUBLES ARRAY<DOUBLE>, STRINGS ARRAY<VARCHAR>, DECIMALS ARRAY<DECIMAL(2, 1)>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_remove with all primitive types",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "bools" : [ false, true, false ],
+        "bad_bool" : true,
+        "ints" : [ 0, 0, 1, 0, -1 ],
+        "bad_int" : -1,
+        "bigints" : [ 345, -123, 345 ],
+        "bad_bigint" : 345,
+        "doubles" : [ 0.0, 0.2, -12345.678, 0.2 ],
+        "bad_double" : 0.2,
+        "strings" : [ "foo", "bar", "foo" ],
+        "bad_string" : "foo",
+        "decimals" : [ 1.0, -0.2, 1.0, -9.9 ],
+        "bad_decimal" : -0.2
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "bools" : [ null, false, true ],
+        "bad_bool" : true,
+        "ints" : [ 0, null, 1, 0, -1 ],
+        "bad_int" : -1,
+        "bigints" : [ null, -123, 345 ],
+        "bad_bigint" : 345,
+        "doubles" : [ 0.3, -12345.678, null, 0.3 ],
+        "bad_double" : 0.3,
+        "strings" : [ "foo", "Food", null, "food" ],
+        "bad_string" : "foo",
+        "decimals" : [ 1.0, 1.1, 1.1, -0.2, null, 1.0 ],
+        "bad_decimal" : -0.2
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "bools" : [ null, false, true ],
+        "bad_bool" : null,
+        "ints" : [ 0, null, 1, 0, -1 ],
+        "bad_int" : null,
+        "bigints" : [ null, -123, 345 ],
+        "bad_bigint" : null,
+        "doubles" : [ 0.3, -12345.678, null, 0.3 ],
+        "bad_double" : null,
+        "strings" : [ "foo", "Food", null, "food" ],
+        "bad_string" : null,
+        "decimals" : [ 1.0, 1.1, 1.1, -0.2, null, 1.0 ],
+        "bad_decimal" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "bools" : [ ],
+        "bad_bool" : true,
+        "ints" : [ ],
+        "bad_int" : -1,
+        "bigints" : [ ],
+        "bad_bigint" : 345,
+        "doubles" : [ ],
+        "bad_double" : 0.2,
+        "strings" : [ ],
+        "bad_string" : "foo",
+        "decimals" : [ ],
+        "bad_decimal" : -0.2
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "bools" : null,
+        "bad_bool" : true,
+        "ints" : null,
+        "bad_int" : -1,
+        "bigints" : null,
+        "bad_bigint" : 345,
+        "doubles" : null,
+        "bad_double" : 0.2,
+        "strings" : null,
+        "bad_string" : "foo",
+        "decimals" : null,
+        "bad_decimal" : -0.2
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "BOOLS" : [ false, false ],
+        "INTS" : [ 0, 0, 1, 0 ],
+        "BIGINTS" : [ -123 ],
+        "DOUBLES" : [ 0.0, -12345.678 ],
+        "STRINGS" : [ "bar" ],
+        "DECIMALS" : [ 1.0, 1.0, -9.9 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "BOOLS" : [ null, false ],
+        "INTS" : [ 0, null, 1, 0 ],
+        "BIGINTS" : [ null, -123 ],
+        "DOUBLES" : [ -12345.678, null ],
+        "STRINGS" : [ "Food", null, "food" ],
+        "DECIMALS" : [ 1.0, 1.1, 1.1, null, 1.0 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "BOOLS" : [ false, true ],
+        "INTS" : [ 0, 1, 0, -1 ],
+        "BIGINTS" : [ -123, 345 ],
+        "DOUBLES" : [ 0.3, -12345.678, 0.3 ],
+        "STRINGS" : [ "foo", "Food", "food" ],
+        "DECIMALS" : [ 1.0, 1.1, 1.1, -0.2, 1.0 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "BOOLS" : [ ],
+        "INTS" : [ ],
+        "BIGINTS" : [ ],
+        "DOUBLES" : [ ],
+        "STRINGS" : [ ],
+        "DECIMALS" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "BOOLS" : null,
+        "INTS" : null,
+        "BIGINTS" : null,
+        "DOUBLES" : null,
+        "STRINGS" : null,
+        "DECIMALS" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, bools ARRAY<BOOLEAN>, bad_bool BOOLEAN, ints ARRAY<INT>, bad_int INT, bigints ARRAY<BIGINT>, bad_bigint BIGINT, doubles ARRAY<DOUBLE>, bad_double DOUBLE, strings ARRAY<STRING>, bad_string STRING, decimals ARRAY<DECIMAL(2,1)>, bad_decimal DECIMAL(2,1)) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_remove(bools, bad_bool) as bools, array_remove(ints, bad_int) as ints, array_remove(bigints, bad_bigint) as bigints, array_remove(doubles, bad_double) as doubles, array_remove(strings, bad_string) as strings, array_remove(decimals, bad_decimal) as decimals FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_all_primitive_types/6.1.0_1594957049270/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_all_primitive_types/6.1.0_1594957049270/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_complex_types/6.1.0_1594957049604/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_complex_types/6.1.0_1594957049604/plan.json
@@ -1,0 +1,130 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, LISTS ARRAY<ARRAY<STRING>>, BAD_LIST ARRAY<STRING>, MAPS ARRAY<MAP<STRING, INTEGER>>, BAD_MAP MAP<STRING, INTEGER>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `LISTS` ARRAY<ARRAY<STRING>>, `BAD_LIST` ARRAY<STRING>, `MAPS` ARRAY<MAP<STRING, INTEGER>>, `BAD_MAP` MAP<STRING, INTEGER>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_REMOVE(INPUT.LISTS, INPUT.BAD_LIST) LISTS,\n  ARRAY_REMOVE(INPUT.MAPS, INPUT.BAD_MAP) MAPS\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `LISTS` ARRAY<ARRAY<STRING>>, `MAPS` ARRAY<MAP<STRING, INTEGER>>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `LISTS` ARRAY<ARRAY<STRING>>, `BAD_LIST` ARRAY<STRING>, `MAPS` ARRAY<MAP<STRING, INTEGER>>, `BAD_MAP` MAP<STRING, INTEGER>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_REMOVE(LISTS, BAD_LIST) AS LISTS", "ARRAY_REMOVE(MAPS, BAD_MAP) AS MAPS" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_complex_types/6.1.0_1594957049604/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_complex_types/6.1.0_1594957049604/spec.json
@@ -1,0 +1,144 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1594957049604,
+  "path" : "query-validation-tests\\array-remove.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<LISTS ARRAY<ARRAY<VARCHAR>>, BAD_LIST ARRAY<VARCHAR>, MAPS ARRAY<MAP<VARCHAR, INT>>, BAD_MAP MAP<VARCHAR, INT>> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<LISTS ARRAY<ARRAY<VARCHAR>>, MAPS ARRAY<MAP<VARCHAR, INT>>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_remove with complex types",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "lists" : [ [ "foo", "bar", "foo" ], [ "foo", "bar", "foo" ], [ "foo" ] ],
+        "bad_list" : [ "foo", "bar", "foo" ],
+        "maps" : [ {
+          "apple" : 1,
+          "banana" : 2
+        }, {
+          "apple" : 3,
+          "banana" : 4
+        }, {
+          "apple" : 1,
+          "banana" : 2
+        } ],
+        "bad_map" : {
+          "apple" : 1,
+          "banana" : 2
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "lists" : [ null, [ "foo" ], [ "foo", "bar" ] ],
+        "bad_list" : [ "foo" ],
+        "maps" : [ {
+          "apple" : 1,
+          "banana" : 2
+        }, {
+          "apple" : 3,
+          "banana" : 4
+        }, null ],
+        "bad_map" : {
+          "apple" : 1,
+          "banana" : 2
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "lists" : [ ],
+        "bad_list" : [ "foo" ],
+        "maps" : [ ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "lists" : null,
+        "bad_list" : [ "foo" ],
+        "maps" : null,
+        "bad_map" : {
+          "apple" : 1,
+          "banana" : 2
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "LISTS" : [ [ "foo" ] ],
+        "MAPS" : [ {
+          "apple" : 3,
+          "banana" : 4
+        } ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "LISTS" : [ null, [ "foo", "bar" ] ],
+        "MAPS" : [ {
+          "apple" : 3,
+          "banana" : 4
+        }, null ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "LISTS" : [ ],
+        "MAPS" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "LISTS" : null,
+        "MAPS" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, lists ARRAY<ARRAY<STRING>>, bad_list ARRAY<STRING>, maps ARRAY<MAP<STRING,INT>>, bad_map MAP<STRING, INT>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_remove(lists, bad_list) as lists, array_remove(maps, bad_map) as maps FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_complex_types/6.1.0_1594957049604/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_complex_types/6.1.0_1594957049604/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_literal_array/6.1.0_1594957049161/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_literal_array/6.1.0_1594957049161/plan.json
@@ -1,0 +1,130 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, DUMMY INTEGER) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `DUMMY` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  ARRAY_REMOVE(ARRAY['foo', 'bar', 'foo'], 'foo') A1\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `A1` ARRAY<STRING>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `DUMMY` INTEGER"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY_REMOVE(ARRAY['foo', 'bar', 'foo'], 'foo') AS A1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.schema.registry.url" : "",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.metrics.extension" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_literal_array/6.1.0_1594957049161/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_literal_array/6.1.0_1594957049161/spec.json
@@ -1,0 +1,75 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1594957049161,
+  "path" : "query-validation-tests\\array-remove.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : "STRUCT<DUMMY INT> NOT NULL",
+    "CSAS_OUTPUT_0.OUTPUT" : "STRUCT<A1 ARRAY<VARCHAR>> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "array_remove with literal array",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "dummy" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "dummy" : 0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "A1" : [ "bar" ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "A1" : [ "bar" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, array_remove(array['foo', 'bar', 'foo'], 'foo') as a1 FROM INPUT;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_literal_array/6.1.0_1594957049161/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/array-remove_-_array_remove_with_literal_array/6.1.0_1594957049161/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/array-remove.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/array-remove.json
@@ -1,0 +1,107 @@
+{
+  "comments": [
+    "Tests covering the use of the ARRAY_REMOVE function."
+  ],
+  "tests": [
+    {
+      "name": "array_remove with literal array",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, dummy INTEGER) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_remove(array['foo', 'bar', 'foo'], 'foo') as a1 FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"dummy": 0 }},
+        {"topic": "test_topic", "key": "r2", "value": {"dummy": 0 }}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"A1": ["bar"]}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"A1": ["bar"]}}
+      ]
+    },
+    {
+      "name": "array_remove with all primitive types",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, bools ARRAY<BOOLEAN>, bad_bool BOOLEAN, ints ARRAY<INT>, bad_int INT, bigints ARRAY<BIGINT>, bad_bigint BIGINT, doubles ARRAY<DOUBLE>, bad_double DOUBLE, strings ARRAY<STRING>, bad_string STRING, decimals ARRAY<DECIMAL(2,1)>, bad_decimal DECIMAL(2,1)) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_remove(bools, bad_bool) as bools, array_remove(ints, bad_int) as ints, array_remove(bigints, bad_bigint) as bigints, array_remove(doubles, bad_double) as doubles, array_remove(strings, bad_string) as strings, array_remove(decimals, bad_decimal) as decimals FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {
+          "bools": [false, true, false], "bad_bool": true,
+          "ints": [0,0,1,0,-1], "bad_int": -1,
+          "bigints": [345,-123,345], "bad_bigint": 345,
+          "doubles": [0.0, 0.2, -12345.678, 0.2], "bad_double": 0.2,
+          "strings": ["foo", "bar", "foo"], "bad_string": "foo",
+          "decimals": [1.0, -0.2, 1.0, -9.9], "bad_decimal": -0.2}},
+        {"topic": "test_topic", "key": "r2", "value": {
+          "bools": [null, false, true], "bad_bool": true,
+          "ints": [0,null,1,0,-1], "bad_int": -1,
+          "bigints": [null,-123, 345], "bad_bigint": 345,
+          "doubles": [0.3, -12345.678, null, 0.3], "bad_double": 0.3,
+          "strings": ["foo", "Food", null, "food"], "bad_string": "foo",
+          "decimals": [1.0, 1.1, 1.1, -0.2, null, 1.0], "bad_decimal": -0.2}},
+        {"topic": "test_topic", "key": "r3", "value": {
+          "bools": [null, false, true], "bad_bool": null,
+          "ints": [0,null,1,0,-1], "bad_int": null,
+          "bigints": [null,-123, 345], "bad_bigint": null,
+          "doubles": [0.3, -12345.678, null, 0.3], "bad_double": null,
+          "strings": ["foo", "Food", null, "food"], "bad_string": null,
+          "decimals": [1.0, 1.1, 1.1, -0.2, null, 1.0], "bad_decimal": null}},
+        {"topic": "test_topic", "key": "r4", "value": {
+          "bools": [], "bad_bool": true,
+          "ints": [], "bad_int": -1,
+          "bigints": [], "bad_bigint": 345,
+          "doubles": [], "bad_double": 0.2,
+          "strings": [], "bad_string": "foo",
+          "decimals": [], "bad_decimal": -0.2}},
+        {"topic": "test_topic", "key": "r5", "value": {
+          "bools": null, "bad_bool": true,
+          "ints": null, "bad_int": -1,
+          "bigints": null, "bad_bigint": 345,
+          "doubles": null, "bad_double": 0.2,
+          "strings": null, "bad_string": "foo",
+           "decimals": null, "bad_decimal": -0.2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"BOOLS": [false,false], "INTS": [0,0,1,0], "BIGINTS": [-123], "DOUBLES": [0.0,-12345.678], "STRINGS": ["bar"], "DECIMALS": [1.0,1.0,-9.9]}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"BOOLS": [null,false], "INTS": [0,null,1,0], "BIGINTS": [null,-123], "DOUBLES": [-12345.678,null], "STRINGS": ["Food", null, "food"], "DECIMALS": [1.0,1.1,1.1,null,1.0]}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"BOOLS": [false,true], "INTS": [0,1,0,-1], "BIGINTS": [-123,345], "DOUBLES": [0.3,-12345.678,0.3], "STRINGS": ["foo", "Food", "food"], "DECIMALS": [1.0,1.1,1.1,-0.2,1.0]}},
+        {"topic": "OUTPUT", "key": "r4", "value": {"BOOLS": [], "INTS": [], "BIGINTS": [], "DOUBLES": [], "STRINGS": [], "DECIMALS": []}},
+        {"topic": "OUTPUT", "key": "r5", "value": {"BOOLS": null, "INTS": null, "BIGINTS": null, "DOUBLES": null, "STRINGS": null, "DECIMALS": null}}
+      ]
+    },
+    {
+      "name": "array_remove with complex types",
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, lists ARRAY<ARRAY<STRING>>, bad_list ARRAY<STRING>, maps ARRAY<MAP<STRING,INT>>, bad_map MAP<STRING, INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, array_remove(lists, bad_list) as lists, array_remove(maps, bad_map) as maps FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {
+          "lists": [ ["foo", "bar", "foo"], ["foo", "bar", "foo"], ["foo"] ], 
+          "bad_list": ["foo", "bar", "foo"], 
+          "maps": [ {"apple": 1, "banana": 2}, {"apple": 3, "banana": 4}, {"apple": 1, "banana": 2} ],
+          "bad_map": {"apple": 1, "banana": 2} }},
+        {"topic": "test_topic", "key": "r2", "value": {
+          "lists": [ null, ["foo"], ["foo", "bar"] ], 
+          "bad_list": ["foo"], 
+          "maps": [ {"apple": 1, "banana": 2}, {"apple": 3, "banana": 4}, null],
+          "bad_map": {"apple": 1, "banana": 2} }},
+        {"topic": "test_topic", "key": "r3", "value": {
+          "lists": [ ], 
+          "bad_list": ["foo"], 
+          "maps": [ ] }},
+        {"topic": "test_topic", "key": "r4", "value": {
+          "lists": null, 
+          "bad_list": ["foo"], 
+          "maps": null,
+          "bad_map": {"apple": 1, "banana": 2} }}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"LISTS": [ ["foo"] ], "MAPS": [{"apple": 3, "banana": 4} ] }},
+        {"topic": "OUTPUT", "key": "r2", "value": {"LISTS": [ null, ["foo", "bar"] ], "MAPS": [ {"apple": 3, "banana": 4}, null ] }},
+        {"topic": "OUTPUT", "key": "r3", "value": {"LISTS": [ ], "MAPS": [ ] }},
+        {"topic": "OUTPUT", "key": "r4", "value": {"LISTS": null, "MAPS": null }}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Just when you thought there couldn't possibly be any more array UDFs required...

`array_remove( array, element)` removes all elements equal to `element` from `array`.

Unit & QTT tests plus historical plans for the same.

Scalar-functions doc page updated.

