### PR TITLE
chore: do not try to re-register schema multiple times on failure

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/MissingTopicClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/MissingTopicClassifier.java
@@ -49,7 +49,7 @@ public class MissingTopicClassifier implements QueryErrorClassifier {
   @Override
   public Type classify(final Throwable e) {
     LOG.info(
-        "Attempting to classify error for {} as missing topic error. Required topics: {}",
+        "Attempting to classify missing topic error. Query ID: {} Required topics: {}",
         queryId,
         requiredTopics
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/MissingTopicClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/MissingTopicClassifier.java
@@ -48,7 +48,12 @@ public class MissingTopicClassifier implements QueryErrorClassifier {
 
   @Override
   public Type classify(final Throwable e) {
-    LOG.info("Attempting to classify error for {}", queryId);
+    LOG.info(
+        "Attempting to classify error for {} as missing topic error. Required topics: {}",
+        queryId,
+        requiredTopics
+    );
+
     for (String requiredTopic : requiredTopics) {
       if (!topicClient.isTopicExists(requiredTopic)) {
         LOG.warn("Query {} requires topic {} which cannot be found.", queryId, requiredTopic);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/RegisterSchemaCallback.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/RegisterSchemaCallback.java
@@ -17,12 +17,12 @@ package io.confluent.ksql.execution.streams;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.serde.StaticTopicSerde;
 import io.confluent.ksql.util.KsqlConstants;
-import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +30,7 @@ class RegisterSchemaCallback implements StaticTopicSerde.Callback {
 
   private static final Logger LOG = LoggerFactory.getLogger(RegisterSchemaCallback.class);
   private final SchemaRegistryClient srClient;
+  private final Set<SchemaRegisterEvent> failedAttempts = new HashSet<>();
 
   RegisterSchemaCallback(final SchemaRegistryClient srClient) {
     this.srClient = Objects.requireNonNull(srClient, "srClient");
@@ -43,17 +44,66 @@ class RegisterSchemaCallback implements StaticTopicSerde.Callback {
   ) {
     final String sourceSubject = source + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
     final String changelogSubject = changelog + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
-    try {
-      // all schema registry events start with a magic byte 0x0 and then four bytes
-      // indicating the schema id - we extract that schema id from the data that failed
-      // to deserialize and then register it into the changelog subject
-      final int id = ByteBuffer.wrap(data, 1, Integer.BYTES).getInt();
 
-      LOG.info("Trying to fetch & register schema id {} under subject {}", id, changelogSubject);
-      final ParsedSchema schema = srClient.getSchemaBySubjectAndId(sourceSubject, id);
-      srClient.register(changelogSubject, schema);
-    } catch (IOException | RestClientException e) {
-      LOG.warn("Failed during deserialization callback for topic " + source, e);
+    // all schema registry events start with a magic byte 0x0 and then four bytes
+    // indicating the schema id - we extract that schema id from the data that failed
+    // to deserialize and then register it into the changelog subject
+    final int id = ByteBuffer.wrap(data, 1, Integer.BYTES).getInt();
+    final SchemaRegisterEvent event = new SchemaRegisterEvent(id, sourceSubject, changelogSubject);
+
+    try {
+      if (!failedAttempts.contains(event)) {
+        LOG.info("Trying to fetch & register schema id {} under subject {}", id, changelogSubject);
+        final ParsedSchema schema = srClient.getSchemaBySubjectAndId(sourceSubject, id);
+        srClient.register(changelogSubject, schema);
+      }
+    } catch (Exception e) {
+      LOG.warn("Failed during deserialization callback for topic {}. "
+          + "Will not try again to register id {} under subject {}.",
+          source,
+          id,
+          changelogSubject,
+          e
+      );
+
+      failedAttempts.add(event);
+    }
+  }
+
+  private static final class SchemaRegisterEvent {
+    final int id;
+    final String sourceSubject;
+    final String changelogSubject;
+
+    private SchemaRegisterEvent(
+        final int id,
+        final String sourceSubject,
+        final String changelogSubject
+    ) {
+      this.id = id;
+      this.sourceSubject = sourceSubject;
+      this.changelogSubject = changelogSubject;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      final SchemaRegisterEvent that = (SchemaRegisterEvent) o;
+      return id == that.id
+          && Objects.equals(sourceSubject, that.sourceSubject)
+          && Objects.equals(changelogSubject, that.changelogSubject);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, sourceSubject, changelogSubject);
     }
   }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/RegisterSchemaCallbackTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/RegisterSchemaCallbackTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.execution.streams;
 
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +23,7 @@ import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,13 +37,17 @@ public class RegisterSchemaCallbackTest {
   private static final String SOURCE = "s1";
   private static final String CHANGELOG = "s2";
   private static final int ID = 1;
+  private static final int ID2 = 2;
   private static final byte[] SOME_DATA = new byte[]{0x0, 0x0, 0x0, 0x0, 0x1};
+  private static final byte[] OTHER_DATA = new byte[]{0x0, 0x0, 0x0, 0x0, 0x2};
 
   @Mock
   private SchemaRegistryClient srClient;
   @Mock
   private ParsedSchema schema;
-  
+  @Mock
+  private ParsedSchema schema2;
+
   @Test
   public void shouldRegisterIdFromData() throws IOException, RestClientException {
     // Given:
@@ -53,6 +59,39 @@ public class RegisterSchemaCallbackTest {
 
     // Then:
     verify(srClient).register(CHANGELOG + SUFFIX, schema);
+  }
+
+  @Test
+  public void shouldNotRegisterFailedIdTwice() throws IOException, RestClientException {
+    // Given:
+    when(srClient.getSchemaBySubjectAndId(SOURCE + SUFFIX, ID)).thenReturn(schema);
+    when(srClient.register(CHANGELOG + SUFFIX, schema)).thenThrow(new KsqlException(""));
+    final RegisterSchemaCallback call = new RegisterSchemaCallback(srClient);
+
+    // When:
+    call.onDeserializationFailure(SOURCE, CHANGELOG, SOME_DATA);
+    call.onDeserializationFailure(SOURCE, CHANGELOG, SOME_DATA);
+
+    // Then:
+    verify(srClient, times(1)).getSchemaBySubjectAndId(SOURCE + SUFFIX, ID);
+    verify(srClient).register(CHANGELOG + SUFFIX, schema);
+  }
+
+  @Test
+  public void shouldRegisterOtherSchemaIdIfFirstFails() throws IOException, RestClientException {
+    // Given:
+    when(srClient.getSchemaBySubjectAndId(SOURCE + SUFFIX, ID2)).thenReturn(schema2);
+    when(srClient.getSchemaBySubjectAndId(SOURCE + SUFFIX, ID)).thenReturn(schema);
+    when(srClient.register(CHANGELOG + SUFFIX, schema)).thenThrow(new KsqlException(""));
+    final RegisterSchemaCallback call = new RegisterSchemaCallback(srClient);
+
+    // When:
+    call.onDeserializationFailure(SOURCE, CHANGELOG, SOME_DATA);
+    call.onDeserializationFailure(SOURCE, CHANGELOG, OTHER_DATA);
+
+    // Then:
+    verify(srClient, times(1)).getSchemaBySubjectAndId(SOURCE + SUFFIX, ID2);
+    verify(srClient).register(CHANGELOG + SUFFIX, schema2);
   }
 
 }


### PR DESCRIPTION
### Description 

It is possible that due to #5823 we will attempt to register the same schema over and over again when a de-serialization failure happens if the schemas are incompatible. This PR limits the number of attempts to one.

### Testing done 

Unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

