### PR TITLE
docs: cherry-pick: add quick reference guide for ksqlDB SQL syntax (DOCS-4923)

### DIFF
--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -7,6 +7,7 @@ description: Learn to create ksqlDB applications
 
 These topics show how to develop ksqlDB applications.
 
+- [ksqlDB SQL quick reference](ksqldb-reference/quick-reference.md)
 - [Develop with ksqlDB clients](ksqldb-clients/index.md)
 - [Configure ksqlDB CLI](../operate-and-deploy/installation/cli-config.md) 
 - [Create a ksqlDB Stream](create-a-stream.md)

--- a/docs/developer-guide/ksqldb-reference/drop-stream.md
+++ b/docs/developer-guide/ksqldb-reference/drop-stream.md
@@ -22,7 +22,7 @@ Description
 Drops an existing stream.
 
 If the DELETE TOPIC clause is present, the stream's source topic is
-marked for deletion. If the topic format is `AVRO` or `PROTOBUF`, the
+marked for deletion. If the topic format is `AVRO`, `PROTOBUF`, or `JSON_SR`, the
 corresponding schema is deleted. Topic deletion is asynchronous, and actual
 removal from brokers may take some time to complete.
 

--- a/docs/developer-guide/ksqldb-reference/drop-type.md
+++ b/docs/developer-guide/ksqldb-reference/drop-type.md
@@ -19,7 +19,7 @@ DROP TYPE <type_name> AS <type>;
 Description
 -----------
 
-Removes a type alias from KSQL. This statement doesn't fail if the type is in
+Removes a type alias from ksqlDB. This statement doesn't fail if the type is in
 use in active queries or user-defined functions, because the DROP TYPE
 statement doesn't track whether queries are using the type. This means that you
 can drop a type any time, and old queries continue to work. Also, old queries

--- a/docs/developer-guide/ksqldb-reference/index.md
+++ b/docs/developer-guide/ksqldb-reference/index.md
@@ -6,16 +6,18 @@ description: Learn to program ksqlDB to create streaming applications.
 keywords: ksqldb, api, reference, function, operator, metadata, connector, query
 ---
 
-Functions and Operators
------------------------
+## SQL Quick Reference
+
+- [SQL Quick Reference](quick-reference.md)
+
+## Functions and Operators
 
 - [Aggregate Functions](aggregate-functions.md)
 - [Operators](operators.md)
 - [Scalar Functions](scalar-functions.md)
 - [Table Functions](table-functions.md)
 
-Streams and Tables
-------------------
+## Streams and Tables
 
 - [CREATE STREAM AS SELECT](create-stream-as-select.md)
 - [CREATE STREAM](create-stream.md)
@@ -28,32 +30,27 @@ Streams and Tables
 - [INSERT VALUES](insert-values.md)
 - [PRINT](print.md)
 
-
-Queries
--------
+## Queries
 
 - [SELECT (Pull Query)](select-pull-query.md)
 - [SELECT (Push Query)](select-push-query.md)
 - [EXPLAIN](explain.md)
 - [TERMINATE](terminate.md)
 
-Connectors
-----------
+## Connectors
 
 - [CREATE CONNECTOR](create-connector.md)
 - [DESCRIBE CONNECTOR](describe-connector.md)
 - [DROP CONNECTOR](drop-connector.md)
 - [SHOW CONNECTORS](show-connectors.md)
 
-Custom Types
-------------
+## Custom Types
 
 - [CREATE TYPE](create-type.md)
 - [DROP TYPE](drop-table.md)
 - [SHOW TYPES](show-types.md)
 
-Metadata
---------
+## Metadata
 
 - [DESCRIBE FUNCTION](describe-function.md)
 - [SHOW FUNCTIONS](show-functions.md)
@@ -64,8 +61,7 @@ Metadata
 - [SHOW TOPICS](show-topics.md)
 - [SPOOL](spool.md)
 
-Execution
----------
+## Execution
 
 - [RUN SCRIPT](run-script.md)
 

--- a/docs/developer-guide/ksqldb-reference/print.md
+++ b/docs/developer-guide/ksqldb-reference/print.md
@@ -19,7 +19,7 @@ PRINT topicName [FROM BEGINNING] [INTERVAL interval] [LIMIT limit]
 Description
 -----------
 
-Print the contents of Kafka topics to the ksqlDB CLI.
+Print the contents of {{ site.ak }} topics to the ksqlDB CLI.
 
 The _topicName_ is case sensitive. Quote the name if it contains invalid characters.
 See [Valid Identifiers](../../concepts/schemas.md#valid-identifiers) for more information.

--- a/docs/developer-guide/ksqldb-reference/quick-reference.md
+++ b/docs/developer-guide/ksqldb-reference/quick-reference.md
@@ -1,0 +1,548 @@
+---
+layout: page
+title: ksqlDB Quick Reference
+tagline:  Summary of SQL syntax for ksqlDB queries and statements
+description: Quick reference for SQL statements and queries in ksqlDB
+keywords: ksqldb, sql, syntax, query, stream, table
+---
+
+For detailed descriptions of ksqlDB SQL statements and keywords, see the 
+[ksqlDB API reference](./ksqldb-reference).
+
+For details on SQL syntax, see [ksqlDB syntax reference](../../syntax-reference/index).
+
+
+## ADVANCE BY
+Specify the duration of a "hop" in a HOPPING window. For more information,
+see [Time and Windows in ksqlDB](../../../concepts/time-and-windows-in-ksqldb-queries).
+
+```sql
+SELECT [...], aggregate_function
+  WINDOW HOPPING (SIZE <time_span> <time_units>, ADVANCE BY <time_span> <time_units>) [...]
+```
+
+## AND / OR
+Logical AND/OR operators in a WHERE clause. For more information, see
+[SELECT](../../ksqldb-reference/select-push-query/#example).
+
+```sql hl_lines="4"
+SELECT column_name(s)
+  FROM stream_name | table_name
+  WHERE condition          
+    AND|OR condition
+```
+
+## AS
+Alias a column, expression, or type. For more information, see
+[Create a table](../../create-a-table/#create-a-ksqldb-table-from-a-ksqldb-stream).
+
+```sql hl_lines="1"
+SELECT column_name AS column_alias
+  FROM stream_name | table_name
+```
+
+## BETWEEN
+Constrain a value to a specified range in a WHERE clause. For more information, see
+[BETWEEN](../../ksqldb-reference/select-push-query/#between).
+
+```sql
+WHERE expression [NOT] BETWEEN start_expression AND end_expression;            
+```
+
+## CASE
+Select a condition from one or more expressions. For more information, see
+[CASE](../../ksqldb-reference/select-push-query/#case).
+
+```sql
+SELECT
+  CASE
+    WHEN condition THEN result
+    [ WHEN … THEN … ]
+    …
+    [ WHEN … THEN … ]
+    [ ELSE result ]
+  END
+FROM stream_name | table_name;
+```
+
+## CAST
+Change the type of an expression to a different type. For more information, see
+[CAST](../../ksqldb-reference/select-push-query/#cast).
+
+```sql
+CAST (expression AS data_type);
+```
+
+## CREATE CONNECTOR
+Create a new connector in the {{ site.kconnectlong }} cluster. For more
+information, see [CREATE CONNECTOR](../../ksqldb-reference/create-connector).
+
+```sql
+CREATE SOURCE | SINK CONNECTOR connector_name
+  WITH( property_name = expression [, ...]);
+```
+
+## CREATE STREAM
+Register a stream on a {{ site.ak }} topic. For more information, see
+[CREATE STREAM](../../ksqldb-reference/create-stream).
+
+```sql
+CREATE STREAM stream_name ( { column_name data_type (KEY) } [, ...] 
+  WITH ( property_name = expression [, ...] );            
+```
+
+## CREATE STREAM AS SELECT
+Create a new materialized stream and corresponding {{ site.ak }} topic, and
+stream the result of the query into the topic. For more information, see
+[CREATE STREAM AS SELECT](../../ksqldb-reference/create-stream-as-select).
+
+```sql
+CREATE STREAM stream_name
+  [WITH ( property_name = expression [, ...] )]
+  AS SELECT  select_expr [, ...]
+  FROM from_stream
+  [[ LEFT | FULL | INNER ] JOIN [join_table | join_stream]
+    [ WITHIN [(before TIMEUNIT, after TIMEUNIT) | N TIMEUNIT] ]
+    ON join_criteria]* 
+  [ WHERE condition ]
+  [PARTITION BY column_name]
+  EMIT CHANGES;
+```
+
+## CREATE TABLE
+Register a stream on a {{ site.ak }} topic. For more information, see
+[CREATE TABLE](../../ksqldb-reference/create-table).
+
+```sql
+CREATE TABLE table_name ( { column_name data_type (PRIMARY KEY) } [, ...] )
+  WITH ( property_name = expression [, ...] );
+```
+
+## CREATE TABLE AS SELECT
+Create a new materialized table and corresponding {{ site.ak }} topic, and
+stream the result of the query as a changelog into the topic. For more
+information, see [CREATE TABLE AS SELECT](../../ksqldb-reference/create-table-as-select). 
+
+```sql
+CREATE TABLE table_name
+  [WITH ( property_name = expression [, ...] )]
+  AS SELECT  select_expr [, ...]
+  FROM from_stream | from_table
+  [[ LEFT | FULL | INNER ] JOIN [join_table | join_stream] ON join_criteria]* 
+  [ WINDOW window_expression ]
+  [ WHERE condition ]
+  [ GROUP BY grouping_expression ]
+  [ HAVING having_expression ]
+  EMIT CHANGES;
+```
+
+## CREATE TYPE
+Alias a complex type declaration. For more information, see
+[CREATE TYPE](../../ksqldb-reference/create-type).
+
+```sql
+CREATE TYPE <type_name> AS <type>;
+```
+
+## DESCRIBE
+List columns in a stream or table along with their data types and other
+attributes. For more information, see [DESCRIBE](../../ksqldb-reference/describe).
+
+```sql
+DESCRIBE [EXTENDED] (stream_name | table_name);
+```
+
+## DESCRIBE CONNECTOR
+List details about a connector. For more information, see
+[DESCRIBE CONNECTOR](../../ksqldb-reference/describe-connector).
+
+```sql
+DESCRIBE CONNECTOR connector_name;
+```
+
+## DESCRIBE FUNCTION
+List details about a function, including input parameters and return type.
+For more information, see [DESCRIBE FUNCTION](../../ksqldb-reference/describe-function).
+
+```sql
+DESCRIBE FUNCTION function_name;
+```
+
+## DROP CONNECTOR
+Delete a connector from the {{ site.kconnect }} cluster. For more information,
+see [DROP CONNECTOR](../../ksqldb-reference/drop-connector).
+
+```sql
+DROP CONNECTOR connector_name;
+```
+
+## DROP STREAM
+Drop an existing stream and optionally mark the stream's source topic for
+deletion. For more information, see [DROP STREAM](../../ksqldb-reference/drop-stream).
+
+```sql
+DROP STREAM [IF EXISTS] stream_name [DELETE TOPIC];
+```
+
+## DROP TABLE
+Drop an existing table and optionally mark the table's source topic for
+deletion. For more information, see [DROP TABLE](../../ksqldb-reference/drop-table).
+
+```sql
+DROP TABLE [IF EXISTS] table_name [DELETE TOPIC];
+```
+
+## DROP TYPE
+Remove a type alias from ksqlDB. For more information, see
+[DROP TYPE](../../ksqldb-reference/drop-type).
+
+```sql
+DROP TYPE <type_name> AS <type>;
+```
+
+## EMIT CHANGES
+Specify a push query in a SELECT statement. For more information, see
+[Push Queries](../../concepts/queries/push).
+
+```sql
+CREATE STREAM stream_name
+  AS SELECT  select_expr [, ...]
+  FROM from_stream
+  EMIT CHANGES;
+```
+
+## EXPLAIN
+Show the execution plan for a SQL expression or running query. For more
+information, see [EXPLAIN](../../ksqldb-reference/explain).
+
+```sql
+EXPLAIN (sql_expression | query_id);
+```
+
+## FULL JOIN
+Select all records when there is a match in the left stream/table _or_ the
+right stream/table records. Equivalent to FULL OUTER JOIN. For more information,
+see [Join streams and tables](../joins/join-streams-and-tables).
+
+```sql hl_lines="3"
+SELECT column_name(s)
+  FROM stream_name1 | table_name1
+   FULL JOIN stream_name2 | table_name2
+   ON <stream_name1|table_name1>.column_name=<stream_name2|table_name2>.column_name
+```
+
+## GROUP BY
+Group records in a window. Required by the WINDOW clause. For more information,
+see [Time and Windows in ksqlDB](../../concepts/time-and-windows-in-ksqldb-queries).
+
+```sql hl_lines="4"
+SELECT column_name, aggregate_function(column_name)
+  FROM table_name
+  WHERE column_name operator value
+  GROUP BY column_name
+```
+
+## HAVING
+Extract records from an aggregation that fulfill a specified condition.
+
+```sql hl_lines="5"
+SELECT column_name, aggregate_function(column_name)
+  FROM table_name
+  WHERE column_name operator value
+  GROUP BY column_name
+  HAVING aggregate_function(column_name) operator value
+```
+
+## HOPPING
+Group input records into fixed-sized, possibly overlapping windows,
+based on the timestamps of the records. For more information, see
+[HOPPING](../../ksqldb-reference/select-push-query/#hopping-window).
+
+```sql hl_lines="3"
+SELECT WINDOWSTART, WINDOWEND, aggregate_function
+  FROM from_stream
+  WINDOW HOPPING window_expression
+  EMIT CHANGES;
+```
+
+## IF EXISTS
+Test whether a stream or table is present in ksqlDB.
+
+```sql
+DROP STREAM [IF EXISTS] stream_name [DELETE TOPIC];
+DROP TABLE  [IF EXISTS] table_name  [DELETE TOPIC];
+```
+
+## IN
+Specify multiple values in a WHERE clause.
+
+```sql hl_lines="4"
+SELECT column_name(s)
+  FROM stream_name | table_name
+  WHERE column_name
+  IN (value1,value2,..)
+```
+
+## INNER JOIN
+Select records in a stream or table that have matching values in another stream
+or table. For more information, see
+[Join streams and tables](../joins/join-streams-and-tables).
+
+```sql hl_lines="3"
+SELECT column_name(s)
+  FROM stream_name1 | table_name1
+   INNER JOIN stream_name2 | table_name2
+   ON <stream_name1|table_name1>.column_name=<stream_name2|table_name2>.column_name
+```
+
+## INSERT INTO
+Stream the result of a SELECT query into an existing stream and its underlying
+{{ site.ak }} topic. For more information, see [INSERT INTO](../../ksqldb-reference/insert-into).
+
+```sql
+INSERT INTO stream_name
+  SELECT select_expr [., ...]
+  FROM from_stream
+  [ LEFT | FULL | INNER ] JOIN [join_table | join_stream]
+    [ WITHIN [(before TIMEUNIT, after TIMEUNIT) | N TIMEUNIT] ]
+    ON join_criteria
+  [ WHERE condition ]
+  [ PARTITION BY column_name ]
+  EMIT CHANGES;
+```
+
+## INSERT VALUES
+Produce a row into an existing stream or table and its underlying {{ site.ak }}
+topic based on explicitly specified values. For more information, see
+[INSERT VALUES](../../ksqldb-reference/insert-values).
+
+```sql
+INSERT INTO stream_name|table_name [(column_name [, ...]])]
+  VALUES (value [,...]);
+```
+
+## LEFT JOIN
+Select all records from the left stream/table and the matched records from the
+right stream/table. For more information, see
+[Join streams and tables](../joins/join-streams-and-tables).
+
+```sql hl_lines="3"
+SELECT column_name(s)
+  FROM stream_name1 | table_name1
+   LEFT JOIN stream_name2 | table_name2
+   ON <stream_name1|table_name1>.column_name=<stream_name2|table_name2>.column_name
+```
+
+## LIKE
+Match a string with the specified pattern. For more information, see
+[LIKE](../../ksqldb-reference/select-push-query/#like).
+
+```sql hl_lines="3"
+  SELECT select_expr [., ...]
+    FROM from_stream | from_table
+    WHERE condition LIKE pattern_string;
+```
+
+## PARTITION BY
+Repartition a stream. For more information, see
+[Partition Data to Enable Joins](../joins/partition-data).
+
+```sql hl_lines="6"
+CREATE STREAM stream_name
+  WITH ([...,]
+        PARTITIONS=number_of_partitions)
+  AS SELECT select_expr [., ...]
+  FROM from_stream
+  PARTITION BY key_field
+  EMIT CHANGES;
+```
+
+## PRINT
+Print the contents of {{ site.ak }} topics to the ksqlDB CLI. For more
+information, see [PRINT](../../ksqldb-reference/print).
+
+```sql
+PRINT topicName [FROM BEGINNING] [INTERVAL interval] [LIMIT limit]
+```
+
+## RUN SCRIPT
+Execute predefined queries and commands from a file. For more
+information, see [RUN SCRIPT](../../ksqldb-reference/run-script).
+
+```sql
+RUN SCRIPT <path-to-query-file>;
+```
+
+## SELECT (Pull Query)
+Pull the current value from a materialized table and terminate. For more
+information, see [SELECT (Pull Query)](../../ksqldb-reference/select-pull-query).
+
+```sql
+SELECT select_expr [, ...]
+  FROM aggregate_table
+  WHERE key_column=key
+  [AND window_bounds];
+```
+
+## SELECT (Push Query)
+Push a continuous stream of updates to a stream or table. For more
+information, see [SELECT (Push Query)](../../ksqldb-reference/select-push-query).
+
+```sql
+SELECT select_expr [, ...]
+  FROM from_item
+  [ LEFT JOIN join_table ON join_criteria ]
+  [ WINDOW window_expression ]
+  [ WHERE condition ]
+  [ GROUP BY grouping_expression ]
+  [ HAVING having_expression ]
+  EMIT CHANGES
+  [ LIMIT count ];
+```
+
+## SESSION
+Group input records into a session window. For more information, see
+[SELECT (Push Query)](../../ksqldb-reference/select-push-query/#session-window).
+
+```sql hl_lines="3"
+SELECT WINDOWSTART, WINDOWEND, aggregate_function
+  FROM from_stream
+  WINDOW SESSION window_expression
+  EMIT CHANGES;
+```
+
+## SHOW CONNECTORS
+List all connectors in the {{ site.kconnect }} cluster. For more information,
+see [SHOW CONNECTORS](../../ksqldb-reference/show-connectors).
+
+```sql
+SHOW | LIST CONNECTORS;
+```
+
+## SHOW FUNCTIONS
+List available scalar and aggregate functions available. For more information,
+see [SHOW FUNCTIONS](../../ksqldb-reference/show-functions).
+
+```sql
+SHOW | LIST FUNCTIONS;
+```
+
+## SHOW PROPERTIES
+List the [configuration settings](../../operate-and-deploy/installation/server-config/config-reference.md)
+that are currently in effect. For more information, see [SHOW PROPERTIES](../../ksqldb-reference/show-properties).
+
+```sql
+SHOW PROPERTIES;
+```
+
+## SHOW QUERIES
+List queries that are currently running in the cluster. For more information,
+see [SHOW QUERIES](../../ksqldb-reference/show-queries).
+
+```sql
+SHOW | LIST QUERIES [EXTENDED];
+```
+
+## SHOW STREAMS
+List the currently defined streams. For more information,
+see [SHOW STREAMS](../../ksqldb-reference/show-streams).
+
+```sql
+SHOW | LIST STREAMS [EXTENDED];
+```
+
+## SHOW TABLES
+List the currently defined tables. For more information,
+see [SHOW TABLES](../../ksqldb-reference/show-tables).
+
+```sql
+SHOW | LIST TABLES [EXTENDED];
+```
+
+## SHOW TOPICS
+List the available topics in the {{ site.ak }} cluster that ksqlDB is
+configured to connect to. For more information, see
+[SHOW TOPICS](../../ksqldb-reference/show-topics).
+
+```sql
+SHOW | LIST [ALL] TOPICS [EXTENDED];
+```
+
+## SHOW TYPES
+List all custom types and their type definitions. For more information,
+see [SHOW TYPES](../../ksqldb-reference/show-types).
+
+```sql
+SHOW | LIST TYPES;
+```
+
+## SIZE
+Specify the duration of a HOPPING or TUMBLING window. For more information,
+see [Time and Windows in ksqlDB](../../concepts/time-and-windows-in-ksqldb-queries).
+
+```sql hl_lines="3"
+SELECT WINDOWSTART, WINDOWEND, aggregate_function
+  FROM from_stream
+  WINDOW TUMBLING (SIZE <time_span> <time_units>)
+  EMIT CHANGES;
+```
+
+## SPOOL
+Store issued commands and their results in a file. For more information,
+see [SPOOL](../../ksqldb-reference/show-spool).
+
+```sql
+SPOOL <file_name|OFF>
+```
+
+## TERMINATE
+End a persistent query. For more information, see [SPOOL](../../ksqldb-reference/terminate).
+
+```sql
+TERMINATE query_id;
+```
+
+## TUMBLING
+Group input records into fixed-sized, non-overlapping windows based on the
+timestamps of the records. For more information, see
+[TUMBLING](../../ksqldb-reference/select-push-query/#tumbling-window).
+
+```sql hl_lines="3"
+SELECT WINDOWSTART, WINDOWEND, aggregate_function
+  FROM from_stream
+  WINDOW TUMBLING window_expression
+  EMIT CHANGES;
+```
+
+## WHERE
+Extract records that fulfill a specified condition. For more information, see
+[SELECT](../../ksqldb-reference/select-push-query/#example).  
+
+```sql hl_lines="3"
+SELECT column_name(s)
+  FROM from_stream | from_table
+  WHERE column_name operator value
+```
+
+## WINDOW
+Group input records that have the same key into a window, for operations like
+aggregations and joins. For more information, see
+[WINDOW](../../ksqldb-reference/select-push-query/#window).
+
+```sql hl_lines="3"
+SELECT WINDOWSTART, WINDOWEND, aggregate_function
+  FROM from_stream
+  WINDOW window_expression
+  EMIT CHANGES;
+```
+
+## WINDOWSTART / WINDOWEND
+Specify the beginning and end bounds a window. For more information, see
+[WINDOW](../../ksqldb-reference/select-push-query/#window).
+
+```sql hl_lines="1"
+SELECT WINDOWSTART, WINDOWEND, aggregate_function
+  FROM from_stream
+  WINDOW window_expression
+  EMIT CHANGES;
+```

--- a/docs/developer-guide/ksqldb-reference/select-pull-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-pull-query.md
@@ -23,8 +23,8 @@ Description
 -----------
 
 Pulls the current value from the materialized table and terminates. The result
-of this statement isn't persisted in a Kafka topic and is printed out only in
-the console.
+of this statement isn't persisted in a {{ site.ak }} topic and is printed out
+only in the console.
 
 Pull queries enable you to fetch the current state of a materialized view.
 Because materialized views are incrementally updated as new events arrive,

--- a/docs/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-push-query.md
@@ -116,7 +116,7 @@ SET 'auto.offset.reset' = 'earliest';
 #### WINDOW
 
 !!! note
-  You can use the WINDOW clause only if the `from_item` is a stream.
+    You can use the WINDOW clause only if the `from_item` is a stream.
 
 
 The WINDOW clause lets you control how to group input records *that have
@@ -126,9 +126,11 @@ or joins. Windows are tracked per record key.
 Windowing adds two additional system columns to the data, which provide
 the window bounds: `WINDOWSTART` and `WINDOWEND`.
 
-ksqlDB supports the following WINDOW types:
+ksqlDB supports the following WINDOW types.
 
-**TUMBLING**: Tumbling windows group input records into fixed-sized,
+#### TUMBLING window
+
+Tumbling windows group input records into fixed-sized,
 non-overlapping windows based on the records' timestamps. You must
 specify the *window size* for tumbling windows. Tumbling windows are a
 special case of hopping windows, where the window size is equal to the
@@ -145,7 +147,9 @@ SELECT windowstart, windowend, item_id, SUM(quantity)
   EMIT CHANGES;
 ```
 
-**HOPPING**: Hopping windows group input records into fixed-sized,
+#### HOPPING window
+
+Hopping windows group input records into fixed-sized,
 (possibly) overlapping windows based on the records' timestamps. You
 must specify the *window size* and the *advance interval* for
 hopping windows.
@@ -161,7 +165,9 @@ SELECT windowstart, windowend, item_id, SUM(quantity)
   EMIT CHANGES;
 ```
 
-**SESSION**: Session windows group input records into so-called
+#### SESSION window
+
+Session windows group input records into so-called
 sessions. You must specify the *session inactivity gap* parameter
 for session windows. For example, imagine you set the inactivity gap
 to 5 minutes. If, for a given record key such as "alice", no new

--- a/docs/developer-guide/ksqldb-reference/show-topics.md
+++ b/docs/developer-guide/ksqldb-reference/show-topics.md
@@ -19,7 +19,7 @@ SHOW | LIST [ALL] TOPICS [EXTENDED];
 Description
 -----------
 
-SHOW TOPICS lists the available topics in the Kafka cluster that ksqlDB is
+SHOW TOPICS lists the available topics in the {{ site.ak }} cluster that ksqlDB is
 configured to connect to (default setting for `bootstrap.servers`:
 `localhost:9092`). SHOW TOPICS EXTENDED also displays consumer groups
 and their active consumer counts.

--- a/docs/developer-guide/syntax-reference.md
+++ b/docs/developer-guide/syntax-reference.md
@@ -3,44 +3,58 @@ layout: page
 title: ksqlDB Syntax Reference
 tagline:  Syntax for ksqlDB queries and statements
 description: Syntax Reference for statements and queries in ksqlDB
-keywords: ksqldb, syntax, api
+keywords: ksqldb, sql, syntax, query, api
 ---
 
-ksqlDB SQL has similar semantics to ANSI SQL:
+The ksqlDB SQL language enables queries, transforms, aggregations, joins, and
+other operations on streaming data. ksqlDB SQL has a familiar syntax that's similar to
+[ANSI SQL](https://blog.ansi.org/2018/10/sql-standard-iso-iec-9075-2016-ansi-x3-135/).
+
+### SQL quick reference
+
+For a summary of supported SQL statements and keywords, see the
+[ksqlDB SQL quick reference](../ksqldb-reference/quick-reference).
+
+### Syntax notes
 
 -   Terminate SQL statements with a semicolon `;`.
 -   Escape single-quote characters (`'`) inside string literals by using
     two successive single quotes (`''`). For example, to escape `'T'`,
     write `''T''`.
 
-Terminology
------------
+### Terminology
 
-When using ksqlDB, the following terminology is used.
+ksqlDB SQL uses standard relational database terminology and extends it for
+stream processing.
 
 ### Stream
 
-A stream is an unbounded sequence of structured data ("facts"). For
-example, we could have a stream of financial transactions such as "Alice
-sent $100 to Bob, then Charlie sent $50 to Bob". Facts in a stream are
-immutable, which means new facts can be inserted to a stream, but
-existing facts can never be updated or deleted. Streams can be created
-from an {{ site.aktm }} topic or derived from an existing stream. A
-stream's underlying data is durably stored (persisted) within a Kafka
-topic on the Kafka brokers.
+A ksqlDB stream is an unbounded sequence of structured data. Each individual
+unit of data represents a _fact_ and may be referred to as a "record", "message",
+or "event". For example, a stream could be a sequence of financial transactions,
+like "Alice sent $100 to Bob, then Charlie sent $50 to Bob".
+
+Facts in a stream are _immutable_, which means that new facts can be inserted
+into a stream, but existing facts can never be updated or deleted.
+
+Streams can be created from an {{ site.aktm }} topic or derived from an
+existing stream. A stream's underlying data is durably stored, or _persisted_,
+in a topic on the {{ site.ak }} brokers.
 
 ### Table
 
-A table is a view of a stream, or another table, and represents a
-collection of evolving facts. For example, we could have a table that
-contains the latest financial information such as "Bob's current account
-balance is $150". It is the equivalent of a traditional database table
-but enriched by streaming semantics such as windowing. Facts in a table
-are mutable, which means new facts can be inserted to the table, and
-existing facts can be updated or deleted. Tables can be created from a
-Kafka topic or derived from existing streams and tables. In both cases,
-a table's underlying data is durably stored (persisted) within a Kafka
-topic on the Kafka brokers.
+A ksqlDB table is a view of a stream or another table. A table represents a
+collection of evolving facts. For example, a table might contain the latest
+financial information for an account, like "Bob's current balance is $150".
+A ksqlDB table is the equivalent of a traditional database table, enriched
+with streaming semantics, like windowing.
+
+Facts in a table are _mutable_, which means that new facts can be inserted to
+the table, and existing facts can be updated and deleted.
+
+Tables can be created from a {{ site.ak }} topic or derived from existing
+streams and tables. In both cases, a table's underlying data is durably
+persisted in a topic on the {{ site.ak }} brokers.
 
 ### STRUCT
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - Reference:
     - Syntax Reference: developer-guide/syntax-reference.md
     - Statements:
+      - SQL quick reference: developer-guide/ksqldb-reference/quick-reference.md
       - Statement Index: developer-guide/ksqldb-reference/index.md
       - CREATE CONNECTOR: developer-guide/ksqldb-reference/create-connector.md
       - CREATE STREAM: developer-guide/ksqldb-reference/create-stream.md


### PR DESCRIPTION
* docs: add quick reference guide for syntax

* docs: move new quick-reference page to ref section