### PR TITLE
docs: cherry-pick: clarify syntax for KEY in CS statement (DOCS-4935)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/create-stream.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream.md
@@ -13,7 +13,7 @@ Synopsis
 --------
 
 ```sql
-CREATE STREAM stream_name ( { column_name data_type (KEY) } [, ...] )
+CREATE STREAM stream_name ( { column_name data_type [KEY] } [, ...] )
   WITH ( property_name = expression [, ...] );
 ```
 

--- a/docs/developer-guide/ksqldb-reference/create-table.md
+++ b/docs/developer-guide/ksqldb-reference/create-table.md
@@ -10,7 +10,7 @@ Synopsis
 --------
 
 ```sql
-CREATE TABLE table_name ( { column_name data_type (PRIMARY KEY) } [, ...] )
+CREATE TABLE table_name ( { column_name data_type [PRIMARY KEY] } [, ...] )
   WITH ( property_name = expression [, ...] );
 ```
 
@@ -42,7 +42,7 @@ Each column is defined by:
    [data types](../syntax-reference.md#ksqldb-data-types) supported by ksqlDB.
  * `PRIMARY KEY`: columns that are stored in the Kafka message's key should be marked as
    `PRIMARY KEY` columns. If a column is not marked as a `PRIMARY KEY` column ksqlDB loads it
-   from the Kafka message's value. Unlike a stream's `KEY` column, a table's `PRIMARY KEY` column(s)
+   from the {{ site.ak }} message's value. Unlike a stream's `KEY` column, a table's `PRIMARY KEY` column(s)
    are NON NULL. Any records in the Kafka topic with NULL key columns are dropped.
    
 Each row within the table has a `ROWTIME` pseudo column, which represents the _last modified time_ 

--- a/docs/developer-guide/ksqldb-reference/quick-reference.md
+++ b/docs/developer-guide/ksqldb-reference/quick-reference.md
@@ -87,7 +87,7 @@ Register a stream on a {{ site.ak }} topic. For more information, see
 [CREATE STREAM](../../ksqldb-reference/create-stream).
 
 ```sql
-CREATE STREAM stream_name ( { column_name data_type (KEY) } [, ...] 
+CREATE STREAM stream_name ( { column_name data_type [KEY] } [, ...] 
   WITH ( property_name = expression [, ...] );            
 ```
 


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5863.