### PR TITLE
chore: dont list all topics to determine single topic existence (MINOR)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -178,10 +178,6 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
         return false;
       }
 
-      if (Throwables.getRootCause(e) instanceof TopicAuthorizationException) {
-        return false;
-      }
-
       throw new KafkaResponseGetFailedException("Failed to check if exists for topic: " + topic, e);
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -166,13 +166,13 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   public boolean isTopicExists(final String topic) {
     LOG.trace("Checking for existence of topic '{}'", topic);
     try {
-      final DescribeTopicsResult describe = ExecutorUtil.executeWithRetries(
+      ExecutorUtil.executeWithRetries(
           () -> adminClient.get().describeTopics(
               ImmutableList.of(topic),
-              new DescribeTopicsOptions().includeAuthorizedOperations(true)),
+              new DescribeTopicsOptions().includeAuthorizedOperations(true)
+          ).values().get(topic).get(),
           RetryBehaviour.ON_RETRYABLE
       );
-      describe.values().get(topic).get();
       return true;
     } catch (final Exception e) {
       if (Throwables.getRootCause(e) instanceof UnknownTopicOrPartitionException) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -47,7 +47,6 @@ import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
-import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -714,19 +714,6 @@ public class KafkaTopicClientImplTest {
     verify(adminClient, never()).listTopics();
   }
 
-  @Test
-  public void shouldNotShowTopicWithAclError() {
-    // Given
-    when(adminClient.describeTopics(any(), any()))
-        .thenAnswer(describeTopicsResult(new TopicAuthorizationException("meh")));
-
-    // When
-    final boolean exists = kafkaTopicClient.isTopicExists("foobar");
-
-    // Then
-    assertThat(exists, is(false));
-  }
-
   private static ConfigEntry defaultConfigEntry(final String key, final String value) {
     final ConfigEntry config = mock(ConfigEntry.class);
     when(config.name()).thenReturn(key);


### PR DESCRIPTION
### Description 

We shouldn't be using `listTopics` to determine whether or not a single topic exists. This PR changes it to use the `describeTopics` API to check for only a single topic.

### Testing done 

Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

