### PR TITLE
fix: improve confusing error message in schema registry injector

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -129,9 +129,11 @@ public class SchemaRegisterInjector implements Injector {
           if (!srClient.testCompatibility(subject, parsedSchema)) {
             throw new KsqlStatementException(
                 String.format(
-                    "Could not register schema for subject "
-                        + "'%s' because it is incompatible with existing schema.",
-                    subject),
+                    "Could not create source from topic with subject "
+                        + "'%s' because the ksql generated schema %s is incompatible with existing "
+                        + "registered schema.",
+                    subject,
+                    parsedSchema.canonicalString()),
                 statementText);
           }
         } else {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
@@ -208,7 +208,11 @@ public class SchemaRegisterInjectorTest {
     final KsqlStatementException e = assertThrows(KsqlStatementException.class, () -> injector.inject(statement));
 
     // Then:
-    assertThat(e.getMessage(), containsString("Could not register schema for subject 'expectedName-value' because it is incompatible with existing schema."));
+    assertThat(e.getMessage(), containsString("" +
+        "Could not create source from topic with subject 'expectedName-value' because the ksql "
+        + "generated schema {\"type\":\"record\",\"name\":\"KsqlDataSourceSchema\",\"namespace\":\"io.confluent.ksql.avro_schemas\","
+        + "\"fields\":[{\"name\":\"F1\",\"type\":[\"null\",\"string\"],\"default\":null}],\"connect.name\":\"io.confluent.ksql.avro_schemas.KsqlDataSourceSchema\"} "
+        + "is incompatible with existing registered schema."));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Fixes a confusing error message:
```
# old error message
`Could not register schema for subject ‘foo-value’ because it is incompatible with existing schema.`

# new error message
Could not create stream from toipc with subject 'foo-value' because the ksql generated schema {"type":"record","name":"KsqlDataSourceSchema","namespace":"io.confluent.ksql.avro_schemas","fields":[{"name":"F1","type":["null","string"],"default":null}],"connect.name":"io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"} is incompatible with existing registered schema.
```

### Testing done 

updated unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

