### PR TITLE
fix: change default grace period to zero

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.parser.OutputRefinement;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.PartitionBy;
@@ -113,6 +114,10 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
 
   @Override
   public Optional<WindowExpression> getWindowExpression() {
+    if (original.getRefinementInfo().isPresent()
+    && original.getRefinementInfo().get().getOutputRefinement() == OutputRefinement.FINAL) {
+      
+    }
     return original.getWindowExpression();
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -125,13 +125,18 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
 
   @Override
   public Optional<WindowExpression> getWindowExpression() {
-    /* Rewrites window expression to have 0 grace period if none is specified during a suppression
-     Otherwise return the original window expression
-     */
-    if (!original.getRefinementInfo().isPresent() || !original.getWindowExpression().isPresent()
-        || original.getWindowExpression().get().getKsqlWindowExpression()
-        .getGracePeriod().isPresent()
-        || original.getRefinementInfo().get().getOutputRefinement() == OutputRefinement.CHANGES
+    final Optional<WindowExpression> windowExpression = original.getWindowExpression();
+    final Optional<RefinementInfo> refinementInfo = original.getRefinementInfo();
+
+    /* Return the original window expression, unless there is no grace period provided during a
+    suppression, in which case we rewrite the window expression to have a default grace period
+    of zero.
+    */
+    if (!(windowExpression.isPresent()
+        && !windowExpression.get().getKsqlWindowExpression().getGracePeriod().isPresent()
+        && refinementInfo.isPresent()
+        && refinementInfo.get().getOutputRefinement() == OutputRefinement.FINAL
+         )
     ) {
       return original.getWindowExpression();
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -31,7 +31,6 @@ import io.confluent.ksql.execution.windows.TumblingWindowExpression;
 import io.confluent.ksql.execution.windows.WindowTimeClause;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
-import io.confluent.ksql.parser.OutputRefinement;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.PartitionBy;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -124,7 +124,10 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
 
   @Override
   public Optional<WindowExpression> getWindowExpression() {
-    if (!original.getRefinementInfo().isPresent() || !original.getWindowExpression().isPresent()) {
+    if (!original.getRefinementInfo().isPresent() || !original.getWindowExpression().isPresent()
+        || original.getWindowExpression().get().getKsqlWindowExpression()
+        .getGracePeriod().isPresent()
+    ) {
       return original.getWindowExpression();
     }
     final WindowExpression window = original.getWindowExpression().get();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.execution.windows.TumblingWindowExpression;
 import io.confluent.ksql.execution.windows.WindowTimeClause;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.OutputRefinement;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.PartitionBy;
@@ -124,9 +125,13 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
 
   @Override
   public Optional<WindowExpression> getWindowExpression() {
+    /* Rewrites window expression to have 0 grace period if none is specified during a suppression
+     Otherwise return the original window expression
+     */
     if (!original.getRefinementInfo().isPresent() || !original.getWindowExpression().isPresent()
         || original.getWindowExpression().get().getKsqlWindowExpression()
         .getGracePeriod().isPresent()
+        || original.getRefinementInfo().get().getOutputRefinement() == OutputRefinement.CHANGES
     ) {
       return original.getWindowExpression();
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/RewrittenAnalysisTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/RewrittenAnalysisTest.java
@@ -1,0 +1,140 @@
+package io.confluent.ksql.analyzer;
+
+import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.windows.HoppingWindowExpression;
+import io.confluent.ksql.execution.windows.KsqlWindowExpression;
+import io.confluent.ksql.execution.windows.SessionWindowExpression;
+import io.confluent.ksql.execution.windows.TumblingWindowExpression;
+import io.confluent.ksql.execution.windows.WindowTimeClause;
+import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.serde.RefinementInfo;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+public class RewrittenAnalysisTest {
+
+  @Mock
+  private Analysis analysis;
+  @Mock
+  private BiFunction<Expression, ExpressionTreeRewriter.Context<Void>, Optional<Expression>> rewriter;
+  @Mock
+  private WindowTimeClause size;
+  @Mock
+  private WindowTimeClause advanceBy;
+  @Mock
+  private WindowTimeClause gap;
+  @Mock
+  private Optional<NodeLocation> location;
+  @Mock
+  private Optional<WindowTimeClause> retention;
+  @Mock
+  private HoppingWindowExpression hoppingWindow;
+  @Mock
+  private TumblingWindowExpression tumblingWindow;
+  @Mock
+  private SessionWindowExpression sessionWindow;
+  @Mock
+  private KsqlWindowExpression unsupportedWindowType;
+  @Mock
+  private Optional<WindowExpression> windowExpressionOptional;
+  @Mock
+  private WindowExpression windowExpression;
+  @Mock
+  private Optional<RefinementInfo> refinementInfo;
+
+  private RewrittenAnalysis rewrittenAnalysis;
+  private String windowName = "windowName";
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  public void setUp() {
+    rewrittenAnalysis = new RewrittenAnalysis(analysis, rewriter);
+
+    when(analysis.getRefinementInfo()).thenReturn(refinementInfo);
+    when(refinementInfo.isPresent()).thenReturn(true);
+    when(analysis.getWindowExpression()).thenReturn(windowExpressionOptional);
+    when(windowExpressionOptional.isPresent()).thenReturn(true);
+    when(windowExpressionOptional.get()).thenReturn(windowExpression);
+    when(windowExpression.getWindowName()).thenReturn(windowName);
+  }
+
+  @Test
+  public void shouldCreateNewTumblingWindowWithZeroGracePeriodDefault() {
+    // Given:
+    when(windowExpression.getKsqlWindowExpression()).thenReturn(tumblingWindow);
+    when(tumblingWindow.getLocation()).thenReturn(location);
+    when(tumblingWindow.getRetention()).thenReturn(retention);
+    when(tumblingWindow.getSize()).thenReturn(size);
+
+    // When:
+    Optional<WindowExpression> result = rewrittenAnalysis.getWindowExpression();
+
+    // Then:
+    assertThat(result.get().getKsqlWindowExpression().getGracePeriod(), not(Optional.empty()));
+  }
+
+  @Test
+  public void shouldCreateNewHoppingWindowWithZeroGracePeriodDefault() {
+    // Given:
+    when(windowExpression.getKsqlWindowExpression()).thenReturn(hoppingWindow);
+    when(hoppingWindow.getLocation()).thenReturn(location);
+    when(hoppingWindow.getRetention()).thenReturn(retention);
+    when(hoppingWindow.getSize()).thenReturn(size);
+    when(hoppingWindow.getAdvanceBy()).thenReturn(advanceBy);
+
+    // When:
+    Optional<WindowExpression> result = rewrittenAnalysis.getWindowExpression();
+
+    // Then:
+    assertThat(result.get().getKsqlWindowExpression().getGracePeriod(), not(Optional.empty()));
+  }
+
+  @Test
+  public void shouldCreateNewSessionWindowWithZeroGracePeriodDefault() {
+    // Given:
+    when(windowExpression.getKsqlWindowExpression()).thenReturn(sessionWindow);
+    when(sessionWindow.getLocation()).thenReturn(location);
+    when(sessionWindow.getRetention()).thenReturn(retention);
+    when(sessionWindow.getGap()).thenReturn(gap);
+
+    // When:
+    Optional<WindowExpression> result = rewrittenAnalysis.getWindowExpression();
+
+    // Then:
+    assertThat(result.get().getKsqlWindowExpression().getGracePeriod(), not(Optional.empty()));
+  }
+
+  @Test
+  public void shouldThrowIfUnsupportedWindowType() {
+    // Given:
+    when(windowExpression.getKsqlWindowExpression()).thenReturn(unsupportedWindowType);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> rewrittenAnalysis.getWindowExpression()
+    );
+
+    // Then
+    assertThat(e.getMessage(), containsString("WINDOW type must be HOPPING, TUMBLING, or SESSION"));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/RewrittenAnalysisTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/RewrittenAnalysisTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.analyzer;
 
 import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter;


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
When `EMIT FINAL` is used appropriately on a windowed aggregation, but no grace period specified, the previous behavior made the default grace period to be 24h. This patch changes this default to 0.
### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
Created `RewrittenAnalysisTest` and added relevant unit tests
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

