### PR TITLE
docs: update beta CP dependencies for 0.11.0 (MINOR)

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -68,7 +68,7 @@ Start by creating a `pom.xml` for your Java application:
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/6.0.0-beta200608020919/1/maven/</url>
+            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.ksqldbcpversion }}/1/maven/</url>
         </repository>
     </repositories>
 
@@ -79,7 +79,7 @@ Start by creating a `pom.xml` for your Java application:
         </pluginRepository>
         <pluginRepository>
             <id>confluent</id>
-            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/6.0.0-beta200608020919/1/maven/</url>
+            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.ksqldbcpversion }}/1/maven/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,6 +207,7 @@ extra:
         kafkaversion: 2.5
         kafkarelease: 5.5.0-ccs
         ksqldbversion: 0.11.0
+        ksqldbcpversion: 6.1.0-beta200715032424
         release: 0.11.0
         cprelease: 5.5.0
         releasepostbranch: 5.5.0-post


### PR DESCRIPTION
### Description 

Until we're able to publish beta CP dependencies for standalone ksqlDB releases to a stable repo, we'll have to update the dependency version on each release. This PR pulls the version into a mkdocs variable to make this easier (and make it so we're less likely to forget).

This needs to be cherry-picked to `0.11.x-ksqldb`. I'll do that once this PR is approved and merged.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

