### PR TITLE
feat: New ksql.properties.overrides.denylist to deny clients configs overrides

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.properties;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import io.confluent.ksql.util.KsqlException;
 
 import java.util.Collection;
@@ -37,14 +38,14 @@ public class DenyListPropertyValidator {
 
   /**
    * Validates if a list of properties are part of the list of denied properties.
-   * @throws if a property is part of the denied list.
+   * @throws if at least one property is part of the denied list.
    */
   public void validateAll(final Map<String, Object> properties) {
-    properties.forEach((name ,v) -> {
-      if (immutableProps.contains(name)) {
-        throw new KsqlException(String.format("A property override was set locally for a "
-            + "property that the server prohibits overrides for: '%s'", name));
-      }
-    });
+    final Set<String> propsDenied = Sets.intersection(immutableProps, properties.keySet());
+    if (!propsDenied.isEmpty()) {
+      throw new KsqlException(String.format("One or more properties overrides set locally are "
+          + "prohibited by the KSQL server (use UNSET to reset their default value): %s",
+          propsDenied));
+    }
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import io.confluent.ksql.util.KsqlException;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Class that validates if a property, or list of properties, is part of a list of denied
+ * properties.
+ */
+public class DenyListPropertyValidator extends LocalPropertyValidator {
+  public DenyListPropertyValidator(final Collection<String> immutableProps) {
+    super(immutableProps);
+  }
+
+  /**
+   * Validates if a list of properties are part of the list of denied properties.
+   * @throws if a property is part of the denied list.
+   */
+  public void validateAll(final Map<String, Object> properties) {
+    properties.forEach((k ,v) -> {
+      try {
+        validate(k, v);
+      } catch (final Exception e) {
+        throw new KsqlException(e.getMessage());
+      }
+    });
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -333,6 +333,12 @@ public class KsqlConfig extends AbstractConfig {
       + "error messages (per query) to hold in the internal query errors queue and display"
       + "in the query description when executing the `EXPLAIN <query>` command.";
 
+  public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST =
+      "ksql.properties.overrides.denylist";
+  public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DEFAULT = "";
+  public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
+      + "properties that KSQL users cannot override.";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -761,6 +767,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_ERROR_MAX_QUEUE_SIZE_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_ERROR_MAX_QUEUE_SIZE_DOC
+        )
+        .define(
+            KSQL_PROPERTIES_OVERRIDES_DENYLIST,
+            Type.LIST,
+            KSQL_PROPERTIES_OVERRIDES_DENYLIST_DEFAULT,
+            Importance.LOW,
+            KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -335,8 +335,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST =
       "ksql.properties.overrides.denylist";
-  public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DEFAULT = "";
-  public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
+  private static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
       + "properties that KSQL users cannot override.";
 
   private enum ConfigGeneration {
@@ -771,7 +770,7 @@ public class KsqlConfig extends AbstractConfig {
         .define(
             KSQL_PROPERTIES_OVERRIDES_DENYLIST,
             Type.LIST,
-            KSQL_PROPERTIES_OVERRIDES_DENYLIST_DEFAULT,
+            "",
             Importance.LOW,
             KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC
         )

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
@@ -48,8 +48,10 @@ public class DenyListPropertyValidatorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Cannot override property 'immutable-property'"
+        "A property override was set locally for a property that the server prohibits "
+            + "overrides for: 'immutable-property'"
     ));
+
   }
 
   @Test

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
@@ -31,7 +31,8 @@ public class DenyListPropertyValidatorTest {
   @Before
   public void setUp() {
     validator = new DenyListPropertyValidator(Arrays.asList(
-        "immutable-property"
+        "immutable-property-1",
+        "immutable-property-2"
     ));
   }
 
@@ -41,21 +42,23 @@ public class DenyListPropertyValidatorTest {
     final KsqlException e = assertThrows(
         KsqlException.class,
         () -> validator.validateAll(ImmutableMap.of(
-            "immutable-property", "v1",
-            "anything", "v2"
+            "immutable-property-1", "v1",
+            "anything", "v2",
+            "immutable-property-2", "v3"
         ))
     );
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "A property override was set locally for a property that the server prohibits "
-            + "overrides for: 'immutable-property'"
+        "One or more properties overrides set locally are prohibited by the KSQL server "
+            + "(use UNSET to reset their default value): "
+            + "[immutable-property-1, immutable-property-2]"
     ));
 
   }
 
   @Test
-  public void shouldNotThrowOnConfigurableProp() {
+  public void shouldNotThrowOnAllowedProp() {
     validator.validateAll(ImmutableMap.of(
         "mutable-1", "v1",
         "anything", "v2"

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+
+public class DenyListPropertyValidatorTest {
+  private DenyListPropertyValidator validator;
+
+  @Before
+  public void setUp() {
+    validator = new DenyListPropertyValidator(Arrays.asList(
+        "immutable-property"
+    ));
+  }
+
+  @Test
+  public void shouldThrowOnDenyListedProperty() {
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of(
+            "immutable-property", "v1",
+            "anything", "v2"
+        ))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Cannot override property 'immutable-property'"
+    ));
+  }
+
+  @Test
+  public void shouldNotThrowOnConfigurableProp() {
+    validator.validateAll(ImmutableMap.of(
+        "mutable-1", "v1",
+        "anything", "v2"
+    ));
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -212,7 +212,7 @@ public class KsqlResource implements KsqlConfigurable {
           securityContext,
           TERMINATE_CLUSTER,
           new SessionProperties(
-              request.getStreamsProperties(),
+              streamsProperties,
               localHost,
               localUrl,
               false

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -69,9 +69,9 @@ public class WSQueryEndpoint {
   private final Optional<KsqlAuthorizationValidator> authorizationValidator;
   private final Errors errorHandler;
   private final PullQueryExecutor pullQueryExecutor;
+  private final DenyListPropertyValidator denyListPropertyValidator;
 
   private WebSocketSubscriber<?> subscriber;
-  private DenyListPropertyValidator denyListPropertyValidator;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public WSQueryEndpoint(
@@ -85,7 +85,8 @@ public class WSQueryEndpoint {
       final Duration commandQueueCatchupTimeout,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final PullQueryExecutor pullQueryExecutor
+      final PullQueryExecutor pullQueryExecutor,
+      final DenyListPropertyValidator denyListPropertyValidator
   ) {
     this(ksqlConfig,
         statementParser,
@@ -99,7 +100,8 @@ public class WSQueryEndpoint {
         commandQueueCatchupTimeout,
         authorizationValidator,
         errorHandler,
-        pullQueryExecutor
+        pullQueryExecutor,
+        denyListPropertyValidator
     );
   }
 
@@ -118,7 +120,8 @@ public class WSQueryEndpoint {
       final Duration commandQueueCatchupTimeout,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
-      final PullQueryExecutor pullQueryExecutor
+      final PullQueryExecutor pullQueryExecutor,
+      final DenyListPropertyValidator denyListPropertyValidator
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.statementParser = Objects.requireNonNull(statementParser, "statementParser");
@@ -137,9 +140,8 @@ public class WSQueryEndpoint {
         Objects.requireNonNull(authorizationValidator, "authorizationValidator");
     this.errorHandler = Objects.requireNonNull(errorHandler, "errorHandler");
     this.pullQueryExecutor = Objects.requireNonNull(pullQueryExecutor, "pullQueryExecutor");
-
-    this.denyListPropertyValidator = new DenyListPropertyValidator(
-        ksqlConfig.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));
+    this.denyListPropertyValidator =
+        Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
   }
 
   public void executeStreamQuery(final ServerWebSocket webSocket, final MultiMap requestParams,
@@ -250,7 +252,6 @@ public class WSQueryEndpoint {
 
   private void handleQuery(final RequestContext info, final Query query) {
     final Map<String, Object> clientLocalProperties = info.request.getConfigOverrides();
-    denyListPropertyValidator.validateAll(clientLocalProperties);
 
     final WebSocketSubscriber<StreamedRow> streamSubscriber =
         new WebSocketSubscriber<>(info.websocket);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogServerUtils;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
@@ -135,6 +136,8 @@ public class KsqlRestApplicationTest {
   private EndpointResponse response;
   @Mock
   private QueryMonitor queryMonitor;
+  @Mock
+  private DenyListPropertyValidator denyListPropertyValidator;
 
   @Mock
   private SchemaRegistryClient schemaRegistryClient;
@@ -495,7 +498,8 @@ public class KsqlRestApplicationTest {
         Optional.of(heartbeatAgent),
         Optional.of(lagReportingAgent),
         vertx,
-        queryMonitor
+        queryMonitor,
+        denyListPropertyValidator
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.query.id.SpecificQueryIdGenerator;
@@ -94,6 +95,9 @@ public class RecoveryTest {
   @Mock
   @SuppressWarnings("unchecked")
   private final Producer<CommandId, Command> transactionalProducer = (Producer<CommandId, Command>) mock(Producer.class);
+  @Mock
+  private DenyListPropertyValidator denyListPropertyValidator =
+      mock(DenyListPropertyValidator.class);
 
   private final KsqlServer server1 = new KsqlServer(commands);
   private final KsqlServer server2 = new KsqlServer(commands);
@@ -226,7 +230,8 @@ public class RecoveryTest {
           Duration.ofMillis(0),
           ()->{},
           Optional.of((sc, metastore, statement) -> { }),
-          mock(Errors.class)
+          mock(Errors.class),
+          denyListPropertyValidator
       );
 
       this.statementExecutor.configure(ksqlConfig);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2214,7 +2214,8 @@ public class KsqlResourceTest {
     // Then:
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        is("Cannot override property '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
+        is("A property override was set locally for a property that the server prohibits "
+            + "overrides for: '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
   }
 
   @Test
@@ -2251,7 +2252,8 @@ public class KsqlResourceTest {
     // Then:
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        is("Cannot override property '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
+        is("A property override was set locally for a property that the server prohibits "
+            + "overrides for: '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
   }
 
   private void givenKsqlConfigWith(final Map<String, Object> additionalConfig) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.resources;
 import static io.confluent.ksql.parser.ParserMatchers.configured;
 import static io.confluent.ksql.parser.ParserMatchers.preparedStatementText;
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_FORBIDDEN_KAFKA_ACCESS;
+import static io.confluent.ksql.rest.entity.ClusterTerminateRequest.DELETE_TOPIC_LIST_PROP;
 import static io.confluent.ksql.rest.entity.CommandId.Action.CREATE;
 import static io.confluent.ksql.rest.entity.CommandId.Action.DROP;
 import static io.confluent.ksql.rest.entity.CommandId.Action.EXECUTE;
@@ -97,6 +98,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
@@ -291,6 +293,8 @@ public class KsqlResourceTest {
   private Producer<CommandId, Command> transactionalProducer;
   @Mock
   private Errors errorsHandler;
+  @Mock
+  private DenyListPropertyValidator denyListPropertyValidator;
 
   private KsqlResource ksqlResource;
   private SchemaRegistryClient schemaRegistryClient;
@@ -399,7 +403,8 @@ public class KsqlResourceTest {
             topicInjectorFactory.apply(ec),
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
-        errorsHandler
+        errorsHandler,
+        denyListPropertyValidator
     );
 
     // When:
@@ -429,7 +434,8 @@ public class KsqlResourceTest {
             topicInjectorFactory.apply(ec),
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
-        errorsHandler
+        errorsHandler,
+        denyListPropertyValidator
     );
 
     // When:
@@ -2174,52 +2180,39 @@ public class KsqlResourceTest {
             topicInjectorFactory.apply(ec),
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
-        errorsHandler
+        errorsHandler,
+        denyListPropertyValidator
     );
 
     ksqlResource.configure(ksqlConfig);
   }
 
   @Test
-  public void shouldThrowOnDenyListedStreamProperty() {
+  public void shouldThrowOnDenyListValidatorWhenTerminateCluster() {
+    final Map<String, Object> terminateStreamProperties =
+        ImmutableMap.of(DELETE_TOPIC_LIST_PROP, Collections.singletonList("Foo"));
+
     // Given:
-    ksqlResource = new KsqlResource(
-        ksqlEngine,
-        commandStore,
-        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
-        activenessRegistrar,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjectorFactory.apply(sc),
-            topicInjectorFactory.apply(ec),
-            new TopicDeleteInjector(ec, sc)),
-        Optional.of(authorizationValidator),
-        errorsHandler
+    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator).validateAll(
+        terminateStreamProperties
     );
-    final Map<String, Object> props = new HashMap<>(ksqlRestConfig.getKsqlConfigProperties());
-    props.put(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST,
-        StreamsConfig.NUM_STREAM_THREADS_CONFIG);
-    ksqlResource.configure(new KsqlConfig(props));
 
     // When:
-    final EndpointResponse response = ksqlResource.handleKsqlStatements(
+    final EndpointResponse response = ksqlResource.terminateCluster(
         securityContext,
-        new KsqlRequest(
-            "query",
-            ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, "1"), // stream properties
-            emptyMap(), // config properties
-            null
-        )
+        VALID_TERMINATE_REQUEST
     );
 
     // Then:
-    assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
-    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        is("A property override was set locally for a property that the server prohibits "
-            + "overrides for: '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
+    verify(denyListPropertyValidator).validateAll(terminateStreamProperties);
+    assertThat(response.getStatus(), equalTo(INTERNAL_SERVER_ERROR.code()));
+    assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
+    assertThat(((KsqlStatementErrorMessage) response.getEntity()).getMessage(),
+        containsString("deny override"));
   }
 
   @Test
-  public void shouldThrowOnDenyListedConfigProperty() {
+  public void shouldThrowOnDenyListValidatorWhenHandleKsqlStatement() {
     // Given:
     ksqlResource = new KsqlResource(
         ksqlEngine,
@@ -2231,29 +2224,33 @@ public class KsqlResourceTest {
             topicInjectorFactory.apply(ec),
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
-        errorsHandler
+        errorsHandler,
+        denyListPropertyValidator
     );
     final Map<String, Object> props = new HashMap<>(ksqlRestConfig.getKsqlConfigProperties());
     props.put(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST,
         StreamsConfig.NUM_STREAM_THREADS_CONFIG);
     ksqlResource.configure(new KsqlConfig(props));
+    final Map<String, Object> overrides =
+        ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+    doThrow(new KsqlException("deny override")).when(denyListPropertyValidator)
+        .validateAll(overrides);
 
     // When:
     final EndpointResponse response = ksqlResource.handleKsqlStatements(
         securityContext,
         new KsqlRequest(
             "query",
-            emptyMap(), // stream properties
-            ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, "1"), // config properties
+            overrides,  // stream properties
+            emptyMap(),
             null
         )
     );
 
     // Then:
+    verify(denyListPropertyValidator).validateAll(overrides);
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
-    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        is("A property override was set locally for a property that the server prohibits "
-            + "overrides for: '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
+    assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(), is("deny override"));
   }
 
   private void givenKsqlConfigWith(final Map<String, Object> additionalConfig) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.rest.ApiJsonMapper;
+import io.confluent.ksql.rest.Errors;
+import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.server.StatementParser;
+import io.confluent.ksql.rest.server.computation.CommandQueue;
+import io.confluent.ksql.rest.server.execution.PullQueryExecutor;
+import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
+import io.confluent.ksql.security.KsqlSecurityContext;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.version.metrics.ActivenessRegistrar;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.ServerWebSocket;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WSQueryEndpointTest {
+  private static final ObjectMapper OBJECT_MAPPER = ApiJsonMapper.INSTANCE.get();
+
+  @Mock
+  private ServerWebSocket serverWebSocket;
+  @Mock
+  private KsqlSecurityContext ksqlSecurityContext;
+  @Mock
+  private DenyListPropertyValidator denyListPropertyValidator;
+
+  private WSQueryEndpoint wsQueryEndpoint;
+
+  @Before
+  public void setUp() {
+    wsQueryEndpoint = new WSQueryEndpoint(
+        mock(KsqlConfig.class),
+        mock(StatementParser.class),
+        mock(KsqlEngine.class),
+        mock(CommandQueue.class),
+        mock(ListeningScheduledExecutorService.class),
+        mock(ActivenessRegistrar.class),
+        mock(Duration.class),
+        Optional.empty(),
+        mock(Errors.class),
+        mock(PullQueryExecutor.class),
+        denyListPropertyValidator
+    );
+  }
+
+  @Test
+  public void shouldCallPropertyValidatorOnExecuteStream()
+      throws JsonProcessingException {
+    // Given
+    final Map<String, Object> overrides =
+        ImmutableMap.of(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+    final MultiMap params = buildRequestParams("show streams;", overrides);
+
+    // When
+    executeStreamQuery(params);
+
+    // Then
+    // WS sockets do not throw any exception (closes silently). We can only verify the validator
+    // was called.
+    verify(denyListPropertyValidator).validateAll(overrides);
+  }
+
+  private MultiMap buildRequestParams(final String command, final Map<String, Object> streamProps)
+      throws JsonProcessingException {
+    final MultiMap params = MultiMap.caseInsensitiveMultiMap();
+    final KsqlRequest request = new KsqlRequest(
+        command, streamProps, Collections.emptyMap(), 1L);
+
+    params.add("request", OBJECT_MAPPER.writeValueAsString(request));
+    return params;
+  }
+
+  private void executeStreamQuery(final MultiMap params) {
+    wsQueryEndpoint.executeStreamQuery(serverWebSocket, params, ksqlSecurityContext);
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -382,7 +382,8 @@ public class StreamedQueryResourceTest {
         StreamsConfig.NUM_STREAM_THREADS_CONFIG);
     testResource.configure(new KsqlConfig(props));
     when(errorsHandler.generateResponse(any(), any()))
-        .thenReturn(badRequest("Cannot override property 'num.stream.threads'"));
+        .thenReturn(badRequest("A property override was set locally for a property that the "
+            + "server prohibits overrides for: 'num.stream.threads'"));
 
     // When:
     final EndpointResponse response = testResource.streamQuery(
@@ -400,7 +401,8 @@ public class StreamedQueryResourceTest {
     // Then:
     assertThat(response.getStatus(), CoreMatchers.is(BAD_REQUEST.code()));
     assertThat(((KsqlErrorMessage) response.getEntity()).getMessage(),
-        is("Cannot override property '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
+        is("A property override was set locally for a property that the server prohibits "
+            + "overrides for: '" + StreamsConfig.NUM_STREAM_THREADS_CONFIG + "'"));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Added a new configuration `ksql.properties.overrides.denylist` to specify which server properties cannot be overridden by the KSQL clients/users.

There is currently an internal hard-coded list of properties that cannot be overriden. However, there are KSQL admins that also want other properties to be in the list. To make this dynamic, this new denylist property allow those admins to specify which properties should not be overridden, without making changes in the code.

The only disadvantage on this dynamic property over the hard-coded is the validation happens only until executing a DDL or query statements.

### Testing done 
- Added unit tests
- Verify the CLI manually
```
ksql> set 'ksql.streams.num.stream.threads'='4';
Successfully changed local property 'ksql.streams.num.stream.threads' from '4' to '4'.

ksql> show streams;
Cannot override property 'ksql.streams.num.stream.threads'

ksql> unset 'ksql.streams.num.stream.threads';
Successfully unset local property 'ksql.streams.num.stream.threads' (value was '4').

ksql> show streams;

 Stream Name         | Kafka Topic                 | Format 
------------------------------------------------------------
 KSQL_PROCESSING_LOG | default_ksql_processing_log | JSON   
------------------------------------------------------------
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

