### PR TITLE
chore: introduce physical plan upgrade validation for basic upgrades

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -216,6 +216,8 @@ final class EngineContext {
       // queries
       final PersistentQueryMetadata oldQuery = persistentQueries.get(queryId);
       if (oldQuery != null) {
+        oldQuery.getPhysicalPlan()
+            .validateUpgrade(((PersistentQueryMetadata) query).getPhysicalPlan());
         oldQuery.close();
       }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -258,7 +258,8 @@ public final class QueryExecutor {
         overrides,
         queryCloseCallback,
         ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG),
-        classifier
+        classifier,
+        physicalPlan
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
@@ -45,6 +46,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
   private final PhysicalSchema resultSchema;
   private final DataSourceType dataSourceType;
   private final Optional<MaterializationProvider> materializationProvider;
+  private final ExecutionStep<?> physicalPlan;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public PersistentQueryMetadata(
@@ -65,7 +67,8 @@ public class PersistentQueryMetadata extends QueryMetadata {
       final Map<String, Object> overriddenProperties,
       final Consumer<QueryMetadata> closeCallback,
       final long closeTimeout,
-      final QueryErrorClassifier errorClassifier
+      final QueryErrorClassifier errorClassifier,
+      final ExecutionStep<?> physicalPlan
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
@@ -91,6 +94,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
     this.materializationProvider =
         requireNonNull(materializationProvider, "materializationProvider");
     this.dataSourceType = Objects.requireNonNull(dataSourceType, "dataSourceType");
+    this.physicalPlan = requireNonNull(physicalPlan, "physicalPlan");
   }
 
   private PersistentQueryMetadata(
@@ -104,6 +108,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
     this.resultSchema = other.resultSchema;
     this.materializationProvider = other.materializationProvider;
     this.dataSourceType = other.dataSourceType;
+    this.physicalPlan = other.physicalPlan;
   }
 
   public PersistentQueryMetadata copyWith(final Consumer<QueryMetadata> closeCallback) {
@@ -132,6 +137,10 @@ public class PersistentQueryMetadata extends QueryMetadata {
 
   public PhysicalSchema getPhysicalSchema() {
     return resultSchema;
+  }
+
+  public ExecutionStep<?> getPhysicalPlan() {
+    return physicalPlan;
   }
 
   public Optional<Materialization> getMaterialization(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.is;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
+import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.ColumnName;
@@ -40,7 +41,9 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category({IntegrationTest.class})
 public class ReplaceIntTest {
 
   @ClassRule

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
@@ -19,7 +19,12 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.testing.EffectivelyImmutable;
+import io.confluent.ksql.util.KsqlException;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
@@ -55,4 +60,130 @@ public interface ExecutionStep<S> {
   List<ExecutionStep<?>> getSources();
 
   S build(PlanBuilder planBuilder);
+
+  /**
+   * Checks whether or not this execution step can be safely replaced
+   * with {@code other} without causing upgrade issues such as corrupted
+   * state stores or repartition topics.
+   *
+   * <p>{@code validateUpgrade} checks compatibility by starting from the
+   * parent and then traversing down the execution step tree. This means that
+   * at any given point, the implementation can assume that the path above
+   * the current node is upgrade compatible.
+   *
+   * <p>The implementation relies on two different types of nodes:
+   *  <ol>
+   *    <li><b>Enforcing Steps</b>: these steps are "stopping" points in the validation
+   *    tree and will bring the {@code to} tree to match the enforcing step, skipping
+   *    any passive steps that show up in between./li>
+   *
+   *    <li><b>Passive Steps</b>: these are steps that can be added/removed to topologies
+   *    without causing any issues to upgrades. They will delegate their upgrade
+   *    validation to their corresponding source nodes</li>
+   *  </ol>
+   * </p>
+   *
+   * <p>With this implementation strategy, we essentially have two pointers
+   * into query plans: the source and the target. We traverse the trees advancing
+   * the pointer in the source tree until we hit an enforcing step. The enforcing
+   * step will advance the pointer until either the target tree has a matching,
+   * valid enforcing step or there is an invalid step in between at which point
+   * an exception will be propagated.
+   *
+   * <p>For example, consider the following two trees:
+   * <pre>
+   *   source (s): SINK -> SELECT -> SELECT_KEY -> SOURCE
+   *   target (t): SINK -> FILTER -> SELECT_KEY -> SOURCE
+   * </pre>
+   * Within these trees, the {@code SINK}, {@code SELECT_KEY} and {@code SOURCE}
+   * nodes are <i>enforcing</i> steps and the others are <i>passive</i> steps. The
+   * algorithm would first compare the two SINK steps, then advance {@code s} until
+   * the {@code s.SELECT_KEY} step. Since {@code t.FILTER} is passive, it can be skipped,
+   * at which point the algorithm would hit another <i>enforcing</i> node ({@code t.SELECT_KEY}).
+   * It would then compare those two steps and the two {@code SOURCE} steps to determine
+   * whether or not the two trees are compatible. This essentially "reduces" the two trees
+   * only to their enforcing nodes and makes sure that those are compatible with one
+   * another.
+   *
+   * <p>The default implementation does not support upgrades, taking an "allowlist"
+   * approach instead of a "denylist" approach so that we can guarantee that only
+   * query upgrades that we've reasoned about and stamped with an approval will be
+   * supported.
+   *
+   * @param to the execution step to upgrade to
+   * @throws io.confluent.ksql.util.KsqlException if the upgrade is incompatible
+   */
+  default void validateUpgrade(@Nonnull ExecutionStep<?> to) {
+    if (type() == StepType.PASSIVE) {
+      to.validateUpgrade(getSources().get(0));
+    } else {
+      throw new IllegalStateException("ENFORCING steps must implement validateUpgrade");
+    }
+  }
+
+  default StepType type() {
+    throw new KsqlException("Upgrades not yet supported for " + getClass().getName());
+  }
+
+  /**
+   * Utility method to help with {@link #validateUpgrade(ExecutionStep)} when
+   * certain properties much match to be compatible. This helps because checkstyle
+   * complains when code outside of an equals method has too many comparisons.
+   *
+   * @param that        the other execution step
+   * @param properties  the properties to compare
+   *
+   * @throws io.confluent.ksql.util.KsqlException if any property does not match
+   */
+  default void mustMatch(ExecutionStep<?> that, List<Property> properties) {
+    for (final Property property : properties) {
+      final Object a = property.apply(this);
+      final Object b = property.apply(that);
+      if (!Objects.equals(a, b)) {
+        throw new KsqlException(String.format(
+            "Query is not upgradeable. Plan step of type %s must have matching %s. "
+                + "Values differ: %s vs. %s",
+            getClass(), property.name, a, b));
+      }
+    }
+  }
+
+  /**
+   * Used to help indicate which type of execution step is when comparing two
+   * steps for upgrade compatibility. See {@link #validateUpgrade(ExecutionStep)} to
+   * further understand how this enum is used in the comparison algorithm.
+   */
+  enum StepType {
+
+    /**
+     * An {@code ENFORCING} execution step requires that another compatible node
+     * exists in the corresponding tree of the target upgrade path.
+     */
+    ENFORCING,
+
+    /**
+     * A {@code PASSIVE} execution step can be removed or added without restriction
+     * in different physical plans.
+     */
+    PASSIVE
+  }
+
+  @Immutable
+  class Property {
+
+    private final String name;
+    @EffectivelyImmutable
+    private final Function<ExecutionStep<?>, ?> getter;
+
+    Property(final String name, final Function<ExecutionStep<?>, ?> getter) {
+      this.name = name;
+      this.getter = getter;
+    }
+
+    Object apply(final ExecutionStep<?> step) {
+      return getter.apply(step);
+    }
+
+  }
+
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFilter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFilter.java
@@ -64,6 +64,11 @@ public class StreamFilter<K> implements ExecutionStep<KStreamHolder<K>> {
   }
 
   @Override
+  public StepType type() {
+    return StepType.PASSIVE;
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelect.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelect.java
@@ -102,6 +102,11 @@ public class StreamSelect<K> implements ExecutionStep<KStreamHolder<K>> {
   }
 
   @Override
+  public StepType type() {
+    return StepType.PASSIVE;
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.test.model.KsqlVersion;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.TestCaseBuilder;
 import io.confluent.ksql.test.tools.TopologyAndConfigs;
+import io.confluent.ksql.util.KsqlConfig;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,7 +48,9 @@ public final class PlannedTestUtils {
 
   public static boolean isNotExcluded(final TestCase testCase) {
     // Place temporary logic here to exclude test cases based on feature flags, etc.
-    return true;
+    return !(boolean) testCase
+        .properties()
+        .getOrDefault(KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED, false);
   }
 
   public static boolean isSamePlan(

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/upgrades.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/upgrades.json
@@ -1,0 +1,210 @@
+{
+  "comments": [
+    "These tests cover the execution portion of CREATE OR REPLACE to ensure that the validation ",
+    "passes for upgrades that are expected to be compatible and fails for those that are",
+    "incompatible. This test does not pipe any data through the statements because the testing",
+    "framework does not support running statements after piping some data through and the change",
+    "is not trivial to implement."
+  ],
+  "tests": [
+    {
+      "name": "DDL - STREAM - add fields",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE OR REPLACE STREAM foo (id VARCHAR KEY, col1 VARCHAR, col2 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT * FROM foo;"
+      ],
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "name": "DDL - STREAM - remove fields",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR, col2 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE OR REPLACE STREAM foo (id VARCHAR KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT * FROM foo;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot REPLACE data source: DataSource '`FOO`' has schema = `ID` STRING KEY, `COL1` STRING, `COL2` STRING which is not upgradeable to `ID` STRING KEY, `COL1` STRING(The following columns are changed or missing: [`COL2` STRING])"
+      }
+    },
+    {
+      "name": "DDL - TABLE - add fields",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE TABLE foo (id VARCHAR PRIMARY KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE OR REPLACE TABLE foo (id VARCHAR PRIMARY KEY, col1 VARCHAR, col2 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE TABLE bar AS SELECT * FROM foo;"
+      ],
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "name": "DDL - TABLE - remove fields",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE TABLE foo (id VARCHAR PRIMARY KEY, col1 VARCHAR, col2 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE OR REPLACE TABLE foo (id VARCHAR PRIMARY KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE TABLE bar AS SELECT * FROM foo;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot REPLACE data source: DataSource '`FOO`' has schema = `ID` STRING KEY, `COL1` STRING, `COL2` STRING which is not upgradeable to `ID` STRING KEY, `COL1` STRING(The following columns are changed or missing: [`COL2` STRING])"
+      }
+    },
+    {
+      "name": "DML - STREAM - add filter",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT * FROM foo;",
+        "CREATE OR REPLACE STREAM bar AS SELECT * FROM foo WHERE col1 = '123';"
+      ],
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "name": "DML - STREAM - change filter",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT * FROM foo WHERE col1 = '321';",
+        "CREATE OR REPLACE STREAM bar AS SELECT * FROM foo WHERE col1 = '123';"
+      ],
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "name": "DML - STREAM - remove filter",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT * FROM foo WHERE col1 = '321';",
+        "CREATE OR REPLACE STREAM bar AS SELECT * FROM foo;"
+      ],
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "name": "DML - STREAM - add column",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR, col2 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT id, col1 FROM foo;",
+        "CREATE OR REPLACE STREAM bar AS SELECT id, col1, col2 FROM foo;"
+      ],
+      "inputs": [],
+      "outputs": []
+    },
+    {
+      "name": "DML - STREAM - remove column",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR, col2 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT id, col1, col2 FROM foo;",
+        "CREATE OR REPLACE STREAM bar AS SELECT id, col1 FROM foo;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot REPLACE data source: DataSource '`BAR`' has schema = `ID` STRING KEY, `COL1` STRING, `COL2` STRING which is not upgradeable to `ID` STRING KEY, `COL1` STRING(The following columns are changed or missing: [`COL2` STRING])"
+      }
+    },
+    {
+      "name": "DML - STREAM - change column",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR, col2 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT id, col1, col2 FROM foo;",
+        "CREATE OR REPLACE STREAM bar AS SELECT id, col1, col2 AS col3 FROM foo;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot REPLACE data source: DataSource '`BAR`' has schema = `ID` STRING KEY, `COL1` STRING, `COL2` STRING which is not upgradeable to `ID` STRING KEY, `COL1` STRING, `COL3` STRING(The following columns are changed or missing: [`COL2` STRING])"
+      }
+    },
+    {
+      "name": "DML - STREAM - change key same schema",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR, col2 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT col1 AS id, col2 FROM foo PARTITION BY col1;",
+        "CREATE OR REPLACE STREAM bar AS SELECT id, col2 FROM foo;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Upgrades not yet supported for io.confluent.ksql.execution.plan.StreamSelectKey"
+      }
+    },
+    {
+      "name": "DML - STREAM - change source",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM baz (id VARCHAR KEY, col1 VARCHAR) WITH (kafka_topic='baz', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT id, col1 FROM foo;",
+        "CREATE OR REPLACE STREAM bar AS SELECT id, col1 FROM baz;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Query is not upgradeable. Plan step of type class io.confluent.ksql.execution.plan.StreamSource must have matching topicName. Values differ: foo vs. baz"
+      }
+    },
+    {
+      "name": "DML - STREAM - change timestampColumn",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM foo (id VARCHAR KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE STREAM bar AS SELECT id, col1 FROM foo;",
+        "CREATE OR REPLACE STREAM bar WITH (timestamp='col1', timestamp_format='YYYY') AS SELECT id, col1 FROM bar;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot REPLACE data source: DataSource '`BAR`' has timestampColumn = Optional.empty which is not upgradeable to Optional[TimestampColumn{column=`COL1`, format=Optional[YYYY]}]"
+      }
+    },
+    {
+      "name": "DML - TABLE - add filter",
+      "properties": {
+        "ksql.create.or.replace.enabled": true
+      },
+      "statements": [
+        "CREATE TABLE foo (id VARCHAR PRIMARY KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');",
+        "CREATE TABLE bar AS SELECT * FROM foo;",
+        "CREATE OR REPLACE TABLE bar AS SELECT * FROM foo WHERE col1 = '123';"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Upgrades not yet supported for io.confluent.ksql.execution.plan.TableSink"
+      }
+    }
+  ]
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
@@ -97,6 +98,9 @@ public class QueryDescriptionFactoryTest {
   private BlockingRowQueue queryQueue;
   @Mock
   private KsqlTopic sinkTopic;
+  @Mock
+  private ExecutionStep<?> physicalPlan;
+
   private QueryMetadata transientQuery;
   private PersistentQueryMetadata persistentQuery;
   private QueryDescription transientQueryDescription;
@@ -142,7 +146,9 @@ public class QueryDescriptionFactoryTest {
         PROP_OVERRIDES,
         queryCloseCallback,
         closeTimeout,
-        QueryErrorClassifier.DEFAULT_CLASSIFIER);
+        QueryErrorClassifier.DEFAULT_CLASSIFIER,
+        physicalPlan
+    );
 
     persistentQueryDescription = QueryDescriptionFactory.forQueryMetadata(persistentQuery, STATUS_MAP);
   }


### PR DESCRIPTION
### Description 

This PR introduces the physical plan validation framework for query upgrades, and the most basic set of validations for stream upgrades involving filters/selects. To avoid making this PR too large, all other upgrades are omitted. 

The validation strategy is documented in `ExecutionStep#validateUpgrade`

### Testing done 

QTT tests to make sure that expected upgrades succeed/fail respectively.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

