### PR TITLE
fix: close query on invalid use of HTTP/2 with /query endpoint (6.0.x)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/OldApiUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/OldApiUtils.java
@@ -89,15 +89,16 @@ public final class OldApiUtils {
     // a plain String, other times it's an object that needs to be JSON encoded, other times
     // it represents a stream.
     if (endpointResponse.getEntity() instanceof StreamingOutput) {
+      final StreamingOutput streamingOutput = (StreamingOutput) endpointResponse.getEntity();
       if (routingContext.request().version() == HttpVersion.HTTP_2) {
         // The old /query endpoint uses chunked encoding which is not supported in HTTP2
         routingContext.response().setStatusCode(METHOD_NOT_ALLOWED.code())
             .setStatusMessage("The /query endpoint is not available using HTTP2").end();
+        streamingOutput.close();
         return;
       }
       response.putHeader(TRANSFER_ENCODING, CHUNKED_ENCODING);
-      streamEndpointResponse(server, routingContext,
-          (StreamingOutput) endpointResponse.getEntity());
+      streamEndpointResponse(server, routingContext, streamingOutput);
     } else {
       if (endpointResponse.getEntity() == null) {
         response.end();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/StreamingOutput.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/StreamingOutput.java
@@ -18,7 +18,11 @@ package io.confluent.ksql.api.server;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public interface StreamingOutput {
+public interface StreamingOutput extends AutoCloseable {
 
   void write(OutputStream output) throws IOException;
+
+  @Override
+  void close();
+
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -48,6 +48,7 @@ class QueryStreamWriter implements StreamingOutput {
   private volatile Exception streamsException;
   private volatile boolean limitReached = false;
   private volatile boolean connectionClosed;
+  private boolean closed;
 
   QueryStreamWriter(
       final TransientQueryMetadata queryMetadata,
@@ -104,7 +105,7 @@ class QueryStreamWriter implements StreamingOutput {
       log.error("Exception occurred while writing to connection stream: ", exception);
       outputException(out, exception);
     } finally {
-      queryMetadata.close();
+      close();
     }
   }
 
@@ -112,6 +113,14 @@ class QueryStreamWriter implements StreamingOutput {
     objectMapper.writeValue(output, row);
     output.write(",\n".getBytes(StandardCharsets.UTF_8));
     output.flush();
+  }
+
+  @Override
+  public synchronized void close() {
+    if (!closed) {
+      queryMetadata.close();
+      closed = true;
+    }
   }
 
   private StreamedRow buildHeader() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -50,6 +50,7 @@ public class TopicStreamWriter implements StreamingOutput {
   private long messagesWritten;
   private long messagesPolled;
   private volatile boolean connectionClosed;
+  private boolean closed;
 
   public static TopicStreamWriter create(
       final ServiceContext serviceContext,
@@ -137,7 +138,15 @@ public class TopicStreamWriter implements StreamingOutput {
       log.error("Exception encountered while writing to output stream", exception);
       outputException(out, exception);
     } finally {
+      close();
+    }
+  }
+
+  @Override
+  public synchronized void close() {
+    if (!closed) {
       topicConsumer.close();
+      closed = true;
     }
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.rest.ApiJsonMapper;
@@ -194,6 +195,9 @@ public class RestApiTest {
 
   @Test
   public void shouldExecutePushQueryOverWebSocketWithV1ContentType() {
+    // Given:
+    verifyNumPushQueries(0);
+
     // When:
     final List<String> messages = makeWebSocketRequest(
         "SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT " + LIMIT + ";",
@@ -209,10 +213,14 @@ public class RestApiTest {
         + "{\"name\":\"USERID\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
         + "{\"name\":\"VIEWTIME\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
         + "]"));
+    verifyNumPushQueries(0);
   }
 
   @Test
   public void shouldExecutePushQueryOverWebSocketWithJsonContentType() {
+    // Given:
+    verifyNumPushQueries(0);
+
     // When:
     final List<String> messages = makeWebSocketRequest(
         "SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT " + LIMIT + ";",
@@ -228,6 +236,7 @@ public class RestApiTest {
         + "{\"name\":\"USERID\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
         + "{\"name\":\"VIEWTIME\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
         + "]"));
+    verifyNumPushQueries(0);
   }
 
   @Test
@@ -294,6 +303,9 @@ public class RestApiTest {
 
   @Test
   public void shouldExecutePushQueryOverRest() {
+    // Given:
+    verifyNumPushQueries(0);
+
     // When:
     final String response = rawRestQueryRequest(
         "SELECT USERID, PAGEID, VIEWTIME from " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT "
@@ -311,6 +323,8 @@ public class RestApiTest {
     assertThat(messages.get(1), is("{\"row\":{\"columns\":[\"USER_1\",\"PAGE_1\",1]}},"));
     assertThat(messages.get(2), is("{\"row\":{\"columns\":[\"USER_2\",\"PAGE_2\",2]}},"));
     assertThat(messages.get(3), is("{\"finalMessage\":\"Limit Reached\"}]"));
+
+    verifyNumPushQueries(0);
   }
 
   @Test
@@ -397,7 +411,7 @@ public class RestApiTest {
 
   @Test
   public void shouldExecutePullQueryOverRest() {
-    // When:
+    // Given:
     final Supplier<List<String>> call = () -> {
       final String response = rawRestQueryRequest(
           "SELECT COUNT, USERID from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';"
@@ -405,10 +419,38 @@ public class RestApiTest {
       return Arrays.asList(response.split(System.lineSeparator()));
     };
 
-    // Then:
+    // When:
     final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
-    assertThat(messages, hasSize(HEADER + 1));
 
+    // Then:
+    assertThat(messages, hasSize(HEADER + 1));
+    assertThat(messages.get(0), startsWith("[{\"header\":{\"queryId\":\""));
+    assertThat(messages.get(0),
+        endsWith("\",\"schema\":\"`COUNT` BIGINT, `USERID` STRING KEY\"}},"));
+    assertThat(messages.get(1), is("{\"row\":{\"columns\":[1,\"USER_1\"]}}]"));
+  }
+
+  @Test
+  public void shouldExecutePullQueryOverRestHttp2() {
+    // Given
+    final KsqlRequest request = new KsqlRequest(
+        "SELECT COUNT, USERID from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';",
+        ImmutableMap.of(),
+        Collections.emptyMap(),
+        null
+    );
+    final Supplier<List<String>> call = () -> {
+      final String response = rawRestRequest(
+          HttpVersion.HTTP_2, HttpMethod.POST, "/query", request
+      ).body().toString();
+      return Arrays.asList(response.split(System.lineSeparator()));
+    };
+
+    // When:
+    final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
+
+    // Then:
+    assertThat(messages, hasSize(HEADER + 1));
     assertThat(messages.get(0), startsWith("[{\"header\":{\"queryId\":\""));
     assertThat(messages.get(0),
         endsWith("\",\"schema\":\"`COUNT` BIGINT, `USERID` STRING KEY\"}},"));
@@ -456,10 +498,11 @@ public class RestApiTest {
 
   @Test
   public void shouldFailToExecuteQueryUsingRestWithHttp2() {
-
     // Given:
     KsqlRequest ksqlRequest = new KsqlRequest("SELECT * from " + AGG_TABLE + " EMIT CHANGES;",
         Collections.emptyMap(), Collections.emptyMap(), null);
+
+    verifyNumPushQueries(0);
 
     // When:
     HttpResponse<Buffer> resp = RestIntegrationTestUtil.rawRestRequest(REST_APP,
@@ -467,6 +510,8 @@ public class RestApiTest {
 
     // Then:
     assertThat(resp.statusCode(), is(405));
+
+    verifyNumPushQueries(0);
   }
 
   private boolean topicExists(final String topicName) {
@@ -500,6 +545,14 @@ public class RestApiTest {
     }
   }
 
+  private static HttpResponse<Buffer> rawRestRequest(
+      final HttpVersion httpVersion,
+      final HttpMethod method,
+      final String uri,
+      final Object requestBody) {
+    return RestIntegrationTestUtil.rawRestRequest(REST_APP, httpVersion, method, uri, requestBody);
+  }
+
   private static List<String> makeWebSocketRequest(
       final String sql,
       final String mediaType,
@@ -522,6 +575,10 @@ public class RestApiTest {
         throw new AssertionError("Invalid JSON message received: " + msg, e);
       }
     }
+  }
+
+  private static void verifyNumPushQueries(final int numPushQueries) {
+    assertThatEventually(REST_APP::getTransientQueries, hasSize(numPushQueries));
   }
 
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import io.vertx.core.Vertx;
@@ -210,6 +211,12 @@ public class TestKsqlRestApp extends ExternalResource {
     }
   }
 
+  public Set<String> getTransientQueries() {
+    try (final KsqlRestClient client = buildKsqlClient()) {
+      return getTransientQueries(client);
+    }
+  }
+
   public void closePersistentQueries() {
     try (final KsqlRestClient client = buildKsqlClient()) {
       terminateQueries(getPersistentQueries(client), client);
@@ -326,6 +333,14 @@ public class TestKsqlRestApp extends ExternalResource {
   }
 
   private static Set<String> getPersistentQueries(final KsqlRestClient client) {
+    return getQueries(client, KsqlQueryType.PERSISTENT);
+  }
+
+  private static Set<String> getTransientQueries(final KsqlRestClient client) {
+    return getQueries(client, KsqlQueryType.PUSH);
+  }
+
+  private static Set<String> getQueries(final KsqlRestClient client, final KsqlQueryType queryType) {
     final RestResponse<KsqlEntityList> response = client.makeKsqlRequest("SHOW QUERIES;");
     if (response.isErroneous()) {
       throw new AssertionError("Failed to get persistent queries."
@@ -334,7 +349,7 @@ public class TestKsqlRestApp extends ExternalResource {
 
     final Queries queries = (Queries) response.getResponse().get(0);
     return queries.getQueries().stream()
-        .filter(query -> query.getQueryType() == KsqlConstants.KsqlQueryType.PERSISTENT)
+        .filter(query -> query.getQueryType() == queryType)
         .map(RunningQuery::getId)
         .map(QueryId::toString)
         .collect(Collectors.toSet());


### PR DESCRIPTION
### Description 

Backport https://github.com/confluentinc/ksql/pull/5883 to 6.0.x

### Testing done 

Manual + integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

