### PR TITLE
docs: add note for java client CP pom

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -104,10 +104,10 @@ Start by creating a `pom.xml` for your Java application:
 ```
 
 !!! note
-      If you’re using ksqlDB for Confluent Platform (CP), use the CP-specific modules,
-      available at `http://packages.confluent.io/maven/`, by replacing the repositories
-      in the example POM above with a repository with this URL instead. Also update
-      `ksqldb.version` to be a CP version, such as `6.0.0`, instead.
+      If you’re using ksqlDB for Confluent Platform (CP), use the CP-specific modules
+      from [http://packages.confluent.io/maven/](http://packages.confluent.io/maven/)
+      by replacing the repositories in the example POM above with a repository with this
+      URL instead. Also update `ksqldb.version` to be a CP version, such as `6.0.0`, instead.
 
 Create your example app at `src/main/java/my/ksqldb/app/ExampleApp.java`:
 

--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -130,6 +130,7 @@ public class ExampleApp {
     
     // Send requests with the client by following the other examples
     
+    // Terminate any open connections and close the client
     client.close();
   }
 }

--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -103,6 +103,12 @@ Start by creating a `pom.xml` for your Java application:
 </project>
 ```
 
+!!! note
+      If you’re using ksqlDB for Confluent Platform (CP), use the CP-specific modules,
+      available at `http://packages.confluent.io/maven/`, by replacing the repositories
+      in the example POM above with a repository with this URL instead. Also update
+      `ksqldb.version` to be a CP version, such as `6.0.0`, instead.
+
 Create your example app at `src/main/java/my/ksqldb/app/ExampleApp.java`:
 
 ```java


### PR DESCRIPTION
### Description 

The Java client docs are geared towards usage with standalone ksqlDB. This PR adds a note for how the client may be used with CP, and also backports a minor clarification from master.

I'm going to merge this change forward into master after merging to 6.0.x, even though it should NOT go live until CP 6.0 is released. This should be fine since CP 6.0 is scheduled for before ksqlDB 0.12.0.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

