### PR TITLE
fix: adds a handler to gracefully shutdown

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/Executable.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/Executable.java
@@ -21,19 +21,24 @@ package io.confluent.ksql.rest.server;
 public interface Executable {
 
   /**
-   * Starts the executable asynchronously.
+   * Starts the executable asynchronously. Guaranteed to be called before shutdown.
    */
   default void startAsync() throws Exception {}
 
   /**
-   * Triggers a shutdown asynchronously, in order to ensure that the shutdown
-   * has finished use {@link #awaitTerminated()}
+   * Called to notify threads awaiting termination (see #awaitTerminated)
+   * that it's time to shutdown.
    */
-  default void triggerShutdown() throws Exception {}
+  default void notifyTerminated() {}
 
   /**
-   * Awaits the {@link #triggerShutdown()} to finish. This is a blocking
-   * operation.
+   * Shutdown the service.
+   */
+  default void shutdown() throws Exception {}
+
+  /**
+   * Awaits the {@link #notifyTerminated()} notification. This is a blocking
+   * operation. Guaranteed to be called before shutdown.
    */
   default void awaitTerminated() throws InterruptedException {}
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +34,7 @@ public class KsqlServerMain {
 
   private static final Logger log = LoggerFactory.getLogger(KsqlServerMain.class);
 
+  private final Executor shutdownHandler;
   private final Executable executable;
 
   public static void main(final String[] args) {
@@ -55,29 +58,46 @@ public class KsqlServerMain {
       final Optional<String> queriesFile = serverOptions.getQueriesFile(properties);
       final Executable executable = createExecutable(
           properties, queriesFile, installDir, ksqlConfig);
-      new KsqlServerMain(executable).tryStartApp();
+      new KsqlServerMain(
+          executable,
+          r -> Runtime.getRuntime().addShutdownHook(new Thread(r))
+      ).tryStartApp();
     } catch (final Exception e) {
       log.error("Failed to start KSQL", e);
       System.exit(-1);
     }
   }
 
-  KsqlServerMain(final Executable executable) {
+  KsqlServerMain(final Executable executable, final Executor shutdownHandler) {
     this.executable = Objects.requireNonNull(executable, "executable");
+    this.shutdownHandler = Objects.requireNonNull(shutdownHandler, "shutdownHandler");
   }
 
   void tryStartApp() throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    shutdownHandler.execute(() -> {
+      executable.notifyTerminated();
+      try {
+        latch.await();
+      } catch (final InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
     try {
-      log.info("Starting server");
-      executable.startAsync();
-      log.info("Server up and running");
-      executable.awaitTerminated();
-    } catch (Throwable t) {
-      log.error("Unhandled exception in server startup", t);
-      throw t;
+      try {
+        log.info("Starting server");
+        executable.startAsync();
+        log.info("Server up and running");
+        executable.awaitTerminated();
+      } catch (Throwable t) {
+        log.error("Unhandled exception in server startup", t);
+        throw t;
+      } finally {
+        log.info("Server shutting down");
+        executable.shutdown();
+      }
     } finally {
-      log.info("Server shutting down");
-      executable.triggerShutdown();
+      latch.countDown();
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MultiExecutable.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/MultiExecutable.java
@@ -43,8 +43,13 @@ public final class MultiExecutable implements Executable  {
   }
 
   @Override
-  public void triggerShutdown() throws Exception {
-    doAction(Executable::triggerShutdown);
+  public void shutdown() throws Exception {
+    doAction(Executable::shutdown);
+  }
+
+  @Override
+  public void notifyTerminated() {
+    doAction(Executable::notifyTerminated);
   }
 
   @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -129,12 +129,17 @@ public class StandaloneExecutor implements Executable {
       versionChecker.start(KsqlModuleType.SERVER, properties);
     } catch (final Exception e) {
       log.error("Failed to start KSQL Server with query file: " + queriesFile, e);
-      triggerShutdown();
       throw e;
     }
   }
 
-  public void triggerShutdown() {
+  @Override
+  public void notifyTerminated() {
+    shutdownLatch.countDown();
+  }
+
+  @Override
+  public void shutdown() {
     try {
       ksqlEngine.close();
     } catch (final Exception e) {
@@ -145,7 +150,6 @@ public class StandaloneExecutor implements Executable {
     } catch (final Exception e) {
       log.warn("Failed to cleanly shutdown services", e);
     }
-    shutdownLatch.countDown();
   }
 
   @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
@@ -95,7 +95,7 @@ public class ConnectIntegrationTest {
 
   @AfterClass
   public static void tearDownClass() {
-    CONNECT.triggerShutdown();
+    CONNECT.shutdown();
   }
 
   private KsqlRestClient ksqlRestClient;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -202,7 +202,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldCloseServiceContextOnClose() {
     // When:
-    app.triggerShutdown();
+    app.shutdown();
 
     // Then:
     verify(serviceContext).close();
@@ -211,7 +211,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldCloseSecurityExtensionOnClose() {
     // When:
-    app.triggerShutdown();
+    app.shutdown();
 
     // Then:
     verify(securityExtension).close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -15,7 +15,9 @@
 
 package io.confluent.ksql.rest.server;
 
+import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.newCapture;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,6 +29,8 @@ import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.util.KsqlServerException;
 import java.io.File;
+import java.util.concurrent.Executor;
+import org.easymock.Capture;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.easymock.MockType;
@@ -40,12 +44,14 @@ public class KsqlServerMainTest {
 
   @Mock(MockType.NICE)
   private Executable executable;
+  @Mock(MockType.NICE)
+  private Executor shutdownHandler;
 
   private final File mockStreamsStateDir = mock(File.class);
 
   @Before
   public void setUp() {
-    main = new KsqlServerMain(executable);
+    main = new KsqlServerMain(executable, shutdownHandler);
     when(mockStreamsStateDir.exists()).thenReturn(true);
     when(mockStreamsStateDir.mkdirs()).thenReturn(true);
     when(mockStreamsStateDir.isDirectory()).thenReturn(true);
@@ -57,7 +63,7 @@ public class KsqlServerMainTest {
   @Test
   public void shouldStopAppOnJoin() throws Exception {
     // Given:
-    executable.triggerShutdown();
+    executable.shutdown();
     expectLastCall();
     replay(executable);
 
@@ -74,7 +80,7 @@ public class KsqlServerMainTest {
     executable.startAsync();
     expectLastCall().andThrow(new RuntimeException("Boom"));
 
-    executable.triggerShutdown();
+    executable.shutdown();
     expectLastCall();
     replay(executable);
 
@@ -85,6 +91,23 @@ public class KsqlServerMainTest {
     } catch (final Exception e) {
       // Expected
     }
+
+    // Then:
+    verify(executable);
+  }
+
+  @Test
+  public void shouldNotifyAppOnTerminate() throws Exception {
+    // Given:
+    final Capture<Runnable> captureShutdownHandler = newCapture();
+    shutdownHandler.execute(capture(captureShutdownHandler));
+    executable.notifyTerminated();
+    replay(shutdownHandler, executable);
+    main.tryStartApp();
+    final Runnable handler = captureShutdownHandler.getValue();
+
+    // When:
+    handler.run();
 
     // Then:
     verify(executable);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -102,6 +102,7 @@ public class KsqlServerMainTest {
     final Capture<Runnable> captureShutdownHandler = newCapture();
     shutdownHandler.execute(capture(captureShutdownHandler));
     executable.notifyTerminated();
+    expectLastCall();
     replay(shutdownHandler, executable);
     main.tryStartApp();
     final Runnable handler = captureShutdownHandler.getValue();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/MultiExecutableTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/MultiExecutableTest.java
@@ -70,14 +70,27 @@ public class MultiExecutableTest {
   }
 
   @Test
+  public void shouldNotifyAllToShutdown() throws Exception {
+    // When:
+    multiExecutable.notifyTerminated();
+
+    // Then:
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(executable1, executable2);
+    inOrder.verify(executable1).notifyTerminated();
+    inOrder.verify(executable2).notifyTerminated();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
   public void shouldStopAll() throws Exception {
     // When:
-    multiExecutable.triggerShutdown();
+    multiExecutable.shutdown();
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(executable1, executable2);
-    inOrder.verify(executable1).triggerShutdown();
-    inOrder.verify(executable2).triggerShutdown();
+    inOrder.verify(executable1).shutdown();
+    inOrder.verify(executable2).shutdown();
     inOrder.verifyNoMoreInteractions();
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -52,7 +52,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
@@ -131,7 +130,7 @@ public class StandaloneExecutorFunctionalTest {
 
   @After
   public void tearDown() throws Exception {
-    standalone.triggerShutdown();
+    standalone.shutdown();
     standalone.awaitTerminated();
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -131,7 +131,6 @@ public class StandaloneExecutorFunctionalTest {
   @After
   public void tearDown() throws Exception {
     standalone.shutdown();
-    standalone.awaitTerminated();
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -362,7 +362,6 @@ public class StandaloneExecutorTest {
     verify(versionChecker).start(eq(KsqlModuleType.SERVER), captor.capture());
     assertThat(captor.getValue().getProperty("confluent.support.metrics.enable"), equalTo("false"));
     standaloneExecutor.shutdown();
-    standaloneExecutor.awaitTerminated();
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -361,7 +361,7 @@ public class StandaloneExecutorTest {
     // Then:
     verify(versionChecker).start(eq(KsqlModuleType.SERVER), captor.capture());
     assertThat(captor.getValue().getProperty("confluent.support.metrics.enable"), equalTo("false"));
-    standaloneExecutor.triggerShutdown();
+    standaloneExecutor.shutdown();
     standaloneExecutor.awaitTerminated();
   }
 
@@ -712,7 +712,7 @@ public class StandaloneExecutorTest {
   @Test
   public void shouldCloseEngineOnStop() {
     // When:
-    standaloneExecutor.triggerShutdown();
+    standaloneExecutor.shutdown();
 
     // Then:
     verify(ksqlEngine).close();
@@ -721,7 +721,7 @@ public class StandaloneExecutorTest {
   @Test
   public void shouldCloseServiceContextOnStop() {
     // When:
-    standaloneExecutor.triggerShutdown();
+    standaloneExecutor.shutdown();
 
     // Then:
     verify(serviceContext).close();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -268,7 +268,7 @@ public class TestKsqlRestApp extends ExternalResource {
     listeners.clear();
     internalListener = null;
     try {
-      ksqlRestApplication.triggerShutdown();
+      ksqlRestApplication.shutdown();
     } catch (final Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### Description 

Couple changes related to application lifecycle management. Firstly, adds a shutdown handler
that gracefully shuts down the service when the jvm determines its time to shut down (e.g.
when it receives a termination signal). Secondly, this patch reorganizes some of the startup,
steady-state, and shutdown code to make shutdown easier to reason about. Specifically, all
these methods are now called from the same thread, so both the thread-safety and order of
execution are guaranteed. All the shutdown hook does is notify the main thread and then wait
for it to exit.

### Testing done 

unit test to ensure shutdown handler is called
manual testing of shutdown process

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

