### PR TITLE
docs: make the version of Voluble a var

### DIFF
--- a/docs/how-to-guides/use-connector-management.md
+++ b/docs/how-to-guides/use-connector-management.md
@@ -43,7 +43,7 @@ mkdir confluent-hub-components
 Run the following command to get the [Voluble](https://github.com/MichaelDrogalis/voluble) data generator connector:
 
 ```
-confluent-hub install --component-dir confluent-hub-components --no-prompt mdrogalis/voluble:0.3.0
+confluent-hub install --component-dir confluent-hub-components --no-prompt mdrogalis/voluble:{{ site.voluble_version }}
 ```
 
 After running this command, `confluent-hub-components` should contain the Voluble jars. If you are running in clustered mode, you must install the connector on every server.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,3 +214,4 @@ extra:
         releasepostbranch: 5.5.0-post
         scalaversion: 2.12
         version: 5.5
+        voluble_version: 0.3.1


### PR DESCRIPTION
### Description 

I release a new version of Voluble once in a while. Seems good to make this a var so people get the latest fixes.
