### PR TITLE
build: temporarily suppress deprecation warnings for RETIRES config

### DIFF
--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -216,9 +216,9 @@ public class KsqlConfigTest {
   @Test
   public void shouldSetStreamsConfigAdminClientProperties() {
     final KsqlConfig ksqlConfig = new KsqlConfig(
-        Collections.singletonMap(AdminClientConfig.RETRIES_CONFIG, 3));
+        Collections.singletonMap(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 3));
     final Object result = ksqlConfig.getKsqlStreamConfigProps().get(
-        AdminClientConfig.RETRIES_CONFIG);
+        AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG);
     assertThat(result, equalTo(3));
   }
 

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -246,6 +246,7 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
    *
    * @return base set of producer properties.
    */
+  @SuppressWarnings("deprecation")
   public Map<String, Object> producerConfig() {
     final Map<String, Object> config = new HashMap<>(getClientProperties());
     config.put(ProducerConfig.ACKS_CONFIG, "all");
@@ -623,6 +624,7 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     Configuration.setConfiguration(null);
   }
 
+  @SuppressWarnings("deprecation")
   private AdminClient adminClient() {
     final Map<String, Object> props = new HashMap<>(getClientProperties());
     props.put(AdminClientConfig.RETRIES_CONFIG, 5);

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -268,6 +268,7 @@ class KafkaEmbedded {
     return config.getProperty(KafkaConfig.LogDirProp());
   }
 
+  @SuppressWarnings("deprecation")
   private AdminClient adminClient() {
     final ImmutableMap<String, Object> props = ImmutableMap.of(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList(),


### PR DESCRIPTION
Note, this is a testing only change.

This PR changes the deprecated `RETRIES` config and instead uses the recommended `DELIVERY_TIMEOUT_MS` configuration. See https://cwiki.apache.org/confluence/display/KAFKA/KIP-572%3A+Improve+timeouts+and+retries+in+Kafka+Streams and 
```java
    /**
     * <code>retries</code>
     * @deprecated since 2.7
     */
    @Deprecated
    public static final String RETRIES_CONFIG = CommonClientConfigs.RETRIES_CONFIG;
    private static final String RETRIES_DOC = "(Deprecated) Setting a value greater than zero will cause the client to resend any record whose send fails with a potentially transient error."
            + " Note that this retry is no different than if the client resent the record upon receiving the error."
            + " Allowing retries without setting <code>" + MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION + "</code> to 1 will potentially change the"
            + " ordering of records because if two batches are sent to a single partition, and the first fails and is retried but the second"
            + " succeeds, then the records in the second batch may appear first. Note additionally that produce requests will be"
            + " failed before the number of retries has been exhausted if the timeout configured by"
            + " <code>" + DELIVERY_TIMEOUT_MS_CONFIG + "</code> expires first before successful acknowledgement. Users should generally"
            + " prefer to leave this config unset and instead use <code>" + DELIVERY_TIMEOUT_MS_CONFIG + "</code> to control"
            + " retry behavior.";
```