### PR TITLE
chore: dont retry isTopicExists on UnknownTopicOrPartitionException

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -53,7 +53,6 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -53,6 +53,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;
@@ -170,7 +171,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
               ImmutableList.of(topic),
               new DescribeTopicsOptions().includeAuthorizedOperations(true)
           ).values().get(topic).get(),
-          RetryBehaviour.ON_RETRYABLE
+          RetryBehaviour.ON_RETRYABLE.and(e -> !(e instanceof UnknownTopicOrPartitionException))
       );
       return true;
     } catch (final Exception e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.kafka.common.errors.RetriableException;
 import org.slf4j.Logger;
@@ -32,9 +33,19 @@ public final class ExecutorUtil {
   private ExecutorUtil() {
   }
 
-  public enum RetryBehaviour {
-    ALWAYS,
-    ON_RETRYABLE
+  public enum RetryBehaviour implements Predicate<Throwable> {
+    ALWAYS {
+      @Override
+      public boolean test(final Throwable throwable) {
+        return throwable instanceof Exception;
+      }
+    },
+    ON_RETRYABLE {
+      @Override
+      public boolean test(final Throwable throwable) {
+        return throwable instanceof RetriableException;
+      }
+    }
   }
 
   @FunctionalInterface
@@ -59,9 +70,16 @@ public final class ExecutorUtil {
     return executeWithRetries(executable, retryBehaviour, () -> RETRY_BACKOFF_MS);
   }
 
-  static <T> T executeWithRetries(
+  public static <T> T executeWithRetries(
       final Callable<T> executable,
-      final RetryBehaviour retryBehaviour,
+      final Predicate<Throwable> shouldRetry
+  ) throws Exception {
+    return executeWithRetries(executable, shouldRetry, () -> RETRY_BACKOFF_MS);
+  }
+
+  public static <T> T executeWithRetries(
+      final Callable<T> executable,
+      final Predicate<Throwable> shouldRetry,
       final Supplier<Duration> retryBackOff
   ) throws Exception {
     Exception lastException = null;
@@ -73,9 +91,7 @@ public final class ExecutorUtil {
         return executable.call();
       } catch (final Exception e) {
         final Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
-        if (cause instanceof RetriableException
-            || (cause instanceof Exception && retryBehaviour == RetryBehaviour.ALWAYS)) {
-          log.info("Retrying request. Retry no: " + retries, e);
+        if (shouldRetry.test(cause)) {
           lastException = e;
         } else if (cause instanceof Exception) {
           throw (Exception) cause;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
@@ -92,6 +92,7 @@ public final class ExecutorUtil {
       } catch (final Exception e) {
         final Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
         if (shouldRetry.test(cause)) {
+          log.info("Retrying request. Retry no: " + retries, e);
           lastException = e;
         } else if (cause instanceof Exception) {
           throw (Exception) cause;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -189,15 +189,14 @@ public class KafkaTopicClientImplTest {
     givenTopicExists("topicName", 1, 2);
 
     when(adminClient.describeTopics(any(), any()))
-        .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh")))
-        .thenAnswer(describeTopicsResult()); // The second and third time, return the right response.
+        .thenAnswer(describeTopicsResult()) // checks that topic exists
+        .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh"))) // fails during validateProperties
+        .thenAnswer(describeTopicsResult()); // succeeds the third time
 
     // When:
     kafkaTopicClient.createTopic("topicName", 1, (short) 2);
 
     // Then:
-    // first two times are in the `isTopicExists` call and the second is in `describeTopic` when
-    // confirming the number of partitions
     verify(adminClient, times(3)).describeTopics(any(), any());
   }
 
@@ -276,15 +275,14 @@ public class KafkaTopicClientImplTest {
     givenTopicExists("topicName", 1, 2);
 
     when(adminClient.describeTopics(any(), any()))
-        .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh")))
-        .thenAnswer(describeTopicsResult()); // The second/third time, return the right response.
+        .thenAnswer(describeTopicsResult()) // checks that topic exists
+        .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh"))) // fails during validateProperties
+        .thenAnswer(describeTopicsResult()); // succeeds the third time
 
     // When:
     kafkaTopicClient.validateCreateTopic("topicName", 1, (short) 2);
 
     // Then:
-    // first two times are in the `isTopicExists` call and the second is in `describeTopic` when
-    // confirming the number of partitions
     verify(adminClient, times(3)).describeTopics(any(), any());
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -714,6 +714,15 @@ public class KafkaTopicClientImplTest {
     verify(adminClient, never()).listTopics();
   }
 
+  @Test
+  public void shouldNotRetryIsTopicExistsOnUnknownTopicException() {
+    // When
+    kafkaTopicClient.isTopicExists("foobar");
+
+    // Then
+    verify(adminClient, times(1)).describeTopics(any(), any());
+  }
+
   private static ConfigEntry defaultConfigEntry(final String key, final String value) {
     final ConfigEntry config = mock(ConfigEntry.class);
     when(config.name()).thenReturn(key);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/ExecutorUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/ExecutorUtilTest.java
@@ -82,7 +82,7 @@ public class ExecutorUtilTest {
 
   @Test
   public void shouldNotRetryOnNonRetriableException() throws Exception {
-    // Expect
+    // Given:
     final AtomicBoolean firstCall = new AtomicBoolean(true);
     final Callable<Object> throwsException = () -> {
       if (firstCall.get()) {
@@ -105,7 +105,7 @@ public class ExecutorUtilTest {
 
   @Test
   public void shouldNotRetryOnCustomRetryableDenied() throws Exception {
-    // Expect
+    // Given:
     final AtomicBoolean firstCall = new AtomicBoolean(true);
     final Callable<Object> throwsException = () -> {
       if (firstCall.get()) {
@@ -119,7 +119,7 @@ public class ExecutorUtilTest {
 
     // When:
     final RuntimeException e = assertThrows(
-        RuntimeException.class,
+        UnknownTopicOrPartitionException.class,
         () -> ExecutorUtil.executeWithRetries(throwsException, e2 -> !(e2 instanceof UnknownTopicOrPartitionException))
     );
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/ExecutorUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/ExecutorUtilTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.junit.Test;
 
 public class ExecutorUtilTest {
@@ -96,6 +97,30 @@ public class ExecutorUtilTest {
     final RuntimeException e = assertThrows(
         RuntimeException.class,
         () -> ExecutorUtil.executeWithRetries(throwsException, ON_RETRYABLE)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("First non-retry exception"));
+  }
+
+  @Test
+  public void shouldNotRetryOnCustomRetryableDenied() throws Exception {
+    // Expect
+    final AtomicBoolean firstCall = new AtomicBoolean(true);
+    final Callable<Object> throwsException = () -> {
+      if (firstCall.get()) {
+        firstCall.set(false);
+        // this is a retryable exception usually
+        throw new UnknownTopicOrPartitionException("First non-retry exception");
+      } else {
+        throw new RuntimeException("Test should not retry");
+      }
+    };
+
+    // When:
+    final RuntimeException e = assertThrows(
+        RuntimeException.class,
+        () -> ExecutorUtil.executeWithRetries(throwsException, e2 -> !(e2 instanceof UnknownTopicOrPartitionException))
     );
 
     // Then:


### PR DESCRIPTION
### Description 

The retry behavior was causing all `isTopicExists` calls where the topic is expected not to exist to hang for 2.5s (5x 500ms)

### Testing done 

Unit test ensures only is called once.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

