### PR TITLE
chore: add build param for overriding ksqlDB version (MINOR)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def baseConfig = {
 
 def defaultParams = [
     booleanParam(name: 'RELEASE_BUILD',
-        description: 'Is this a release build. If so, GIT_REVISION must be specified, and the downstream CCloud job will not be triggered.',
+        description: 'Is this a release build. If so, GIT_REVISION and KSQLDB_VERSION must be specified, and the downstream CCloud job will not be triggered.',
         defaultValue: false),
     string(name: 'GIT_REVISION',
         description: 'The git SHA to build ksqlDB from.',
@@ -58,6 +58,11 @@ def job = {
     if (params.RELEASE_BUILD && params.GIT_REVISION == '') {
         currentBuild.result = 'ABORTED'
         error("You must provide the GIT_REVISION when doing a release build.")
+    }
+
+    if (params.RELEASE_BUILD && params.KSQLDB_VERSION == '') {
+        currentBuild.result = 'ABORTED'
+        error("You must provide the KSQLDB_VERSION when doing a release build.")
     }
 
     if (params.PROMOTE_TO_PRODUCTION && params.KSQLDB_VERSION == '') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 def baseConfig = {
     owner = 'ksql'
     slackChannel = '#ksql-alerts'
-    ksql_db_version = "0.11.0"  // next version to be released
+    ksql_db_version = "0.12.0"  // next version to be released
     cp_version = "6.1.0-beta200715032424"  // must be a beta version from the packaging build
     packaging_build_number = "1"
     default_git_revision = 'refs/heads/master'
@@ -27,7 +27,7 @@ def defaultParams = [
         description: 'Promote images to production (DockerHub) for release build images only.'),
     string(name: 'KSQLDB_VERSION',
         defaultValue: '',
-        description: 'KSQLDB version to promote to production.'),
+        description: 'If PROMOTE_TO_PRODUCTION, ksqlDB version to promote to production. Else, override the ksql_db_version defined in the Jenkinsfile, representing the next version to be released.'),
     booleanParam(name: 'UPDATE_LATEST_TAG',
         defaultValue: false,
         description: 'Should the latest tag on docker hub be updated to point at this new image version. Only relevant if PROMOTE_TO_PRODUCTION is true.')
@@ -66,6 +66,11 @@ def job = {
     }
 
     config.release = params.RELEASE_BUILD
+
+    // Use ksqlDB version param if provided
+    if (params.KSQLDB_VERSION != '') {
+        config.ksql_db_version = params.KSQLDB_VERSION
+    }
 
     if (config.release) {
         // For a release build check out the provided git sha instead of the master branch.


### PR DESCRIPTION
### Description 

This PR updates the release job to override the `ksql_db_version` from the Jenkinsfile with the build param `KSQLDB_VERSION`, if specified. This will allow us to bump `ksql_db_version` to the next release version as soon as the release branch for the ongoing release is cut, while also allowing the release manager to cut new RCs for the ongoing release. By bumping `ksql_db_version` as soon as a release branch is cut, nightly builds from master will be tagged with the next release version rather than the current one, avoiding confusion where the latest tag for a particular RC (0.11.0, currently) may have been cut from master rather than the relevant release branch.

This PR also bumps the next release version to 0.12.0 accordingly, since the 0.11.x branch has already been cut.

### Testing done 

Jenkins replay.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

