### PR TITLE
test: fix JoinIntTest by changing generated timestamp for table source

### DIFF
--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -246,11 +246,10 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
    *
    * @return base set of producer properties.
    */
-  @SuppressWarnings("deprecation")
   public Map<String, Object> producerConfig() {
     final Map<String, Object> config = new HashMap<>(getClientProperties());
     config.put(ProducerConfig.ACKS_CONFIG, "all");
-    config.put(ProducerConfig.RETRIES_CONFIG, 10);
+    config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 60_000);
     return config;
   }
 
@@ -624,10 +623,9 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     Configuration.setConfiguration(null);
   }
 
-  @SuppressWarnings("deprecation")
   private AdminClient adminClient() {
     final Map<String, Object> props = new HashMap<>(getClientProperties());
-    props.put(AdminClientConfig.RETRIES_CONFIG, 5);
+    props.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 60_000);
     props.putAll(SecureKafkaHelper.getSecureCredentialsConfig(INTER_BROKER_USER));
 
     return AdminClient.create(props);

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -268,11 +268,10 @@ class KafkaEmbedded {
     return config.getProperty(KafkaConfig.LogDirProp());
   }
 
-  @SuppressWarnings("deprecation")
   private AdminClient adminClient() {
     final ImmutableMap<String, Object> props = ImmutableMap.of(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList(),
-        AdminClientConfig.RETRIES_CONFIG, 5);
+        AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 60_000);
 
     return AdminClient.create(props);
   }


### PR DESCRIPTION
### Description 

There's some weird behavior going on in the `JoinIntTest`, but I'm fixing it here to unblock the master branch for now. 

Essentially we have a stream of events that are produced using a timestamp extractor that extracts timestamps equal to the offset within the stream. Since there are 8 events in the stream, the max timestamp is `8L` and the first timestamp is `1L`. The raw time on these events (without the extractor) is `System.currentTimeInMillis()` There is also a table that is produced with `System.currentTimeInMillis() - 500` to ensure that the join events show up "before" the stream events. The problem is that when the timestamp extractor is applied, the table events are no longer "before" the stream events.

The weird part, is that it works if we set the timestamp to anything less than `9L` - meaning that if my stream event has timestamp 1L it can join with a table entry that has timestamp 8L only if there exists an event in the stream that has a timestamp greater than or equal to 8L.

Anyway, until we figure that out, this fixes master.

PS I'm also removing the deprecated suppression and replacing them with other configs.

### Testing done 

Test only change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

