### PR TITLE
chore: isTopicExists should not throw if topic has denied authorization

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -173,6 +173,9 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           RetryBehaviour.ON_RETRYABLE.and(e -> !(e instanceof UnknownTopicOrPartitionException))
       );
       return true;
+    } catch (final TopicAuthorizationException e) {
+      LOG.debug("Topic {} has denied authorization. Marking topic as not existing.", topic);
+      return false;
     } catch (final Exception e) {
       if (Throwables.getRootCause(e) instanceof UnknownTopicOrPartitionException) {
         return false;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -174,8 +174,8 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       );
       return true;
     } catch (final TopicAuthorizationException e) {
-      LOG.debug("Topic {} has denied authorization. Marking topic as not existing.", topic);
-      return false;
+      throw new KsqlTopicAuthorizationException(
+          AclOperation.DESCRIBE, Collections.singleton(topic));
     } catch (final Exception e) {
       if (Throwables.getRootCause(e) instanceof UnknownTopicOrPartitionException) {
         return false;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -721,6 +721,19 @@ public class KafkaTopicClientImplTest {
     verify(adminClient, times(1)).describeTopics(any(), any());
   }
 
+  @Test
+  public void shouldNotThrowIsTopicExistsOnAuthorizationException() {
+    // Given
+    when(adminClient.describeTopics(eq(ImmutableList.of("foobar")), any()))
+        .thenAnswer(describeTopicsResult(new TopicAuthorizationException("foobar")));
+
+    // When
+    final boolean topicExists = kafkaTopicClient.isTopicExists("foobar");
+
+    // Then
+    assertThat(topicExists, is(false));
+  }
+
   private static ConfigEntry defaultConfigEntry(final String key, final String value) {
     final ConfigEntry config = mock(ConfigEntry.class);
     when(config.name()).thenReturn(key);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -722,16 +722,20 @@ public class KafkaTopicClientImplTest {
   }
 
   @Test
-  public void shouldNotThrowIsTopicExistsOnAuthorizationException() {
+  public void shouldThrowIsTopicExistsOnAuthorizationException() {
     // Given
     when(adminClient.describeTopics(eq(ImmutableList.of("foobar")), any()))
         .thenAnswer(describeTopicsResult(new TopicAuthorizationException("foobar")));
 
     // When
-    final boolean topicExists = kafkaTopicClient.isTopicExists("foobar");
+    final Exception e = assertThrows(
+        KsqlTopicAuthorizationException.class,
+        () -> kafkaTopicClient.isTopicExists("foobar")
+    );
 
     // Then
-    assertThat(topicExists, is(false));
+    assertThat(e.getMessage(),
+        containsString("Authorization denied to Describe on topic(s): [foobar]"));
   }
 
   private static ConfigEntry defaultConfigEntry(final String key, final String value) {


### PR DESCRIPTION
### Description 
KSQL should treated unauthorized topics as not existing. Recently, there was a change in the `KafkaTopicClientImpl.isTopicExists()` that causes the method to throw a TopicAuthorizationException if the topic does not exist. This code used to call the `listTopicNames().contains(topic)` which wasn't including the topic thus returning false when it is not authorized to see it.

### Testing done 
Added unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

