### PR TITLE
chore: add a config to set stats dump period

### DIFF
--- a/ksqldb-rocksdb-config-setter/pom.xml
+++ b/ksqldb-rocksdb-config-setter/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>5.18.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/ksqldb-rocksdb-config-setter/src/main/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfig.java
+++ b/ksqldb-rocksdb-config-setter/src/main/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfig.java
@@ -56,6 +56,13 @@ public class KsqlBoundedMemoryRocksDBConfig extends AbstractConfig {
       "Percentage of the RocksDB block cache to set aside for high-priority entries, i.e., "
       + "index and filter blocks.";
 
+  public static final String STATS_DUMP_PERIOD_CONFIG =
+      CONFIG_PREFIX + "stats.dump.period.seconds";
+  private static final int STATS_DUMP_PERIOD_DEFAULT = 0;
+  private static final String STATS_DUMP_PERIOD_DOC =
+      "Frequency at which to dump stats to the rocksdb log. Defaults to 0, which disables"
+          + "dumping stats.";
+
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(
           BLOCK_CACHE_SIZE,
@@ -92,7 +99,13 @@ public class KsqlBoundedMemoryRocksDBConfig extends AbstractConfig {
           Type.DOUBLE,
           INDEX_FILTER_BLOCK_RATIO_DEFAULT,
           Importance.LOW,
-          INDEX_FILTER_BLOCK_RATIO_DOC
+          INDEX_FILTER_BLOCK_RATIO_DOC)
+      .define(
+          STATS_DUMP_PERIOD_CONFIG,
+          Type.INT,
+          STATS_DUMP_PERIOD_DEFAULT,
+          Importance.LOW,
+          STATS_DUMP_PERIOD_DOC
       );
 
   public KsqlBoundedMemoryRocksDBConfig(final Map<?, ?> properties) {

--- a/ksqldb-rocksdb-config-setter/src/main/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigSetter.java
+++ b/ksqldb-rocksdb-config-setter/src/main/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigSetter.java
@@ -37,6 +37,7 @@ public class KsqlBoundedMemoryRocksDBConfigSetter implements RocksDBConfigSetter
   private static org.rocksdb.Cache cache;
   private static org.rocksdb.WriteBufferManager writeBufferManager;
   private static final AtomicBoolean configured = new AtomicBoolean(false);
+  private static int statsDumpPeriodSec;
 
   @Override
   public void configure(final Map<String, ?> config) {
@@ -65,6 +66,8 @@ public class KsqlBoundedMemoryRocksDBConfigSetter implements RocksDBConfigSetter
 
       limitTotalMemory(pluginConfig, cacheFactory, bufferManagerFactory);
       configureNumThreads(pluginConfig, options);
+      statsDumpPeriodSec = pluginConfig.getInt(
+          KsqlBoundedMemoryRocksDBConfig.STATS_DUMP_PERIOD_CONFIG);
     } catch (final IllegalArgumentException e) {
       reset();
       throw e;
@@ -139,7 +142,7 @@ public class KsqlBoundedMemoryRocksDBConfigSetter implements RocksDBConfigSetter
     tableConfig.setCacheIndexAndFilterBlocksWithHighPriority(true);
     tableConfig.setPinTopLevelIndexAndFilter(true);
 
-    options.setStatsDumpPeriodSec(0);
+    options.setStatsDumpPeriodSec(statsDumpPeriodSec);
 
     options.setTableFormatConfig(tableConfig);
   }

--- a/ksqldb-rocksdb-config-setter/src/test/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigSetterTest.java
+++ b/ksqldb-rocksdb-config-setter/src/test/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigSetterTest.java
@@ -56,13 +56,16 @@ public class KsqlBoundedMemoryRocksDBConfigSetterTest {
   private static final long CACHE_SIZE = 16 * 1024 * 1024 * 1024L;
   private static final long WRITE_BUFFER_SIZE = 8 * 1024 * 1024 * 1024L;
   private static final int NUM_BACKGROUND_THREADS = 4;
+  private static final int STATS_DUMP_PERIOD_SECONDS = 123;
 
-  private static final Map<String, Object> CONFIG_PROPS = new HashMap<>(ImmutableMap.of(
-      "ksql.plugins.rocksdb.cache.size", CACHE_SIZE,
-      "ksql.plugins.rocksdb.write.buffer.size", WRITE_BUFFER_SIZE,
-      "ksql.plugins.rocksdb.write.buffer.cache.use", true,
-      "ksql.plugns.rocksdb.cache.limit.strict", false,
-      "ksql.plugins.rocksdb.num.background.threads", NUM_BACKGROUND_THREADS)
+  private static final Map<String, Object> CONFIG_PROPS = new HashMap<>(ImmutableMap.<String, Object>builder()
+      .put("ksql.plugins.rocksdb.cache.size", CACHE_SIZE)
+      .put("ksql.plugins.rocksdb.write.buffer.size", WRITE_BUFFER_SIZE)
+      .put("ksql.plugins.rocksdb.write.buffer.cache.use", true)
+      .put("ksql.plugns.rocksdb.cache.limit.strict", false)
+      .put("ksql.plugins.rocksdb.num.background.threads", NUM_BACKGROUND_THREADS)
+      .put("ksql.plugins.rocksdb.stats.dump.period.seconds", 123)
+      .build()
   );
 
   @Mock
@@ -170,7 +173,7 @@ public class KsqlBoundedMemoryRocksDBConfigSetterTest {
 
     // Then:
     verify(rocksOptions).setWriteBufferManager(bufferManager);
-    verify(rocksOptions).setStatsDumpPeriodSec(0);
+    verify(rocksOptions).setStatsDumpPeriodSec(123);
     verify(rocksOptions).setTableFormatConfig(tableConfig);
 
     verify(tableConfig).setBlockCache(blockCache);

--- a/ksqldb-rocksdb-config-setter/src/test/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigTest.java
+++ b/ksqldb-rocksdb-config-setter/src/test/java/io/confluent/ksql/rocksdb/KsqlBoundedMemoryRocksDBConfigTest.java
@@ -106,4 +106,20 @@ public class KsqlBoundedMemoryRocksDBConfigTest {
         pluginConfig.getDouble(KsqlBoundedMemoryRocksDBConfig.INDEX_FILTER_BLOCK_RATIO_CONFIG),
         is(0.0));
   }
+
+  @Test
+  public void shouldDefaultStatsDumpRatioConfig() {
+    // Given:
+    final Map<String, Object> configs = ImmutableMap.of(
+        "ksql.plugins.rocksdb.cache.size", CACHE_SIZE
+    );
+
+    // When:
+    final KsqlBoundedMemoryRocksDBConfig pluginConfig = new KsqlBoundedMemoryRocksDBConfig(configs);
+
+    // Then:
+    assertThat(
+        pluginConfig.getDouble(KsqlBoundedMemoryRocksDBConfig.STATS_DUMP_PERIOD_CONFIG),
+        is(0));
+  }
 }


### PR DESCRIPTION
### Description 
Adds a config to set the frequency that rocksdb dumps its internal stats to the log. This includes
detailed information about memory usage and internal operations (see https://www.bookstack.cn/read/rocksdb-en/bd7605a030d6e546.md for more details). We've turned this off by default because when it's on rocksdb
allocates a thread per rocksdb instance for dumping stats.

### Testing done 
unit tests
