### PR TITLE
fix: avoid losing cause of processing errors

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/logging/processing/RecordProcessingError.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/logging/processing/RecordProcessingError.java
@@ -22,7 +22,6 @@ import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.MessageTy
 import io.confluent.ksql.logging.processing.ProcessingLogger.ErrorMessage;
 import io.confluent.ksql.util.ErrorMessageUtil;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -124,7 +123,7 @@ public final class RecordProcessingError implements ProcessingLogger.ErrorMessag
             )
             .put(
                 ProcessingLogMessageSchema.RECORD_PROCESSING_ERROR_FIELD_CAUSE,
-                exception.map(RecordProcessingError::getCause)
+                exception.map(ErrorMessageUtil::getErrorMessages)
                     .orElse(Collections.emptyList())
             );
 
@@ -136,12 +135,6 @@ public final class RecordProcessingError implements ProcessingLogger.ErrorMessag
     }
 
     return recordProcessingError;
-  }
-
-  private static List<String> getCause(final Throwable e) {
-    final List<String> cause = ErrorMessageUtil.getErrorMessages(e);
-    cause.remove(0);
-    return cause;
   }
 
   private static String serializeRow(final GenericRow record) {

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/logging/processing/RecordProcessingErrorTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/logging/processing/RecordProcessingErrorTest.java
@@ -38,7 +38,7 @@ public class RecordProcessingErrorTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String errorMsg = "error msg";
   private static final Throwable cause = new Exception("cause1", new Exception("cause2"));
-  private static final Throwable error = new Exception(errorMsg, cause);
+  private static final Throwable error = new Exception("cause0", cause);
 
   private final ProcessingLogConfig config = new ProcessingLogConfig(
       Collections.singletonMap(ProcessingLogConfig.INCLUDE_ROWS, true)
@@ -70,7 +70,7 @@ public class RecordProcessingErrorTest {
     assertThat(
         recordProcessingError.get(
             ProcessingLogMessageSchema.RECORD_PROCESSING_ERROR_FIELD_CAUSE),
-        equalTo(ErrorMessageUtil.getErrorMessages(cause)));
+        equalTo(ErrorMessageUtil.getErrorMessages(error)));
     final List<?> rowAsList =
         OBJECT_MAPPER.readValue(
             recordProcessingError.getString(


### PR DESCRIPTION
### Description 

This change removes code that was dropping the first 'cause' of a processing logger error.

Found this when investigating https://github.com/confluentinc/ksql/issues/5707.

I *think* the code previously did this because the `errorMsg` was taken from the first 'cause' of the passed in `Exception`. However, the code now accepts a custom `errorMsg`, which may not match the first 'cause' of the supplied exception.

For example:

```java
// Old code:
} catch (final Exception e) {
   // msg.errorMsg is first line of of 'e.cause',
   // msg.cause is all other lines of 'e.cause'
   final ErrorMessage msg = RecordProcessingError.recordProcessingError(e, row);
   ...
}

// New code:
} catch (final Exception e) {
   // msg.errorMsg is "Error doing something"
   // msg.cause drops first line of 'e.cause' ... which is dropping useful information!
   final ErrorMessage msg = RecordProcessingError.recordProcessingError("Error doing something", e, row);
   ...
}
```

There may still be some uses where the first line of the cause duplicates the error msg. However, better to have duplicate data than to drop important information.

### Testing done 

Usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

