### PR TITLE
docs: add instructions on how to use locally created docker images

### DIFF
--- a/ksqldb-docker/README.md
+++ b/ksqldb-docker/README.md
@@ -13,6 +13,7 @@ To build a new image with local changes:
 
 1. Build docker images from local changes.
     ```
+    > mvn clean
     > mvn -Pdocker package -DskipTests -Dspotbugs.skip -Dcheckstyle.skip  -Ddockerfile.skip=false -Dskip.docker.build=false -Ddocker.upstream-tag=latest-ubi8 -Ddocker.tag=local.build  -Ddocker.upstream-registry=''
     ```
    Change `docker.upstream-tag` if you want to depend on anything other than the latest master upstream, e.g. 5.4.x-latest.
@@ -26,3 +27,14 @@ To build a new image with local changes:
     ```
     placeholder/confluentinc/ksqldb-docker       local.build   94210cd14384   About an hour ago   716MB
     ```
+   
+1. To use with the `docker-compose.yml` file in the root of the project, run the following additional commands to create
+   copies of the image with the required `ksqldb-server` and `ksqldb-cli` image names:
+   
+   ```
+   > docker tag placeholder/confluentinc/ksqldb-docker:local.build placeholder/confluentinc/ksqldb-server:local.build
+   > docker tag placeholder/confluentinc/ksqldb-docker:local.build placeholder/confluentinc/ksqldb-cli:local.build
+   ```
+   
+   To use the images uncomment the properties at the bottom of the `.env` file in the root of the project and run
+   `docker-compose up -d` from the root directory.


### PR DESCRIPTION
Add some instructions on how to use the locally built docker images with the repo's docker-compose file.