### PR TITLE
chore: bump vertx version to 3.9.1

### DIFF
--- a/ksqldb-api/pom.xml
+++ b/ksqldb-api/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>ksqldb-api</artifactId>
 
   <properties>
-    <vertx.version>3.8.4</vertx.version>
+    <vertx.version>3.9.1</vertx.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/ksqldb-api/src/main/java/io/confluent/ksql/api/impl/Utils.java
+++ b/ksqldb-api/src/main/java/io/confluent/ksql/api/impl/Utils.java
@@ -37,7 +37,7 @@ public final class Utils {
    * @param <T>     The type of the result
    */
   public static <T> void connectPromise(final Future<T> future, final Promise<T> promise) {
-    future.setHandler(ar -> {
+    future.onComplete(ar -> {
       if (ar.succeeded()) {
         promise.complete(ar.result());
       } else {


### PR DESCRIPTION
### Description 

fix security vulnerabilities caused by having netty v4.1.42, which is coming from vertx version 3.8.4. 

the minimum required netty-codec version is 4.1.46 to fix the vulnerability, which requires the vertx version to be upgraded to 3.9.x.

```
[INFO] --------------------< io.confluent.ksql:ksqldb-api >--------------------
[INFO] Building ksqldb-api 5.5.2-SNAPSHOT                               [16/26]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ ksqldb-api ---
[INFO] io.confluent.ksql:ksqldb-api:jar:5.5.2-SNAPSHOT
[INFO] +- io.vertx:vertx-core:jar:3.9.1:compile
[INFO] |  +- io.netty:netty-common:jar:4.1.49.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.1.49.Final:compile
[INFO] |  +- io.netty:netty-transport:jar:4.1.49.Final:compile
[INFO] |  +- io.netty:netty-handler:jar:4.1.49.Final:compile
[INFO] |  |  \- io.netty:netty-codec:jar:4.1.49.Final:compile
[INFO] |  +- io.netty:netty-handler-proxy:jar:4.1.49.Final:compile
[INFO] |  |  \- io.netty:netty-codec-socks:jar:4.1.49.Final:compile
[INFO] |  +- io.netty:netty-codec-http:jar:4.1.49.Final:compile
[INFO] |  +- io.netty:netty-codec-http2:jar:4.1.49.Final:compile
[INFO] |  +- io.netty:netty-resolver:jar:4.1.49.Final:compile
[INFO] |  +- io.netty:netty-resolver-dns:jar:4.1.49.Final:compile
[INFO] |  |  \- io.netty:netty-codec-dns:jar:4.1.49.Final:compile
```

Netty version now The netty version is now 4.1.49:

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

