### PR TITLE
chore: Add query error timestamp to QueryError list, and return on API

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -93,7 +93,7 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -578,11 +578,11 @@ public class Console implements Closeable {
   private void printQueryError(final QueryDescription query) {
     writer().println();
 
-    final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss.SSS");
+    final DateTimeFormatter dateFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss,SSS (z)");
     for (final QueryError error : query.getQueryErrors()) {
-      final Timestamp timestamp = new Timestamp(error.getTimestamp());
-      final String errorDate = timestamp.toInstant()
-          .atZone(ZoneId.systemDefault()).format(dateFormatter);
+      final Instant ts = Instant.ofEpochMilli(error.getTimestamp());
+      final String errorDate = ts.atZone(ZoneId.systemDefault()).format(dateFormatter);
 
       writer().println(String.format("%-20s : %s", "Error Date", errorDate));
       writer().println(String.format("%-20s : %s", "Error Details", error.getErrorMessage()));

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -93,6 +93,9 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -574,7 +577,14 @@ public class Console implements Closeable {
 
   private void printQueryError(final QueryDescription query) {
     writer().println();
+
+    final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss.SSS");
     for (final QueryError error : query.getQueryErrors()) {
+      final Timestamp timestamp = new Timestamp(error.getTimestamp());
+      final String errorDate = timestamp.toInstant()
+          .atZone(ZoneId.systemDefault()).format(dateFormatter);
+
+      writer().println(String.format("%-20s : %s", "Error Date", errorDate));
       writer().println(String.format("%-20s : %s", "Error Details", error.getErrorMessage()));
       writer().println(String.format("%-20s : %s", "Error Type", error.getType()));
     }

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -86,6 +86,9 @@ import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -362,6 +365,8 @@ public class ConsoleTest {
 
   @Test
   public void shouldPrintExplainQueryWithError() {
+    final long timestamp = 1596644936314L;
+
     // Given:
     final QueryDescriptionEntity queryEntity = new QueryDescriptionEntity(
         "statement",
@@ -381,7 +386,7 @@ public class ConsoleTest {
             ImmutableMap.of("overridden.prop", 42),
             ImmutableMap.of(new KsqlHostInfoEntity("foo", 123), KsqlQueryStatus.ERROR),
             KsqlQueryType.PERSISTENT,
-            ImmutableList.of(new QueryError(1596644936314L, "error", Type.SYSTEM))
+            ImmutableList.of(new QueryError(timestamp, "error", Type.SYSTEM))
         )
     );
 
@@ -429,6 +434,10 @@ public class ConsoleTest {
           "  \"warnings\" : [ ]\n" +
           "} ]\n"));
     } else {
+      final DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss,SSS (z)");
+      final String localTime = Instant.ofEpochMilli(timestamp)
+          .atZone(ZoneId.systemDefault()).format(format);
+
       assertThat(output, is("\n" +
           "ID                   : id\n" +
           "Query Type           : PERSISTENT\n" +
@@ -467,7 +476,7 @@ public class ConsoleTest {
           " overridden.prop | 42    \n" +
           "-------------------------\n" +
           "\n" +
-          "Error Date           : 2020-08-05 11:28:56.314\n" +
+          "Error Date           : " + localTime + "\n" +
           "Error Details        : error\n" +
           "Error Type           : SYSTEM\n"
       ));

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -381,7 +381,7 @@ public class ConsoleTest {
             ImmutableMap.of("overridden.prop", 42),
             ImmutableMap.of(new KsqlHostInfoEntity("foo", 123), KsqlQueryStatus.ERROR),
             KsqlQueryType.PERSISTENT,
-            ImmutableList.of(new QueryError("error", Type.SYSTEM))
+            ImmutableList.of(new QueryError(1596644936314L, "error", Type.SYSTEM))
         )
     );
 
@@ -420,6 +420,7 @@ public class ConsoleTest {
           "    },\n" +
           "    \"queryType\" : \"PERSISTENT\",\n" +
           "    \"queryErrors\" : [ {\n" +
+          "      \"timestamp\" : 1596644936314,\n" +
           "      \"errorMessage\" : \"error\",\n" +
           "      \"type\" : \"SYSTEM\"\n" +
           "    } ],\n" +
@@ -466,6 +467,7 @@ public class ConsoleTest {
           " overridden.prop | 42    \n" +
           "-------------------------\n" +
           "\n" +
+          "Error Date           : 2020-08-05 11:28:56.314\n" +
           "Error Details        : error\n" +
           "Error Type           : SYSTEM\n"
       ));

--- a/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryError.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/query/QueryError.java
@@ -27,16 +27,23 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class QueryError {
 
+  private final long timestamp;
   private final String errorMessage;
   private final Type type;
 
   @JsonCreator
   public QueryError(
+      @JsonProperty("timestamp") final long timestamp,
       @JsonProperty("errorMessage") final String errorMessage,
       @JsonProperty("type") final Type type
   ) {
     this.errorMessage = Objects.requireNonNull(errorMessage, "errorMessage");
     this.type = Objects.requireNonNull(type, "type");
+    this.timestamp = timestamp;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
   }
 
   public String getErrorMessage() {
@@ -85,11 +92,12 @@ public final class QueryError {
 
     final QueryError that = (QueryError) o;
     return Objects.equals(errorMessage, that.errorMessage)
-        && type == that.type;
+        && type == that.type
+        && timestamp == that.timestamp;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(errorMessage, type);
+    return Objects.hash(errorMessage, type, timestamp);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -145,7 +145,12 @@ public abstract class QueryMetadata {
   private void uncaughtHandler(final Thread t, final Throwable e) {
     LOG.error("Unhandled exception caught in streams thread {}.", t.getName(), e);
     final QueryError queryError =
-        new QueryError(Throwables.getStackTraceAsString(e), errorClassifier.classify(e));
+        new QueryError(
+            System.currentTimeMillis(),
+            Throwables.getStackTraceAsString(e),
+            errorClassifier.classify(e)
+        );
+
     queryStateListener.ifPresent(lis -> lis.onError(queryError));
     queryErrors.add(queryError);
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
@@ -128,7 +128,7 @@ public class QueryStateListenerTest {
   @Test
   public void shouldUpdateOnError() {
     // When:
-    listener.onError(new QueryError("foo", Type.USER));
+    listener.onError(new QueryError(1, "foo", Type.USER));
 
     // Then:
     assertThat(currentGaugeValue(METRIC_NAME_2), is("USER"));


### PR DESCRIPTION
### Description 
The current list of query errors displayed in the Console and API only includes an error message and the error type. This PR adds the timestamp when the error was generated.

### Testing done 
Updated unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

