### PR TITLE
docs: cherry-pick: update syntax reference for base-one index (DOCS-5058)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/operators.md
+++ b/docs/developer-guide/ksqldb-reference/operators.md
@@ -83,7 +83,7 @@ The subscript operator (`[subscript_expr]`) is used to
 reference the value at an array index or a map key.
 
 ```sql
-SELECT USERID, NICKNAMES[0] FROM USERS EMIT CHANGES;
+SELECT USERID, NICKNAMES[1] FROM USERS EMIT CHANGES;
 ```
 
 STRUCT dereference

--- a/docs/developer-guide/syntax-reference.md
+++ b/docs/developer-guide/syntax-reference.md
@@ -206,8 +206,8 @@ ksqlDB supports fields that are arrays of another type. All the elements
 in the array must be of the same type. The element type can be any valid
 SQL type.
 
-The elements of an array are zero-indexed and can be accessed by using
-the `[]` operator passing in the index. For example, `SOME_ARRAY[0]`
+The elements of an array are one-indexed and can be accessed by using
+the `[]` operator passing in the index. For example, `SOME_ARRAY[1]`
 retrieves the first element from the array. For more information, see
 [Operators](ksqldb-reference/operators.md).
 

--- a/docs/tutorials/examples.md
+++ b/docs/tutorials/examples.md
@@ -345,7 +345,7 @@ zipcode for each user:
 
 ```sql
 CREATE STREAM pageviews_interest_contact AS
-  SELECT interests[0] AS first_interest,
+  SELECT interests[1] AS first_interest,
          contactinfo['zipcode'] AS zipcode,
          contactinfo['city'] AS city,
          viewtime,


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5949.