### PR TITLE
docs: update event-driven microservices example data timestamps

### DIFF
--- a/docs/tutorials/event-driven-microservice.md
+++ b/docs/tutorials/event-driven-microservice.md
@@ -177,7 +177,7 @@ INSERT INTO transactions (
     'derek@example.com',
     '352642227248344',
     '0cf100ca-993c-427f-9ea5-e892ef350363',
-    '2020-04-25T12:50:30',
+    '2020-04-22T12:50:30',
     18.97
 );
 
@@ -187,7 +187,7 @@ INSERT INTO transactions (
     'colin@example.com',
     '373913272311617',
     'de9831c0-7cf1-4ebf-881d-0415edec0d6b',
-    '2020-04-19T09:45:15',
+    '2020-04-22T09:45:15',
     12.50
 );
 
@@ -207,7 +207,7 @@ INSERT INTO transactions (
     'derek@example.com',
     '352642227248344',
     '5d916e65-1af3-4142-9fd3-302dd55c512f',
-    '2020-04-25T12:50:25',
+    '2020-04-22T12:50:25',
     3200.80
 );
 
@@ -217,7 +217,7 @@ INSERT INTO transactions (
     'derek@example.com',
     '352642227248344',
     'd7d47fdb-75e9-46c0-93f6-d42ff1432eea',
-    '2020-04-25T12:51:55',
+    '2020-04-22T12:51:55',
     154.32
 );
 
@@ -237,7 +237,7 @@ INSERT INTO transactions (
     'colin@example.com',
     '373913272311617',
     '2360d53e-3fad-4e9a-b306-b166b7ca4f64',
-    '2020-04-19T09:45:35',
+    '2020-04-22T09:45:35',
     234.65
 );
 
@@ -247,7 +247,7 @@ INSERT INTO transactions (
     'colin@example.com',
     '373913272311617',
     'de9831c0-7cf1-4ebf-881d-0415edec0d6b',
-    '2020-04-19T09:44:03',
+    '2020-04-22T09:44:03',
     150.00
 );
 ```


### PR DESCRIPTION
### Description 

It's a bit "lucky" that the event-driven microservices tutorial works right now. The CTAS statement that creates the anomalies tables (https://docs.ksqldb.io/en/latest/tutorials/event-driven-microservice/#create-the-anomalies-table) doesn't specify a window grace period, so the default of 23 hours is used. However, the timestamps of the seeded transaction events (https://docs.ksqldb.io/en/latest/tutorials/event-driven-microservice/#seed-some-transaction-events) contain out of order data with timestamps by differ by up to 6 days. As a result, if the source stream is created with 1 partition rather than 8, the grace period means the window that's supposed to accumulate 3 events (according to the tutorial) will have closed after just the first event, and the possible_anomalies table will be empty. I think why the tutorial works right now is because with 8 partitions and only 3 unique keys, the other 2 keys happen to land on different partitions from the one expected to appear in the possible_anomalies tutorial, so stream time is not advanced and the tutorial "works" as expected.

This PR updates the timestamps of the different records so the default grace period of 23 hours is sufficient. Another option is to instead add an explicit grace period to the CTAS that is large enough to accommodate the out of order sample data. We can do this if we want to explain the concept of grace periods in the tutorial but IMHO the sample data being out of order by up to 6 or 7 days felt unrealistic anyway.

I'll cherry-pick to 0.11.x-ksqldb and 0.11.0-ksqldb to make this live once merged.

### Testing done 

Docs-only change. Sanity checked the tutorial.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

