### PR TITLE
fix: NPE when udf metrics enabled

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -53,6 +53,11 @@ ksql.logging.processing.stream.auto.create=true
 # processing contains sensitive information.
 #ksql.logging.processing.rows.include=true
 
+#------- Metrics config --------
+
+# Turn on collection of metrics of function invocations:
+# ksql.udf.collect.metrics=true
+
 #------ External service config -------
 
 #------ Kafka -------

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
@@ -37,23 +37,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
-import org.apache.kafka.common.metrics.stats.Max;
-import org.apache.kafka.common.metrics.stats.Rate;
-import org.apache.kafka.common.metrics.stats.WindowedCount;
 
 /**
  * Utility class for loading different types of user defined funcrions
  */
 public final class FunctionLoaderUtils {
-
-  private static final String UDF_METRIC_GROUP = "ksql-udf";
 
   private FunctionLoaderUtils() {
   }
@@ -117,41 +108,6 @@ public final class FunctionLoaderUtils {
           e
       );
     }
-  }
-
-  static void addSensor(
-      final String sensorName, final String udfName, final Optional<Metrics> theMetrics
-  ) {
-    theMetrics.ifPresent(metrics -> {
-      if (metrics.getSensor(sensorName) == null) {
-        final Sensor sensor = metrics.sensor(sensorName);
-        sensor.add(
-            metrics.metricName(sensorName + "-avg", UDF_METRIC_GROUP,
-                "Average time for an invocation of " + udfName + " udf"
-            ),
-            new Avg()
-        );
-        sensor.add(
-            metrics.metricName(sensorName + "-max", UDF_METRIC_GROUP,
-                "Max time for an invocation of " + udfName + " udf"
-            ),
-            new Max()
-        );
-        sensor.add(
-            metrics.metricName(sensorName + "-count", UDF_METRIC_GROUP,
-                "Total number of invocations of " + udfName + " udf"
-            ),
-            new WindowedCount()
-        );
-        sensor.add(
-            metrics.metricName(sensorName + "-rate", UDF_METRIC_GROUP,
-                "The average number of occurrence of " + udfName + " operation per second "
-                    + udfName + " udf"
-            ),
-            new Rate(TimeUnit.SECONDS, new WindowedCount())
-        );
-      }
-    });
   }
 
   static ParamType getReturnType(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionMetrics.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
+
+public final class FunctionMetrics {
+
+  static final String AVG_DESC = "Average time for invocations of the %s";
+  static final String MAX_DESC = "Max time for invocations of the %s";
+  static final String COUNT_DESC = "Total number of invocations of the %s";
+  static final String RATE_DESC = "The rate of invocations (invocations per second) of the %s";
+
+  private FunctionMetrics() {
+  }
+
+  /**
+   * Gets an existing invocation sensor, or creates one if needed.
+   *
+   * <p>Sensor created with avg, max, count and rate metrics.
+   *
+   * @param metrics the metrics service.
+   * @param sensorName the name of the sensor
+   * @param groupName the name of the group
+   * @param functionDescription the description of the function.
+   */
+  public static void initInvocationSensor(
+      final Optional<Metrics> metrics,
+      final String sensorName,
+      final String groupName,
+      final String functionDescription
+  ) {
+    metrics.ifPresent(m -> getInvocationSensor(m, sensorName, groupName, functionDescription));
+  }
+
+  /**
+   * Gets an existing invocation sensor, or creates one if needed.
+   *
+   * <p>Sensor created with avg, max, count and rate metrics.
+   *
+   * @param metrics the metrics service.
+   * @param sensorName the name of the sensor
+   * @param groupName the name of the group
+   * @param functionDescription the description of the function.
+   */
+  public static Sensor getInvocationSensor(
+      final Metrics metrics,
+      final String sensorName,
+      final String groupName,
+      final String functionDescription
+  ) {
+    final Sensor existing = metrics.getSensor(sensorName);
+    if (existing != null) {
+      return existing;
+    }
+
+    final Sensor newSensor = metrics.sensor(sensorName);
+
+    final BiFunction<String, String, MetricName> metricNamer = (suffix, descPattern) -> {
+      final String description = String.format(descPattern, functionDescription);
+      return metrics.metricName(sensorName + "-" + suffix, groupName, description);
+    };
+
+    newSensor.add(
+        metricNamer.apply("avg", AVG_DESC),
+        new Avg()
+    );
+
+    newSensor.add(
+        metricNamer.apply("max", MAX_DESC),
+        new Max()
+    );
+
+    newSensor.add(
+        metricNamer.apply("count", COUNT_DESC),
+        new WindowedCount()
+    );
+
+    newSensor.add(
+        metricNamer.apply("rate", RATE_DESC),
+        new Rate(TimeUnit.SECONDS, new WindowedCount())
+    );
+
+    return newSensor;
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionMetrics.java
@@ -71,38 +71,36 @@ public final class FunctionMetrics {
       final String groupName,
       final String functionDescription
   ) {
-    final Sensor existing = metrics.getSensor(sensorName);
-    if (existing != null) {
-      return existing;
+    final Sensor sensor = metrics.sensor(sensorName);
+    if (sensor.hasMetrics()) {
+      return sensor;
     }
-
-    final Sensor newSensor = metrics.sensor(sensorName);
 
     final BiFunction<String, String, MetricName> metricNamer = (suffix, descPattern) -> {
       final String description = String.format(descPattern, functionDescription);
       return metrics.metricName(sensorName + "-" + suffix, groupName, description);
     };
 
-    newSensor.add(
+    sensor.add(
         metricNamer.apply("avg", AVG_DESC),
         new Avg()
     );
 
-    newSensor.add(
+    sensor.add(
         metricNamer.apply("max", MAX_DESC),
         new Max()
     );
 
-    newSensor.add(
+    sensor.add(
         metricNamer.apply("count", COUNT_DESC),
         new WindowedCount()
     );
 
-    newSensor.add(
+    sensor.add(
         metricNamer.apply("rate", RATE_DESC),
         new Rate(TimeUnit.SECONDS, new WindowedCount())
     );
 
-    return newSensor;
+    return sensor;
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.common.metrics.Metrics;
 import org.slf4j.Logger;
@@ -45,9 +46,9 @@ class UdafLoader {
       final Optional<Metrics> metrics,
       final SqlTypeParser typeParser
   ) {
-    this.functionRegistry = functionRegistry;
-    this.metrics = metrics;
-    this.typeParser = typeParser;
+    this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+    this.typeParser = Objects.requireNonNull(typeParser, "typeParser");
   }
 
   void loadUdafFromClass(final Class<?> theClass, final String path) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.kafka.common.Configurable;
@@ -54,9 +55,9 @@ public class UdfLoader {
       final SqlTypeParser typeParser,
       final boolean throwExceptionOnLoadFailure
   ) {
-    this.functionRegistry = functionRegistry;
-    this.metrics = metrics;
-    this.typeParser = typeParser;
+    this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+    this.typeParser = Objects.requireNonNull(typeParser, "typeParser");
     this.throwExceptionOnLoadFailure = throwExceptionOnLoadFailure;
   }
 
@@ -84,7 +85,8 @@ public class UdfLoader {
     @SuppressWarnings("unchecked") final Class<? extends Kudf> udfClass = metrics
         .map(m -> (Class) UdfMetricProducer.class)
         .orElse(PluggableUdf.class);
-    FunctionLoaderUtils.addSensor(sensorName, functionName, metrics);
+
+    FunctionMetrics.initInvocationSensor(metrics, sensorName, "ksql-udf", functionName + " udf");
 
     final UdfFactory factory = new UdfFactory(
         udfClass,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.common.metrics.Metrics;
 import org.slf4j.Logger;
@@ -50,9 +51,9 @@ public class UdtfLoader {
       final SqlTypeParser typeParser,
       final boolean throwExceptionOnLoadFailure
   ) {
-    this.functionRegistry = functionRegistry;
-    this.metrics = metrics;
-    this.typeParser = typeParser;
+    this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+    this.typeParser = Objects.requireNonNull(typeParser, "typeParser");
     this.throwExceptionOnLoadFailure = throwExceptionOnLoadFailure;
   }
 
@@ -67,7 +68,8 @@ public class UdtfLoader {
     }
     final String functionName = udtfDescriptionAnnotation.name();
     final String sensorName = "ksql-udtf-" + functionName;
-    FunctionLoaderUtils.addSensor(sensorName, functionName, metrics);
+
+    FunctionMetrics.initInvocationSensor(metrics, sensorName, "ksql-udtf", functionName + " udtf");
 
     final UdfMetadata metadata = new UdfMetadata(
         udtfDescriptionAnnotation.name(),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
@@ -71,7 +71,6 @@ public class UserFunctionLoader {
         "parentClassLoader can't be null"
     );
     this.blacklist = Objects.requireNonNull(blacklist, "blacklist can't be null");
-    Objects.requireNonNull(metrics, "metrics can't be null");
     this.loadCustomerUdfs = loadCustomerUdfs;
     final SqlTypeParser typeParser = SqlTypeParser.create(TypeRegistry.EMPTY);
     this.udfLoader = new UdfLoader(functionRegistry, metrics, typeParser, false);
@@ -143,8 +142,8 @@ public class UserFunctionLoader {
       final MutableFunctionRegistry metaStore,
       final String ksqlInstallDir
   ) {
-    final Boolean loadCustomerUdfs = config.getBoolean(KsqlConfig.KSQL_ENABLE_UDFS);
-    final Boolean collectMetrics = config.getBoolean(KsqlConfig.KSQL_COLLECT_UDF_METRICS);
+    final boolean loadCustomerUdfs = config.getBoolean(KsqlConfig.KSQL_ENABLE_UDFS);
+    final boolean collectMetrics = config.getBoolean(KsqlConfig.KSQL_COLLECT_UDF_METRICS);
     final String extDirName = config.getString(KsqlConfig.KSQL_EXT_DIR);
     final File pluginDir = KsqlConfig.DEFAULT_EXT_DIR.equals(extDirName)
         ? new File(ksqlInstallDir, extDirName)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/FunctionMetricsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/FunctionMetricsTest.java
@@ -51,14 +51,36 @@ public class FunctionMetricsTest {
   }
 
   @Test
-  public void shouldInitializeOnFirstCall() {
+  public void shouldGetSensorWithCorrectName() {
+    // When:
+    FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    verify(metrics).sensor(SENSOR_NAME);
+  }
+
+  @Test
+  public void shouldReturnSensorOnFirstCall() {
     // When:
     final Sensor result = FunctionMetrics
         .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
 
     // Then:
     assertThat(result, is(sensor));
-    verify(metrics).sensor(SENSOR_NAME);
+  }
+
+  @Test
+  public void shouldReturnSensorOnSubsequentCalls() {
+    // Given:
+    when(sensor.hasMetrics()).thenReturn(true);
+
+    // When:
+    final Sensor result = FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    assertThat(result, is(sensor));
   }
 
   @Test
@@ -118,30 +140,16 @@ public class FunctionMetricsTest {
   }
 
   @Test
-  public void shouldReturnAnyExisting() {
-    // Given:
-    when(metrics.getSensor(any())).thenReturn(sensor);
-
-    // When:
-    final Sensor result = FunctionMetrics
-        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
-
-    // Then:
-    verify(metrics).getSensor(SENSOR_NAME);
-    assertThat(result, is(sensor));
-  }
-
-  @Test
   public void shouldNotInitializeOnSubsequentCalls() {
     // Given:
-    when(metrics.getSensor(any())).thenReturn(sensor);
+    when(sensor.hasMetrics()).thenReturn(true);
 
     // When:
     FunctionMetrics
         .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
 
     // Then:
-    verify(metrics, never()).sensor(any());
+    verify(sensor, never()).add(any(MetricName.class), any());
   }
 
   private static String description(final String formatString) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/FunctionMetricsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/FunctionMetricsTest.java
@@ -1,0 +1,150 @@
+package io.confluent.ksql.function;
+
+import static io.confluent.ksql.function.FunctionMetrics.AVG_DESC;
+import static io.confluent.ksql.function.FunctionMetrics.COUNT_DESC;
+import static io.confluent.ksql.function.FunctionMetrics.MAX_DESC;
+import static io.confluent.ksql.function.FunctionMetrics.RATE_DESC;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FunctionMetricsTest {
+
+  private static final String SENSOR_NAME = "sensorName";
+  private static final String GROUP_NAME = "groupName";
+  private static final String FUNC_NAME = "Func name";
+
+  @Mock
+  private Metrics metrics;
+  @Mock
+  private Sensor sensor;
+  @Mock
+  private MetricName metricName;
+  @Mock
+  private MetricName specificMetricName;
+
+  @Before
+  public void setup() {
+    when(metrics.sensor(any())).thenReturn(sensor);
+
+    when(metrics.metricName(any(String.class), any(String.class), any(String.class)))
+        .thenReturn(metricName);
+  }
+
+  @Test
+  public void shouldInitializeOnFirstCall() {
+    // When:
+    final Sensor result = FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    assertThat(result, is(sensor));
+    verify(metrics).sensor(SENSOR_NAME);
+  }
+
+  @Test
+  public void shouldRegisterAvgMetric() {
+    // Given:
+    when(metrics.metricName(SENSOR_NAME + "-avg", GROUP_NAME, description(AVG_DESC)))
+        .thenReturn(specificMetricName);
+
+    // When:
+    FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    verify(sensor).add(eq(specificMetricName), isA(Avg.class));
+  }
+
+  @Test
+  public void shouldRegisterMaxMetric() {
+    // Given:
+    when(metrics.metricName(SENSOR_NAME + "-max", GROUP_NAME, description(MAX_DESC)))
+        .thenReturn(specificMetricName);
+
+    // When:
+    FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    verify(sensor).add(eq(specificMetricName), isA(Max.class));
+  }
+
+  @Test
+  public void shouldRegisterCountMetric() {
+    // Given:
+    when(metrics.metricName(SENSOR_NAME + "-count", GROUP_NAME, description(COUNT_DESC)))
+        .thenReturn(specificMetricName);
+
+    // When:
+    FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    verify(sensor).add(eq(specificMetricName), isA(WindowedCount.class));
+  }
+
+  @Test
+  public void shouldRegisterRateMetric() {
+    // Given:
+    when(metrics.metricName(SENSOR_NAME + "-rate", GROUP_NAME, description(RATE_DESC)))
+        .thenReturn(specificMetricName);
+
+    // When:
+    FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    verify(sensor).add(eq(specificMetricName), isA(Rate.class));
+  }
+
+  @Test
+  public void shouldReturnAnyExisting() {
+    // Given:
+    when(metrics.getSensor(any())).thenReturn(sensor);
+
+    // When:
+    final Sensor result = FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    verify(metrics).getSensor(SENSOR_NAME);
+    assertThat(result, is(sensor));
+  }
+
+  @Test
+  public void shouldNotInitializeOnSubsequentCalls() {
+    // Given:
+    when(metrics.getSensor(any())).thenReturn(sensor);
+
+    // When:
+    FunctionMetrics
+        .getInvocationSensor(metrics, SENSOR_NAME, GROUP_NAME, FUNC_NAME);
+
+    // Then:
+    verify(metrics, never()).sensor(any());
+  }
+
+  private static String description(final String formatString) {
+    return String.format(formatString, FUNC_NAME);
+  }
+}


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/5890

Fixes an NPE thrown when the second instance of a UDAF is initialized. The NPE was being thrown due to a bug in the code that failed to initialise the sensor fields in the `UdafAggregateFunction` class if the sensor already existed.

The commit also refactors the code used to add function invocation metrics such that all three function types: UDF, UDTF and UDAF, use the same function to register metrics.

Unit tests added to ensure this single code path doesn't throw an NPE or return null on the subsequent invocation.

Also added `ksql.udf.collect.metrics` metric to the server config file, so users are more likely to be able to find it and try it out.

Moved UDTF functions out of the `ksql-udf` group and into `ksql-udtf` group. Having them in the former was another bug.

### Testing done 

Added unit tests plus manual validation that metric names didn't change with new code, (except intentional move of UDTF metrics into own group).

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

