### PR TITLE
feat: Support [IF EXISTS] on DROP TYPE command

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -65,7 +65,7 @@ public class CommandFactories implements DdlCommandFactory {
         new CreateSourceFactory(serviceContext),
         new DropSourceFactory(metaStore),
         new RegisterTypeFactory(),
-        new DropTypeFactory()
+        new DropTypeFactory(metaStore)
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTypeFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTypeFactory.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.ddl.commands;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.execution.ddl.commands.DropTypeCommand;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.DropType;
@@ -26,7 +25,6 @@ import java.util.Objects;
 public class DropTypeFactory {
   private final MetaStore metaStore;
 
-  @VisibleForTesting
   DropTypeFactory(final MetaStore metaStore) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
   }
@@ -35,10 +33,8 @@ public class DropTypeFactory {
     final String typeName = statement.getTypeName();
     final boolean ifExists = statement.getIfExists();
 
-    if (!metaStore.resolveType(typeName).isPresent()) {
-      if (!ifExists) {
-        throw new KsqlException("Type " + typeName + " does not exist.");
-      }
+    if (!ifExists && !metaStore.resolveType(typeName).isPresent()) {
+      throw new KsqlException("Type " + typeName + " does not exist.");
     }
 
     return new DropTypeCommand(typeName);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -266,7 +266,7 @@ public class CommandFactoriesTest {
   @Test
   public void shouldCreateDropType() {
     // Given:
-    final DropType dropType = new DropType(Optional.empty(), SOME_TYPE_NAME);
+    final DropType dropType = new DropType(Optional.empty(), SOME_TYPE_NAME, false);
 
     // When:
     final DropTypeCommand cmd = (DropTypeCommand) commandFactories.create(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DropTypeFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DropTypeFactoryTest.java
@@ -16,14 +16,12 @@
 package io.confluent.ksql.ddl.commands;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.execution.ddl.commands.DropTypeCommand;
 import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.parser.DropType;
 import java.util.Optional;
 
@@ -37,7 +35,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DropTypeFactoryTest {
-  private static final String SOME_TYPE_NAME = "some_type";
+  private static final String EXISTING_TYPE = "existing_type";
+  private static final String NOT_EXISTING_TYPE = "not_existing_type";
 
   private DropTypeFactory factory;
 
@@ -48,7 +47,7 @@ public class DropTypeFactoryTest {
 
   @Before
   public void setUp() {
-    when(metaStore.resolveType(SOME_TYPE_NAME)).thenReturn(Optional.of(customType));
+    when(metaStore.resolveType(EXISTING_TYPE)).thenReturn(Optional.of(customType));
 
     factory = new DropTypeFactory(metaStore);
   }
@@ -56,31 +55,43 @@ public class DropTypeFactoryTest {
   @Test
   public void shouldCreateDropType() {
     // Given:
-    final DropType dropType = new DropType(Optional.empty(), SOME_TYPE_NAME, false);
+    final DropType dropType = new DropType(Optional.empty(), EXISTING_TYPE, false);
 
     // When:
     final DropTypeCommand cmd = factory.create(dropType);
 
     // Then:
-    assertThat(cmd.getTypeName(), equalTo(SOME_TYPE_NAME));
+    assertThat(cmd.getTypeName(), equalTo(EXISTING_TYPE));
   }
 
   @Test
-  public void shouldCreateTypeOnMissingNameWithIfExists() {
+  public void shouldCreateDropTypeForExistingTypeAndIfExistsSet() {
     // Given:
-    final DropType dropType = new DropType(Optional.empty(), SOME_TYPE_NAME, true);
+    final DropType dropType = new DropType(Optional.empty(), EXISTING_TYPE, true);
 
     // When:
     final DropTypeCommand cmd = factory.create(dropType);
 
     // Then:
-    assertThat(cmd.getTypeName(), equalTo(SOME_TYPE_NAME));
+    assertThat(cmd.getTypeName(), equalTo(EXISTING_TYPE));
   }
 
   @Test
-  public void shouldFailCreateTypeOnMissingName() {
+  public void shouldNotFailCreateTypeIfTypeDoesNotExistAndIfExistsSet () {
     // Given:
-    final DropType dropType = new DropType(Optional.empty(), "ADDRESS", false);
+    final DropType dropType = new DropType(Optional.empty(), NOT_EXISTING_TYPE, true);
+
+    // When:
+    final DropTypeCommand cmd = factory.create(dropType);
+
+    // Then:
+    assertThat(cmd.getTypeName(), equalTo(NOT_EXISTING_TYPE));
+  }
+
+  @Test
+  public void shouldFailCreateTypeIfTypeDoesNotExist() {
+    // Given:
+    final DropType dropType = new DropType(Optional.empty(), NOT_EXISTING_TYPE, false);
 
     // When:
     final Exception e = assertThrows(
@@ -89,6 +100,6 @@ public class DropTypeFactoryTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), equalTo("Type ADDRESS does not exist."));
+    assertThat(e.getMessage(), equalTo("Type " + NOT_EXISTING_TYPE + " does not exist."));
   }
 }

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -67,7 +67,7 @@ statement
     | DROP CONNECTOR identifier                                             #dropConnector
     | EXPLAIN  (statement | identifier)                                     #explain
     | CREATE TYPE identifier AS type                                        #registerType
-    | DROP TYPE identifier                                                  #dropType
+    | DROP TYPE (IF EXISTS)? identifier                                     #dropType
     ;
 
 query

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -653,7 +653,11 @@ public class AstBuilder {
 
     @Override
     public Node visitDropType(final DropTypeContext ctx) {
-      return new DropType(getLocation(ctx), getIdentifierText(ctx.identifier()));
+      return new DropType(
+          getLocation(ctx),
+          getIdentifierText(ctx.identifier()),
+          ctx.EXISTS() != null
+      );
     }
 
     @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DropType.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DropType.java
@@ -26,14 +26,24 @@ import java.util.Optional;
 public class DropType extends Statement implements ExecutableDdlStatement {
 
   private final String typeName;
+  private final boolean ifExists;
 
-  public DropType(final Optional<NodeLocation> location, final String typeName) {
+  public DropType(
+      final Optional<NodeLocation> location,
+      final String typeName,
+      final boolean ifExists
+  ) {
     super(location);
     this.typeName = Objects.requireNonNull(typeName, "typeName");
+    this.ifExists = ifExists;
   }
 
   public String getTypeName() {
     return typeName;
+  }
+
+  public boolean getIfExists() {
+    return ifExists;
   }
 
   @Override
@@ -50,18 +60,20 @@ public class DropType extends Statement implements ExecutableDdlStatement {
       return false;
     }
     final DropType that = (DropType) o;
-    return Objects.equals(typeName, that.typeName);
+    return Objects.equals(typeName, that.typeName)
+        && ifExists == that.ifExists;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(typeName);
+    return Objects.hash(typeName, ifExists);
   }
 
   @Override
   public String toString() {
     return "DropType{"
-        + "typeName='" + typeName + '\''
+        + "typeName='" + typeName + "',"
+        + "ifExists=" + ifExists
         + '}';
   }
 }


### PR DESCRIPTION
### Description 
Add support for `IF EXISTS` on the `DROP TYPE` command. 

New syntax:
```
DROP TYPE [IF EXISTS] <type_name>;
```

If the `IF EXISTS` is specified, then the command should not throw any error if the type does not exist.

### Testing done 
Added unit tests
Verified manually
```
ksql> drop type address;
Type ADDRESS does not exist.

ksql> drop type if exists address;

 Message                       
-------------------------------
 Type 'ADDRESS' does not exist 
-------------------------------
```

The above works similar to `DROP STREAM [IF EXISTS]`
```
ksql> drop stream a;
Source A does not exist.

ksql> drop stream if exists a;

 Message                    
----------------------------
 Source `A` does not exist. 
----------------------------
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

