### PR TITLE
docs: add keywords table

### DIFF
--- a/docs/reference2/sql-syntax/lexical-structure.md
+++ b/docs/reference2/sql-syntax/lexical-structure.md
@@ -32,133 +32,133 @@ The following table shows all keywords in ksqlDB SQL.
 
 | keyword      | description                         | related keywords                         | example                                                              |
 |--------------|-------------------------------------|------------------------------------------|----------------------------------------------------------------------|
-| ADVANCE      |                                     | BY                                       | `ADVANCE BY`                                                         |
-| ALL          |                                     |                                          |                                                                      |
+| ADVANCE      | hop size in hopping WINDOW          | BY                                       | `WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 SECONDS)`            |
+| ALL          | list hidden topics                  | SHOW                                     | `SHOW ALL TOPICS`                                                    |
 | ANALYZE      |                                     |                                          |                                                                      |
-| AND          | logical AND operator                |                                          |                                                                      |
-| ARRAY        | one-indexed array of elements       |                                          |                                                                      |
+| AND          | logical AND operator                | WHERE                                    | `WHERE userid<>'User_1' AND userid<>'User_2'`                        |
+| ARRAY        | one-indexed array of elements       | SELECT                                   | `SELECT ARRAY[1, 2] FROM s1 EMIT CHANGES;`                           |
 | AS           | alias a column, expression, or type |                                          |                                                                      |
 | AT           |                                     |                                          |                                                                      |
-| BEGINNING    |                                     | FROM                                     | `FROM BEGINNING`                                                     |
-| BETWEEN      | constrain a value to a range        |                                          |                                                                      |
-| BY           |                                     | GROUP, ADVANCE                           | `GROUP BY`, `ADVANCE BY`                                             |
-| CASE         | select a condition from expressions | WHEN                                     |                                                                      |
-| CAST         | change expression type              |                                          |                                                                      |
+| BEGINNING    | print from start of topic           | PRINT FROM                               | `PRINT <topic-name> FROM BEGINNING;`                                 |
+| BETWEEN      | constrain a value to a range        | WHERE                                    | `SELECT event FROM events WHERE event_id BETWEEN 10 AND 20 …`        |
+| BY           | specify expression                  | GROUP, ADVANCE, PARTITION                | `GROUP BY regionid`, `ADVANCE BY 10 SECONDS`, `PARTITION BY userid`  |
+| CASE         | select a condition from expressions | WHEN                                     | `SELECT CASE WHEN condition THEN result [ WHEN … THEN … ] … END`     |
+| CAST         | change expression type              |                                          | `SELECT id, CONCAT(CAST(COUNT(*) AS VARCHAR), '_HELLO') FROM views …`|
 | CATALOG      |                                     |                                          |                                                                      |
-| CHANGES      |                                     | EMIT                                     | `EMIT CHANGES`                                                       |
+| CHANGES      | specify push query                  | EMIT                                     | `SELECT * FROM users EMIT CHANGES;`                                  |
 | COLUMN       |                                     |                                          |                                                                      |
 | COLUMNS      |                                     |                                          |                                                                      |
-| CONNECTOR    |                                     |                                          |                                                                      |
-| CONNECTORS   |                                     |                                          |                                                                      |
-| CREATE       |                                     | STREAM, TABLE, CONNECTOR, TYPE           |                                                                      |
+| CONNECTOR    | manage a connector                  | CREATE, DESCRIBE, DROP                   |  `CREATE SOURCE CONNECTOR 'jdbc-connector' WITH( …`                  |
+| CONNECTORS   | list all connectors                 | SHOW, LIST                               |  `SHOW CONNECTORS;`                                                  |
+| CREATE       | create an object                    | STREAM, TABLE, CONNECTOR, TYPE           |  `CREATE STREAM rock_songs (artist VARCHAR, title VARCHAR) …`        |
 | DATE         |                                     |                                          |                                                                      |
-| DAY          |                                     |                                          |                                                                      |
-| DAYS         |                                     |                                          |                                                                      |
+| DAY          | time unit of one day for a window   | WITHIN, RETENTION, SIZE                  |  `WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1 DAY)`                |
+| DAYS         | time unit of days for a window      | WITHIN, RETENTION, SIZE                  |  `WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1000 DAYS)`            |
 | DECIMAL      | decimal numeric type                |                                          |                                                                      |
-| DELETE       |                                     | TOPIC                                    | `[DELETE TOPIC]`                                                     |
-| DESCRIBE     | list details                        | STREAM, TABLE, CONNECTOR, TYPE, FUNCTION |                                                                      |
+| DELETE       | remove a {{ site.ak}} topic         | DROP, TOPIC                              | `DROP TABLE <table-name> DELETE TOPIC;`                              |
+| DESCRIBE     | list details for an object          | STREAM, TABLE, CONNECTOR, TYPE, FUNCTION | `DESCRIBE PAGEVIEWS;`                                                |
 | DISTINCT     |                                     |                                          |                                                                      |
-| DROP         | delete                              | STREAM, TABLE, CONNECTOR, TYPE           |                                                                      |
-| ELSE         |                                     | IF                                       |                                                                      |
-| EMIT         |                                     | CHANGES                                  | `EMIT CHANGES`                                                       |
-| END          |                                     | CASE                                     |                                                                      |
+| DROP         | delete an object                    | STREAM, TABLE, CONNECTOR, TYPE           | `DROP CONNECTOR <connector-name>;`                                   |
+| ELSE         | condition in WHEN statement         | WHEN, THEN                               | `CASE WHEN units<2 THEN 'sm' WHEN units<4 THEN 'med' ELSE 'large' …` |
+| EMIT         | specify push query                  | CHANGES, FINAL                           | `SELECT * FROM users EMIT CHANGES;`                                  |
+| END          | close a CASE block                  | CASE                                     | `SELECT CASE WHEN condition THEN result [ WHEN … THEN … ] … END`     |
 | ESCAPE       |                                     |                                          |                                                                      |
-| EXISTS       |                                     | IF                                       | `[IF EXISTS]`                                                        |
-| EXPLAIN      | show execution plan                 |                                          |                                                                      |
+| EXISTS       | test whether object exists          | IF                                       | `DROP STREAM IF EXISTS <stream-name>;`                               |
+| EXPLAIN      | show execution plan                 |                                          | `EXPLAIN <query-name>;` or `EXPLAIN <expression>;`                   |
 | EXPORT       |                                     |                                          |                                                                      |
-| EXTENDED     |                                     | SHOW, LIST, DESCRIBE                     |                                                                      |
+| EXTENDED     | list details for an object          | SHOW, LIST, DESCRIBE                     | `DESCRIBE EXTENDED <stream-name>;`                                   |
 | FALSE        | Boolean value of FALSE              |                                          |                                                                      |
-| FINAL        |                                     |                                          |                                                                      |
-| FROM         |                                     | SELECT                                   | `SELECT * FROM users;`                                               |
-| FULL         |                                     | JOIN                                     |                                                                      |
-| FUNCTION     |                                     | SHOW, LIST, DESCRIBE                     |                                                                      |
-| FUNCTIONS    |                                     | SHOW, LIST, DESCRIBE                     |                                                                      |
-| GRACE        |                                     | PERIOD                                   | `WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)`                |
-| GROUP        |                                     | BY                                       | `GROUP BY`                                                           |
-| HAVING       | filter condition                    |                                          |                                                                      |
-| HOPPING      |                                     | WINDOW                                   | `WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 SECONDS)`            |
-| HOUR         |                                     |                                          |                                                                      |
-| HOURS        |                                     |                                          |                                                                      |
-| IF           |                                     |                                          |                                                                      |
+| FINAL        | specify pull query                  | CHANGES                                  | `SELECT * FROM users EMIT FINAL;`                                    |
+| FROM         | specify record source for queries   | SELECT                                   | `SELECT * FROM users;`                                               |
+| FULL         | specify FULL JOIN                   | OUTER JOIN                               | `CREATE TABLE t AS SELECT * FROM l FULL OUTER JOIN r ON l.ID = r.ID;`|
+| FUNCTION     | list details for a function         | SHOW, LIST, DESCRIBE                     | `DESCRIBE FUNCTION <function-name>;`                                 |
+| FUNCTIONS    | list all functions                  | SHOW, LIST, DESCRIBE                     | `SHOW FUNCTIONS;`                                                    |
+| GRACE        | grace period for a tumbling window  | PERIOD                                   | `WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)`                |
+| GROUP        | group rows with the same values     | BY                                       | `SELECT regionid, COUNT(*) FROM pageviews GROUP BY regionid`         |
+| HAVING       | condition expression                |                                          | `GROUP BY card_number HAVING COUNT(*) > 3`                           |
+| HOPPING      | specify a hopping window            | WINDOW, ADVANCE BY                       | `WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 SECONDS)`            |
+| HOUR         | time unit of one hour for a window  | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 1 HOUR, RETENTION 1 DAY)`                     |
+| HOURS        | time unit of hours for a window     | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 2 HOURS, RETENTION 1 DAY)`                    |
+| IF           | test whether object exists          | EXISTS                                   | `DROP STREAM IF EXISTS <stream-name>;`                               |
 | IN           | specify multiple values             | WHERE                                    | `WHERE name IN (value1, value2, ...)`                                |
-| INNER        |                                     | JOIN                                     |                                                                      |
-| INSERT       |                                     | INTO, VALUES                             | `INSERT INTO stream_name ...`                                        |
-| INTEGER      | integer numeric type                |                                          |                                                                      |
-| INTERVAL     |                                     | PRINT                                    | `PRINT topicName INTERVAL interval 5`                                |
-| INTO         |                                     | INSERT                                   | `INSERT INTO stream_name ...`                                        |
+| INNER        | specify INNER JOIN                  | JOIN                                     | `CREATE TABLE t AS SELECT * FROM l INNER JOIN r ON l.ID = r.ID;`     |
+| INSERT       | insert new records in a stream/table| INTO, VALUES                             | `INSERT INTO <stream-name> ...`                                      |
+| INTEGER      | integer numeric type                |                                          | `CREATE TABLE profiles (id INTEGER PRIMARY KEY, …`                   |
+| INTERVAL     | number of messages to skip in PRINT | PRINT                                    | `PRINT <topic-name> INTERVAL 5;`                                     |
+| INTO         | stream/table to insert values       | INSERT                                   | `INSERT INTO stream_name ...`                                        |
 | IS           |                                     |                                          |                                                                      |
-| JOIN         | match records                       |                                          |                                                                      |
-| KEY          |                                     | PRIMARY                                  | `userId INT PRIMARY KEY`                                             |
-| LEFT         |                                     | JOIN                                     | `LEFT JOIN users ON pageviews.userid = users.userid`                 |
-| LIKE         |                                     | WHERE                                    | `WHERE UCASE(gender)='FEMALE' AND LCASE (regionid) LIKE '%_6'`       |
-| LIMIT        |                                     | SELECT                                   | `SELECT * FROM users EMIT CHANGES LIMIT 5;`                          |
-| LIST         |                                     |                                          |                                                                      |
+| JOIN         | match records in streams/tables     | LEFT, INNER, OUTER                       | `CREATE TABLE t AS SELECT * FROM l INNER JOIN r ON l.ID = r.ID;`     |
+| KEY          | specify key column                  | PRIMARY                                  | `CREATE TABLE users (userId INT PRIMARY KEY, …`                      |
+| LEFT         | specify LEFT JOIN                   | JOIN                                     | `CREATE TABLE t AS SELECT * FROM l LEFT JOIN r ON l.ID = r.ID;`      |
+| LIKE         | match pattern                       | WHERE                                    | `WHERE UCASE(gender)='FEMALE' AND LCASE (regionid) LIKE '%_6'`       |
+| LIMIT        | number of records to output         | SELECT                                   | `SELECT * FROM users EMIT CHANGES LIMIT 5;`                          |
+| LIST         | list objects                        | QUERIES, STREAMS, TABLES, TYPES, …       | `SHOW STREAMS;`                                                      |
 | LOAD         |                                     |                                          |                                                                      |
-| MAP          | `map` data type                     |                                          |                                                                      |
+| MAP          | `map` data type                     | SELECT                                   | `SELECT MAP(k1:=v1, k2:=v1*2) FROM s1 EMIT CHANGES;`                 |
 | MATERIALIZED |                                     |                                          |                                                                      |
-| MILLISECOND  |                                     |                                          |                                                                      |
-| MILLISECONDS |                                     |                                          |                                                                      |
-| MINUTE       |                                     |                                          |                                                                      |
-| MINUTES      |                                     |                                          |                                                                      |
-| MONTH        |                                     |                                          |                                                                      |
-| MONTHS       |                                     |                                          |                                                                      |
+| MILLISECOND  | time unit of one ms for a window    | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 1 MILLISECOND, RETENTION 1 DAY)`              |
+| MILLISECONDS | time unit of ms for a window        | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 100 MILLISECONDS, RETENTION 1 DAY)`           |
+| MINUTE       | time unit of one min for a window   | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 1 MINUTE, RETENTION 1 DAY)`                   |
+| MINUTES      | time unit of mins for a window      | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 30 MINUTES, RETENTION 1 DAY)`                 |
+| MONTH        | time unit of one month for a window | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 1 HOUR, RETENTION 1 MONTH)`                   |
+| MONTHS       | time unit of months for a window    | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 1 HOUR, RETENTION 2 MONTHs)`                  |
 | NAMESPACE    |                                     |                                          |                                                                      |
 | NOT          | logical NOT operator                |                                          |                                                                      |
-| NULL         |                                     |                                          |                                                                      |
-| ON           |                                     | JOIN                                     | `LEFT JOIN users ON pageviews.userid = users.userid`                 |
-| OR           | logical OR operator                 |                                          |                                                                      |
-| OUTER        |                                     | JOIN                                     |                                                                      |
-| PARTITION    |                                     | BY                                       | `PARTITION BY key_field`                                             |
-| PARTITIONS   |                                     | CREATE                                   | `CREATE STREAM users_rekeyed WITH (PARTITIONS=6) AS ...`             |
-| PERIOD       |                                     | GRACE                                    |                                                                      |
-| PRIMARY      |                                     | KEY                                      |                                                                      |
-| PRINT        |                                     |                                          |                                                                      |
-| PROPERTIES   |                                     | LIST, SHOW                               | `SHOW PROPERTIES;`                                                   |
-| QUERIES      |                                     | LIST, SHOW                               | `SHOW QUERIES;`                                                      |
+| NULL         | field with no value                 |                                          |                                                                      |
+| ON           | specify join criteria               | JOIN                                     | `LEFT JOIN users ON pageviews.userid = users.userid`                 |
+| OR           | logical OR operator                 | WHERE                                    | `WHERE userid='User_1' OR userid='User_2'`                           |
+| OUTER        | specify OUTER JOIN                  | JOIN                                     | `CREATE TABLE t AS SELECT * FROM l FULL OUTER JOIN r ON l.ID = r.ID;`|
+| PARTITION    | repartition a stream                | BY                                       | `PARTITION BY <key-field>`                                           |
+| PARTITIONS   | partitions to distribute keys over  | CREATE                                   | `CREATE STREAM users_rekeyed WITH (PARTITIONS=6) AS …`               |
+| PERIOD       | grace period for a tumbling window  | GRACE                                    | `WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)`                |
+| PRIMARY      | specify primary key column          | KEY                                      | `CREATE TABLE users (userId INT PRIMARY KEY, …`                      |
+| PRINT        | output records in a topic           | FROM BEGINNING                           | `PRINT <topic-name> FROM BEGINNING;`                                 |
+| PROPERTIES   | list all properties                 | LIST, SHOW                               | `SHOW PROPERTIES;`                                                   |
+| QUERIES      | list all queries                    | LIST, SHOW                               | `SHOW QUERIES;`                                                      |
 | QUERY        |                                     |                                          |                                                                      |
 | RENAME       |                                     |                                          |                                                                      |
 | REPLACE      | string replace                      |                                          | `REPLACE(col1, 'foo', 'bar')`                                        |
 | RESET        |                                     |                                          |                                                                      |
-| RETENTION    |                                     | WINDOW                                   | `WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1000 DAYS)`             |
+| RETENTION    | time to retain past windows         | WINDOW                                   | `WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1000 DAYS)`             |
 | RIGHT        |                                     |                                          |                                                                      |
-| RUN          |                                     | SCRIPT                                   | `RUN SCRIPT <path-to-query-file>;`                                   |
+| RUN          | execute queries from a file         | SCRIPT                                   | `RUN SCRIPT <path-to-query-file>;`                                   |
 | SAMPLE       |                                     |                                          |                                                                      |
-| SCRIPT       |                                     | RUN                                      | `RUN SCRIPT <path-to-query-file>;`                                   |
-| SECOND       |                                     |                                          |                                                                      |
-| SECONDS      |                                     |                                          |                                                                      |
+| SCRIPT       | execute queries from a file         | RUN                                      | `RUN SCRIPT <path-to-query-file>;`                                   |
+| SECOND       | time unit of one sec for a window   | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 1 SECOND, RETENTION 1 DAY)`                   |
+| SECONDS      | time unit of secs for a window      | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1 DAY)`                 |
 | SELECT       | query a stream or table             |                                          |                                                                      |
-| SESSION      |                                     | WINDOW                                   | `WINDOW SESSION (60 SECONDS)`                                        |
+| SESSION      | specify a session window            | WINDOW                                   | `WINDOW SESSION (60 SECONDS)`                                        |
 | SET          | assign a property value             |                                          | `SET 'auto.offset.reset'='earliest';`                                |
-| SHOW         |                                     |                                          |                                                                      |
-| SINK         |                                     | CREATE CONNECTOR                         | `CREATE SINK CONNECTOR ...`                                          |
-| SIZE         |                                     | WINDOW                                   | `WINDOW TUMBLING (SIZE 5 SECONDS)`                                   |
-| SOURCE       |                                     | CREATE CONNECTOR                         | `CREATE SOURCE CONNECTOR ...`                                        |
-| STREAM       |                                     |                                          |                                                                      |
-| STREAMS      |                                     | LIST, SHOW                               | `SHOW STREAMS;`                                                      |
-| STRUCT       | struct data type                    |                                          |                                                                      |
-| TABLE        |                                     |                                          |                                                                      |
-| TABLES       |                                     | LIST, SHOW                               | `SHOW TABLES;`                                                       |
+| SHOW         | list objects                        | QUERIES, STREAMS, TABLES, TYPES, …       | `SHOW FUNCTIONS;`                                                    |
+| SINK         | create a sink connector             | CREATE CONNECTOR                         | `CREATE SINK CONNECTOR …`                                            |
+| SIZE         | time length of a window             | WINDOW                                   | `WINDOW TUMBLING (SIZE 5 SECONDS)`                                   |
+| SOURCE       | create a source connector           | CREATE CONNECTOR                         | `CREATE SOURCE CONNECTOR …`                                          |
+| STREAM       | register a stream on a topic        | CREATE, AS SELECT                        | `CREATE STREAM users_orig AS SELECT * FROM users EMIT CHANGES;`      |
+| STREAMS      | list all streams                    | LIST, SHOW                               | `SHOW STREAMS;`                                                      |
+| STRUCT       | struct data type                    | SELECT                                   | `SELECT STRUCT(f1 := v1, f2 := v2) FROM s1 EMIT CHANGES;`            |
+| TABLE        | register a table on a topic         | CREATE, AS SELECT                        | `CREATE TABLE users (id BIGINT PRIMARY KEY, …`                       |
+| TABLES       | list all tables                     | LIST, SHOW                               | `SHOW TABLES;`                                                       |
 | TERMINATE    | end a persistent query              |                                          | `TERMINATE query_id;`                                                |
-| THEN         |                                     | IF                                       |                                                                      |
+| THEN         | return expression in a CASE block   | WHEN, ELSE                               | `CASE WHEN units<2 THEN 'sm' WHEN units<4 THEN 'med' ELSE 'large' …` |
 | TIME         |                                     |                                          |                                                                      |
-| TIMESTAMP    |                                     |                                          |                                                                      |
+| TIMESTAMP    | specify a timestamp column          | CREATE, WITH                             | `CREATE STREAM pageviews WITH (TIMESTAMP='viewtime', …`              |
 | TO           |                                     |                                          |                                                                      |
-| TOPIC        |                                     |                                          |                                                                      |
-| TOPICS       |                                     | LIST, SHOW                               | `SHOW TOPICS;`                                                       |
+| TOPIC        | specify {{site.ak}} topic to delete | DELETE                                   | `DROP TABLE <table-name> DELETE TOPIC;`                              |
+| TOPICS       | list all streams                    | LIST, SHOW                               | `SHOW TOPICS;`                                                       |
 | TRUE         | Boolean value of TRUE               |                                          |                                                                      |
-| TUMBLING     |                                     | WINDOW                                   | `WINDOW TUMBLING (SIZE 5 SECONDS)`                                   |
-| TYPE         |                                     | CREATE, DROP                             | `CREATE TYPE <type_name> AS <type>;`                                 |
-| TYPES        |                                     | LIST, SHOW                               | `SHOW TYPES;`                                                        |
+| TUMBLING     | specify a tumbling window           | WINDOW                                   | `WINDOW TUMBLING (SIZE 5 SECONDS)`                                   |
+| TYPE         | alias a complex type declaration    | CREATE, DROP                             | `CREATE TYPE <type_name> AS <type>;`                                 |
+| TYPES        | list all custom TYPE aliases        | LIST, SHOW, TYPE                         | `SHOW TYPES;`                                                        |
 | UNSET        | unassign a property value           |                                          | `UNSET 'auto.offset.reset';`                                         |
-| VALUES       |                                     | INSERT                                   | `INSERT INTO foo VALUES ('key', 'A');`                               |
+| VALUES       | list of values to insert            | INSERT                                   | `INSERT INTO foo VALUES ('key', 'A');`                               |
 | VIEW         |                                     |                                          |                                                                      |
-| WHEN         |                                     | CASE                                     |                                                                      |
-| WHERE        |                                     | SELECT                                   | `SELECT * FROM pageviews WHERE pageid < 'Page_20'`                   |
-| WINDOW       |                                     | CREATE, SELECT                           | `SELECT userid, COUNT(*) FROM users WINDOW SESSION (60 SECONDS) ...` |
-| WITH         |                                     | CREATE                                   | `CREATE STREAM pageviews WITH (TIMESTAMP='viewtime', ...`            |
-| WITHIN       | use with windowed JOIN              | JOIN                                     | `SELECT * FROM impressions i JOIN clicks c WITHIN 1 minute ...`      |
-| YEAR         |                                     |                                          |                                                                      |
-| YEARS        |                                     |                                          |                                                                      |
+| WHEN         | specify condition in a CASE block   | CASE, THEN, ELSE                         | `SELECT CASE WHEN condition THEN result [ WHEN … THEN … ] …`         |
+| WHERE        | filter records by a condition       | SELECT                                   | `SELECT * FROM pageviews WHERE pageid < 'Page_20'`                   |
+| WINDOW       | groups rows with the same keys      | CREATE, SELECT                           | `SELECT userid, COUNT(*) FROM users WINDOW SESSION (60 SECONDS) …`   |
+| WITH         | specify object creation params      | CREATE                                   | `CREATE STREAM pageviews WITH (TIMESTAMP='viewtime', …`              |
+| WITHIN       | time range in a windowed JOIN       | JOIN                                     | `SELECT * FROM impressions i JOIN clicks c WITHIN 1 minute …`        |
+| YEAR         | time unit of one year for a window  | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 1 HOUR, RETENTION 1 YEAR)`                    |
+| YEARS        | time unit of years for a window     | WITHIN, RETENTION, SIZE                  | `WINDOW TUMBLING (SIZE 1 HOUR, RETENTION 2 YEARS)`                   |
 | ZONE         |                                     |                                          |                                                                      |
 
 

--- a/docs/reference2/sql-syntax/lexical-structure.md
+++ b/docs/reference2/sql-syntax/lexical-structure.md
@@ -27,6 +27,145 @@ keywords: ksqldb, sql, keyword, identifier, constant, operator
   - examples: select, insert, where
   - case insensitive
 
+The following table shows all keywords in ksqlDB SQL.
+
+
+| keyword     | description                   | example 
+|-------------|-------------------------------|----------------------------
+| ADVANCE     | use with BY                   | `ADVANCE BY`
+| ALL         |                               |
+| ANALYZE     |                               |
+| AND         | logical AND operator          |
+| ARRAY       | one-indexed array of elements |
+| AS          | alias a column, expression, or type |
+| AT          |                               |
+| BEGINNING   | use with FROM                 | `FROM BEGINNING`
+| BETWEEN     | constrain a value to a range  |
+| BY          | use with GROUP or ADVANCE     | `GROUP BY`, `ADVANCE BY` 
+| CASE        | select a condition from expressions | 
+| CAST        | change the type of an expression |
+| CATALOG     |                               |
+| CHANGES     | use with EMIT                 | `EMIT CHANGES`
+| COLUMN      |                               |
+| COLUMNS     |                               |
+| CONNECTOR   |                               |
+| CONNECTORS  |                               |
+| CREATE      | use with STREAM, TABLE, CONNECTOR, or TYPE |
+| DATE        |                               |
+| DAY         |                               |
+| DAYS        |                               |
+| DECIMAL     | decimal numeric type          |
+| DELETE      | use with TOPIC                | `[DELETE TOPIC]`
+| DESCRIBE    | list details of a stream, table, connector, or function |
+| DISTINCT    |                               |
+| DROP        | delete a stream, table, connector, or type |
+| ELSE        | use with IF                   |
+| EMIT        | use with CHANGES              | `EMIT CHANGES`
+| END         | use with CASE                 |
+| ESCAPE      |                               |
+| EXISTS      | use with IF                   | `[IF EXISTS]`
+| EXPLAIN     | show the execution plan of an expression or query |
+| EXPORT      |                               |
+| EXTENDED    | use with SHOW, LIST, or DESCRIBE |
+| FALSE       | Boolean value of FALSE        |
+| FINAL       |                               |
+| FROM        | use with SELECT               | `SELECT * FROM users;`
+| FULL        | use with JOIN                 |
+| FUNCTION    | use with SHOW, LIST, or DESCRIBE |
+| FUNCTIONS   | use with SHOW, LIST, or DESCRIBE |
+| GRACE       | use with PERIOD                          | `WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)`
+| GROUP       | use with BY                              | `GROUP BY`
+| HAVING      | extract records from an aggregation that fulfill a condition |
+| HOPPING     | use with WINDOW                          | `WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 SECONDS)`
+| HOUR        |                                |
+| HOURS       |                                |
+| IF          |                                |
+| IN          | specify multiple values in a WHERE clause | `WHERE name IN (value1, value2, ...)`
+| INNER       | use with JOIN                  |
+| INSERT      | use with INTO or VALUES        | `INSERT INTO stream_name ...`
+| INTEGER     | integer numeric type           |
+| INTERVAL    | use with PRINT                 | `PRINT topicName INTERVAL interval 5`
+| INTO        | use with INSERT                | `INSERT INTO stream_name ...`
+| IS          |                                |
+| JOIN        | match records from two streams or tables |
+| KEY         | use with PRIMARY               | `userId INT PRIMARY KEY`
+| LEFT        | use with JOIN                  | `LEFT JOIN users ON pageviews.userid = users.userid`
+| LIKE        | use with WHERE                 | `WHERE UCASE(gender)='FEMALE' AND LCASE (regionid) LIKE '%_6'`
+| LIMIT       | use with SELECT                | `SELECT * FROM users EMIT CHANGES LIMIT 5;`
+| LIST        |                                |
+| LOAD        |                                |
+| MAP         | `map` data type                |
+| MATERIALIZED|                                |
+| MILLISECOND |                                |
+| MILLISECONDS|                                |
+| MINUTE      |                                |
+| MINUTES     |                                |
+| MONTH       |                                |
+| MONTHS      |                                |
+| NAMESPACE   |                                |
+| NOT         | logical NOT operator           |
+| NULL        |                                |
+| ON          | use with JOIN                  | `LEFT JOIN users ON pageviews.userid = users.userid`
+| OR          | logical OR operator            |
+| OUTER       | use with JOIN                  |                  
+| PARTITION   | use with BY                    | `PARTITION BY key_field`
+| PARTITIONS  | user with CREATE               | `CREATE STREAM users_rekeyed WITH (PARTITIONS=6) AS ...`
+| PERIOD      | use with GRACE                 |
+| PRIMARY     | use with KEY                   |
+| PRINT       |                                |
+| PROPERTIES  | use with LIST or SHOW          | `SHOW PROPERTIES;`
+| QUERIES     | use with LIST or SHOW          | `SHOW QUERIES;`
+| QUERY       |                                |
+| RENAME      |                                |
+| REPLACE     | string replace                 | `REPLACE(col1, 'foo', 'bar')`
+| RESET       |                                |
+| RETENTION   | use with WINDOW                | `WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1000 DAYS)`
+| RIGHT       |                                |
+| RUN         | use with SCRIPT                | `RUN SCRIPT <path-to-query-file>;`
+| SAMPLE      |                                |
+| SCRIPT      | use with RUN                   | `RUN SCRIPT <path-to-query-file>;`
+| SECOND      |                                |
+| SECONDS     |                                |
+| SELECT      | query a stream or table        |
+| SESSION     | use with WINDOW                | `WINDOW SESSION (60 SECONDS)`
+| SET         | assign a property value        | `SET 'auto.offset.reset'='earliest';`
+| SHOW        |                                |
+| SINK        | use with CREATE CONNECTOR      | `CREATE SINK CONNECTOR ...`
+| SIZE        | use with WINDOW                | `WINDOW TUMBLING (SIZE 5 SECONDS)`
+| SOURCE      | use with CREATE CONNECTOR      | `CREATE SOURCE CONNECTOR ...`
+| STREAM      |                                |
+| STREAMS     | use with LIST or SHOW          | `SHOW STREAMS;`
+| STRUCT      | struct data type               |
+| TABLE       |                                |
+| TABLES      | use with LIST or SHOW          | `SHOW TABLES;`
+| TERMINATE   | end a persistent query         | `TERMINATE query_id;`
+| THEN        | use with IF                    |
+| TIME        |                                |
+| TIMESTAMP   |                                |
+| TO          |                                |
+| TOPIC       |                                |
+| TOPICS      | use with LIST or SHOW          | `SHOW TOPICS;`
+| TRUE        | Boolean value of TRUE          |
+| TUMBLING    | use with WINDOW                | `WINDOW TUMBLING (SIZE 5 SECONDS)`
+| TYPE        | use with CREATE and DROP       | `CREATE TYPE <type_name> AS <type>;`
+| TYPES       | use with LIST or SHOW          | `SHOW TYPES;`
+| UNSET       | unassign a property value      | `UNSET 'auto.offset.reset';`
+| VALUES      | use with INSERT                | `INSERT INTO foo VALUES ('key', 'A');`
+| VIEW        |                                |
+| WHEN        | use with CASE                  |
+| WHERE       | use with SELECT                | `SELECT * FROM pageviews WHERE pageid < 'Page_20'`
+| WINDOW      | use with CREATE and SELECT     | `SELECT userid, COUNT(*) FROM users WINDOW SESSION (60 SECONDS) ...`
+| WITH        | use with CREATE                | `CREATE STREAM pageviews WITH (TIMESTAMP='viewtime', ...`
+| WITHIN      | use with windowed JOIN         | `SELECT * FROM impressions i JOIN clicks c WITHIN 1 minute ON i.user = c.user`
+| YEAR        |                                |
+| YEARS       |                                |
+| ZONE        |                                |
+
+
+
+
+
+
 ## Identifiers
 
 - Identifiers = user-space symbols

--- a/docs/reference2/sql-syntax/lexical-structure.md
+++ b/docs/reference2/sql-syntax/lexical-structure.md
@@ -30,136 +30,136 @@ keywords: ksqldb, sql, keyword, identifier, constant, operator
 The following table shows all keywords in ksqlDB SQL.
 
 
-| keyword     | description                   | example 
-|-------------|-------------------------------|----------------------------
-| ADVANCE     | use with BY                   | `ADVANCE BY`
-| ALL         |                               |
-| ANALYZE     |                               |
-| AND         | logical AND operator          |
-| ARRAY       | one-indexed array of elements |
-| AS          | alias a column, expression, or type |
-| AT          |                               |
-| BEGINNING   | use with FROM                 | `FROM BEGINNING`
-| BETWEEN     | constrain a value to a range  |
-| BY          | use with GROUP or ADVANCE     | `GROUP BY`, `ADVANCE BY` 
-| CASE        | select a condition from expressions | 
-| CAST        | change the type of an expression |
-| CATALOG     |                               |
-| CHANGES     | use with EMIT                 | `EMIT CHANGES`
-| COLUMN      |                               |
-| COLUMNS     |                               |
-| CONNECTOR   |                               |
-| CONNECTORS  |                               |
-| CREATE      | use with STREAM, TABLE, CONNECTOR, or TYPE |
-| DATE        |                               |
-| DAY         |                               |
-| DAYS        |                               |
-| DECIMAL     | decimal numeric type          |
-| DELETE      | use with TOPIC                | `[DELETE TOPIC]`
-| DESCRIBE    | list details of a stream, table, connector, or function |
-| DISTINCT    |                               |
-| DROP        | delete a stream, table, connector, or type |
-| ELSE        | use with IF                   |
-| EMIT        | use with CHANGES              | `EMIT CHANGES`
-| END         | use with CASE                 |
-| ESCAPE      |                               |
-| EXISTS      | use with IF                   | `[IF EXISTS]`
-| EXPLAIN     | show the execution plan of an expression or query |
-| EXPORT      |                               |
-| EXTENDED    | use with SHOW, LIST, or DESCRIBE |
-| FALSE       | Boolean value of FALSE        |
-| FINAL       |                               |
-| FROM        | use with SELECT               | `SELECT * FROM users;`
-| FULL        | use with JOIN                 |
-| FUNCTION    | use with SHOW, LIST, or DESCRIBE |
-| FUNCTIONS   | use with SHOW, LIST, or DESCRIBE |
-| GRACE       | use with PERIOD                          | `WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)`
-| GROUP       | use with BY                              | `GROUP BY`
-| HAVING      | extract records from an aggregation that fulfill a condition |
-| HOPPING     | use with WINDOW                          | `WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 SECONDS)`
-| HOUR        |                                |
-| HOURS       |                                |
-| IF          |                                |
-| IN          | specify multiple values in a WHERE clause | `WHERE name IN (value1, value2, ...)`
-| INNER       | use with JOIN                  |
-| INSERT      | use with INTO or VALUES        | `INSERT INTO stream_name ...`
-| INTEGER     | integer numeric type           |
-| INTERVAL    | use with PRINT                 | `PRINT topicName INTERVAL interval 5`
-| INTO        | use with INSERT                | `INSERT INTO stream_name ...`
-| IS          |                                |
-| JOIN        | match records from two streams or tables |
-| KEY         | use with PRIMARY               | `userId INT PRIMARY KEY`
-| LEFT        | use with JOIN                  | `LEFT JOIN users ON pageviews.userid = users.userid`
-| LIKE        | use with WHERE                 | `WHERE UCASE(gender)='FEMALE' AND LCASE (regionid) LIKE '%_6'`
-| LIMIT       | use with SELECT                | `SELECT * FROM users EMIT CHANGES LIMIT 5;`
-| LIST        |                                |
-| LOAD        |                                |
-| MAP         | `map` data type                |
-| MATERIALIZED|                                |
-| MILLISECOND |                                |
-| MILLISECONDS|                                |
-| MINUTE      |                                |
-| MINUTES     |                                |
-| MONTH       |                                |
-| MONTHS      |                                |
-| NAMESPACE   |                                |
-| NOT         | logical NOT operator           |
-| NULL        |                                |
-| ON          | use with JOIN                  | `LEFT JOIN users ON pageviews.userid = users.userid`
-| OR          | logical OR operator            |
-| OUTER       | use with JOIN                  |                  
-| PARTITION   | use with BY                    | `PARTITION BY key_field`
-| PARTITIONS  | user with CREATE               | `CREATE STREAM users_rekeyed WITH (PARTITIONS=6) AS ...`
-| PERIOD      | use with GRACE                 |
-| PRIMARY     | use with KEY                   |
-| PRINT       |                                |
-| PROPERTIES  | use with LIST or SHOW          | `SHOW PROPERTIES;`
-| QUERIES     | use with LIST or SHOW          | `SHOW QUERIES;`
-| QUERY       |                                |
-| RENAME      |                                |
-| REPLACE     | string replace                 | `REPLACE(col1, 'foo', 'bar')`
-| RESET       |                                |
-| RETENTION   | use with WINDOW                | `WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1000 DAYS)`
-| RIGHT       |                                |
-| RUN         | use with SCRIPT                | `RUN SCRIPT <path-to-query-file>;`
-| SAMPLE      |                                |
-| SCRIPT      | use with RUN                   | `RUN SCRIPT <path-to-query-file>;`
-| SECOND      |                                |
-| SECONDS     |                                |
-| SELECT      | query a stream or table        |
-| SESSION     | use with WINDOW                | `WINDOW SESSION (60 SECONDS)`
-| SET         | assign a property value        | `SET 'auto.offset.reset'='earliest';`
-| SHOW        |                                |
-| SINK        | use with CREATE CONNECTOR      | `CREATE SINK CONNECTOR ...`
-| SIZE        | use with WINDOW                | `WINDOW TUMBLING (SIZE 5 SECONDS)`
-| SOURCE      | use with CREATE CONNECTOR      | `CREATE SOURCE CONNECTOR ...`
-| STREAM      |                                |
-| STREAMS     | use with LIST or SHOW          | `SHOW STREAMS;`
-| STRUCT      | struct data type               |
-| TABLE       |                                |
-| TABLES      | use with LIST or SHOW          | `SHOW TABLES;`
-| TERMINATE   | end a persistent query         | `TERMINATE query_id;`
-| THEN        | use with IF                    |
-| TIME        |                                |
-| TIMESTAMP   |                                |
-| TO          |                                |
-| TOPIC       |                                |
-| TOPICS      | use with LIST or SHOW          | `SHOW TOPICS;`
-| TRUE        | Boolean value of TRUE          |
-| TUMBLING    | use with WINDOW                | `WINDOW TUMBLING (SIZE 5 SECONDS)`
-| TYPE        | use with CREATE and DROP       | `CREATE TYPE <type_name> AS <type>;`
-| TYPES       | use with LIST or SHOW          | `SHOW TYPES;`
-| UNSET       | unassign a property value      | `UNSET 'auto.offset.reset';`
-| VALUES      | use with INSERT                | `INSERT INTO foo VALUES ('key', 'A');`
-| VIEW        |                                |
-| WHEN        | use with CASE                  |
-| WHERE       | use with SELECT                | `SELECT * FROM pageviews WHERE pageid < 'Page_20'`
-| WINDOW      | use with CREATE and SELECT     | `SELECT userid, COUNT(*) FROM users WINDOW SESSION (60 SECONDS) ...`
-| WITH        | use with CREATE                | `CREATE STREAM pageviews WITH (TIMESTAMP='viewtime', ...`
-| WITHIN      | use with windowed JOIN         | `SELECT * FROM impressions i JOIN clicks c WITHIN 1 minute ON i.user = c.user`
-| YEAR        |                                |
-| YEARS       |                                |
-| ZONE        |                                |
+| keyword      | description                         | related keywords                         | example                                                              |
+|--------------|-------------------------------------|------------------------------------------|----------------------------------------------------------------------|
+| ADVANCE      |                                     | BY                                       | `ADVANCE BY`                                                         |
+| ALL          |                                     |                                          |                                                                      |
+| ANALYZE      |                                     |                                          |                                                                      |
+| AND          | logical AND operator                |                                          |                                                                      |
+| ARRAY        | one-indexed array of elements       |                                          |                                                                      |
+| AS           | alias a column, expression, or type |                                          |                                                                      |
+| AT           |                                     |                                          |                                                                      |
+| BEGINNING    |                                     | FROM                                     | `FROM BEGINNING`                                                     |
+| BETWEEN      | constrain a value to a range        |                                          |                                                                      |
+| BY           |                                     | GROUP, ADVANCE                           | `GROUP BY`, `ADVANCE BY`                                             |
+| CASE         | select a condition from expressions | WHEN                                     |                                                                      |
+| CAST         | change expression type              |                                          |                                                                      |
+| CATALOG      |                                     |                                          |                                                                      |
+| CHANGES      |                                     | EMIT                                     | `EMIT CHANGES`                                                       |
+| COLUMN       |                                     |                                          |                                                                      |
+| COLUMNS      |                                     |                                          |                                                                      |
+| CONNECTOR    |                                     |                                          |                                                                      |
+| CONNECTORS   |                                     |                                          |                                                                      |
+| CREATE       |                                     | STREAM, TABLE, CONNECTOR, TYPE           |                                                                      |
+| DATE         |                                     |                                          |                                                                      |
+| DAY          |                                     |                                          |                                                                      |
+| DAYS         |                                     |                                          |                                                                      |
+| DECIMAL      | decimal numeric type                |                                          |                                                                      |
+| DELETE       |                                     | TOPIC                                    | `[DELETE TOPIC]`                                                     |
+| DESCRIBE     | list details                        | STREAM, TABLE, CONNECTOR, TYPE, FUNCTION |                                                                      |
+| DISTINCT     |                                     |                                          |                                                                      |
+| DROP         | delete                              | STREAM, TABLE, CONNECTOR, TYPE           |                                                                      |
+| ELSE         |                                     | IF                                       |                                                                      |
+| EMIT         |                                     | CHANGES                                  | `EMIT CHANGES`                                                       |
+| END          |                                     | CASE                                     |                                                                      |
+| ESCAPE       |                                     |                                          |                                                                      |
+| EXISTS       |                                     | IF                                       | `[IF EXISTS]`                                                        |
+| EXPLAIN      | show execution plan                 |                                          |                                                                      |
+| EXPORT       |                                     |                                          |                                                                      |
+| EXTENDED     |                                     | SHOW, LIST, DESCRIBE                     |                                                                      |
+| FALSE        | Boolean value of FALSE              |                                          |                                                                      |
+| FINAL        |                                     |                                          |                                                                      |
+| FROM         |                                     | SELECT                                   | `SELECT * FROM users;`                                               |
+| FULL         |                                     | JOIN                                     |                                                                      |
+| FUNCTION     |                                     | SHOW, LIST, DESCRIBE                     |                                                                      |
+| FUNCTIONS    |                                     | SHOW, LIST, DESCRIBE                     |                                                                      |
+| GRACE        |                                     | PERIOD                                   | `WINDOW TUMBLING (SIZE 1 HOUR, GRACE PERIOD 2 HOURS)`                |
+| GROUP        |                                     | BY                                       | `GROUP BY`                                                           |
+| HAVING       | filter condition                    |                                          |                                                                      |
+| HOPPING      |                                     | WINDOW                                   | `WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 SECONDS)`            |
+| HOUR         |                                     |                                          |                                                                      |
+| HOURS        |                                     |                                          |                                                                      |
+| IF           |                                     |                                          |                                                                      |
+| IN           | specify multiple values             | WHERE                                    | `WHERE name IN (value1, value2, ...)`                                |
+| INNER        |                                     | JOIN                                     |                                                                      |
+| INSERT       |                                     | INTO, VALUES                             | `INSERT INTO stream_name ...`                                        |
+| INTEGER      | integer numeric type                |                                          |                                                                      |
+| INTERVAL     |                                     | PRINT                                    | `PRINT topicName INTERVAL interval 5`                                |
+| INTO         |                                     | INSERT                                   | `INSERT INTO stream_name ...`                                        |
+| IS           |                                     |                                          |                                                                      |
+| JOIN         | match records                       |                                          |                                                                      |
+| KEY          |                                     | PRIMARY                                  | `userId INT PRIMARY KEY`                                             |
+| LEFT         |                                     | JOIN                                     | `LEFT JOIN users ON pageviews.userid = users.userid`                 |
+| LIKE         |                                     | WHERE                                    | `WHERE UCASE(gender)='FEMALE' AND LCASE (regionid) LIKE '%_6'`       |
+| LIMIT        |                                     | SELECT                                   | `SELECT * FROM users EMIT CHANGES LIMIT 5;`                          |
+| LIST         |                                     |                                          |                                                                      |
+| LOAD         |                                     |                                          |                                                                      |
+| MAP          | `map` data type                     |                                          |                                                                      |
+| MATERIALIZED |                                     |                                          |                                                                      |
+| MILLISECOND  |                                     |                                          |                                                                      |
+| MILLISECONDS |                                     |                                          |                                                                      |
+| MINUTE       |                                     |                                          |                                                                      |
+| MINUTES      |                                     |                                          |                                                                      |
+| MONTH        |                                     |                                          |                                                                      |
+| MONTHS       |                                     |                                          |                                                                      |
+| NAMESPACE    |                                     |                                          |                                                                      |
+| NOT          | logical NOT operator                |                                          |                                                                      |
+| NULL         |                                     |                                          |                                                                      |
+| ON           |                                     | JOIN                                     | `LEFT JOIN users ON pageviews.userid = users.userid`                 |
+| OR           | logical OR operator                 |                                          |                                                                      |
+| OUTER        |                                     | JOIN                                     |                                                                      |
+| PARTITION    |                                     | BY                                       | `PARTITION BY key_field`                                             |
+| PARTITIONS   |                                     | CREATE                                   | `CREATE STREAM users_rekeyed WITH (PARTITIONS=6) AS ...`             |
+| PERIOD       |                                     | GRACE                                    |                                                                      |
+| PRIMARY      |                                     | KEY                                      |                                                                      |
+| PRINT        |                                     |                                          |                                                                      |
+| PROPERTIES   |                                     | LIST, SHOW                               | `SHOW PROPERTIES;`                                                   |
+| QUERIES      |                                     | LIST, SHOW                               | `SHOW QUERIES;`                                                      |
+| QUERY        |                                     |                                          |                                                                      |
+| RENAME       |                                     |                                          |                                                                      |
+| REPLACE      | string replace                      |                                          | `REPLACE(col1, 'foo', 'bar')`                                        |
+| RESET        |                                     |                                          |                                                                      |
+| RETENTION    |                                     | WINDOW                                   | `WINDOW TUMBLING (SIZE 30 SECONDS, RETENTION 1000 DAYS)`             |
+| RIGHT        |                                     |                                          |                                                                      |
+| RUN          |                                     | SCRIPT                                   | `RUN SCRIPT <path-to-query-file>;`                                   |
+| SAMPLE       |                                     |                                          |                                                                      |
+| SCRIPT       |                                     | RUN                                      | `RUN SCRIPT <path-to-query-file>;`                                   |
+| SECOND       |                                     |                                          |                                                                      |
+| SECONDS      |                                     |                                          |                                                                      |
+| SELECT       | query a stream or table             |                                          |                                                                      |
+| SESSION      |                                     | WINDOW                                   | `WINDOW SESSION (60 SECONDS)`                                        |
+| SET          | assign a property value             |                                          | `SET 'auto.offset.reset'='earliest';`                                |
+| SHOW         |                                     |                                          |                                                                      |
+| SINK         |                                     | CREATE CONNECTOR                         | `CREATE SINK CONNECTOR ...`                                          |
+| SIZE         |                                     | WINDOW                                   | `WINDOW TUMBLING (SIZE 5 SECONDS)`                                   |
+| SOURCE       |                                     | CREATE CONNECTOR                         | `CREATE SOURCE CONNECTOR ...`                                        |
+| STREAM       |                                     |                                          |                                                                      |
+| STREAMS      |                                     | LIST, SHOW                               | `SHOW STREAMS;`                                                      |
+| STRUCT       | struct data type                    |                                          |                                                                      |
+| TABLE        |                                     |                                          |                                                                      |
+| TABLES       |                                     | LIST, SHOW                               | `SHOW TABLES;`                                                       |
+| TERMINATE    | end a persistent query              |                                          | `TERMINATE query_id;`                                                |
+| THEN         |                                     | IF                                       |                                                                      |
+| TIME         |                                     |                                          |                                                                      |
+| TIMESTAMP    |                                     |                                          |                                                                      |
+| TO           |                                     |                                          |                                                                      |
+| TOPIC        |                                     |                                          |                                                                      |
+| TOPICS       |                                     | LIST, SHOW                               | `SHOW TOPICS;`                                                       |
+| TRUE         | Boolean value of TRUE               |                                          |                                                                      |
+| TUMBLING     |                                     | WINDOW                                   | `WINDOW TUMBLING (SIZE 5 SECONDS)`                                   |
+| TYPE         |                                     | CREATE, DROP                             | `CREATE TYPE <type_name> AS <type>;`                                 |
+| TYPES        |                                     | LIST, SHOW                               | `SHOW TYPES;`                                                        |
+| UNSET        | unassign a property value           |                                          | `UNSET 'auto.offset.reset';`                                         |
+| VALUES       |                                     | INSERT                                   | `INSERT INTO foo VALUES ('key', 'A');`                               |
+| VIEW         |                                     |                                          |                                                                      |
+| WHEN         |                                     | CASE                                     |                                                                      |
+| WHERE        |                                     | SELECT                                   | `SELECT * FROM pageviews WHERE pageid < 'Page_20'`                   |
+| WINDOW       |                                     | CREATE, SELECT                           | `SELECT userid, COUNT(*) FROM users WINDOW SESSION (60 SECONDS) ...` |
+| WITH         |                                     | CREATE                                   | `CREATE STREAM pageviews WITH (TIMESTAMP='viewtime', ...`            |
+| WITHIN       | use with windowed JOIN              | JOIN                                     | `SELECT * FROM impressions i JOIN clicks c WITHIN 1 minute ...`      |
+| YEAR         |                                     |                                          |                                                                      |
+| YEARS        |                                     |                                          |                                                                      |
+| ZONE         |                                     |                                          |                                                                      |
 
 
 


### PR DESCRIPTION
### Description 
First attempt at a table that collects all of the ksqlDB keywords. I scraped these from our ANTLR spec, and I suspect some of them aren't in play yet. The table is big enough that we might want it to have its own page. 