### PR TITLE
docs: add DROP TYPE [IF EXISTS] docs

### DIFF
--- a/docs/developer-guide/ksqldb-reference/drop-type.md
+++ b/docs/developer-guide/ksqldb-reference/drop-type.md
@@ -13,7 +13,7 @@ Synopsis
 --------
 
 ```sql
-DROP TYPE <type_name> AS <type>;
+DROP TYPE [IF EXISTS] <type_name> AS <type>;
 ```
 
 Description
@@ -25,6 +25,9 @@ statement doesn't track whether queries are using the type. This means that you
 can drop a type any time, and old queries continue to work. Also, old queries
 running with a dropped type and don't change if you register a new type with
 the same name.
+
+If the IF EXISTS clause is present, the statement doesn't fail if the
+type doesn't exist.
 
 Example
 -------

--- a/docs/developer-guide/ksqldb-reference/index.md
+++ b/docs/developer-guide/ksqldb-reference/index.md
@@ -47,7 +47,7 @@ keywords: ksqldb, api, reference, function, operator, metadata, connector, query
 ## Custom Types
 
 - [CREATE TYPE](create-type.md)
-- [DROP TYPE](drop-table.md)
+- [DROP TYPE](drop-type.md)
 - [SHOW TYPES](show-types.md)
 
 ## Metadata

--- a/docs/developer-guide/ksqldb-reference/quick-reference.md
+++ b/docs/developer-guide/ksqldb-reference/quick-reference.md
@@ -243,7 +243,7 @@ Remove a type alias from ksqlDB. For more information, see
 [DROP TYPE](../../ksqldb-reference/drop-type).
 
 ```sql
-DROP TYPE <type_name> AS <type>;
+DROP TYPE [IF EXISTS] <type_name> AS <type>;
 ```
 
 ## EMIT CHANGES


### PR DESCRIPTION
### Description 
KSQL added support for `DROP TYPE [IF EXISTS]` here: https://github.com/confluentinc/ksql/commit/431c2ff651a455d1c327616fa7f8bd005ffe79f4

This PR adds the new `IF EXISTS` reference in all the doc type docs.

### Testing done 
Not necessary

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

