### PR TITLE
docs: QTT readme fixes + add synthetic key topic to index (MINOR)

### DIFF
--- a/ksqldb-functional-tests/README.md
+++ b/ksqldb-functional-tests/README.md
@@ -65,8 +65,8 @@ The following is a template test file:
       "name": "my first positive test",
       "description": "an example positive test where the output is verified",
       "statements": [
-        "CREATE STREAM input (ID bigint KEY, NAME STRING) WITH (kafka_topic='input_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT ** FROM input WHERE id < 10;"
+        "CREATE STREAM input (ID BIGINT KEY, NAME STRING) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE STREAM output AS SELECT * FROM input WHERE id < 10;"
       ],
       "inputs": [
         {"topic": "input_topic", "key": 8, "value": {"name": "bob"}, "timestamp": 0},
@@ -80,7 +80,7 @@ The following is a template test file:
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "ID INT KEY, NAME STRING"}
+          {"name": "OUTPUT", "type": "stream", "schema": "ID BIGINT KEY, NAME STRING"}
         ]
       }
     },
@@ -92,14 +92,14 @@ The following is a template test file:
         "max": "5.4.1"
       },
       "statements": [
-        "CREATE STREAM test (ID name) WITH (kafka_topic='input_topic', value_format='JSON');",
-        "INSERT INTO test (name, number) VALUES ('foo', 45)",
-        "INSERT INTO test (name, number) VALUES ('bar', 646)",
-        "CREATE STREAM output AS SELECT value FROM test;"
+        "CREATE STREAM test (name VARCHAR KEY, number INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "INSERT INTO test (name, number) VALUES ('foo', 45);",
+        "INSERT INTO test (name, number) VALUES ('bar', 646);",
+        "CREATE STREAM output AS SELECT name, number FROM test;"
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "foo", "value": {"number": 45}},
-        {"topic": "OUTPUT", "key": 0, "value": {"number": 646}}
+        {"topic": "OUTPUT", "key": "foo", "value": {"NUMBER": 45}},
+        {"topic": "OUTPUT", "key": "bar", "value": {"NUMBER": 646}}
       ]
     },
     {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Join Index: developer-guide/joins/index.md
       - Joining collections: developer-guide/joins/join-streams-and-tables.md
       - Partitioning requirements: developer-guide/joins/partition-data.md
+      - Synthetic key columns: developer-guide/joins/synthetic-keys.md
     - Architecture: concepts/ksqldb-architecture.md
     - Time and Windows: concepts/time-and-windows-in-ksqldb-queries.md
     - Serialization: developer-guide/serialization.md


### PR DESCRIPTION
### Description 

Two miscellaneous docs changes:
- The example QTTs in the QTT README don't pass as written. This PR fixes the examples.
- The join synthetic keys topic (https://docs.ksqldb.io/en/0.10.1-ksqldb/developer-guide/joins/synthetic-keys/) isn't part of the docs index so the table of contents on the left (on the live page) shows the overview nav rather than more useful links. This PR fixes this by adding the topic to the docs index.

The synthetic-keys topic was introduced in 0.10.0, which is why this PR targets 6.0.x (aka 0.10.x). I'll cherry-pick to the live docs branches for 0.10.0, 0.10.1, and 0.11.0 once merged (and also 0.11.x for consistency).

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

