### PR TITLE
docs: cherry-pick: annotation function docs when funcs introduced (DOCS-5078)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@
 
 ### BREAKING CHANGES
 
+An associated [blog post](An associated blog post also covers many of these breaking changes: https://www.confluent.io/blog/ksqldb-0-10-updates-key-columns/) also covers many of these breaking changes.
+
 #### Any key name
 
 Statements containing PARTITION BY, GROUP BY, or JOIN clauses now produce different output schemas.

--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -8,6 +8,8 @@ keywords: ksqlDB, function, aggregate
 
 ## `AVG`
 
+Since: 0.6.0
+
 ```sql
 AVG(col1)
 ```
@@ -17,6 +19,8 @@ Stream, Table
 Return the average value for a given column.
 
 ## `COLLECT_LIST`
+
+Since: -
 
 ```sql
 COLLECT_LIST(col1)
@@ -37,8 +41,9 @@ first considering all the records from the first window, then the
 late-arriving record, then the records from the second window in
 the order they were originally processed.
 
-
 ## `COLLECT_SET`
+
+Since: -
 
 ```sql
 COLLECT_SET(col1)
@@ -59,8 +64,9 @@ first considering all the records from the first window, then the
 late-arriving record, then the records from the second window in
 the order they were originally processed.
 
-
 ## `COUNT`
+
+Since: -
 
 ```sql
 COUNT(col1)
@@ -79,6 +85,8 @@ number of rows.
 
 ## `COUNT_DISTINCT`
 
+Since: 0.7.0
+
 ```sql
 COUNT_DISTINCT(col1)
 ```
@@ -91,6 +99,8 @@ to estimate cardinalities of 10^9 with a typical standard error of 2%.
 
 ## `EARLIEST_BY_OFFSET`
 
+Since: 0.10.0
+
 ```sql
 EARLIEST_BY_OFFSET(col1)
 ```
@@ -100,8 +110,9 @@ Stream
 Return the earliest value for a given column. Earliest here is defined as the value in the partition
 with the lowest offset. Rows that have `col1` set to null are ignored.
 
-
 ## `HISTOGRAM`
+
+Since: -
 
 ```sql
 HISTOGRAM(col1)
@@ -123,6 +134,8 @@ the order they were originally processed.
 
 ## `LATEST_BY_OFFSET`
 
+Since: 0.8.0
+
 ```sql
 LATEST_BY_OFFSET(col1)
 ```
@@ -133,6 +146,8 @@ Return the latest value for a given column. Latest here is defined as the value 
 with the greatest offset. Rows that have `col1` set to null are ignored.
 
 ## `MAX`
+
+Since: -
 
 ```sql
 MAX(col1)
@@ -145,6 +160,8 @@ Rows that have `col1` set to null are ignored.
 
 ## `MIN`
 
+Since: -
+
 ```sql
 MIN(col1)
 ```
@@ -155,6 +172,8 @@ Return the minimum value for a given column and window.
 Rows that have `col1` set to null are ignored.
 
 ## `SUM`
+
+Since: -
 
 ```sql
 SUM(col1)
@@ -167,6 +186,8 @@ Rows that have `col1` set to null are ignored.
 
 ## `TOPK`
 
+Since: -
+
 ```sql
 TOPK(col1, k)
 ```
@@ -177,6 +198,8 @@ Return the Top *K* values for the given column and window
 Rows that have `col1` set to null are ignored.
 
 ## `TOPKDISTINCT`
+
+Since: -
 
 ```sql
 TOPKDISTINCT(col1, k)

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -10,6 +10,8 @@ keywords: ksqlDB, function, scalar
 
 ### `ABS`
 
+Since: -
+
 ```sql
 ABS(col1)
 ```
@@ -17,6 +19,8 @@ ABS(col1)
 The absolute value of a value.
 
 ### `AS_VALUE`
+
+Since: 0.9.0
 
 ```sql
 AS_VALUE(keyCol)
@@ -38,6 +42,8 @@ CREATE TABLE AGG AS
 
 ### `CEIL`
 
+Since: -
+
 ```sql
 CEIL(col1)
 ```
@@ -45,6 +51,8 @@ CEIL(col1)
 The ceiling of a value.
 
 ### `ENTRIES`
+
+Since: 0.6.0
 
 ```sql
 ENTRIES(map MAP, sorted BOOLEAN)
@@ -58,6 +66,8 @@ If `sorted` is true, the entries are sorted by key.
 
 ### `EXP`
 
+Since: 0.6.0
+
 ```sql
 EXP(col1)
 ```
@@ -66,6 +76,8 @@ The exponential of a value.
 
 ### `FLOOR`
 
+Since: -
+
 ```sql
 FLOOR(col1)
 ```
@@ -73,6 +85,8 @@ FLOOR(col1)
 The floor of a value.
 
 ### `GENERATE_SERIES`
+
+Since: 0.6.0
 
 ```sql
 GENERATE_SERIES(start, end)
@@ -91,6 +105,8 @@ If not supplied, `step` defaults to `1`. Parameter `step` must be an `INT`.
 
 ### `GEO_DISTANCE`
 
+Since: 0.6.0
+
 ```sql
 GEO_DISTANCE(lat1, lon1, lat2, lon2, unit)
 ```
@@ -101,6 +117,8 @@ in decimal degrees. An optional final parameter specifies `KM`
 
 ### `LN`
 
+Since: 0.6.0
+
 ```sql
 LN(col1)
 ```
@@ -109,6 +127,8 @@ The natural logarithm of a value.
 
 ### `RANDOM`
 
+Since: -
+
 ```sql
 RANDOM()
 ```
@@ -116,6 +136,8 @@ RANDOM()
 Return a random DOUBLE value between 0.0 and 1.0.
 
 ### `ROUND`
+
+Since: 0.6.0
 
 ```sql
 ROUND(col1)
@@ -137,6 +159,8 @@ it defaults to zero.
 
 ### `SIGN`
 
+Since: 0.6.0
+
 ```sql
 SIGN(col1)
 ```
@@ -150,6 +174,8 @@ The sign of a numeric value as an INTEGER:
 
 ### `SQRT`
 
+Since: 0.6.0
+
 ```sql
 SQRT(col1)
 ```
@@ -160,6 +186,8 @@ The square root of a value.
 
 ### `ARRAY`
 
+Since: 0.7.0
+
 ```sql
 ARRAY[col1, col2, ...]
 ```
@@ -167,6 +195,8 @@ ARRAY[col1, col2, ...]
 Construct an array from a variable number of inputs.
 
 ### `ARRAY_CONTAINS`
+
+Since: 0.6.0
 
 ```sql
 ARRAY_CONTAINS(ARRAY[1, 2, 3], 3)
@@ -177,6 +207,8 @@ Given an array, checks if a search value is contained in the array.
 Accepts any `ARRAY` type. The type of the second param must match the element type of the `ARRAY`.
 
 ### `ARRAY_DISTINCT`
+
+Since: 0.10.0
 
 ```sql
 ARRAY_DISTINCT([1, 2, 3])
@@ -195,6 +227,8 @@ ARRAY_DISTINCT(ARRAY['apple', 'apple', NULL, 'cherry'])  => ['apple', NULL, 'che
 
 ### `ARRAY_EXCEPT`
 
+Since: 0.10.0
+
 ```sql
 ARRAY_EXCEPT(array1, array2)
 ```
@@ -210,6 +244,8 @@ ARRAY_EXCEPT(ARRAY['apple', 'apple', NULL, 'cherry'], ARRAY['cherry'])  => ['app
 ```
 
 ### `ARRAY_INTERSECT`
+
+Since: 0.10.0
 
 ```sql
 ARRAY_INTERSECT(array1, array2)
@@ -227,6 +263,8 @@ ARRAY_INTERSECT(ARRAY['apple', 'apple', NULL, 'cherry'], ARRAY['apple'])  => ['a
 
 ### `ARRAY_JOIN`
 
+Since: 0.10.0
+
 ```sql
 ARRAY_JOIN(col1, delimiter)
 ```
@@ -238,6 +276,8 @@ allows for array elements of primitive ksqlDB types.
 
 ### `ARRAY_LENGTH`
 
+Since: 0.8.0
+
 ```sql
 ARRAY_LENGTH(ARRAY[1, 2, 3])
 ```
@@ -247,6 +287,8 @@ Given an array, return the number of elements in the array.
 If the supplied parameter is NULL the method returns NULL.
 
 ### `ARRAY_MAX`
+
+Since: 0.10.0
 
 ```sql
 ARRAY_MAX(['foo', 'bar', 'baz'])
@@ -263,6 +305,8 @@ If the array field is NULL, or contains only NULLs, then NULL is returned.
 
 ### `ARRAY_MIN`
 
+Since: 0.10.0
+
 ```sql
 ARRAY_MIN(['foo', 'bar', 'baz'])
 ```
@@ -277,6 +321,8 @@ Array entries are compared according to their natural sort order, which sorts th
 If the array field is NULL, or contains only NULLs, then NULL is returned.
 
 ### `ARRAY_REMOVE`
+
+Since: 0.11.0
 
 ```sql
 ARRAY_REMOVE(array, element)
@@ -293,6 +339,8 @@ Examples:
 If the array field is NULL then NULL is returned.
 
 ### `ARRAY_SORT`
+
+Since: 0.10.0
 
 ```sql
 ARRAY_SORT(['foo', 'bar', 'baz'], 'ASC|DESC')
@@ -311,6 +359,8 @@ An optional second parameter can be used to specify whether to sort the elements
 
 ### `ARRAY_UNION`
 
+Since: 0.10.0
+
 ```sql
 ARRAY_UNION(array1, array2)
 ```
@@ -327,6 +377,8 @@ ARRAY_UNION(ARRAY['apple', 'apple', NULL, 'cherry'], ARRAY['cherry'])  => ['appl
 
 ### `AS_MAP`
 
+Since: 0.6.0
+
 ```sql
 AS_MAP(keys, vals)
 ```
@@ -334,6 +386,8 @@ AS_MAP(keys, vals)
 Construct a map from a list of keys and a list of values.
 
 ### `ELT`
+
+Since: 0.6.0
 
 ```sql
 ELT(n INTEGER, args VARCHAR[])
@@ -345,6 +399,8 @@ the complement to FIELD.
 
 ### `FIELD`
 
+Since: 0.6.0
+
 ```sql
 FIELD(str VARCHAR, args VARCHAR[])
 ```
@@ -354,6 +410,8 @@ If `str` is NULL, the return value is 0, because NULL is not considered
 to be equal to any value. FIELD is the complement to ELT.
 
 ### `JSON_ARRAY_CONTAINS`
+
+Since: 0.6.0
 
 ```sql
 JSON_ARRAY_CONTAINS('[1, 2, 3]', 3)
@@ -365,6 +423,8 @@ Returns `false` if the first parameter does not contain a JSON array.
 
 ### `MAP`
 
+Since: 0.7.0
+
 ```sql
 MAP(key VARCHAR := value, ...)
 ```
@@ -372,6 +432,8 @@ MAP(key VARCHAR := value, ...)
 Construct a map from specific key-value tuples.
 
 ### `MAP_KEYS`
+
+Since: 0.10.0
 
 ```sql
 MAP_KEYS(a_map)
@@ -388,6 +450,8 @@ map_keys( map('apple' := 10, 'banana' := 20) )  => ['apple', 'banana']
 
 ### `MAP_VALUES`
 
+Since: 0.10.0
+
 ```sql
 MAP_VALUES(a_map)
 ```
@@ -402,6 +466,8 @@ map_values( map('apple' := 10, 'banana' := 20) )  => [10, 20]
 ```
 
 ### `MAP_UNION`
+
+Since: 0.10.0
 
 ```sql
 MAP_UNION(map1, map2)
@@ -420,6 +486,8 @@ map_union( map('apple' := 10, 'banana' := 20), map('apple' := 50) )  => ['apple'
 
 ### `SLICE`
 
+Since: 0.6.0
+
 ```sql
 SLICE(col1, from, to)
 ```
@@ -430,6 +498,8 @@ include both endpoints.
 ## Strings
 
 ### `CHR`
+
+Since: 0.10.0
 
 ```sql
 CHR(decimal_code | utf_string)
@@ -451,6 +521,8 @@ CHR('\u597d')  => '好'
 
 ### `CONCAT`
 
+Since: -
+
 ```sql
 CONCAT(col1, col2, 'hello', ..., col-n)
 ```
@@ -458,6 +530,8 @@ CONCAT(col1, col2, 'hello', ..., col-n)
 Concatenate two or more string expressions. Any input strings which evaluate to NULL are replaced with empty string in the output.
 
 ### `CONCAT_WS`
+
+Since: 0.10.0
 
 ```sql
 CONCAT_WS(separator, expr1, expr2, ...)
@@ -475,6 +549,8 @@ CONCAT_WS(', ', 'apple', 'banana', NULL, 'date')  ->  'apple, banana, date'
 
 ### `ENCODE`
 
+Since: 0.10.0
+
 ```sql
 ENCODE(col1, input_encoding, output_encoding)
 ```
@@ -485,6 +561,8 @@ Given a STRING that is encoded as `input_encoding`, encode it using the `output_
 For example, to encode a string in `hex` to `utf8`, use `ENCODE(string, 'hex', 'utf8')`.
 
 ### `EXTRACTJSONFIELD`
+
+Since: -
 
 ```sql
 EXTRACTJSONFIELD(message, '$.log.cloud')
@@ -526,6 +604,8 @@ instance number from the above JSON object as a INT.
 
 ### `INITCAP`
 
+Since: 0.6.0
+
 ```sql
 INITCAP(col1)
 ```
@@ -534,6 +614,8 @@ Capitalize the first letter in each word and convert all other letters
 to lowercase. Words are delimited by whitespace.
 
 ### `INSTR`
+
+Since: 0.10.0
 
 ```sql
 INSTR(string, substring, [position], [occurrence])
@@ -561,6 +643,8 @@ INSTR('CORPORATE FLOOR', 'MISSING') -> 0
 
 ### `LCASE`
 
+Since: -
+
 ```sql
 LCASE(col1)
 ```
@@ -569,6 +653,8 @@ Convert a string to lowercase.
 
 ### `LEN`
 
+Since: -
+
 ```sql
 LEN(col1)
 ```
@@ -576,6 +662,8 @@ LEN(col1)
 The length of a string.
 
 ### `LPAD`
+
+Since: 0.10.0
 
 ```sql
 LPAD(input, length, padding)
@@ -596,6 +684,8 @@ LPAD('123', 5, '0')  => '00123'
 
 ### `MASK`
 
+Since: 0.6.0
+
 ```sql
 MASK(col1, 'X', 'x', 'n', '-')
 ```
@@ -615,6 +705,8 @@ all default masks. `MASK("My Test $123", '*', NULL, '1', NULL)` will yield
 
 ### `MASK_KEEP_LEFT`
 
+Since: 0.6.0
+
 ```sql
 MASK_KEEP_LEFT(col1, numChars, 'X', 'x', 'n', '-')
 ```
@@ -626,6 +718,8 @@ For example: `MASK_KEEP_LEFT("My Test $123", 4)`
 will return `My Txxx--nnn`.
 
 ### `MASK_KEEP_RIGHT`
+
+Since: 0.6.0
 
 ```sql
 MASK_KEEP_RIGHT(col1, numChars, 'X', 'x', 'n', '-')
@@ -639,6 +733,8 @@ will return `Xx-Xxxx-$123`.
 
 ### `MASK_LEFT`
 
+Since: 0.6.0
+
 ```sql
 MASK_LEFT(col1, numChars, 'X', 'x', 'n', '-')
 ```
@@ -650,6 +746,8 @@ For example, `MASK_LEFT("My Test $123", 4)`
 will return `Xx-Xest $123`.
 
 ### `MASK_RIGHT`
+
+Since: 0.6.0
 
 ```sql
 MASK_RIGHT(col1, numChars, 'X', 'x', 'n', '-')
@@ -663,6 +761,8 @@ will return `My Test -nnn`.
 
 ### `REPLACE`
 
+Since: 0.6.0
+
 ```sql
 REPLACE(col1, 'foo', 'bar')
 ```
@@ -670,6 +770,8 @@ REPLACE(col1, 'foo', 'bar')
 Replace all instances of a substring in a string with a new string.
 
 ### `REGEXP_EXTRACT`
+
+Since: 0.8.0
 
 ```sql
 REGEXP_EXTRACT('.*', col1)
@@ -689,6 +791,8 @@ returns "there".
 
 ### `REGEXP_EXTRACT_ALL`
 
+Since: 0.10.0
+
 ```sql
 REGEXP_EXTRACT_ALL('.*', col1)
 ```
@@ -707,6 +811,8 @@ returns `['there', 'day']`.
 
 ### `REGEXP_REPLACE`
 
+Since: 0.10.0
+
 ```sql
 REGEXP_REPLACE(col1, 'a.b+', 'bar')
 ```
@@ -716,6 +822,8 @@ If either the input string, regular expression, or new string is null,
 the result is null.
 
 ### `REGEXP_SPLIT_TO_ARRAY`
+
+Since: 0.10.0
 
 ```sql
 REGEXP_SPLIT_TO_ARRAY(col1, 'a.b+')
@@ -735,6 +843,8 @@ then an empty element is added to the array.
 
 ### `RPAD`
 
+Since: 0.10.0
+
 ```sql
 RPAD(input, length, padding)
 ```
@@ -751,6 +861,8 @@ RPAD('', 2, 'Bar')  =>  'Ba'
 ```
 
 ### `SPLIT`
+
+Since: 0.6.0
 
 ```sql
 SPLIT(col1, delimiter)
@@ -770,6 +882,8 @@ then an empty space is added to the array.
 
 ### `SPLIT_TO_MAP`
 
+Since: 0.10.0
+
 ```sql
 SPLIT_TO_MAP(input, entryDelimiter, kvDelimiter)
 ```
@@ -786,6 +900,8 @@ SPLIT_TO_MAP('apple':='green'/'cherry':='red', '/', ':=')  => { 'apple':'green',
 ```
 
 ### `SUBSTRING`
+
+Since: -
 
 ```sql
 SUBSTRING(col1, 2, 5)
@@ -805,6 +921,8 @@ returns "stre".
 
 ### `TRIM`
 
+Since: -
+
 ```sql
 TRIM(col1)
 ```
@@ -813,6 +931,8 @@ Trim the spaces from the beginning and end of a string.
 
 ### `UCASE`
 
+Since: -
+
 ```sql
 UCASE(col1)
 ```
@@ -820,6 +940,8 @@ UCASE(col1)
 Convert a string to uppercase.
 
 ### `UUID`
+
+Since: 0.10.0
 
 ```sql
 UUID()
@@ -833,6 +955,8 @@ as a string of five hexadecimal numbers _aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee_.
 
 ### `COALESCE`
 
+Since: 0.9.0
+
 ```sql
 COALESCE(a, b, c, d)
 ```
@@ -843,6 +967,8 @@ Where the parameter type is a complex type, for example `ARRAY` or `STRUCT`, the
 complex type are not inspected. The behaviour is the same: the first NOT NULL element is returned.
 
 ### `IFNULL`
+
+Since: -
 
 ```sql
 IFNULL(expression, altValue)
@@ -857,6 +983,8 @@ complex type are not inspected.
 
 ### `UNIX_DATE`
 
+Since: 0.6.0
+
 ```sql
 UNIX_DATE()
 ```
@@ -866,6 +994,8 @@ may differ depending on the local time of different ksqlDB Server instances.
 
 ### `UNIX_TIMESTAMP`
 
+Since: 0.6.0
+
 ```sql
 UNIX_TIMESTAMP()
 ```
@@ -874,6 +1004,8 @@ Gets the Unix timestamp in milliseconds, represented as a BIGINT. The returned
 timestamp may differ depending on the local time of different ksqlDB Server instances.
 
 ### `DATETOSTRING`
+
+Since: -
 
 ```sql
 DATETOSTRING(START_DATE, 'yyyy-MM-dd')
@@ -887,6 +1019,8 @@ The integer represents days since epoch matching the encoding used by
 
 ### `STRINGTODATE`
 
+Since: -
+
 ```sql
 STRINGTODATE(col1, 'yyyy-MM-dd')
 ```
@@ -898,6 +1032,8 @@ format can be escaped with two successive single
 quotes, `''`, for example: `'yyyy-MM-dd''T'''`.
 
 ### `STRINGTOTIMESTAMP`
+
+Since: -
 
 ```sql
 STRINGTOTIMESTAMP(col1, 'yyyy-MM-dd HH:mm:ss.SSS' [, TIMEZONE])
@@ -917,6 +1053,8 @@ more information on timestamp formats, see
 [DateTimeFormatter](https://cnfl.io/java-dtf).    
 
 ### `TIMESTAMPTOSTRING`
+
+Since: -
 
 ```sql
 TIMESTAMPTOSTRING(ROWTIME, 'yyyy-MM-dd HH:mm:ss.SSS' [, TIMEZONE])
@@ -949,6 +1087,8 @@ more information on timestamp formats, see
 URL_DECODE_PARAM(col1)
 ```
 
+Since: 0.6.0
+
 Unescapes the `URL-param-encoded`_ value in `col1`. This is the inverse of
 `URL_ENCODE_PARAM`.
 
@@ -960,6 +1100,8 @@ Unescapes the `URL-param-encoded`_ value in `col1`. This is the inverse of
 ```sql
 URL_ENCODE_PARAM(col1)
 ```
+
+Since: 0.6.0
 
 Escapes the value of `col1` such that it can
 safely be used in URL query parameters. Note that
@@ -974,6 +1116,8 @@ in the path portion of a URL.
 ```sql
 URL_EXTRACT_FRAGMENT(url)
 ```
+
+Since: 0.6.0
 
 Extract the fragment portion of the specified
 value. Returns NULL if `url` is not a valid URL
@@ -992,6 +1136,8 @@ value will be decoded.
 URL_EXTRACT_HOST(url)
 ```
 
+Since: 0.6.0
+
 Extract the host-name portion of the specified
 value. Returns NULL if the `url` is not a valid  
 URI according to RFC-2396.                       
@@ -1000,6 +1146,8 @@ URI according to RFC-2396.
 - Output: `test.com`                               
 
 ### `URL_EXTRACT_PARAMETER`
+
+Since: 0.6.0
 
 ```sql
 URL_EXTRACT_PARAMETER(url, parameter_name)
@@ -1027,6 +1175,8 @@ URL as a single string, see `URL_EXTRACT_QUERY.`
 URL_EXTRACT_PATH(url)
 ```
 
+Since: 0.6.0
+
 Extracts the path from `url`.
 Returns NULL if `url` is not a valid URI but  
 returns an empty string if the path is empty. 
@@ -1039,6 +1189,8 @@ returns an empty string if the path is empty.
 ```sql
 URL_EXTRACT_PORT(url)
 ```
+
+Since: 0.6.0
 
 Extract the port number from `url`.
 Returns NULL if `url` is not a valid URI or does
@@ -1053,6 +1205,8 @@ not contain an explicit port number.
 URL_EXTRACT_PROTOCOL(url)
 ```
 
+Since: 0.6.0
+
 Extract the protocol from `url`. Returns NULL if
 `url` is an invalid URI or has no protocol.
                                            
@@ -1060,6 +1214,8 @@ Extract the protocol from `url`. Returns NULL if
 - Output: `http`                             
 
 ### `URL_EXTRACT_QUERY`
+
+Since: 0.6.0
 
 ```sql
 URL_EXTRACT_QUERY(url)

--- a/docs/developer-guide/ksqldb-reference/table-functions.md
+++ b/docs/developer-guide/ksqldb-reference/table-functions.md
@@ -94,6 +94,8 @@ Would give:
 
 ### `CUBE`
 
+Since: 0.7.0
+
 ```sql
 cube_explode(array[col1, ..., colN])
 ```
@@ -105,6 +107,8 @@ It produces `2^d` new rows where `d` is the number of columns given as parameter
 Duplicate entries for columns with null value are skipped.
 
 ### `EXPLODE`
+
+Since: 0.6.0
 
 ```sql
 EXPLODE(col1)


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/5954.

Adds a 'Since' field to each function reference indicating which community release the method was introduced in.

Partital fix for https://github.com/confluentinc/ksql/issues/5900.

Co-authored-by: Andy Coates <big-andy-coates@users.noreply.github.com>

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

