### PR TITLE
test: parsing for SQL-driven testing tool

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/NodeLocation.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.parser;
 
 import com.google.errorprone.annotations.Immutable;
+import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
@@ -50,5 +51,25 @@ public final class NodeLocation {
   @Override
   public String toString() {
     return String.format("Line: %d, Col: %d", line, charPositionInLine + 1);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final NodeLocation that = (NodeLocation) o;
+    return line == that.line
+        && charPositionInLine == that.charPositionInLine;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(line, charPositionInLine);
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/DirectiveParser.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/DirectiveParser.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.parser;
+
+import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.ParsingException;
+import io.confluent.ksql.test.parser.TestDirective.Type;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.antlr.v4.runtime.Token;
+
+public final class DirectiveParser {
+
+  static final Pattern DIRECTIVE_REGEX = Pattern.compile(
+      "--@(?<type>[a-zA-Z.]+):\\s*(?<contents>.*)"
+  );
+
+  private DirectiveParser() {
+  }
+
+  public static TestDirective parse(final Token comment) {
+    final NodeLocation loc = new NodeLocation(comment.getLine(), comment.getCharPositionInLine());
+    final Matcher matcher = DIRECTIVE_REGEX.matcher(comment.getText().trim());
+    if (!matcher.find()) {
+      throw new ParsingException(
+          "Expected directive matching pattern " + DIRECTIVE_REGEX + " but got " + comment,
+          null,
+          loc.getLineNumber(),
+          loc.getColumnNumber()
+      );
+    }
+
+    final Type type = Type.from(matcher.group("type").toLowerCase());
+    final String contents = matcher.group("contents");
+
+    return new TestDirective(type, contents, loc);
+  }
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.parser;
+
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.parser.AstBuilder;
+import io.confluent.ksql.parser.CaseInsensitiveStream;
+import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.parser.ParsingException;
+import io.confluent.ksql.parser.SqlBaseLexer;
+import io.confluent.ksql.parser.SqlBaseParser;
+import io.confluent.ksql.parser.SqlBaseParser.TestStatementContext;
+import java.util.Iterator;
+import java.util.Objects;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
+
+/**
+ * The {@code SqlTestReader} is an iterator over a test case that will return
+ * one test statement to execute at a time.
+ *
+ * <p>Since some test directives are not part of the ksqlDB grammar and are
+ * handled via non-default ANTLR channels, this parser has a more complex
+ * iteration. Specifically, the reader uses the {@code SqlBaseParser} to read
+ * statements, but checks to see if any directives were skipped in the underlying
+ * hidden channels.</p>
+ */
+public class SqlTestReader implements Iterator<TestStatement> {
+
+  private static final BaseErrorListener ERROR_LISTENER = new BaseErrorListener() {
+    @Override
+    public void syntaxError(
+        final Recognizer<?, ?> recognizer,
+        final Object offendingSymbol,
+        final int line,
+        final int charPositionInLine,
+        final String message,
+        final RecognitionException e
+    ) {
+      throw new ParsingException(message, e, line, charPositionInLine);
+    }
+  };
+
+  private final SqlBaseParser parser;
+  private final CommonTokenStream tks;
+  private final KsqlExecutionContext engine;
+
+  /* indicates the latest index in tks that has been scanned for directives */
+  private int directiveIdx = 0;
+
+  /* whether or not a statement has been read, but not yet returned */
+  private boolean cachedStatement = false;
+  private TestStatementContext testStatement;
+
+  /**
+   * @param testCase the test case
+   * @param engine   the ksqlDB engine, used to prepare statements
+   */
+  public SqlTestReader(final String testCase, final KsqlExecutionContext engine) {
+    this.engine = Objects.requireNonNull(engine, "engine");
+
+    Objects.requireNonNull(testCase, "testCase");
+    if (testCase.isEmpty()) {
+      throw new IllegalArgumentException("Expected nonempty test case.");
+    }
+
+    final SqlBaseLexer lexer = new SqlBaseLexer(
+        new CaseInsensitiveStream(CharStreams.fromString(testCase)));
+    lexer.removeErrorListeners();
+    lexer.addErrorListener(ERROR_LISTENER);
+
+    tks = new CommonTokenStream(lexer);
+
+    parser = new SqlBaseParser(tks);
+    parser.removeErrorListeners();
+    parser.addErrorListener(ERROR_LISTENER);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return cachedStatement
+        || !parser.isMatchedEOF()
+        || hasMoreDirectives();
+  }
+
+  private boolean hasMoreDirectives() {
+    for (int i = 0; directiveIdx + i < tks.size(); i++) {
+      if (tks.get(directiveIdx + i).getChannel() == SqlBaseLexer.DIRECTIVES) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public TestStatement next() {
+    // because the parser skips over non-default (SqlBaseLexer.DIRECTIVES) channels,
+    // we need to first get the next test statement and then check if we "skipped"
+    // over any comments that contain directives. if we find any directives, we
+    // cache the statement that the parser read and hold off on returning it
+    if (!cachedStatement && !parser.isMatchedEOF()) {
+      testStatement = parser.testStatement(); // advances the token stream
+      cachedStatement = true;
+    }
+
+    // if there's no cachedStatement at this point, we've hit EOF
+    final int currIdx = cachedStatement ? testStatement.getStart().getTokenIndex() : tks.size();
+    while (directiveIdx < currIdx) {
+      final Token tok = tks.get(directiveIdx++);
+      if (tok.getChannel() == SqlBaseLexer.DIRECTIVES) {
+        return TestStatement.of(TestDirective.parse(tok));
+      }
+    }
+
+    cachedStatement = false;
+    if (testStatement.singleStatement() != null) {
+      return TestStatement.of(
+          engine.prepare(DefaultKsqlParser.parsedStatement(testStatement.singleStatement()))
+      );
+    }
+
+    if (testStatement.assertStatement() != null) {
+      return TestStatement.of(
+          new AstBuilder(engine.getMetaStore())
+              .buildAssertStatement(testStatement.assertStatement())
+      );
+    }
+
+    throw new IllegalStateException("Unexpected parse tree for statement " + testStatement);
+  }
+
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.test.parser;
 
-import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.parser.AstBuilder;
 import io.confluent.ksql.parser.CaseInsensitiveStream;
@@ -47,7 +46,7 @@ import org.antlr.v4.runtime.Token;
  * statements, but checks to see if any directives were skipped in the underlying
  * hidden channels.</p>
  */
-public class SqlTestReader implements Iterator<TestStatement> {
+public final class SqlTestReader implements Iterator<TestStatement> {
 
   private static final BaseErrorListener ERROR_LISTENER = new BaseErrorListener() {
     @Override
@@ -62,9 +61,6 @@ public class SqlTestReader implements Iterator<TestStatement> {
       throw new ParsingException(message, e, line, charPositionInLine);
     }
   };
-
-  private static final Pattern TEST_DIRECTIVE_REGEX =
-      Pattern.compile("(?m)^--@test:\\s*(?<name>.*)$");
 
   private final SqlBaseParser parser;
   private final CommonTokenStream tks;
@@ -138,7 +134,7 @@ public class SqlTestReader implements Iterator<TestStatement> {
     while (directiveIdx < currIdx) {
       final Token tok = tks.get(directiveIdx++);
       if (tok.getChannel() == SqlBaseLexer.DIRECTIVES) {
-        return TestStatement.of(TestDirective.parse(tok));
+        return TestStatement.of(DirectiveParser.parse(tok));
       }
     }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestDirective.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestDirective.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.parser;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Functions;
+import io.confluent.ksql.parser.ParsingException;
+import io.confluent.ksql.parser.SqlBaseLexer;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.antlr.v4.runtime.Token;
+
+/**
+ * A test directive indicates special handling of test-only metadata. The
+ * directive is specified in the test sql file as a single-line comment that
+ * begins with * {@code --@} and the directive type and contents are separated
+ * by a colon. The type must contain only letters and "." characters.
+ *
+ * <p>For example, tests are delimited using the {@code TEST} directive, which
+ * would be specified in a file using {@code --@test: name}. The directive types
+ * are case-insensitive.</p>
+ *
+ * <p>The ANTLR grammar that parses comments will handle directives differently
+ * from normal comments, and will send them to the {@link SqlBaseLexer#DIRECTIVES}
+ * channel. See {@link SqlTestReader} for more handling of directives.</p>
+ */
+public class TestDirective {
+
+  static final Pattern DIRECTIVE_REGEX = Pattern.compile(
+      "--@(?<type>[a-zA-Z.]+):\\s*(?<contents>.*)"
+  );
+
+  private final Type type;
+  private final String contents;
+
+  public static TestDirective parse(final Token comment) {
+    final Matcher matcher = DIRECTIVE_REGEX.matcher(comment.getText().trim());
+    if (!matcher.find()) {
+      throw new ParsingException(
+          "Expected directive matching pattern " + DIRECTIVE_REGEX + " but got " + comment,
+          null,
+          comment.getLine(),
+          comment.getCharPositionInLine()
+      );
+    }
+
+    final Type type = Type.from(matcher.group("type").toLowerCase());
+    final String contents = matcher.group("contents");
+
+    return new TestDirective(type, contents);
+  }
+
+  @VisibleForTesting
+  TestDirective(final Type type, final String contents) {
+    this.type = Objects.requireNonNull(type, "type");
+    this.contents = Objects.requireNonNull(contents, "contents");
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public String getContents() {
+    return contents;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final TestDirective that = (TestDirective) o;
+    return type == that.type
+        && Objects.equals(contents, that.contents);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, contents);
+  }
+
+  @Override
+  public String toString() {
+    return "TestDirective{"
+        + "type=" + type
+        + ", contents='" + contents + '\''
+        + '}';
+  }
+
+  public enum Type {
+    TEST("test"),
+    EXPECTED_ERROR("expected.error"),
+    EXPECTED_MESSAGE("expected.message"),
+    UNKNOWN("UNKNOWN")
+    ;
+
+    private static final Map<String, Type> NAME_MAP = Arrays
+        .stream(Type.values())
+        .collect(Collectors.toMap(Type::getTypeName, Functions.identity()));
+
+    private final String typeName;
+
+    Type(final String typeName) {
+      this.typeName = Objects.requireNonNull(typeName, "typeName");
+    }
+
+    public String getTypeName() {
+      return typeName;
+    }
+
+    public static Type from(final String typeName) {
+      return NAME_MAP.getOrDefault(typeName, UNKNOWN);
+    }
+  }
+
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestStatement.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestStatement.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.parser;
+
+import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.AssertStatement;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * A single line of a test execution. A {@code TestStatement} can consist of
+ * either:
+ * <ul>
+ *   <li> a {@link ParsedStatement}, which will issue an update to the ksqlDB, or </li>
+ *   <li> an {@link AssertStatement}, which will ensure data is accurate, or </li>
+ *   <li> a {@link TestDirective}, which will ensure some metadata on the test </li>
+ * </ul>
+ */
+public final class TestStatement {
+
+  private final PreparedStatement<?> engineStatement;
+  private final AssertStatement<?> assertStatement;
+  private final TestDirective directive;
+
+  public static TestStatement of(final PreparedStatement<?> engineStatement) {
+    return new TestStatement(engineStatement, null, null);
+  }
+
+  public static TestStatement of(final AssertStatement<?> assertStatement) {
+    return new TestStatement(null, assertStatement, null);
+  }
+
+  public static TestStatement of(final TestDirective directive) {
+    return new TestStatement(null, null, directive);
+  }
+
+  private TestStatement(
+      final PreparedStatement<?> engineStatement,
+      final AssertStatement<?> assertStatement,
+      final TestDirective directive
+  ) {
+    this.engineStatement = engineStatement;
+    this.assertStatement = assertStatement;
+    this.directive = directive;
+
+    final boolean exactlyOne = Stream.of(engineStatement, assertStatement, directive)
+        .filter(Objects::nonNull)
+        .count() == 1;
+
+    if (!exactlyOne) {
+      throw new IllegalStateException(String.format(
+          "Expected exactly one of engine, assert or directive statement. Got (%s, %s, %s).",
+          engineStatement,
+          assertStatement,
+          directive));
+    }
+  }
+
+  public boolean hasEngineStatement() {
+    return engineStatement != null;
+  }
+
+  public PreparedStatement<?> getEngineStatement() {
+    if (!hasEngineStatement()) {
+      throw new NoSuchElementException("engineStatement");
+    }
+
+    return engineStatement;
+  }
+
+  public boolean hasAssertStatement() {
+    return assertStatement != null;
+  }
+
+  public AssertStatement<?> getAssertStatement() {
+    if (!hasAssertStatement()) {
+      throw new NoSuchElementException("assertStatement");
+    }
+
+    return assertStatement;
+  }
+
+  public boolean hasDirective() {
+    return directive != null;
+  }
+
+  public TestDirective getDirective() {
+    if (!hasDirective()) {
+      throw new NoSuchElementException("directive");
+    }
+
+    return directive;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TestStatement that = (TestStatement) o;
+    return Objects.equals(engineStatement, that.engineStatement)
+        && Objects.equals(assertStatement, that.assertStatement)
+        && Objects.equals(directive, that.directive);
+  }
+
+  @Override
+  public String toString() {
+    return "TestStatement{"
+        + "engineStatement=" + engineStatement
+        + ", assertStatement=" + assertStatement
+        + ", directive=" + directive
+        + '}';
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(engineStatement, assertStatement, directive);
+  }
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestStatement.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestStatement.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.tree.AssertStatement;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 /**
@@ -33,14 +34,14 @@ import java.util.stream.Stream;
 public final class TestStatement {
 
   private final ParsedStatement engineStatement;
-  private final AssertStatement<?> assertStatement;
+  private final AssertStatement assertStatement;
   private final TestDirective directive;
 
   public static TestStatement of(final ParsedStatement engineStatement) {
     return new TestStatement(engineStatement, null, null);
   }
 
-  public static TestStatement of(final AssertStatement<?> assertStatement) {
+  public static TestStatement of(final AssertStatement assertStatement) {
     return new TestStatement(null, assertStatement, null);
   }
 
@@ -50,7 +51,7 @@ public final class TestStatement {
 
   private TestStatement(
       final ParsedStatement engineStatement,
-      final AssertStatement<?> assertStatement,
+      final AssertStatement assertStatement,
       final TestDirective directive
   ) {
     this.engineStatement = engineStatement;
@@ -70,6 +71,20 @@ public final class TestStatement {
     }
   }
 
+  public void handle(
+      final Consumer<ParsedStatement> parsedStatementConsumer,
+      final Consumer<AssertStatement> assertStatementConsumer,
+      final Consumer<TestDirective> testDirectiveConsumer
+  ) {
+    if (engineStatement != null) {
+      parsedStatementConsumer.accept(engineStatement);
+    } else if (assertStatement != null) {
+      assertStatementConsumer.accept(assertStatement);
+    } else if (directive != null) {
+      testDirectiveConsumer.accept(directive);
+    }
+  }
+
   public boolean hasEngineStatement() {
     return engineStatement != null;
   }
@@ -86,7 +101,7 @@ public final class TestStatement {
     return assertStatement != null;
   }
 
-  public AssertStatement<?> getAssertStatement() {
+  public AssertStatement getAssertStatement() {
     if (!hasAssertStatement()) {
       throw new NoSuchElementException("assertStatement");
     }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestStatement.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestStatement.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.test.parser;
 
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
-import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.AssertStatement;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -33,11 +32,11 @@ import java.util.stream.Stream;
  */
 public final class TestStatement {
 
-  private final PreparedStatement<?> engineStatement;
+  private final ParsedStatement engineStatement;
   private final AssertStatement<?> assertStatement;
   private final TestDirective directive;
 
-  public static TestStatement of(final PreparedStatement<?> engineStatement) {
+  public static TestStatement of(final ParsedStatement engineStatement) {
     return new TestStatement(engineStatement, null, null);
   }
 
@@ -50,7 +49,7 @@ public final class TestStatement {
   }
 
   private TestStatement(
-      final PreparedStatement<?> engineStatement,
+      final ParsedStatement engineStatement,
       final AssertStatement<?> assertStatement,
       final TestDirective directive
   ) {
@@ -75,7 +74,7 @@ public final class TestStatement {
     return engineStatement != null;
   }
 
-  public PreparedStatement<?> getEngineStatement() {
+  public ParsedStatement getEngineStatement() {
     if (!hasEngineStatement()) {
       throw new NoSuchElementException("engineStatement");
     }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.parser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.ParsingException;
+import io.confluent.ksql.test.parser.SqlTestReader;
+import io.confluent.ksql.test.parser.TestDirective;
+import io.confluent.ksql.test.parser.TestDirective.Type;
+import io.confluent.ksql.parser.tree.AssertValues;
+import io.confluent.ksql.parser.tree.CreateStream;
+import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
+import io.confluent.ksql.parser.tree.InsertValues;
+import io.confluent.ksql.test.parser.TestStatement;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class SqlTestReaderTest {
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  private KsqlExecutionContext engine;
+  @Mock
+  private MetaStore metaStore;
+  @Mock
+  private CreateStream cs;
+  @Mock
+  private CreateStreamAsSelect csas;
+  @Mock
+  private InsertValues iv;
+
+  @Before
+  public void setUp() {
+    when(engine.getMetaStore()).thenReturn(metaStore);
+  }
+
+  @Test
+  public void shouldParseBasicTest() {
+    // Given:
+    final String contents = ""
+        + "--@test: test1\n"
+        + "CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='json');\n"
+        + "CREATE STREAM bar AS SELECT * FROM foo;\n"
+        + "INSERT INTO foo (id, col1) VALUES (1, 1);\n"
+        + "ASSERT VALUES bar (id, col1) VALUES (1, 1);\n"
+        ;
+
+    when(engine.prepare(any()))
+        .thenReturn((PreparedStatement) PreparedStatement.of("foo", cs))
+        .thenReturn(PreparedStatement.of("foo", csas))
+        .thenReturn(PreparedStatement.of("foo", iv));
+
+    // When:
+    final SqlTestReader reader = new SqlTestReader(contents, engine);
+
+    // Then:
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next(), is(TestStatement.of(new TestDirective(Type.TEST, "test1"))));
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next().getEngineStatement().getStatement(), instanceOf(CreateStream.class));
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next().getEngineStatement().getStatement(), instanceOf(CreateStreamAsSelect.class));
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next().getEngineStatement().getStatement(), instanceOf(InsertValues.class));
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next().getAssertStatement(), instanceOf(AssertValues.class));
+    assertThat(reader.hasNext(), is(false));
+  }
+
+  @Test
+  public void shouldReadDirectivesAtEnd() {
+    final String contents = ""
+        + "--@test: test1\n"
+        + "CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='json');\n"
+        + "--@foo: bar\n";
+
+    when(engine.prepare(any())).thenReturn((PreparedStatement) PreparedStatement.of("foo", cs));
+
+    // When:
+    final SqlTestReader reader = new SqlTestReader(contents, engine);
+
+    // Then:
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next(), is(TestStatement.of(new TestDirective(Type.TEST, "test1"))));
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next().getEngineStatement().getStatement(), instanceOf(CreateStream.class));
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next(), is(TestStatement.of(new TestDirective(Type.UNKNOWN, "bar"))));
+    assertThat(reader.hasNext(), is(false));
+  }
+
+  @Test
+  public void shouldIgnoreComments() {
+    final String contents = ""
+        + "--@test: test1\n"
+        + "--foo\n"
+        + "CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='json');\n"
+        + "--bar\n";
+
+    when(engine.prepare(any())).thenReturn((PreparedStatement) PreparedStatement.of("foo", cs));
+
+    // When:
+    final SqlTestReader reader = new SqlTestReader(contents, engine);
+
+    // Then:
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next(), is(TestStatement.of(new TestDirective(Type.TEST, "test1"))));
+    assertThat(reader.hasNext(), is(true));
+    assertThat(reader.next().getEngineStatement().getStatement(), instanceOf(CreateStream.class));
+    assertThat(reader.hasNext(), is(false));
+  }
+
+  @Test
+  public void shouldThrowOnInvalidStatement() {
+    final String contents = ""
+        + "CREATE foo;\n";
+
+    // When:
+    final SqlTestReader reader = new SqlTestReader(contents, engine);
+    final ParsingException parsingException = assertThrows(ParsingException.class, reader::next);
+
+    // Then:
+    assertThat(parsingException.getMessage(), is("line 1:8: no viable alternative at input 'CREATE foo'"));
+  }
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/TestDirectiveTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/TestDirectiveTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.parser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.confluent.ksql.test.parser.TestDirective;
+import io.confluent.ksql.test.parser.TestDirective.Type;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.Token;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class TestDirectiveTest {
+
+  @Test
+  public void shouldParseKnownDirectives() {
+    // Given:
+    final Token tok = new CommonToken(0, "--@test: bar");
+
+    // When:
+    final TestDirective directive = TestDirective.parse(tok);
+
+    // Then:
+    assertThat(directive, Matchers.is(new TestDirective(Type.TEST, "bar")));
+  }
+
+  @Test
+  public void shouldParseKnownDirectivesCaseInsensitive() {
+    // Given:
+    final Token tok = new CommonToken(0, "--@teST: bar");
+
+    // When:
+    final TestDirective directive = TestDirective.parse(tok);
+
+    // Then:
+    assertThat(directive, Matchers.is(new TestDirective(Type.TEST, "bar")));
+  }
+
+  @Test
+  public void shouldParseUnknownDirectives() {
+    // Given:
+    final Token tok = new CommonToken(0, "--@foo: bar");
+
+    // When:
+    final TestDirective directive = TestDirective.parse(tok);
+
+    // Then:
+    assertThat(directive, Matchers.is(new TestDirective(Type.UNKNOWN, "bar")));
+  }
+
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/TestDirectiveTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/TestDirectiveTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.test.parser;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.confluent.ksql.test.parser.TestDirective;
+import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.test.parser.TestDirective.Type;
 import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.Token;
@@ -26,16 +26,33 @@ import org.junit.Test;
 
 public class TestDirectiveTest {
 
+  private static final NodeLocation LOC = new NodeLocation(1, 1);
+
   @Test
   public void shouldParseKnownDirectives() {
     // Given:
     final Token tok = new CommonToken(0, "--@test: bar");
 
     // When:
-    final TestDirective directive = TestDirective.parse(tok);
+    final TestDirective directive = DirectiveParser.parse(tok);
 
     // Then:
-    assertThat(directive, Matchers.is(new TestDirective(Type.TEST, "bar")));
+    assertThat(directive, Matchers.is(new TestDirective(Type.TEST, "bar", LOC)));
+  }
+
+  @Test
+  public void shouldParseKnownDirectivesAtLocation() {
+    // Given:
+    final CommonToken tok = new CommonToken(0, "--@test: bar");
+    tok.setLine(1);
+    tok.setCharPositionInLine(10);
+
+    // When:
+    final TestDirective directive = DirectiveParser.parse(tok);
+
+    // Then:
+    assertThat(directive, Matchers.is(new TestDirective(Type.TEST, "bar", LOC)));
+    assertThat(directive.getLocation(), Matchers.is(new NodeLocation(1, 10)));
   }
 
   @Test
@@ -44,10 +61,10 @@ public class TestDirectiveTest {
     final Token tok = new CommonToken(0, "--@teST: bar");
 
     // When:
-    final TestDirective directive = TestDirective.parse(tok);
+    final TestDirective directive = DirectiveParser.parse(tok);
 
     // Then:
-    assertThat(directive, Matchers.is(new TestDirective(Type.TEST, "bar")));
+    assertThat(directive, Matchers.is(new TestDirective(Type.TEST, "bar", LOC)));
   }
 
   @Test
@@ -56,10 +73,10 @@ public class TestDirectiveTest {
     final Token tok = new CommonToken(0, "--@foo: bar");
 
     // When:
-    final TestDirective directive = TestDirective.parse(tok);
+    final TestDirective directive = DirectiveParser.parse(tok);
 
     // Then:
-    assertThat(directive, Matchers.is(new TestDirective(Type.UNKNOWN, "bar")));
+    assertThat(directive, Matchers.is(new TestDirective(Type.UNKNOWN, "bar", LOC)));
   }
 
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AssertTable.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AssertTable.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+import io.confluent.ksql.parser.tree.AssertStatement;
+import io.confluent.ksql.parser.tree.CreateTable;
+import java.util.Objects;
+import java.util.Optional;
+
+public class AssertTable extends AssertStatement<CreateTable> {
+
+  public AssertTable(
+      final Optional<NodeLocation> location,
+      final CreateTable statement
+  ) {
+    super(location, statement);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getStatement());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AssertTable)) {
+      return false;
+    }
+    final AssertTable that = (AssertTable) o;
+    return Objects.equals(getStatement(), that.getStatement());
+  }
+
+  @Override
+  public String toString() {
+    return "AssertTable{"
+        + "statement=" + getStatement()
+        + '}';
+  }
+
+}

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AssertTable.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AssertTable.java
@@ -16,22 +16,30 @@
 package io.confluent.ksql.parser;
 
 import io.confluent.ksql.parser.tree.AssertStatement;
+import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.CreateTable;
 import java.util.Objects;
 import java.util.Optional;
 
-public class AssertTable extends AssertStatement<CreateTable> {
+public class AssertTable extends AssertStatement {
+
+  private final CreateTable statement;
 
   public AssertTable(
       final Optional<NodeLocation> location,
       final CreateTable statement
   ) {
-    super(location, statement);
+    super(location);
+    this.statement = Objects.requireNonNull(statement, "statement");
+  }
+
+  public CreateTable getStatement() {
+    return statement;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getStatement());
+    return Objects.hashCode(statement);
   }
 
   @Override
@@ -53,4 +61,8 @@ public class AssertTable extends AssertStatement<CreateTable> {
         + '}';
   }
 
+  @Override
+  protected <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitAssertTable(this, context);
+  }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -64,6 +64,9 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.SqlBaseParser.ArrayConstructorContext;
+import io.confluent.ksql.parser.SqlBaseParser.AssertStreamContext;
+import io.confluent.ksql.parser.SqlBaseParser.AssertTableContext;
+import io.confluent.ksql.parser.SqlBaseParser.AssertValuesContext;
 import io.confluent.ksql.parser.SqlBaseParser.CreateConnectorContext;
 import io.confluent.ksql.parser.SqlBaseParser.DescribeConnectorContext;
 import io.confluent.ksql.parser.SqlBaseParser.DropConnectorContext;
@@ -89,6 +92,9 @@ import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
+import io.confluent.ksql.parser.tree.AssertStatement;
+import io.confluent.ksql.parser.tree.AssertStream;
+import io.confluent.ksql.parser.tree.AssertValues;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.CreateConnector.Type;
 import io.confluent.ksql.parser.tree.CreateStream;
@@ -178,6 +184,10 @@ public class AstBuilder {
   }
 
   public WindowExpression buildWindowExpression(final ParserRuleContext parseTree) {
+    return build(Optional.empty(), parseTree);
+  }
+
+  public AssertStatement<?> buildAssertStatement(final ParserRuleContext parseTree) {
     return build(Optional.empty(), parseTree);
   }
 
@@ -1228,6 +1238,72 @@ public class AstBuilder {
           typeParser.getType(context.type())
       );
     }
+
+    @Override
+    public Node visitAssertValues(final AssertValuesContext context) {
+      final SourceName targetName = ParserUtil.getSourceName(context.sourceName());
+      final Optional<NodeLocation> targetLocation = getLocation(context.sourceName());
+
+      final List<ColumnName> columns;
+      if (context.columns() != null) {
+        columns = context.columns().identifier()
+            .stream()
+            .map(ParserUtil::getIdentifierText)
+            .map(ColumnName::of)
+            .collect(Collectors.toList());
+      } else {
+        columns = ImmutableList.of();
+      }
+
+      final InsertValues insertValues = new InsertValues(
+          targetLocation,
+          targetName,
+          columns,
+          visit(context.values().valueExpression(), Expression.class));
+
+      return new AssertValues(targetLocation, insertValues);
+    }
+
+    @Override
+    public Node visitAssertStream(final AssertStreamContext context) {
+      final List<TableElement> elements = context.tableElements() == null
+          ? ImmutableList.of()
+          : visit(context.tableElements().tableElement(), TableElement.class);
+
+      final Map<String, Literal> properties = processTableProperties(context.tableProperties());
+
+      final CreateStream createStream = new CreateStream(
+          getLocation(context),
+          ParserUtil.getSourceName(context.sourceName()),
+          TableElements.of(elements),
+          false,
+          false,
+          CreateSourceProperties.from(properties)
+      );
+
+      return new AssertStream(getLocation(context), createStream);
+    }
+
+    @Override
+    public Node visitAssertTable(final AssertTableContext context) {
+      final List<TableElement> elements = context.tableElements() == null
+          ? ImmutableList.of()
+          : visit(context.tableElements().tableElement(), TableElement.class);
+
+      final Map<String, Literal> properties = processTableProperties(context.tableProperties());
+
+      final CreateTable createTable = new CreateTable(
+          getLocation(context),
+          ParserUtil.getSourceName(context.sourceName()),
+          TableElements.of(elements),
+          false,
+          false,
+          CreateSourceProperties.from(properties)
+      );
+
+      return new AssertTable(getLocation(context), createTable);
+    }
+
 
     private void throwOnUnknownNameOrAlias(final SourceName name) {
       if (sources.isPresent() && !sources.get().contains(name)) {

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -187,7 +187,7 @@ public class AstBuilder {
     return build(Optional.empty(), parseTree);
   }
 
-  public AssertStatement<?> buildAssertStatement(final ParserRuleContext parseTree) {
+  public AssertStatement buildAssertStatement(final ParserRuleContext parseTree) {
     return build(Optional.empty(), parseTree);
   }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultKsqlParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultKsqlParser.java
@@ -57,12 +57,19 @@ public class DefaultKsqlParser implements KsqlParser {
       final SqlBaseParser.StatementsContext statementsContext = getParseTree(sql);
 
       return statementsContext.singleStatement().stream()
-          .map(stmt -> ParsedStatement.of(getStatementString(stmt), stmt))
+          .map(DefaultKsqlParser::parsedStatement)
           .collect(Collectors.toList());
 
     } catch (final Exception e) {
       throw new ParseFailedException(e.getMessage(), sql, e);
     }
+  }
+
+  public static ParsedStatement parsedStatement(final SingleStatementContext statement) {
+    return ParsedStatement.of(
+        getStatementString(statement),
+        statement
+    );
   }
 
   @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertStatement.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertStatement.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import io.confluent.ksql.parser.Node;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Indicates that the given {@link io.confluent.ksql.parser.Node} is used
+ * for testing purposes.
+ */
+public abstract class AssertStatement<T extends Statement> extends Node  {
+
+  private final T statement;
+
+  protected AssertStatement(
+      final Optional<NodeLocation> location,
+      final T statement
+  ) {
+    super(location);
+    this.statement = Objects.requireNonNull(statement, "statement");
+  }
+
+  public T getStatement() {
+    return statement;
+  }
+}

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertStatement.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertStatement.java
@@ -15,28 +15,19 @@
 
 package io.confluent.ksql.parser.tree;
 
-import io.confluent.ksql.parser.Node;
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
  * Indicates that the given {@link io.confluent.ksql.parser.Node} is used
  * for testing purposes.
  */
-public abstract class AssertStatement<T extends Statement> extends Node  {
-
-  private final T statement;
+public abstract class AssertStatement extends AstNode  {
 
   protected AssertStatement(
-      final Optional<NodeLocation> location,
-      final T statement
+      final Optional<NodeLocation> location
   ) {
     super(location);
-    this.statement = Objects.requireNonNull(statement, "statement");
   }
 
-  public T getStatement() {
-    return statement;
-  }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertStream.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertStream.java
@@ -21,13 +21,20 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class AssertStream extends AssertStatement<CreateStream> {
+public class AssertStream extends AssertStatement {
+
+  private final CreateStream statement;
 
   public AssertStream(
       final Optional<NodeLocation> location,
       final CreateStream statement
   ) {
-    super(location, statement);
+    super(location);
+    this.statement = Objects.requireNonNull(statement, "statement");
+  }
+
+  public CreateStream getStatement() {
+    return statement;
   }
 
   @Override
@@ -52,5 +59,10 @@ public class AssertStream extends AssertStatement<CreateStream> {
     return "AssertStream{"
         + "statement=" + getStatement()
         + '}';
+  }
+
+  @Override
+  protected <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitAssertStream(this, context);
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertStream.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertStream.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class AssertStream extends AssertStatement<CreateStream> {
+
+  public AssertStream(
+      final Optional<NodeLocation> location,
+      final CreateStream statement
+  ) {
+    super(location, statement);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getStatement());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AssertStream)) {
+      return false;
+    }
+    final AssertStream that = (AssertStream) o;
+    return Objects.equals(getStatement(), that.getStatement());
+  }
+
+  @Override
+  public String toString() {
+    return "AssertStream{"
+        + "statement=" + getStatement()
+        + '}';
+  }
+}

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertValues.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertValues.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class AssertValues extends AssertStatement<InsertValues> {
+
+  public AssertValues(
+      final Optional<NodeLocation> location,
+      final InsertValues insertValues
+  ) {
+    super(location, insertValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getStatement());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final AssertValues that = (AssertValues) o;
+    return Objects.equals(getStatement(), that.getStatement());
+  }
+
+  @Override
+  public String toString() {
+    return "AssertValues{"
+        + "statement=" + getStatement()
+        + '}';
+  }
+}

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertValues.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertValues.java
@@ -21,13 +21,20 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class AssertValues extends AssertStatement<InsertValues> {
+public class AssertValues extends AssertStatement {
+
+  private final InsertValues statement;
 
   public AssertValues(
       final Optional<NodeLocation> location,
-      final InsertValues insertValues
+      final InsertValues statement
   ) {
-    super(location, insertValues);
+    super(location);
+    this.statement = Objects.requireNonNull(statement, "statement");
+  }
+
+  public InsertValues getStatement() {
+    return statement;
   }
 
   @Override
@@ -54,5 +61,10 @@ public class AssertValues extends AssertStatement<InsertValues> {
     return "AssertValues{"
         + "statement=" + getStatement()
         + '}';
+  }
+
+  @Override
+  protected <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitAssertValues(this, context);
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import io.confluent.ksql.parser.AssertTable;
 import io.confluent.ksql.parser.DropType;
 import javax.annotation.Nullable;
 
@@ -179,5 +180,17 @@ public abstract class AstVisitor<R, C> {
 
   public R visitDropType(final DropType node, final C context) {
     return visitStatement(node, context);
+  }
+
+  public R visitAssertValues(final AssertValues node, final C context) {
+    return visitStatement(node.getStatement(), context);
+  }
+
+  public R visitAssertStream(final AssertStream node, final C context) {
+    return visitStatement(node.getStatement(), context);
+  }
+
+  public R visitAssertTable(final AssertTable node, final C context) {
+    return visitStatement(node.getStatement(), context);
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AssertTableTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AssertTableTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.parser.tree.CreateTable;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class AssertTableTest {
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  private CreateTable createA;
+  @Mock
+  private CreateTable createB;
+
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new AssertTable(Optional.empty(), createA),
+            new AssertTable(Optional.of(new NodeLocation(1, 1)), createA))
+        .addEqualityGroup(
+            new AssertTable(Optional.empty(), createB))
+        .testEquals();
+    }
+
+  }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertStreamTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertStreamTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class AssertStreamTest {
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  private CreateStream createA;
+  @Mock
+  private CreateStream createB;
+
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new AssertStream(Optional.empty(), createA),
+            new AssertStream(Optional.of(new NodeLocation(1, 1)), createA))
+        .addEqualityGroup(
+            new AssertStream(Optional.empty(), createB))
+        .testEquals();
+  }
+
+}

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertValuesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertValuesTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class AssertValuesTest {
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock
+  private InsertValues insertA;
+  @Mock
+  private InsertValues insertB;
+
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new AssertValues(Optional.empty(), insertA),
+            new AssertValues(Optional.of(new NodeLocation(1, 1)), insertA))
+        .addEqualityGroup(
+            new AssertValues(Optional.empty(), insertB))
+        .testEquals();
+  }
+
+}


### PR DESCRIPTION
### Description 

This PR puts in all of the parsing skeleton required for YATT (see #5965). Specifically:

1. Introduces `SqlTestReader`, the main parser that parses sql tests statement by statement
1. The `TestStatement` class wraps the three different types of statements supported by the reader (engine statements, asserts, directives)
1. The `TestDirective` class models a directive comment (e.g. `--@test: test1`)
1. The `AssertStatement` class and subclasses model the different types of `ASSERT` statements that are parseable as of this PR

Other than that, some minor changes were added to `SqlBase.g4` and elsewhere to better support this change.

### Testing done 

Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

