### PR TITLE
feat: support UDAFs with and without init Args with same param type

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/AggregateFunctionInitArguments.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/AggregateFunctionInitArguments.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.function;
 
-import io.confluent.ksql.util.KsqlException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -64,17 +63,4 @@ public class AggregateFunctionInitArguments {
   public List<Object> args() {
     return initArgs;
   }
-
-  public void ensureArgCount(final int expectedCount, final String functionName) {
-    if (initArgs.size() != expectedCount) {
-      throw new KsqlException(
-          String.format("Invalid parameter count for %s. Need %d args, got %d arg(s)",
-              functionName, expectedCount, initArgs.size()));
-    }
-  }
-
-  public int argsSize() {
-    return initArgs.size();
-  }
-
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/ParameterInfo.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/ParameterInfo.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.function.types.ParamType;
+import java.util.Objects;
 
 @Immutable
 public final class ParameterInfo {
@@ -52,5 +53,35 @@ public final class ParameterInfo {
 
   public boolean isVariadic() {
     return isVariadic;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ParameterInfo that = (ParameterInfo) o;
+    return isVariadic == that.isVariadic
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type)
+        && Objects.equals(description, that.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, description, isVariadic);
+  }
+
+  @Override
+  public String toString() {
+    return "ParameterInfo{"
+        + "name='" + name + '\''
+        + ", type=" + type
+        + ", description='" + description + '\''
+        + ", isVariadic=" + isVariadic
+        + '}';
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -103,10 +103,10 @@ public class UdfIndex<T extends FunctionSignature> {
   void addFunction(final T function) {
     final List<ParamType> parameters = function.parameters();
     if (allFunctions.put(parameters, function) != null) {
-      throw new KsqlException(
-          "Can't add function "
-              + function
-              + " as a function with the same name and argument type already exists "
+      throw new KsqlFunctionException(
+          "Can't add function " + function.name()
+              + " with parameters " + function.parameters()
+              + " as a function with the same name and parameter types already exists "
               + allFunctions.get(parameters)
       );
     }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/ParameterInfoTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/ParameterInfoTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.function.types.ParamTypes;
+import org.junit.Test;
+
+public class ParameterInfoTest {
+
+  @SuppressWarnings("UnstableApiUsage")
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new ParameterInfo("name", ParamTypes.INTEGER, "desc", false),
+            new ParameterInfo("name", ParamTypes.INTEGER, "desc", false)
+        )
+        .addEqualityGroup(
+            new ParameterInfo("diff", ParamTypes.INTEGER, "desc", false)
+        )
+        .addEqualityGroup(
+            new ParameterInfo("name", ParamTypes.BOOLEAN, "desc", false)
+        )
+        .addEqualityGroup(
+            new ParameterInfo("name", ParamTypes.INTEGER, "diff", false)
+        )
+        .addEqualityGroup(
+            new ParameterInfo("name", ParamTypes.INTEGER, "desc", true)
+        )
+        .testEquals();
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -7,6 +7,7 @@ import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -60,6 +61,24 @@ public class UdfIndexTest {
   @Before
   public void setUp() {
     udfIndex = new UdfIndex<>("name", true);
+  }
+
+  @Test
+  public void shouldThrowOnAddIfFunctionWithSameNameAndParamsExists() {
+    // Given:
+    givenFunctions(
+        function(EXPECTED, false, DOUBLE)
+    );
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlFunctionException.class,
+        () -> udfIndex.addFunction(function(EXPECTED, false, DOUBLE))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), startsWith("Can't add function `expected` with parameters [DOUBLE] "
+        + "as a function with the same name and parameter types already exists"));
   }
 
   @Test

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.util.KsqlException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -63,13 +62,12 @@ class UdafFactoryInvoker implements FunctionSignature {
     if (!Modifier.isStatic(method.getModifiers())) {
       throw new KsqlException("UDAF factory methods must be static " + method);
     }
-    final UdafTypes types = new UdafTypes(method, functionName.text(), typeParser);
+    final UdafTypes types = new UdafTypes(method, functionName, typeParser);
     this.functionName = Objects.requireNonNull(functionName);
     this.aggregateArgType = Objects.requireNonNull(types.getAggregateSchema(aggregateSchema));
     this.aggregateReturnType = Objects.requireNonNull(types.getOutputSchema(outputSchema));
     this.metrics = Objects.requireNonNull(metrics);
-    this.params =
-        Collections.singletonList(types.getInputSchema(Objects.requireNonNull(inputSchema)));
+    this.params = types.getInputSchema(Objects.requireNonNull(inputSchema));
     this.paramTypes = params.stream().map(ParameterInfo::type).collect(Collectors.toList());
     this.method = Objects.requireNonNull(method);
     this.description = Objects.requireNonNull(description);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
@@ -56,44 +56,47 @@ class UdafLoader {
     
     final List<UdafFactoryInvoker> invokers = new ArrayList<>();
     for (final Method method : theClass.getMethods()) {
-      if (method.getAnnotation(UdafFactory.class) != null) {
-        if (!Modifier.isStatic(method.getModifiers())) {
-          LOGGER.warn(
-              "Trying to create a UDAF from a non-static factory method. Udaf factory"
-                  + " methods must be static. class={}, method={}, name={}",
-              method.getDeclaringClass(),
-              method.getName(),
-              udafAnnotation.name()
-          );
-          continue;
-        }
-        final UdafFactory annotation = method.getAnnotation(UdafFactory.class);
-        try {
-          LOGGER.info(
-              "Adding UDAF name={} from path={} class={}",
-              udafAnnotation.name(),
-              path,
-              method.getDeclaringClass()
-          );
-          final UdafFactoryInvoker invoker = createUdafFactoryInvoker(
-              method,
-              FunctionName.of(udafAnnotation.name()),
-              annotation.description(),
-              annotation.paramSchema(),
-              annotation.aggregateSchema(),
-              annotation.returnSchema()
-          );
-          invokers.add(invoker);
-        } catch (final Exception e) {
-          LOGGER.warn(
-              "Failed to create UDAF name={}, method={}, class={}, path={}",
-              udafAnnotation.name(),
-              method.getName(),
-              method.getDeclaringClass(),
-              path,
-              e
-          );
-        }
+      if (method.getAnnotation(UdafFactory.class) == null) {
+        continue;
+      }
+
+      if (!Modifier.isStatic(method.getModifiers())) {
+        LOGGER.warn(
+            "Trying to create a UDAF from a non-static factory method. Udaf factory"
+                + " methods must be static. class={}, method={}, name={}",
+            method.getDeclaringClass(),
+            method.getName(),
+            udafAnnotation.name()
+        );
+        continue;
+      }
+
+      final UdafFactory annotation = method.getAnnotation(UdafFactory.class);
+      try {
+        LOGGER.info(
+            "Adding UDAF name={} from path={} class={}",
+            udafAnnotation.name(),
+            path,
+            method.getDeclaringClass()
+        );
+        final UdafFactoryInvoker invoker = createUdafFactoryInvoker(
+            method,
+            FunctionName.of(udafAnnotation.name()),
+            annotation.description(),
+            annotation.paramSchema(),
+            annotation.aggregateSchema(),
+            annotation.returnSchema()
+        );
+        invokers.add(invoker);
+      } catch (final Exception e) {
+        LOGGER.warn(
+            "Failed to create UDAF name={}, method={}, class={}, path={}",
+            udafAnnotation.name(),
+            method.getName(),
+            method.getDeclaringClass(),
+            path,
+            e
+        );
       }
     }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafAggregateFunctionFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafAggregateFunctionFactoryTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.udf.UdfMetadata;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UdafAggregateFunctionFactoryTest {
+
+  @Mock
+  private UdfMetadata metadata;
+  @Mock
+  private UdfIndex<UdafFactoryInvoker> functionIndex;
+  @Mock
+  private UdafFactoryInvoker invoker;
+
+  private UdafAggregateFunctionFactory functionFactory;
+
+  @Before
+  public void setUp() {
+    functionFactory = new UdafAggregateFunctionFactory(metadata, functionIndex);
+
+    when(functionIndex.getFunction(any())).thenReturn(invoker);
+    when(metadata.getName()).thenReturn("BOB");
+  }
+
+  @Test
+  public void shouldAppendInitParamTypesWhenLookingUpFunction() {
+    // When:
+    functionFactory.createAggregateFunction(
+        ImmutableList.of(SqlTypes.STRING),
+        new AggregateFunctionInitArguments(0, ImmutableList.of(1))
+    );
+
+    // Then:
+    verify(functionIndex).getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.INTEGER));
+  }
+
+  @Test
+  public void shouldHandleNullLiteralParams() {
+    // When:
+    functionFactory.createAggregateFunction(
+        ImmutableList.of(SqlTypes.STRING),
+        new AggregateFunctionInitArguments(0, Arrays.asList(null, 5L))
+    );
+
+    // Then:
+    verify(functionIndex).getFunction(Arrays.asList(SqlTypes.STRING, null, SqlTypes.BIGINT));
+  }
+
+  @Test
+  public void shouldHandleInitParamsOfAllPrimitiveTypes() {
+    // When:
+    functionFactory.createAggregateFunction(
+        ImmutableList.of(SqlTypes.STRING),
+        new AggregateFunctionInitArguments(0, ImmutableList.of(true, 1, 1L, 1.0d, "s"))
+    );
+
+    // Then: did not throw.
+  }
+
+  @Test
+  public void shouldThrowOnUnsupportedInitParamType() {
+    // When:
+    final Exception e = assertThrows(KsqlFunctionException.class,
+        () -> functionFactory.createAggregateFunction(
+            ImmutableList.of(SqlTypes.STRING),
+            new AggregateFunctionInitArguments(0, ImmutableList.of(BigDecimal.ONE))
+        )
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("Only primitive init arguments are supported by UDAF BOB, "
+        + "but got " + BigDecimal.ONE));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafTypesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafTypesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.types.ParamTypes;
+import io.confluent.ksql.function.udaf.Udaf;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import java.lang.reflect.Method;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UdafTypesTest {
+
+  private static final FunctionName FUNCTION_NAME = FunctionName.of("Bob");
+
+  @Mock
+  private SqlTypeParser typeParser;
+
+  @Test
+  public void shouldWorkForUdafsWithNoInitParams() {
+    // When:
+    final UdafTypes types = createTypes("udafWithNoInitParams");
+
+    // Then:
+    assertThat(types.getInputSchema(""), is(ImmutableList.of(
+       new ParameterInfo("val", ParamTypes.INTEGER, "", false)
+    )));
+  }
+
+  @Test
+  public void shouldAppendInitParamsToInputSchema() {
+    // When:
+    final UdafTypes types = createTypes("udafWithStringInitParam", String.class);
+
+    // Then:
+    assertThat(types.getInputSchema(""), is(ImmutableList.of(
+        new ParameterInfo("val", ParamTypes.INTEGER, "", false),
+        new ParameterInfo("initParam", ParamTypes.STRING, "", false)
+    )));
+  }
+
+  @SuppressWarnings({"unused", "MethodMayBeStatic"})
+  private Udaf<Integer, Long, Double> udafWithNoInitParams() {
+    return null;
+  }
+
+  @SuppressWarnings({"unused", "MethodMayBeStatic"})
+  private Udaf<Integer, Long, Double> udafWithStringInitParam(final String initParam) {
+    return null;
+  }
+
+  private UdafTypes createTypes(final String methodName, final Class<?>... parameterTypes) {
+    try {
+      final Method method = UdafTypesTest.class.getDeclaredMethod(methodName, parameterTypes);
+      return new UdafTypes(method, FUNCTION_NAME, typeParser);
+    } catch (NoSuchMethodException e) {
+      throw new AssertionError("Invalid test", e);
+    }
+  }
+}


### PR DESCRIPTION
### Description 

As well as an expression, UDAFs support constants being passed. However, prior to this change it was not possible to register a UDAF that have variants that have no constants and constants, or indeed with different constant types.  For example:

```java
@UdafDescription(
    name = "LATEST_BY_OFFSET",
    description = LatestByOffset.DESCRIPTION,
    author = KsqlConstants.CONFLUENT_AUTHOR
)
public final class LatestByOffset {

  ...

  // Version taking no constants:
  @UdafFactory(description = "return the latest value of an integer column",
      aggregateSchema = "STRUCT<SEQ BIGINT, VAL INT>")
  public static Udaf<Integer, Struct, Integer> latestInteger() {
    return latest(STRUCT_INTEGER);
  }

  // Version taking one constant:
  @UdafFactory(description = "return the last N values of an integer column",
      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL INT>>")
  public static Udaf<Integer, List<Struct>, List<Integer>> latestIntegers(final int topNSize) {
    return latestN(STRUCT_INTEGER, topNSize);
  }
```

The above would previously have thrown an error on start up, complaining that "A function with the same name and parameter types is already registered" when `latestIntegers` was being registered, as it incorrectly only took the runtime `INTEGER` parameter, ignoring the `INTEGER` constant parameter.

With this change all parameters are taken into account.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

