### PR TITLE
fix: Uses pull query metrics for all paths, not just /query

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -96,7 +96,7 @@ public class QueryEndpoint {
       final ConfiguredStatement<Query> statement
   ) {
     final PullQueryResult result = pullQueryExecutor.execute(
-        statement, serviceContext, Optional.empty(), Optional.of(false));
+        statement, serviceContext, Optional.of(false));
     final TableRows tableRows = result.getTableRows();
 
     return new PullQueryPublisher(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -57,7 +57,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
   public synchronized void subscribe(final Subscriber<Collection<StreamedRow>> subscriber) {
     final PullQuerySubscription subscription = new PullQuerySubscription(
         subscriber,
-        () -> pullQueryExecutor.execute(query, serviceContext, Optional.empty(), Optional.of(false))
+        () -> pullQueryExecutor.execute(query, serviceContext, Optional.of(false))
     );
 
     subscriber.onSubscribe(subscription);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
@@ -70,13 +70,12 @@ public class PullQueryExecutorTest {
           engine.getKsqlConfig()
       );
       PullQueryExecutor pullQueryExecutor = new PullQueryExecutor(
-          engine.getEngine(), ROUTING_FILTER_FACTORY, engine.getKsqlConfig());
+          engine.getEngine(), ROUTING_FILTER_FACTORY, engine.getKsqlConfig(), Optional.empty());
 
       // When:
       final Exception e = assertThrows(
           KsqlException.class,
-          () -> pullQueryExecutor.execute(query, engine.getServiceContext(), Optional.empty(),
-              Optional.empty())
+          () -> pullQueryExecutor.execute(query, engine.getServiceContext(), Optional.empty())
       );
 
       // Then:
@@ -131,7 +130,7 @@ public class PullQueryExecutorTest {
     @Test
     public void shouldRateLimit() {
       PullQueryExecutor pullQueryExecutor = new PullQueryExecutor(
-          engine.getEngine(), ROUTING_FILTER_FACTORY, engine.getKsqlConfig());
+          engine.getEngine(), ROUTING_FILTER_FACTORY, engine.getKsqlConfig(), Optional.empty());
 
       // When:
       pullQueryExecutor.checkRateLimit();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -83,7 +83,7 @@ public class PullQueryPublisherTest {
         pullQueryExecutor);
 
     PullQueryResult result = new PullQueryResult(entity, Optional.empty());
-    when(pullQueryExecutor.execute(any(), any(), any(), any())).thenReturn(result);
+    when(pullQueryExecutor.execute(any(), any(), any())).thenReturn(result);
     when(entity.getSchema()).thenReturn(SCHEMA);
 
     doAnswer(callRequestAgain()).when(subscriber).onNext(any());
@@ -107,8 +107,7 @@ public class PullQueryPublisherTest {
     subscription.request(1);
 
     // Then:
-    verify(pullQueryExecutor).execute(statement, serviceContext, Optional.empty(),
-        Optional.of(false));
+    verify(pullQueryExecutor).execute(statement, serviceContext, Optional.of(false));
   }
 
   @Test
@@ -121,8 +120,7 @@ public class PullQueryPublisherTest {
 
     // Then:
     verify(subscriber).onNext(any());
-    verify(pullQueryExecutor).execute(statement, serviceContext, Optional.empty(),
-        Optional.of(false));
+    verify(pullQueryExecutor).execute(statement, serviceContext, Optional.of(false));
   }
 
   @Test
@@ -157,7 +155,7 @@ public class PullQueryPublisherTest {
     // Given:
     givenSubscribed();
     final Throwable e = new RuntimeException("Boom!");
-    when(pullQueryExecutor.execute(any(), any(), any(), any())).thenThrow(e);
+    when(pullQueryExecutor.execute(any(), any(), any())).thenThrow(e);
 
     // When:
     subscription.request(1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -187,7 +187,7 @@ public class StreamedQueryResourceTest {
     securityContext = new KsqlSecurityContext(Optional.empty(), serviceContext);
 
     pullQueryExecutor = new PullQueryExecutor(
-        mockKsqlEngine, ROUTING_FILTER_FACTORY, VALID_CONFIG);
+        mockKsqlEngine, ROUTING_FILTER_FACTORY, VALID_CONFIG, Optional.empty());
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
         mockStatementParser,


### PR DESCRIPTION
### Description 
Fixes issue with pull query metrics not being used in every pull query codepath. Now it should be used not only on `/query` by also the web socket code path.

### Testing done 
Ran normal tests.  Also, verified locally that it's now in use.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

