### PR TITLE
refactor: Call the correct pull/push query validator

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
@@ -41,8 +41,8 @@ public class QueryAnalyzer {
   ) {
     this(
         new Analyzer(metaStore, outputTopicPrefix, defaultSerdeOptions),
-        new PushQueryValidator(),
-        new PullQueryValidator()
+        new PullQueryValidator(),
+        new PushQueryValidator()
     );
   }
 
@@ -64,9 +64,9 @@ public class QueryAnalyzer {
     final Analysis analysis = analyzer.analyze(query, sink);
 
     if (query.isPullQuery()) {
-      pushQueryValidator.validate(analysis);
-    } else {
       pullQueryValidator.validate(analysis);
+    } else {
+      pushQueryValidator.validate(analysis);
     }
 
     if (!analysis.getTableFunctions().isEmpty()) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
@@ -50,8 +50,8 @@ public class QueryAnalyzerTest {
   public void setUp() {
     queryAnalyzer = new QueryAnalyzer(
         analyzer,
-        continuousValidator,
-        staticValidator
+        staticValidator,
+        continuousValidator
     );
 
     when(analyzer.analyze(any(), any())).thenReturn(analysis);


### PR DESCRIPTION
### Description 
I found in the `QueryAnalyzer` code an invalid validator call to pull/push queries.

See the first `QueryAnalyzer` that calls another `QueryAnalyzer` constructor with push, then pull validators. But the constructor accepts pull, then push validators. Also the if condition in the `analyze` is calling a different validator.

```
public QueryAnalyzer(
      final MetaStore metaStore,
      final String outputTopicPrefix,
      final Set<SerdeOption> defaultSerdeOptions
  ) {
    this(
        new Analyzer(metaStore, outputTopicPrefix, defaultSerdeOptions),
        new PushQueryValidator(),
        new PullQueryValidator()
    );
  }

@VisibleForTesting
  QueryAnalyzer(
      final Analyzer analyzer,
      final QueryValidator pullQueryValidator,
      final QueryValidator pushQueryValidator
  ) {
    ...
  }

public Analysis analyze(...) {
     ...
     if (query.isPullQuery()) {
      pushQueryValidator.validate(analysis);
    } else {
      pullQueryValidator.validate(analysis);
    }
}
```

This PR fixes the constructor call and if condition to call the correct validator.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

