### PR TITLE
chore: always start queries executed by InteractiveStatementExecutor

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.TerminateCluster;
 import io.confluent.ksql.util.Pair;
-import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.RetryUtil;
 import java.io.Closeable;
 import java.time.Clock;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -181,20 +181,12 @@ public class CommandRunner implements Closeable {
                 maxRetries,
                 STATEMENT_RETRY_MS,
                 MAX_STATEMENT_RETRY_MS,
-                () -> statementExecutor.handleRestore(command),
+                () -> statementExecutor.handleStatement(command),
                 WakeupException.class
             );
             currentCommandRef.set(null);
           }
       );
-
-      final List<PersistentQueryMetadata> queries = statementExecutor
-          .getKsqlEngine()
-          .getPersistentQueries();
-
-      LOG.info("Restarting {} queries.", queries.size());
-
-      queries.forEach(PersistentQueryMetadata::start);
 
       LOG.info("Restore complete");
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -241,9 +241,7 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
     final ExecuteResult result = ksqlEngine.execute(serviceContext, configured);
     if (result.getQuery().isPresent()) {
       queryIdGenerator.setNextId(offset + 1);
-      if (mode == Mode.EXECUTE) {
-        result.getQuery().get().start();
-      }
+      result.getQuery().get().start();
     }
     final String successMessage = getSuccessMessage(result);
     final Optional<QueryId> queryId = result.getQuery().map(QueryMetadata::getQueryId);
@@ -345,9 +343,7 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
     }
 
     final PersistentQueryMetadata persistentQueryMd = (PersistentQueryMetadata) queryMetadata;
-    if (mode == Mode.EXECUTE) {
-      persistentQueryMd.start();
-    }
+    persistentQueryMd.start();
     return persistentQueryMd;
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -134,9 +134,9 @@ public class CommandRunnerTest {
 
     // Then:
     final InOrder inOrder = inOrder(statementExecutor);
-    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand1));
-    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand2));
-    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand3));
+    inOrder.verify(statementExecutor).handleStatement(eq(queuedCommand1));
+    inOrder.verify(statementExecutor).handleStatement(eq(queuedCommand2));
+    inOrder.verify(statementExecutor).handleStatement(eq(queuedCommand3));
   }
 
   @Test
@@ -154,7 +154,7 @@ public class CommandRunnerTest {
     inOrder.verify(commandStore).wakeup();
     inOrder.verify(clusterTerminator).terminateCluster(anyList());
 
-    verify(statementExecutor, never()).handleRestore(any());
+    verify(statementExecutor, never()).handleStatement(any());
   }
 
   @Test
@@ -167,7 +167,7 @@ public class CommandRunnerTest {
     commandRunner.processPriorCommands();
 
     // Then:
-    verify(statementExecutor, never()).handleRestore(any());
+    verify(statementExecutor, never()).handleStatement(any());
   }
 
   @Test
@@ -192,10 +192,10 @@ public class CommandRunnerTest {
 
     // Then:
     final InOrder inOrder = inOrder(statementExecutor);
-    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand1));
-    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand3));
+    inOrder.verify(statementExecutor).handleStatement(eq(queuedCommand1));
+    inOrder.verify(statementExecutor).handleStatement(eq(queuedCommand3));
 
-    verify(statementExecutor, never()).handleRestore(queuedCommand2);
+    verify(statementExecutor, never()).handleStatement(queuedCommand2);
   }
 
   @Test
@@ -254,9 +254,9 @@ public class CommandRunnerTest {
     commandRunner.fetchAndRunCommands();
 
     // Then:
-    verify(statementExecutor, never()).handleRestore(queuedCommand1);
-    verify(statementExecutor, never()).handleRestore(queuedCommand2);
-    verify(statementExecutor, never()).handleRestore(queuedCommand3);
+    verify(statementExecutor, never()).handleStatement(queuedCommand1);
+    verify(statementExecutor, never()).handleStatement(queuedCommand2);
+    verify(statementExecutor, never()).handleStatement(queuedCommand3);
   }
 
   @Test
@@ -323,7 +323,7 @@ public class CommandRunnerTest {
     commandRunner.fetchAndRunCommands();
 
     // Then:
-    verify(statementExecutor, never()).handleRestore(queuedCommand2);
+    verify(statementExecutor, never()).handleStatement(queuedCommand2);
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -217,7 +216,7 @@ public class InteractiveStatementExecutorTest {
     );
 
     // When:
-    statementExecutor.handleRestore(queuedCommand);
+    statementExecutor.handleStatement(queuedCommand);
   }
 
   @Test
@@ -485,7 +484,7 @@ public class InteractiveStatementExecutorTest {
         () -> {
           for (int i = 0; i < priorCommands.size(); i++) {
             final Pair<CommandId, Command> pair = priorCommands.get(i);
-            statementExecutor.handleRestore(
+            statementExecutor.handleStatement(
                 new QueuedCommand(pair.left, pair.right, Optional.empty(), (long) i)
             );
           }
@@ -587,7 +586,7 @@ public class InteractiveStatementExecutorTest {
     mockReplayCSAS(new QueryId("csas-query-id"));
 
     // When:
-    statementExecutorWithMocks.handleRestore(
+    statementExecutorWithMocks.handleStatement(
         new QueuedCommand(
             new CommandId(Type.STREAM, "foo", Action.CREATE),
             new Command("CSAS", emptyMap(), emptyMap(), Optional.empty()),
@@ -651,7 +650,7 @@ public class InteractiveStatementExecutorTest {
         .thenReturn(ExecuteResult.of("SUCCESS"));
 
     // When:
-    statementExecutorWithMocks.handleRestore(
+    statementExecutorWithMocks.handleStatement(
         new QueuedCommand(
             new CommandId(Type.STREAM, "foo", Action.DROP),
             new Command(drop, emptyMap(), emptyMap(), Optional.empty()),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -600,28 +600,6 @@ public class InteractiveStatementExecutorTest {
     verify(mockQueryIdGenerator).setNextId(3L);
   }
 
-  @Test
-  public void shouldSkipStartWhenReplayingLog() {
-    // Given:
-    final QueryId queryId = new QueryId("csas-query-id");
-    final String name = "foo";
-    final PersistentQueryMetadata mockQuery = mockReplayCSAS(queryId);
-
-    // When:
-    statementExecutorWithMocks.handleRestore(
-        new QueuedCommand(
-            new CommandId(Type.STREAM, name, Action.CREATE),
-            new Command("CSAS", emptyMap(), emptyMap(), Optional.empty()),
-            Optional.empty(),
-            0L
-        )
-    );
-
-    // Then:
-    verify(mockQueryIdGenerator, times(1)).setNextId(anyLong());
-    verify(mockQuery, times(0)).start();
-  }
-
   private <T extends Statement> ConfiguredStatement<T> eqConfiguredStatement(
       final PreparedStatement<T> preparedStatement) {
     return argThat(new ConfiguredStatementMatcher<>(preparedStatement));


### PR DESCRIPTION
### Description 
Removes the handleRestore() function as it's no longer necessary after the compaction change https://github.com/confluentinc/ksql/pull/5002

Since we remove terminated queries in compaction, we don't need to wait until the restore is complete to start queries.

### Testing done 
Updated unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

