### PR TITLE
fix: allow implicit cast of numbers literals to decimals on insert/select

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
@@ -17,8 +17,11 @@ package io.confluent.ksql.schema.ksql;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.utils.FormatOptions;
+import io.confluent.ksql.util.DecimalUtil;
+
 import java.util.Objects;
 
 /**
@@ -111,6 +114,20 @@ public final class Column implements SimpleColumn {
     return index;
   }
 
+  public boolean canImplicitlyCast(final SqlType toType) {
+    if (type instanceof SqlDecimal && toType instanceof SqlDecimal) {
+      return DecimalUtil.canImplicitlyCast((SqlDecimal)type, (SqlDecimal)toType);
+    }
+
+    return type.equals(toType);
+  }
+
+  public boolean equalsIgnoreType(final Column that) {
+    return Objects.equals(index, that.index)
+        && Objects.equals(namespace, that.namespace)
+        && Objects.equals(name, that.name);
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -120,10 +137,7 @@ public final class Column implements SimpleColumn {
       return false;
     }
     final Column that = (Column) o;
-    return Objects.equals(index, that.index)
-        && Objects.equals(namespace, that.namespace)
-        && Objects.equals(type, that.type)
-        && Objects.equals(name, that.name);
+    return equalsIgnoreType(that) && Objects.equals(type, that.type);
   }
 
   @Override

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -159,6 +159,27 @@ public final class LogicalSchema {
         .isPresent();
   }
 
+  /**
+   * Returns True if this schema is compatible with {@code other} schema.
+   */
+  public boolean compatibleSchema(final LogicalSchema other) {
+    if (columns().size() != other.columns().size()) {
+      return false;
+    }
+
+    for (int i = 0; i < columns().size(); i++) {
+      final Column s1Column = columns().get(i);
+      final Column s2Column = other.columns().get(i);
+      final SqlType s2Type = s2Column.type();
+
+      if (!s1Column.equalsIgnoreType(s2Column) || !s1Column.canImplicitlyCast(s2Type)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -188,6 +188,21 @@ public final class DecimalUtil {
     }
   }
 
+  /**
+   * Returns True if {@code s1} can be implicitly cast to {@code s2}.
+   * </p>
+   * A decimal {@code s1} can be implicitly cast if precision/scale fits into the {@code s2}
+   * precision/scale.
+   * <ul>
+   *   <li>{@code s1} scale <= {@code s2} scale</li>
+   *   <li>{@code s1} left digits <= {@code s2} left digits</li>
+   * </ul>
+   */
+  public static boolean canImplicitlyCast(final SqlDecimal s1, final SqlDecimal s2) {
+    return s1.getScale() <= s2.getScale()
+        && (s1.getPrecision() - s1.getScale()) <= (s2.getPrecision() - s2.getScale());
+  }
+
   public static BigDecimal cast(final long value, final int precision, final int scale) {
     validateParameters(precision, scale);
     final BigDecimal decimal = new BigDecimal(value, new MathContext(precision));

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
@@ -510,4 +510,56 @@ public class DecimalUtilTest {
         () -> cast("abc", 2, 1)
     );
   }
+
+  @Test
+  public void shouldAllowImplicitlyCastOnEqualSchema() {
+    // Given:
+    final SqlDecimal s1 = SqlTypes.decimal(5, 2);
+    final SqlDecimal s2 = SqlTypes.decimal(5, 2);
+
+    // When:
+    final boolean compatible = DecimalUtil.canImplicitlyCast(s1, s2);
+
+    // Then:
+    assertThat(compatible, is(true));
+  }
+
+  @Test
+  public void shouldAllowImplicitlyCastOnHigherPrecisionAndScale() {
+    // Given:
+    final SqlDecimal s1 = SqlTypes.decimal(5, 2);
+    final SqlDecimal s2 = SqlTypes.decimal(6, 3);
+
+    // When:
+    final boolean compatible = DecimalUtil.canImplicitlyCast(s1, s2);
+
+    // Then:
+    assertThat(compatible, is(true));
+  }
+
+  @Test
+  public void shouldAllowImplicitlyCastOnHigherScale() {
+    // Given:
+    final SqlDecimal s1 = SqlTypes.decimal(2, 1);
+    final SqlDecimal s2 = SqlTypes.decimal(2, 2);
+
+    // When:
+    final boolean compatible = DecimalUtil.canImplicitlyCast(s1, s2);
+
+    // Then:
+    assertThat(compatible, is(false));
+  }
+
+  @Test
+  public void shouldAllowImplicitlyCastOnLowerPrecision() {
+    // Given:
+    final SqlDecimal s1 = SqlTypes.decimal(2, 1);
+    final SqlDecimal s2 = SqlTypes.decimal(1, 1);
+
+    // When:
+    final boolean compatible = DecimalUtil.canImplicitlyCast(s1, s2);
+
+    // Then:
+    assertThat(compatible, is(false));
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -305,7 +305,7 @@ final class EngineExecutor {
     final LogicalSchema resultSchema = outputNode.getSchema();
     final LogicalSchema existingSchema = existing.getSchema();
 
-    if (!resultSchema.equals(existingSchema)) {
+    if (!resultSchema.compatibleSchema(existingSchema)) {
       throw new KsqlException("Incompatible schema between results and sink."
           + System.lineSeparator()
           + "Result schema is " + resultSchema

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ImplicitlyCastResolver.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ImplicitlyCastResolver.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
+import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
+import io.confluent.ksql.execution.expression.tree.LongLiteral;
+import io.confluent.ksql.schema.ksql.types.SqlDecimal;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.DecimalUtil;
+
+import java.math.BigDecimal;
+
+public final class ImplicitlyCastResolver {
+  private ImplicitlyCastResolver() {}
+
+  public static Expression resolve(final Expression expression, final SqlType sqlType) {
+    if (sqlType instanceof SqlDecimal) {
+      return resolveToDecimal(expression, (SqlDecimal)sqlType);
+    }
+
+    return expression;
+  }
+
+  @SuppressWarnings("CyclomaticComplexiIntegerLiteralty")
+  private static Expression resolveToDecimal(
+      final Expression expression,
+      final SqlDecimal toDecimalType
+  ) {
+    final BigDecimal literalValue;
+
+    if (expression instanceof IntegerLiteral) {
+      literalValue =  BigDecimal.valueOf(((IntegerLiteral) expression).getValue());
+    } else if (expression instanceof LongLiteral) {
+      literalValue =  BigDecimal.valueOf(((LongLiteral) expression).getValue());
+    } else if (expression instanceof DoubleLiteral) {
+      literalValue = BigDecimal.valueOf(((DoubleLiteral) expression).getValue());
+    } else if (expression instanceof DecimalLiteral) {
+      literalValue = ((DecimalLiteral) expression).getValue();
+    } else {
+      return expression;
+    }
+
+    final SqlDecimal fromDecimalType = (SqlDecimal) DecimalUtil.fromValue(literalValue);
+    if (DecimalUtil.canImplicitlyCast(fromDecimalType, toDecimalType)) {
+      return new DecimalLiteral(
+          expression.getLocation(),
+          DecimalUtil.cast(literalValue, toDecimalType.getPrecision(), toDecimalType.getScale())
+      );
+    }
+
+    return expression;
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/FinalProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/FinalProjectNodeTest.java
@@ -27,8 +27,9 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
-import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
@@ -66,7 +67,9 @@ public class FinalProjectNodeTest {
   @Mock
   private PlanNode source;
   @Mock
-  private FunctionRegistry functionRegistry;
+  private MetaStore metaStore;
+  @Mock
+  private Analysis.Into into;
 
   private List<SelectItem> selects;
   private FinalProjectNode projectNode;
@@ -88,8 +91,8 @@ public class FinalProjectNodeTest {
         NODE_ID,
         source,
         selects,
-        true,
-        functionRegistry);
+        Optional.of(into),
+        metaStore);
   }
 
   @Test
@@ -116,8 +119,8 @@ public class FinalProjectNodeTest {
         NODE_ID,
         source,
         selects,
-        true,
-        functionRegistry);
+        Optional.of(into),
+        metaStore);
 
     // Then:
     verify(source).validateColumns(RequiredColumns.builder().add(syntheticKeyRef).build());
@@ -142,8 +145,8 @@ public class FinalProjectNodeTest {
             NODE_ID,
             source,
             selects,
-            true,
-            functionRegistry)
+            Optional.of(into),
+            metaStore)
     );
 
     // Then:
@@ -162,8 +165,8 @@ public class FinalProjectNodeTest {
             NODE_ID,
             source,
             selects,
-            true,
-            functionRegistry
+            Optional.of(into),
+            metaStore
         )
     );
 
@@ -186,8 +189,8 @@ public class FinalProjectNodeTest {
             NODE_ID,
             source,
             selects,
-            true,
-            functionRegistry
+            Optional.of(into),
+            metaStore
         )
     );
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ImplicitlyCastResolverTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ImplicitlyCastResolverTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
+import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
+import io.confluent.ksql.execution.expression.tree.Literal;
+import io.confluent.ksql.execution.expression.tree.LongLiteral;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.schema.ksql.types.SqlDecimal;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ImplicitlyCastResolverTest {
+  private static final SqlDecimal DECIMAL_5_2 = SqlDecimal.of(5, 2);
+
+  @Test
+  public void shouldNotResolveNonDecimalTarget() {
+    // When
+    final Expression expression =
+        ImplicitlyCastResolver.resolve(new IntegerLiteral(5), SqlTypes.STRING);
+
+    // Then
+    assertThat(expression, instanceOf(IntegerLiteral.class));
+    assertThat(((IntegerLiteral)expression).getValue(), is(5));
+  }
+
+  @Test
+  public void shouldCastToDecimal() {
+    // Given
+    final Map<Literal, BigDecimal> fromLiterals = ImmutableMap.of(
+        new IntegerLiteral(5), new BigDecimal("5.00"),
+        new LongLiteral(5), new BigDecimal("5.00"),
+        new DoubleLiteral(5), new BigDecimal("5.00"),
+        new DecimalLiteral(BigDecimal.TEN), new BigDecimal("10.00"),
+        new DecimalLiteral(new BigDecimal("10.1")), new BigDecimal("10.10")
+    );
+
+    for (final Map.Entry<Literal, BigDecimal> entry : fromLiterals.entrySet()) {
+      final Literal literal = entry.getKey();
+      final BigDecimal expected = entry.getValue();
+
+      // When
+      final Expression expression =
+          ImplicitlyCastResolver.resolve(literal, DECIMAL_5_2);
+
+      // Then
+      assertThat("Should cast " + literal.getClass().getSimpleName() + " to " + DECIMAL_5_2,
+          expression, instanceOf(DecimalLiteral.class));
+      assertThat("Should cast " + literal.getClass().getSimpleName() + " to " + DECIMAL_5_2,
+          ((DecimalLiteral)expression).getValue(),
+          is(expected)
+      );
+    }
+  }
+
+  @Test
+  public void shouldNotCastToDecimal() {
+    // Given
+    final List<Literal> fromLiterals = Arrays.asList(
+        new BooleanLiteral("true"),
+        new StringLiteral("10.2"),
+        new DecimalLiteral(BigDecimal.valueOf(10.133))
+    );
+
+    for (final Literal literal : fromLiterals) {
+      // When
+      final Expression expression =
+          ImplicitlyCastResolver.resolve(literal, DECIMAL_5_2);
+
+      // Then
+      assertThat("Should not cast " + literal.getClass().getSimpleName() + " to " + DECIMAL_5_2,
+          expression, instanceOf(literal.getClass()));
+      assertThat("Should not cast " + literal.getClass().getSimpleName() + " to " + DECIMAL_5_2,
+          expression.equals(literal), is(true));
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_implicitly_casts/6.1.0_1597343542697/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_implicitly_casts/6.1.0_1597343542697/plan.json
@@ -1,0 +1,141 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM SOURCE (IGNORED STRING) WITH (KAFKA_TOPIC='source', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "SOURCE",
+      "schema" : "`IGNORED` STRING",
+      "topicName" : "source",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TARGET (C1 DECIMAL(5, 2), C2 DECIMAL(5, 2)) WITH (KAFKA_TOPIC='target', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TARGET",
+      "schema" : "`C1` DECIMAL(5, 2), `C2` DECIMAL(5, 2)",
+      "topicName" : "target",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "INSERT INTO TARGET SELECT\n  1 C1,\n  2.0 C2\nFROM SOURCE SOURCE\nEMIT CHANGES",
+    "queryPlan" : {
+      "sources" : [ "SOURCE" ],
+      "sink" : "TARGET",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TARGET"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "source",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "sourceSchema" : "`IGNORED` STRING"
+          },
+          "selectExpressions" : [ "1.00 AS C1", "2.00 AS C2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "target"
+      },
+      "queryId" : "INSERTQUERY_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "false",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : "true",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.suppress.buffer.size" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : ""
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_implicitly_casts/6.1.0_1597343542697/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_implicitly_casts/6.1.0_1597343542697/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1597343542697,
+  "path" : "query-validation-tests/insert-into.json",
+  "schemas" : {
+    "INSERTQUERY_0.KsqlTopic.Source" : "STRUCT<IGNORED VARCHAR> NOT NULL",
+    "INSERTQUERY_0.TARGET" : "STRUCT<C1 DECIMAL(3, 2), C2 DECIMAL(3, 2)> NOT NULL"
+  },
+  "testCase" : {
+    "name" : "implicitly casts",
+    "inputs" : [ {
+      "topic" : "source",
+      "key" : null,
+      "value" : {
+        "ignored" : "v1"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "target",
+      "key" : null,
+      "value" : {
+        "C1" : 1.00,
+        "C2" : 2.00
+      }
+    } ],
+    "topics" : [ {
+      "name" : "source",
+      "schema" : {
+        "type" : "record",
+        "name" : "KsqlDataSourceSchema",
+        "namespace" : "io.confluent.ksql.avro_schemas",
+        "fields" : [ {
+          "name" : "IGNORED",
+          "type" : [ "null", "string" ],
+          "default" : null
+        } ],
+        "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+      },
+      "format" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "target",
+      "schema" : {
+        "type" : "record",
+        "name" : "KsqlDataSourceSchema",
+        "namespace" : "io.confluent.ksql.avro_schemas",
+        "fields" : [ {
+          "name" : "C1",
+          "type" : [ "null", {
+            "type" : "bytes",
+            "scale" : 2,
+            "precision" : 5,
+            "connect.version" : 1,
+            "connect.parameters" : {
+              "scale" : "2",
+              "connect.decimal.precision" : "5"
+            },
+            "connect.name" : "org.apache.kafka.connect.data.Decimal",
+            "logicalType" : "decimal"
+          } ],
+          "default" : null
+        }, {
+          "name" : "C2",
+          "type" : [ "null", {
+            "type" : "bytes",
+            "scale" : 2,
+            "precision" : 5,
+            "connect.version" : 1,
+            "connect.parameters" : {
+              "scale" : "2",
+              "connect.decimal.precision" : "5"
+            },
+            "connect.name" : "org.apache.kafka.connect.data.Decimal",
+            "logicalType" : "decimal"
+          } ],
+          "default" : null
+        } ],
+        "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+      },
+      "format" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM SOURCE (ignored VARCHAR) WITH (kafka_topic='source', value_format='AVRO');", "CREATE STREAM TARGET (c1 DECIMAL(5,2), c2 DECIMAL(5,2)) WITH (kafka_topic='target', value_format='AVRO');", "INSERT INTO TARGET SELECT 1 as c1, 2.0 as c2 FROM SOURCE;" ],
+    "post" : {
+      "topics" : {
+        "topics" : [ {
+          "name" : "source",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "target",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_implicitly_casts/6.1.0_1597343542697/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/insert-into_-_implicitly_casts/6.1.0_1597343542697/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [source])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: target)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
@@ -173,6 +173,20 @@
         {"topic": "_confluent-ksql-some.ksql.service.idquery_INSERTQUERY_0-KSTREAM-JOINOTHER-0000000017-store-changelog", "window": {"start": 0, "end": 1000, "type": "time"}, "key": "v1", "value": {"S2_K": "v1", "S2_ROWTIME": 0, "S2_ID": "s2-key"}},
         {"topic": "OUTPUT", "key": "v1", "value": {"DATA": "s1-keys2-key", "I": 1}}
       ]
+    },
+    {
+      "name": "implicitly casts",
+      "statements": [
+        "CREATE STREAM SOURCE (ignored VARCHAR) WITH (kafka_topic='source', value_format='AVRO');",
+        "CREATE STREAM TARGET (c1 DECIMAL(5,2), c2 DECIMAL(5,2)) WITH (kafka_topic='target', value_format='AVRO');",
+        "INSERT INTO TARGET SELECT 1 as c1, 2.0 as c2 FROM SOURCE;"
+      ],
+      "inputs": [
+        {"topic": "source", "value": {"ignored": "v1"}}
+      ],
+      "outputs": [
+        {"topic": "target", "value": {"C1": 1.00, "C2": 2.00}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/5285

Allows implicitly casting of numeric literals to decimals when executing an `INSERT/SELECT` statement. A conversion from one literal type to another is done in the `SelectionUtil.buildSelectExpressions()` method, which uses the `ImplicitlyCastResolver` to cast a supported type if necessary. 

A conversion of column schema is used Instead of just allowing the schema during the validation in the `EngineExecutor.validateExistingSink()`. The reason is that SchemaRegistry/AVRO does not allow some type of conversions, like INT/BIGINT -> DECIMAL as they are incompatible.

The validation in the `EngineExecutor.validateExistingSink()`` is required only for DECIMAL -> DECIMAL of different precision and scale. `ImplicitlyCastResolver` can only convert to a different scale, but precision is based on the literal number. Without this, the validation will fail due to a different precision.

Implicitly cast is supported on the following literal types:
* INT,BIGINT,DOUBLE -> DECIMAL
* DECIMAL -> DECIMAL from lower to higher precision/scale

When casting any number to DECIMAL, the `ImplicitlyCastResolver` makes sure that the precision/scale of the number is compatible with the target decimal precision/scale. The `DecimalUtil.canImplicitlyCast()` is used to check that.

The reason to not allow non-literals numbers is because INT,BIGINT,DOUBLE numbers found in the topic records might have different precision than the one defined in the target decimal: i.e. `DOUBLE -> DECIMAL(1,0)`. 

Other implicitly conversions, such as INT -> BIGINT,DOUBLE, BIGINT -> DOUBLE are not possible yet as there's another refactor to do to support that. Turns out that when the INT -> BIGINT is allowed by this PR, then when the node reads the statement text from the command topic and parses it, it creates an IntegerLiteral instead of the desired LongLiteral. More refactoring is needed to support that, but this PR is fixing only https://github.com/confluentinc/ksql/issues/5285 for now.

### Testing done 
- Added unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

