### PR TITLE
docs: fixes incorrect docker install default command path

### DIFF
--- a/docs/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -409,20 +409,18 @@ Discover the default command that the container runs when it launches,
 which is either `Entrypoint` or `Cmd`:
 
 ```bash
-{% raw %}
-docker inspect --format='{{.Config.Entrypoint}}' confluentinc/ksqldb-server:{{ site.release }}
-docker inspect --format='{{.Config.Cmd}}' confluentinc/ksqldb-server:{{ site.release }}
-{% endraw %}
+docker inspect --format={% raw %}'{{.Config.Entrypoint}}'{% endraw %} confluentinc/ksqldb-server:{{ site.release }}
+docker inspect --format={% endraw %}'{{.Config.Cmd}}'{% endraw %} confluentinc/ksqldb-server:{{ site.release }}
 ```
 
 Your output should resemble:
 
 ```
     []
-    [/etc/confluent/docker/run]
+    [/usr/bin/docker/run]
 ```
 
-In this example, the default command is `/etc/confluent/docker/run`.
+In this example, the default command is `/usr/bin/docker/run`.
 
 #### Run custom commands before the ksqlDB process starts
 
@@ -446,11 +444,11 @@ ksql-server:
       mkdir -p /data/maxmind
       cd /data/maxmind
       curl https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz | tar xz 
-      /etc/confluent/docker/run
+      /usr/bin/docker/run
 ```
 
 After the `mkdir`, `cd`, `curl`, and `tar` commands run, the
-`/etc/confluent/docker/run` command starts the `ksqldb-server` image
+`/usr/bin/docker/run` command starts the `ksqldb-server` image
 with the specified settings.
 
 !!! note


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
Fix for #6007 
- Fixes the default docker image command to what ksqldb-server actually uses in example code
- Modifies the jinja template escaping to only escape the double brackets within the `--format` params in order to properly template the `{{ site.release }}` version.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
Verified the jinja renders from a local setup but can't verify that it's templated properly from your side.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

