### PR TITLE
refactor: break up InsertValuesExecutor for easier reuse in testing tool

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericExpressionResolver.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericExpressionResolver.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine.generic;
+
+import com.google.common.collect.Iterables;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.codegen.CodeGenRunner;
+import io.confluent.ksql.execution.codegen.ExpressionMetadata;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.NullLiteral;
+import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.logging.processing.RecordProcessingError;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlValueCoercer;
+import io.confluent.ksql.schema.ksql.types.SqlBaseType;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Builds a Java object, coerced to the desired type, from an arbitrary SQL
+ * expression that does not reference any source data.
+ */
+class GenericExpressionResolver extends VisitParentExpressionVisitor<Object, Void> {
+
+  private static final Supplier<String> IGNORED_MSG = () -> "";
+  private static final ProcessingLogger THROWING_LOGGER = errorMessage -> {
+    throw new KsqlException(((RecordProcessingError) errorMessage).getMessage());
+  };
+
+  private final SqlType fieldType;
+  private final ColumnName fieldName;
+  private final LogicalSchema schema;
+  private final SqlValueCoercer sqlValueCoercer = DefaultSqlValueCoercer.INSTANCE;
+  private final FunctionRegistry functionRegistry;
+  private final KsqlConfig config;
+
+  GenericExpressionResolver(
+      final SqlType fieldType,
+      final ColumnName fieldName,
+      final LogicalSchema schema,
+      final FunctionRegistry functionRegistry,
+      final KsqlConfig config
+  ) {
+    this.fieldType = Objects.requireNonNull(fieldType, "fieldType");
+    this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
+    this.schema = Objects.requireNonNull(schema, "schema");
+    this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+    this.config = Objects.requireNonNull(config, "config");
+  }
+
+  @Override
+  protected Object visitExpression(final Expression expression, final Void context) {
+    final ExpressionMetadata metadata =
+        Iterables.getOnlyElement(
+            CodeGenRunner.compileExpressions(
+                Stream.of(expression),
+                "insert value",
+                schema,
+                config,
+                functionRegistry)
+        );
+
+    // we expect no column references, so we can pass in an empty generic row
+    final Object value = metadata.evaluate(new GenericRow(), null, THROWING_LOGGER, IGNORED_MSG);
+
+    return sqlValueCoercer.coerce(value, fieldType)
+        .orElseThrow(() -> {
+          final SqlBaseType valueSqlType = SchemaConverters.javaToSqlConverter()
+              .toSqlType(value.getClass());
+
+          return new KsqlException(
+              String.format("Expected type %s for field %s but got %s(%s)",
+                  fieldType,
+                  fieldName,
+                  valueSqlType,
+                  value));
+        })
+        .orElse(null);
+  }
+
+  @Override
+  public Object visitNullLiteral(final NullLiteral node, final Void context) {
+    return null;
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
@@ -49,13 +49,6 @@ public class GenericRecordFactory {
 
   public GenericRecordFactory(
       final KsqlConfig config,
-      final FunctionRegistry functionRegistry
-  ) {
-    this(config, functionRegistry, System::currentTimeMillis);
-  }
-
-  public GenericRecordFactory(
-      final KsqlConfig config,
       final FunctionRegistry functionRegistry,
       final LongSupplier clock
   ) {
@@ -153,7 +146,7 @@ public class GenericRecordFactory {
           schema,
           functionRegistry,
           config
-      ).process(valueExp, null);
+      ).resolve(valueExp);
 
       values.put(column, value);
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine.generic;
+
+import com.google.common.collect.Streams;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SystemColumns;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * Builds {@link KsqlGenericRecord} from lists of expressions/column names,
+ * coercing any values to the correct java type using the schema of the supplied
+ * {@link DataSource}.
+ */
+public class GenericRecordFactory {
+
+  private final KsqlConfig config;
+  private final FunctionRegistry functionRegistry;
+  private final LongSupplier clock;
+
+  public GenericRecordFactory(
+      final KsqlConfig config,
+      final FunctionRegistry functionRegistry
+  ) {
+    this(config, functionRegistry, System::currentTimeMillis);
+  }
+
+  public GenericRecordFactory(
+      final KsqlConfig config,
+      final FunctionRegistry functionRegistry,
+      final LongSupplier clock
+  ) {
+    this.config = Objects.requireNonNull(config, "config");
+    this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
+  public KsqlGenericRecord build(
+      final List<ColumnName> columnNames,
+      final List<Expression> expressions,
+      final LogicalSchema schema,
+      final DataSourceType dataSourceType
+  ) {
+    final List<ColumnName> columns = columnNames.isEmpty()
+        ? implicitColumns(schema)
+        : columnNames;
+
+    if (columns.size() != expressions.size()) {
+      throw new KsqlException(
+          "Expected a value for each column."
+              + " Expected Columns: " + columnNames
+              + ". Got " + expressions);
+    }
+
+    final LogicalSchema schemaWithRowTime = withRowTime(schema);
+    for (ColumnName col : columns) {
+      if (!schemaWithRowTime.findColumn(col).isPresent()) {
+        throw new KsqlException("Column name " + col + " does not exist.");
+      }
+    }
+
+    final Map<ColumnName, Object> values = resolveValues(
+        columns,
+        expressions,
+        schemaWithRowTime,
+        functionRegistry,
+        config
+    );
+
+    if (dataSourceType == DataSourceType.KTABLE) {
+      final String noValue = schemaWithRowTime.key().stream()
+          .map(Column::name)
+          .filter(colName -> !values.containsKey(colName))
+          .map(ColumnName::text)
+          .collect(Collectors.joining(", "));
+
+      if (!noValue.isEmpty()) {
+        throw new KsqlException("Value for primary key column(s) "
+            + noValue + " is required for tables");
+      }
+    }
+
+    final long ts = (long) values.getOrDefault(SystemColumns.ROWTIME_NAME, clock.getAsLong());
+
+    final Struct key = buildKey(schema, values);
+    final GenericRow value = buildValue(schema, values);
+
+    return KsqlGenericRecord.of(key, value, ts);
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  private static List<ColumnName> implicitColumns(final LogicalSchema schema) {
+    return Streams.concat(
+        schema.key().stream(),
+        schema.value().stream())
+        .map(Column::name)
+        .collect(Collectors.toList());
+  }
+
+  private static LogicalSchema withRowTime(final LogicalSchema schema) {
+    // The set of columns users can supply values for includes the ROWTIME pseudocolumn,
+    // so include it in the schema:
+    return schema.asBuilder()
+        .valueColumn(SystemColumns.ROWTIME_NAME, SystemColumns.ROWTIME_TYPE)
+        .build();
+  }
+
+  private static Map<ColumnName, Object> resolveValues(
+      final List<ColumnName> columns,
+      final List<Expression> expressions,
+      final LogicalSchema schema,
+      final FunctionRegistry functionRegistry,
+      final KsqlConfig config
+  ) {
+    final Map<ColumnName, Object> values = new HashMap<>();
+    for (int i = 0; i < columns.size(); i++) {
+      final ColumnName column = columns.get(i);
+      final SqlType columnType = columnType(column, schema);
+      final Expression valueExp = expressions.get(i);
+
+      final Object value = new GenericExpressionResolver(
+          columnType,
+          column,
+          schema,
+          functionRegistry,
+          config
+      ).process(valueExp, null);
+
+      values.put(column, value);
+    }
+    return values;
+  }
+
+  private static SqlType columnType(final ColumnName column, final LogicalSchema schema) {
+    return schema
+        .findColumn(column)
+        .map(Column::type)
+        .orElseThrow(IllegalStateException::new);
+  }
+
+  private static Struct buildKey(
+      final LogicalSchema schema,
+      final Map<ColumnName, Object> values
+  ) {
+
+    final Struct key = new Struct(schema.keyConnectSchema());
+
+    for (final org.apache.kafka.connect.data.Field field : key.schema().fields()) {
+      final Object value = values.get(ColumnName.of(field.name()));
+      key.put(field, value);
+    }
+
+    return key;
+  }
+
+  private static GenericRow buildValue(
+      final LogicalSchema schema,
+      final Map<ColumnName, Object> values
+  ) {
+    return new GenericRow().appendAll(
+        schema
+            .value()
+            .stream()
+            .map(Column::name)
+            .map(values::get)
+            .collect(Collectors.toList())
+    );
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/KsqlGenericRecord.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/KsqlGenericRecord.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine.generic;
+
+import io.confluent.ksql.GenericRow;
+import java.util.Objects;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * Represents a record in ksqlDB which consists of a {@link Struct} key,
+ * a {@link GenericRow} value and a {@code long} timestamp. This is mostly
+ * used when generating data from SQL expressions.
+ */
+public class KsqlGenericRecord {
+
+  public final Struct key;
+  public final GenericRow value;
+  public final long ts;
+
+  public static KsqlGenericRecord of(
+      final Struct key,
+      final GenericRow value,
+      final long ts
+  ) {
+    return new KsqlGenericRecord(key, value, ts);
+  }
+
+  private KsqlGenericRecord(
+      final Struct key,
+      final GenericRow value,
+      final long ts
+  ) {
+    this.key = key;
+    this.value = value;
+    this.ts = ts;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KsqlGenericRecord that = (KsqlGenericRecord) o;
+    return ts == that.ts
+        && Objects.equals(key, that.key)
+        && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key, value, ts);
+  }
+
+  @Override
+  public String toString() {
+    return "KsqlGenericRecord{"
+        + "key=" + key
+        + ", value=" + value
+        + ", ts=" + ts
+        + '}';
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/KsqlGenericRecord.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/KsqlGenericRecord.java
@@ -24,7 +24,7 @@ import org.apache.kafka.connect.data.Struct;
  * a {@link GenericRow} value and a {@code long} timestamp. This is mostly
  * used when generating data from SQL expressions.
  */
-public class KsqlGenericRecord {
+public final class KsqlGenericRecord {
 
   public final Struct key;
   public final GenericRow value;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/generic/GenericRecordFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/generic/GenericRecordFactoryTest.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine.generic;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
+import io.confluent.ksql.execution.expression.tree.LongLiteral;
+import io.confluent.ksql.execution.expression.tree.NullLiteral;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.function.TestFunctionRegistry;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SystemColumns;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GenericRecordFactoryTest {
+
+  private static final ColumnName KEY = ColumnName.of("K0");
+  private static final ColumnName COL0 = ColumnName.of("COL0");
+  private static final ColumnName COL1 = ColumnName.of("COL1");
+
+  private final AtomicLong clock = new AtomicLong();
+  private final KsqlConfig config = new KsqlConfig(ImmutableMap.of());
+  private final FunctionRegistry functions = TestFunctionRegistry.INSTANCE.get();
+  private final GenericRecordFactory recordFactory = new GenericRecordFactory(config, functions, clock::get);
+
+  @Before
+  public void setUp() {
+    clock.set(0L);
+  }
+
+  @Test
+  public void shouldBuildExpression() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(KEY, COL0);
+    final Expression exp = new FunctionCall(
+        FunctionName.of("CONCAT"),
+        ImmutableList.of(new StringLiteral("a"), new StringLiteral("b"))
+    );
+
+    // When:
+    final KsqlGenericRecord record = recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    );
+
+    // Then:
+    assertThat(record, is(KsqlGenericRecord.of(
+        new Struct(
+            SchemaBuilder.struct()
+                .field(KEY.text(), Schema.OPTIONAL_STRING_SCHEMA)
+                .build())
+            .put(KEY.text(), "ab"),
+        GenericRow.genericRow("ab"),
+        0
+    )));
+  }
+
+  @Test
+  public void shouldHandleArbitraryOrdering() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(COL0, KEY);
+
+    // When:
+    final KsqlGenericRecord record = recordFactory.build(
+        names,
+        ImmutableList.of(new StringLiteral("value"), new StringLiteral("key")),
+        schema,
+        DataSourceType.KSTREAM
+    );
+
+    // Then:
+    assertThat(record, is(KsqlGenericRecord.of(
+        new Struct(
+            SchemaBuilder.struct()
+                .field(KEY.text(), Schema.OPTIONAL_STRING_SCHEMA)
+                .build())
+            .put(KEY.text(), "key"),
+        GenericRow.genericRow("value"),
+        0
+    )));
+  }
+
+  @Test
+  public void shouldBuildCoerceTypes() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.BIGINT)
+        .valueColumn(COL0, SqlTypes.BIGINT)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(KEY, COL0);
+    final Expression exp = new IntegerLiteral(1);
+
+    // When:
+    final KsqlGenericRecord record = recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    );
+
+    // Then:
+    assertThat(record, is(KsqlGenericRecord.of(
+        new Struct(
+            SchemaBuilder.struct()
+                .field(KEY.text(), Schema.OPTIONAL_INT64_SCHEMA)
+                .build())
+            .put(KEY.text(), 1L),
+        GenericRow.genericRow(1L),
+        0
+    )));
+  }
+
+  @Test
+  public void shouldAcceptNullsForAnyColumn() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.BIGINT)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(KEY, COL0);
+
+    // When:
+    final KsqlGenericRecord record = recordFactory.build(
+        names, ImmutableList.of(new NullLiteral(), new NullLiteral()), schema, DataSourceType.KSTREAM
+    );
+
+    // Then:
+    assertThat(record, is(KsqlGenericRecord.of(
+        new Struct(
+            SchemaBuilder.struct()
+                .field(KEY.text(), Schema.OPTIONAL_STRING_SCHEMA)
+                .build())
+            .put(KEY.text(), null),
+        GenericRow.genericRow((Object) null),
+        0
+    )));
+  }
+
+  @Test
+  public void shouldBuildWithRowtime() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(SystemColumns.ROWTIME_NAME, KEY, COL0);
+    final Expression exp = new StringLiteral("a");
+
+    // When:
+    final KsqlGenericRecord record = recordFactory.build(
+        names, ImmutableList.of(new LongLiteral(1L), exp, exp), schema, DataSourceType.KSTREAM
+    );
+
+    // Then:
+    assertThat(record, is(KsqlGenericRecord.of(
+        new Struct(
+            SchemaBuilder.struct()
+                .field(KEY.text(), Schema.OPTIONAL_STRING_SCHEMA)
+                .build())
+            .put(KEY.text(), "a"),
+        GenericRow.genericRow("a"),
+        1
+    )));
+  }
+
+  @Test
+  public void shouldUseClockTime() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(KEY, COL0);
+    final Expression exp = new StringLiteral("a");
+    clock.set(1L);
+
+    // When:
+    final KsqlGenericRecord record = recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    );
+
+    // Then:
+    assertThat(record, is(KsqlGenericRecord.of(
+        new Struct(
+            SchemaBuilder.struct()
+                .field(KEY.text(), Schema.OPTIONAL_STRING_SCHEMA)
+                .build())
+            .put(KEY.text(), "a"),
+        GenericRow.genericRow("a"),
+        1
+    )));
+  }
+
+  @Test
+  public void shouldBuildPartialColumns() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .valueColumn(COL1, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(KEY, COL0);
+    final Expression exp = new StringLiteral("a");
+
+    // When:
+    final KsqlGenericRecord record = recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    );
+
+    // Then:
+    assertThat(record, is(KsqlGenericRecord.of(
+        new Struct(
+            SchemaBuilder.struct()
+                .field(KEY.text(), Schema.OPTIONAL_STRING_SCHEMA)
+                .build())
+            .put(KEY.text(), "a"),
+        GenericRow.genericRow("a", null),
+        0
+    )));
+  }
+
+  @Test
+  public void shouldInferColumns() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of();
+    final Expression exp = new StringLiteral("a");
+
+    // When:
+    final KsqlGenericRecord record = recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    );
+
+    // Then:
+    assertThat(record, is(KsqlGenericRecord.of(
+        new Struct(
+            SchemaBuilder.struct()
+                .field(KEY.text(), Schema.OPTIONAL_STRING_SCHEMA)
+                .build())
+            .put(KEY.text(), "a"),
+        GenericRow.genericRow("a"),
+        0
+    )));
+  }
+
+  @Test
+  public void shouldThrowOnColumnMismatch() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .valueColumn(COL1, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(KEY, COL0, COL1);
+    final Expression exp = new StringLiteral("a");
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    ));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Expected a value for each column"));
+  }
+
+  @Test
+  public void shouldThrowOnColumnMismatchWhenInferred() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .valueColumn(COL1, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of();
+    final Expression exp = new StringLiteral("a");
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    ));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Expected a value for each column"));
+  }
+
+  @Test
+  public void shouldThrowOnUnknownColumn() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .build();
+
+    final List<ColumnName> names = ImmutableList.of(KEY, COL1);
+    final Expression exp = new StringLiteral("a");
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    ));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("does not exist"));
+  }
+
+  @Test
+  public void shouldThrowOnTableMissingKey() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.STRING)
+        .valueColumn(COL1, SqlTypes.STRING)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(COL0, COL1);
+    final Expression exp = new StringLiteral("a");
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KTABLE
+    ));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Value for primary key column"));
+  }
+
+  @Test
+  public void shouldThrowOnTypeMismatchCannotCoerce() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(KEY, SqlTypes.STRING)
+        .valueColumn(COL0, SqlTypes.INTEGER)
+        .build();
+    final List<ColumnName> names = ImmutableList.of(KEY, COL0);
+    final Expression exp = new StringLiteral("a");
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> recordFactory.build(
+        names, ImmutableList.of(exp, exp), schema, DataSourceType.KSTREAM
+    ));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Expected type"));
+  }
+
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -70,8 +70,27 @@ public class CodeGenRunner {
     final CodeGenRunner codeGen = new CodeGenRunner(schema, ksqlConfig, functionRegistry);
 
     return expressions
-        .map(exp -> codeGen.buildCodeGenFromParseTree(exp, type))
+        .map(exp -> compileExpression(exp, type, codeGen))
         .collect(Collectors.toList());
+  }
+
+  public static ExpressionMetadata compileExpression(
+      final Expression expression,
+      final String type,
+      final LogicalSchema schema,
+      final KsqlConfig ksqlConfig,
+      final FunctionRegistry functionRegistry
+  ) {
+    final CodeGenRunner codeGen = new CodeGenRunner(schema, ksqlConfig, functionRegistry);
+    return compileExpression(expression, type, codeGen);
+  }
+
+  private static ExpressionMetadata compileExpression(
+      final Expression expression,
+      final String type,
+      final CodeGenRunner codeGen
+  ) {
+    return codeGen.buildCodeGenFromParseTree(expression, type);
   }
 
   public CodeGenRunner(

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicate.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicate.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.execution.transform.sqlpredicate;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterables;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
@@ -31,7 +30,6 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 public final class SqlPredicate {
 
@@ -46,13 +44,13 @@ public final class SqlPredicate {
   ) {
     this(
         filterExpression,
-        Iterables.getOnlyElement(CodeGenRunner.compileExpressions(
-            Stream.of(filterExpression),
+        CodeGenRunner.compileExpression(
+            filterExpression,
             "Predicate",
             schema,
             ksqlConfig,
             functionRegistry
-        ))
+        )
     );
   }
 

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -356,6 +356,18 @@
       "outputs": [
         {"topic": "test_topic", "key": 1, "value": {"V0": 0.00}}
       ]
+    },
+    {
+      "name": "should fail on column reference",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (K, ID) VALUES (FOO.bar, '10');"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Failed to prepare statement: 'FOO' is not a valid stream/table name or alias.",
+        "status": 400
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

This PR breaks up the `InsertValuesExecutor` into separate classes and adds more unit testing. The motivation is because I plan to reuse `GenericRecordFactory` for YATT (see #5965).

### Testing done 

No functional changes, all copy-pasta - but I added unit tests anyway.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

