### PR TITLE
fix: set restarted query as healthy during a time threshold

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -340,6 +340,12 @@ public class KsqlConfig extends AbstractConfig {
       + "error messages (per query) to hold in the internal query errors queue and display"
       + "in the query description when executing the `EXPLAIN <query>` command.";
 
+  public static final String KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS =
+      "ksql.query.status.running.threshold.seconds";
+  private static final Integer KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DEFAULT = 18000;
+  private static final String KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DOC = "Amount of time in "
+      + "seconds to wait before setting a restarted query status as healthy (or running).";
+
   public static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST =
       "ksql.properties.overrides.denylist";
   private static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
@@ -787,6 +793,13 @@ public class KsqlConfig extends AbstractConfig {
             "",
             Importance.LOW,
             KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC
+        )
+        .define(
+            KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS,
+            Type.INT,
+            KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -342,7 +342,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS =
       "ksql.query.status.running.threshold.seconds";
-  private static final Integer KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DEFAULT = 18000;
+  private static final Integer KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DEFAULT = 300;
   private static final String KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DOC = "Amount of time in "
       + "seconds to wait before setting a restarted query status as healthy (or running).";
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryMonitor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryMonitor.java
@@ -147,13 +147,16 @@ public class QueryMonitor implements Closeable {
             if (now >= retryEvent.queryHealthyTime()) {
               // Clean the errors queue & delete the query from future retries now the query is
               // healthy and has been running after some threshold time
-              query.ifPresent(QueryMetadata::clearErrors);
+              queryMetadata.clearErrors();
               it.remove();
             }
             break;
+          case CREATED:
+            // Do nothing.
+            continue;
           default:
             // Stop attempting restarts for any other status. Either the query is pending
-            // a shutdown or other status that do not track.
+            // a shutdown or other status that we do not track.
             it.remove();
             break;
         }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/QueryStateListener.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/QueryStateListener.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.internal;
 
+import com.google.common.base.Ticker;
 import io.confluent.ksql.query.ErrorStateListener;
 import io.confluent.ksql.query.QueryError;
 import java.util.Collections;
@@ -25,23 +26,43 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.streams.KafkaStreams.State;
 
 public class QueryStateListener implements ErrorStateListener {
+  public static final Ticker CURRENT_TIME_MILLIS_TICKER = new Ticker() {
+    @Override
+    public long read() {
+      return System.currentTimeMillis();
+    }
+  };
+
   private static final String NO_ERROR = "NO_ERROR";
 
   private final Metrics metrics;
   private final MetricName stateMetricName;
   private final MetricName errorMetricName;
+  private final Ticker ticker;
 
+  private volatile State currentState = State.CREATED;
   private volatile String state = "-";
   private volatile String error = NO_ERROR;
+  private volatile long runningSince;
 
   QueryStateListener(
       final Metrics metrics,
       final String groupPrefix,
       final String queryApplicationId
   ) {
+    this(metrics, groupPrefix, queryApplicationId, CURRENT_TIME_MILLIS_TICKER);
+  }
+
+  QueryStateListener(
+      final Metrics metrics,
+      final String groupPrefix,
+      final String queryApplicationId,
+      final Ticker ticker
+  ) {
     Objects.requireNonNull(groupPrefix, "groupPrefix");
     Objects.requireNonNull(queryApplicationId, "queryApplicationId");
     this.metrics = Objects.requireNonNull(metrics, "metrics cannot be null.");
+    this.ticker = Objects.requireNonNull(ticker, "ticker");
 
     this.stateMetricName = metrics.metricName(
         "query-status",
@@ -64,14 +85,24 @@ public class QueryStateListener implements ErrorStateListener {
   @Override
   public void onChange(final State newState, final State oldState) {
     state = newState.toString();
+    currentState = newState;
+
     if (newState != State.ERROR) {
       this.error = NO_ERROR;
+    }
+
+    if (newState.isRunningOrRebalancing() && !oldState.isRunningOrRebalancing()) {
+      runningSince = ticker.read();
     }
   }
 
   @Override
   public void onError(final QueryError error) {
     this.error = error.getType().name();
+  }
+
+  public long uptime() {
+    return (currentState.isRunningOrRebalancing() ? ticker.read() - runningSince : 0);
   }
 
   public void close() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -238,6 +238,10 @@ public abstract class QueryMetadata {
     return ImmutableList.copyOf(queryErrors);
   }
 
+  public long uptime() {
+    return queryStateListener.map(QueryStateListener::uptime).orElse(0L);
+  }
+
   protected boolean isClosed() {
     return closed;
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryMonitorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryMonitorTest.java
@@ -20,6 +20,7 @@ import static org.apache.kafka.streams.KafkaStreams.State.RUNNING;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -28,12 +29,17 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QueryMonitorTest {
+  private static long RETRY_BACKOFF_INITIAL_MS = 1;
+  private static long RETRY_BACKOFF_MAX_MS = 10;
+  private static long STATUS_RUNNING_THRESHOLD_MS = 15;
+
   @Mock
   private PersistentQueryMetadata queryMetadata;
   @Mock
@@ -47,8 +53,15 @@ public class QueryMonitorTest {
 
   @Before
   public void setup() {
-    when(ticker.read()).thenReturn(Long.MAX_VALUE);
-    queryMonitor = new QueryMonitor(ksqlEngine, executor, 1000, 1000, ticker);
+    when(ticker.read()).thenReturn(1L);
+    queryMonitor = new QueryMonitor(
+        ksqlEngine,
+        executor,
+        RETRY_BACKOFF_INITIAL_MS,
+        RETRY_BACKOFF_MAX_MS,
+        STATUS_RUNNING_THRESHOLD_MS,
+        ticker
+    );
   }
 
   @Test
@@ -80,75 +93,89 @@ public class QueryMonitorTest {
   @Test
   public void shouldRetryEventStartWithInitialValues() {
     // Given:
-    final long baseTime = 5;
-    final long currentTime = 20;
+    final long now = 20;
     final QueryId queryId = new QueryId("id-1");
-    when(ticker.read()).thenReturn(currentTime);
+    when(ticker.read()).thenReturn(now);
 
     // When:
-    final QueryMonitor.RetryEvent retryEvent =
-        new QueryMonitor.RetryEvent(ksqlEngine, queryId, baseTime, 100, ticker);
+    final QueryMonitor.RetryEvent retryEvent = new QueryMonitor.RetryEvent(
+        queryId,
+        RETRY_BACKOFF_INITIAL_MS,
+        RETRY_BACKOFF_MAX_MS,
+        STATUS_RUNNING_THRESHOLD_MS,
+        ticker
+    );
 
     // Then:
     assertThat(retryEvent.getNumRetries(), is(0));
-    assertThat(retryEvent.nextRestartTimeMs(), is(currentTime + baseTime));
+    assertThat(retryEvent.nextRestartTimeMs(), is(now + RETRY_BACKOFF_INITIAL_MS));
+    assertThat(retryEvent.queryHealthyTime(), is(now + STATUS_RUNNING_THRESHOLD_MS));
   }
 
   @Test
-  public void shouldRetryEventRestartAndIncrementBackoffTime() {
+  public void shouldRetryEventRestartAndIncrementBackoffAndHealthyTime() {
     // Given:
-    final long baseTime = 20;
-    final long currentTime = 20;
+    final long now = 20;
     final QueryId queryId = new QueryId("id-1");
-    when(ticker.read()).thenReturn(currentTime);
-    when(ksqlEngine.getPersistentQuery(queryId)).thenReturn(Optional.of(queryMetadata));
+    when(ticker.read()).thenReturn(now);
 
     // When:
-    final QueryMonitor.RetryEvent retryEvent =
-        new QueryMonitor.RetryEvent(ksqlEngine, queryId, baseTime, 50, ticker);
-    retryEvent.restart();
+    final QueryMonitor.RetryEvent retryEvent = new QueryMonitor.RetryEvent(
+        queryId,
+        RETRY_BACKOFF_INITIAL_MS,
+        RETRY_BACKOFF_MAX_MS,
+        STATUS_RUNNING_THRESHOLD_MS,
+        ticker
+    );
+    retryEvent.restart(queryMetadata);
 
     // Then:
     assertThat(retryEvent.getNumRetries(), is(1));
-    assertThat(retryEvent.nextRestartTimeMs(), is(currentTime + baseTime * 2));
+    assertThat(retryEvent.nextRestartTimeMs(), is(now + RETRY_BACKOFF_INITIAL_MS * 2));
+    assertThat(retryEvent.queryHealthyTime(), is(now + STATUS_RUNNING_THRESHOLD_MS));
     verify(queryMetadata).restart();
   }
 
   @Test
   public void shouldRetryEventRestartAndNotExceedBackoffMaxTime() {
     // Given:
-    final long baseTime = 20;
-    final long currentTime = 20;
-    final long maxTime = 50;
+    final long now = 20;
     final QueryId queryId = new QueryId("id-1");
-    when(ticker.read()).thenReturn(currentTime);
-    when(ksqlEngine.getPersistentQuery(queryId)).thenReturn(Optional.of(queryMetadata));
+    when(ticker.read()).thenReturn(now);
 
     // When:
-    final QueryMonitor.RetryEvent retryEvent =
-        new QueryMonitor.RetryEvent(ksqlEngine, queryId, baseTime, maxTime, ticker);
-    retryEvent.restart();
-    retryEvent.restart();
+    final QueryMonitor.RetryEvent retryEvent = new QueryMonitor.RetryEvent(
+        queryId,
+        RETRY_BACKOFF_INITIAL_MS,
+        RETRY_BACKOFF_MAX_MS,
+        STATUS_RUNNING_THRESHOLD_MS,
+        ticker
+    );
+    retryEvent.restart(queryMetadata);
+    retryEvent.restart(queryMetadata);
 
     // Then:
     assertThat(retryEvent.getNumRetries(), is(2));
-    assertThat(retryEvent.nextRestartTimeMs(), greaterThanOrEqualTo(currentTime + maxTime));
+    assertThat(retryEvent.nextRestartTimeMs(), lessThan(now + RETRY_BACKOFF_MAX_MS));
   }
 
   @Test
   public void shouldRetryEventNotThrowIfRestartThrowsException() {
     // Given:
-    final long baseTime = 20;
-    final long currentTime = 20;
+    final long now = 20;
     final QueryId queryId = new QueryId("id-1");
-    when(ticker.read()).thenReturn(currentTime);
-    when(ksqlEngine.getPersistentQuery(queryId)).thenReturn(Optional.of(queryMetadata));
+    when(ticker.read()).thenReturn(now);
     doThrow(IllegalStateException.class).when(queryMetadata).restart();
 
     // When:
-    final QueryMonitor.RetryEvent retryEvent =
-        new QueryMonitor.RetryEvent(ksqlEngine, queryId, baseTime, 50, ticker);
-    retryEvent.restart();
+    final QueryMonitor.RetryEvent retryEvent = new QueryMonitor.RetryEvent(
+        queryId,
+        RETRY_BACKOFF_INITIAL_MS,
+        RETRY_BACKOFF_MAX_MS,
+        STATUS_RUNNING_THRESHOLD_MS,
+        ticker
+    );
+    retryEvent.restart(queryMetadata);
 
     // Then:
     verify(queryMetadata).restart();
@@ -179,6 +206,7 @@ public class QueryMonitorTest {
     when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
 
     // When
+    when(ticker.read()).thenReturn(1L).thenReturn(RETRY_BACKOFF_INITIAL_MS + 2);
     queryMonitor.restartFailedQueries(); // 1st restart
 
     // Mock the query is in ERROR state, but then terminated manually
@@ -188,7 +216,6 @@ public class QueryMonitorTest {
     // Internally, the query is found as ERROR because getPersistentQueries() returns it, but
     // it will never be restarted because getPersistentQuery() does not return it.
     queryMonitor.restartFailedQueries(); // 2nd restart will not restart a non-present query
-
 
     // Then:
     verify(query, times(1)).restart();
@@ -202,6 +229,7 @@ public class QueryMonitorTest {
     when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
 
     // When:
+    when(ticker.read()).thenReturn(1L).thenReturn(RETRY_BACKOFF_INITIAL_MS + 2);
     queryMonitor.restartFailedQueries();
 
     // Then:
@@ -216,8 +244,9 @@ public class QueryMonitorTest {
     when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
 
     // When:
+    when(ticker.read()).thenReturn(1L).thenReturn(RETRY_BACKOFF_INITIAL_MS + 2);
     queryMonitor.restartFailedQueries();
-    when(ticker.read()).thenReturn(10000L);
+    when(ticker.read()).thenReturn(RETRY_BACKOFF_INITIAL_MS * 2 + 3);
     queryMonitor.restartFailedQueries();
 
     // Then:
@@ -230,7 +259,7 @@ public class QueryMonitorTest {
     final PersistentQueryMetadata query = mockPersistentQueryMetadata("id-1", ERROR);
     when(ksqlEngine.getPersistentQueries()).thenReturn(Arrays.asList(query));
     when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
-    when(ticker.read()).thenReturn(0L);
+    when(ticker.read()).thenReturn(RETRY_BACKOFF_INITIAL_MS - 1);
 
     // When:
     queryMonitor.restartFailedQueries();
@@ -248,13 +277,53 @@ public class QueryMonitorTest {
     when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
 
     // When:
+    when(ticker.read()).thenReturn(1L).thenReturn(RETRY_BACKOFF_INITIAL_MS + 2);
     queryMonitor.restartFailedQueries();
-    when(ticker.read()).thenReturn(10000L);
+    when(ticker.read()).thenReturn(RETRY_BACKOFF_INITIAL_MS + 3);
     when(query.isError()).thenReturn(false);
+    when(query.getState()).thenReturn(RUNNING);
     queryMonitor.restartFailedQueries(); // 2nd round should not restart before backoff time
 
     // Then:
     verify(query, times(1)).restart();
+  }
+
+  @Test
+  public void shouldRestartedQueryNotClearErrorsBeforeHealthyTime() {
+    // Given:
+    final PersistentQueryMetadata query = mockPersistentQueryMetadata("id-1", ERROR);
+    when(ksqlEngine.getPersistentQueries()).thenReturn(Arrays.asList(query));
+    when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
+
+    // When:
+    queryMonitor.restartFailedQueries();
+    when(ticker.read()).thenReturn(RETRY_BACKOFF_INITIAL_MS + 1);
+    when(query.isError()).thenReturn(false);
+    when(query.getState()).thenReturn(RUNNING);
+    // 2nd round should not clear query errors before healthy time
+    queryMonitor.restartFailedQueries();
+
+    // Then:
+    verify(query, never()).clearErrors();
+  }
+
+  @Test
+  public void shouldRestartedQueryClearErrorsAfterHealthyTime() {
+// Given:
+    final PersistentQueryMetadata query = mockPersistentQueryMetadata("id-1", ERROR);
+    when(ksqlEngine.getPersistentQueries()).thenReturn(Arrays.asList(query));
+    when(ksqlEngine.getPersistentQuery(query.getQueryId())).thenReturn(Optional.of(query));
+
+    // When:
+    queryMonitor.restartFailedQueries();
+    when(ticker.read()).thenReturn(STATUS_RUNNING_THRESHOLD_MS + 1);
+    when(query.isError()).thenReturn(false);
+    when(query.getState()).thenReturn(RUNNING);
+    // 2nd round should not clear query errors before healthy time
+    queryMonitor.restartFailedQueries();
+
+    // Then:
+    verify(query, times(1)).clearErrors();
   }
 
   private PersistentQueryMetadata mockPersistentQueryMetadata(
@@ -264,6 +333,7 @@ public class QueryMonitorTest {
     final PersistentQueryMetadata query = mock(PersistentQueryMetadata.class);
     when(query.getQueryId()).thenReturn(new QueryId(queryId));
     when(query.isError()).thenReturn(queryState == ERROR);
+    when(query.getState()).thenReturn(ERROR);
     return query;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
@@ -23,10 +23,16 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Ticker;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
 import com.google.common.testing.NullPointerTester;
 import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryError.Type;
@@ -42,9 +48,13 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 @RunWith(MockitoJUnitRunner.class)
 public class QueryStateListenerTest {
-
+  private static final long SOME_TIME = 1;
   private static final MetricName METRIC_NAME_1 =
       new MetricName("bob", "g1", "d1", ImmutableMap.of());
   private static final MetricName METRIC_NAME_2 =
@@ -52,6 +62,8 @@ public class QueryStateListenerTest {
 
   @Mock
   private Metrics metrics;
+  @Mock
+  private Ticker ticker;
   @Captor
   private ArgumentCaptor<Gauge<String>> gaugeCaptor;
   private QueryStateListener listener;
@@ -62,7 +74,7 @@ public class QueryStateListenerTest {
         .thenReturn(METRIC_NAME_1)
         .thenReturn(METRIC_NAME_2);
 
-    listener = new QueryStateListener(metrics, "", "app-id");
+    listener = new QueryStateListener(metrics, "", "app-id", ticker);
   }
 
   @Test
@@ -142,6 +154,97 @@ public class QueryStateListenerTest {
     // Then:
     verify(metrics).removeMetric(METRIC_NAME_1);
     verify(metrics).removeMetric(METRIC_NAME_2);
+  }
+
+  @Test
+  public void shouldResetUptime() {
+    // Given:
+    final Multimap<State, State> states = ArrayListMultimap.create();
+
+    states.put(State.CREATED, State.RUNNING);
+    states.put(State.CREATED, State.REBALANCING);
+    states.put(State.ERROR, State.RUNNING);
+    states.put(State.ERROR, State.REBALANCING);
+
+    // These states transitions are not valid for Kafka streams, but KSQL does not know about it
+    states.put(State.NOT_RUNNING, State.RUNNING);
+    states.put(State.NOT_RUNNING, State.REBALANCING);
+    states.put(State.PENDING_SHUTDOWN, State.RUNNING);
+    states.put(State.PENDING_SHUTDOWN, State.REBALANCING);
+
+    final long tickForUptime = states.size();
+    long nextTick = 1;
+    for (final Map.Entry<State, State> stateTransition : states.entries()) {
+      final State from = stateTransition.getKey();
+      final State to = stateTransition.getValue();
+
+      // When:
+      when(ticker.read()).thenReturn(nextTick++).thenReturn(tickForUptime);
+      listener.onChange(to, from);
+
+      // Then:
+      verify(ticker).read();
+      assertThat(listener.uptime(), is(tickForUptime - nextTick + 1));
+
+      reset(ticker);
+    }
+  }
+
+  @Test
+  public void shouldNotResetUptime() {
+    // Given:
+    final Multimap<State, State> states = ArrayListMultimap.create();
+    states.put(State.RUNNING, State.REBALANCING);
+    states.put(State.REBALANCING, State.RUNNING);
+    states.put(State.RUNNING, State.RUNNING);
+    states.put(State.REBALANCING, State.REBALANCING);
+
+    // Set the initial time, and verify it won't change
+    when(ticker.read()).thenReturn(SOME_TIME);
+    listener.onChange(State.RUNNING, State.CREATED);
+    reset(ticker);
+
+    final long tickForUptime = states.size();
+    for (final Map.Entry<State, State> stateTransition : states.entries()) {
+      final State from = stateTransition.getKey();
+      final State to = stateTransition.getValue();
+
+      // When:
+      listener.onChange(to, from);
+
+      // Then:
+      verify(ticker, never()).read();
+      when(ticker.read()).thenReturn(tickForUptime);
+      assertThat(listener.uptime(), is(tickForUptime - SOME_TIME));
+
+      reset(ticker);
+    }
+  }
+
+  @Test
+  public void shouldReturnZeroUptime() {
+    // Given:
+    final Multimap<State, State> states = ArrayListMultimap.create();
+    states.put(State.RUNNING, State.ERROR);
+    states.put(State.REBALANCING, State.ERROR);
+    states.put(State.RUNNING, State.PENDING_SHUTDOWN);
+    states.put(State.REBALANCING, State.PENDING_SHUTDOWN);
+    states.put(State.RUNNING, State.NOT_RUNNING);
+    states.put(State.REBALANCING, State.NOT_RUNNING);
+    states.put(State.RUNNING, State.CREATED);
+    states.put(State.REBALANCING, State.CREATED);
+
+    for (final Map.Entry<State, State> stateTransition : states.entries()) {
+      final State from = stateTransition.getKey();
+      final State to = stateTransition.getValue();
+
+      // When:
+      listener.onChange(to, from);
+
+      // Then:
+      verify(ticker, never()).read();
+      assertThat(listener.uptime(), is(0L));
+    }
   }
 
   private String currentGaugeValue(final MetricName name) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -113,6 +113,25 @@ public class QueryMetadataTest {
   }
 
   @Test
+  public void shouldGetUptimeFromStateListener() {
+    // Given:
+    when(kafkaStreams.state()).thenReturn(State.RUNNING);
+    when(listener.uptime()).thenReturn(5L);
+
+    // When:
+    query.setQueryStateListener(listener);
+
+    // Then:
+    assertThat(query.uptime(), is(5L));
+  }
+
+  @Test
+  public void shouldReturnZeroUptimeIfNoStateListenerSet() {
+    // When/Then:
+    assertThat(query.uptime(), is(0L));
+  }
+
+  @Test
   public void shouldConnectAnyListenerToStreamAppOnStart() {
     // Given:
     query.setQueryStateListener(listener);


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/6009

Use the config `ksql.query.status.running.threshold.seconds` to specify a threshold when stop tracking query error retries and set the query as healthy and running. All past query errors will be cleared after the threshold time expires.

I also took the time to make some minor improvements to the query monitor code.

### Testing done 
Add unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

