### PR TITLE
chore: add source config to javadoc plugin (MINOR)

### DIFF
--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -182,7 +182,7 @@
 -j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 -'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 -})(window,document,'script','dataLayer','GTM-WRL2Z8Z');</script>]]></header>
-                    <footer>&nbsp;</footer> <!-- prevent duplication of the header content -->
+                    <footer>&#xA0;</footer> <!-- prevent duplication of the header content -->
                     <doclint>none</doclint>
                     <keywords>true</keywords>
                     <nodeprecated>true</nodeprecated>

--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -165,6 +165,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
+                    <source>8</source>
                     <reportOutputDirectory>../docs/developer-guide/ksqldb-clients/java-client</reportOutputDirectory>
                     <stylesheetfile>javadoc.css</stylesheetfile>
                     <destDir>api</destDir>


### PR DESCRIPTION
### Description 

This is required in order for the maven javadoc plugin to succeed in Jenkins on Java 11. (Otherwise the build fails with
```
[2020-08-12T18:17:23.095Z] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.2.0:javadoc (default-cli) on project ksqldb-api-client: An error has occurred in Javadoc report generation: Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set. -> [Help 1]
```
).

This PR also updates the whitespace char in the client pom so the latest versions-maven-plugin version doesn't fail with
```
[2020-08-11T07:05:38.051Z] [ERROR] Failed to execute goal org.codehaus.mojo:versions-maven-plugin:2.8.1:set (default-cli) on project ksqldb-parent: Execution default-cli of goal org.codehaus.mojo:versions-maven-plugin:2.8.1:set failed: Error parsing /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/ksqldb-api-client/pom.xml: Undeclared general entity "nbsp"
[2020-08-11T07:05:38.051Z] [ERROR]  at [row,col {unknown-source}]: [184,34]
[2020-08-11T07:05:38.051Z] [ERROR] -> [Help 1]
```

### Testing done 

Non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

