### PR TITLE
docs: cherry-pick: copy edits for new schema inference content (DOCS-5116)

### DIFF
--- a/docs/concepts/schemas.md
+++ b/docs/concepts/schemas.md
@@ -11,23 +11,261 @@ available in the data, just like a the columns in a traditional SQL database tab
 
 ## Key vs Value columns
 
-KsqlDB supports both key and value columns. These map to the data held in the keys and values of the
-underlying {{ site.ak }} topic message.
+ksqlDB supports both key and value columns. These map to the data held in the
+key and value of the underlying {{ site.ak }} topic message.
 
 A column is defined by a combination of its [name](#valid-identifiers), its [SQL data type](#sql-data-types),
 and possibly a namespace.
 
 Key columns have a `KEY` or `PRIMARY KEY` suffix for streams and tables, respectively.
-ksqlDB currently only supports a single key column.
+ksqlDB supports a single key column only.
 
-Value columns have no namespace suffix. There can be one or more value columns amd the value columns
-can have any name.
+Value columns have no namespace suffix. There can be one or more value columns.
 
-For example, the following declares a schema with a single key column and several value columns:
+For example, the following example statement declares a stream with a single
+key column and several value columns:
 
 ```sql
-ID BIGINT, STRING NAME, ADDRESS ADDRESS_TYPE
+CREATE STREAM USER_UPDATES (
+   ID BIGINT KEY, 
+   STRING NAME, 
+   ADDRESS ADDRESS_TYPE
+ ) WITH (
+   ...
+ );
 ```
+
+This statement declares a table with a primary key and value columns:
+
+```sql
+CREATE TABLE USERS (
+   ID BIGINT PRIMARY KEY, 
+   STRING NAME, 
+   ADDRESS ADDRESS_TYPE
+ ) WITH (
+   ...
+ );
+```
+
+Tables _require_ a primary key, but the key column of a stream is optional.
+For example, the following statement defines a stream with no key column:
+
+```sql
+CREATE STREAM APP_LOG (
+   LOG_LEVEL STRING,
+   APP_NAME STRING,
+   MESSAGE STRING
+ ) WITH (
+   ...
+ );
+```
+
+!!! tip
+    [How Keys Work in ksqlDB](https://www.confluent.io/blog/ksqldb-0-10-updates-key-columns) 
+    has more details on key columns and provides guidance for when you may
+    want to use streams with and without key columns.
+
+## Schema Inference
+
+For supported [serialization formats](../developer-guide/serialization.md),
+ksqlDB can integrate with [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
+ksqlDB automatically retrieves (reads) and registers (writes) schemas as needed,
+which spares you from defining columns and data types manually in `CREATE`
+statements and from manual interaction with {{ site.sr }}. Before using schema
+inference in ksqlDB, make sure that the {{ site.sr }} is up and running and
+ksqlDB is [configured to use it](../operate-and-deploy/installation/server-config/avro-schema.md).
+
+Here's what you can do with schema inference in ksqlDB:
+
+-   Declare streams and tables on {{ site.ak }} topics with supported value formats by using 
+    `CREATE STREAM` and `CREATE TABLE` statements, without needing to declare the value columns.
+-   Declare derived views with `CREATE STREAM AS SELECT` and `CREATE TABLE AS SELECT` statements.
+    The schema of the view is registered in {{ site.sr }} automatically.
+-   Convert data to different formats with `CREATE STREAM AS SELECT` and
+    `CREATE TABLE AS SELECT` statements, by declaring the required output
+    format in the `WITH` clause. For example, you can convert a stream from
+    Avro to JSON.
+
+Only the schema of the message *value* can be retrieved from {{ site.sr }}. Message
+*keys* must be compatible with the [`KAFKA` format](../developer-guide/serialization.md#kafka)
+to be accessible within ksqlDB. ksqlDB ignores schemas that have been registered
+for message keys. 
+
+!!! note
+    Message *keys* in Avro and Protobuf are not supported. If your message keys
+    are in an unsupported format, see [What to do if your key is not set or is in a different format](../developer-guide/syntax-reference.md#what-to-do-if-your-key-is-not-set-or-is-in-a-different-format). 
+    JSON message keys can be accessed by defining the key as a single `STRING` value, which will 
+    contain the JSON document.
+    
+Although ksqlDB doesn't support loading the message key's schema from {{ site.sr }},
+you can provide the key column definition within the `CREATE TABLE` or `CREATE STREAM`
+statement, if the data records are compatible with ksqlDB. This is known as
+_partial schema inference_, because the key schema is provided explicitly.
+
+Tables require a `PRIMARY KEY`, so you must supply one explicitly in your
+`CREATE TABLE` statement. `KEY` columns are optional for streams, so if you
+don't supply one the stream is created without a key column.
+
+The following example statements show how to create streams and tables that have 
+Avro-formatted data. If you want to use Protobuf- or JSON-formatted data,
+substitute `PROTOBUF`, `JSON` or `JSON_SR` for `AVRO` in each statement.
+
+!!! note
+    ksqlDB handles the `JSON` and `JSON_SR` formats differently. While the
+    `JSON` format is capable of _reading_ the schema from {{ site.sr }},
+    `JSON_SR` both reads and registers new schemas, as necessary.
+
+### Create a new stream
+
+#### Without a key column
+
+The following statement shows how to create a new `pageviews` stream by
+reading from a {{ site.ak }} topic that has Avro-formatted message values.
+
+```sql
+CREATE STREAM pageviews
+  WITH (
+    KAFKA_TOPIC='pageviews-avro-topic',
+    VALUE_FORMAT='AVRO'
+  );
+```
+
+In this example, you don't need to define any columns in the CREATE statement. 
+ksqlDB infers this information automatically from the latest registered schema
+for the `pageviews-avro-topic` topic. ksqlDB uses the most recent schema at the
+time the statement is first executed.
+
+!!! important
+    The schema must be registered in {{ site.sr }} under the subject
+    `pageviews-avro-topic-value`.
+
+#### With a key column
+
+The following statement shows how to create a new `pageviews` stream by reading
+from a {{ site.ak }} topic that has Avro-formatted message values and a
+`KAFKA`-formatted `INT` message key.
+
+```sql
+CREATE STREAM pageviews (
+    pageId INT KEY
+  ) WITH (
+    KAFKA_TOPIC='pageviews-avro-topic',
+    VALUE_FORMAT='AVRO'
+  );
+```
+
+In the previous example, you need only supply the key column in the CREATE
+statement.  ksqlDB infers the value columns automatically from the latest
+registered schema for the `pageviews-avro-topic` topic. ksqlDB uses the most
+recent schema at the time the statement is first executed.
+
+!!! note
+    The schema must be registered in {{ site.sr }} under the subject
+    `pageviews-avro-topic-value`.
+
+### Create a new table
+
+The following statement shows how to create a new `users` table by reading
+from a {{ site.ak }} topic that has Avro-formatted message values and a
+`KAFKA`-formatted `BIGINT` message key.
+
+```sql
+CREATE TABLE users (
+    userId BIGINT PRIMARY KEY
+  ) WITH (
+    KAFKA_TOPIC='users-avro-topic',
+    VALUE_FORMAT='AVRO'
+  );
+```
+
+In the previous example, you need only supply the key column in the CREATE
+statement. ksqlDB infers the value columns automatically from the latest
+registered schema for the `users-avro-topic` topic. ksqlDB uses the most
+recent schema at the time the statement is first executed.
+
+!!! note
+    The schema must be registered in {{ site.sr }} under the subject
+    `users-avro-topic-value`.
+
+### Create a new source with selected columns
+
+If you want to create a STREAM or TABLE that has only a subset of the available
+fields in the Avro schema, you must explicitly define the columns.
+
+The following statement shows how to create a new `pageviews_reduced`
+stream, which is similar to the previous example, but with only a few of
+the available fields in the Avro data. In this example, only the
+`viewtime` and `url` value columns are picked.
+
+```sql
+CREATE STREAM pageviews_reduced (
+    viewtime BIGINT,
+    url VARCHAR
+  ) WITH (
+    KAFKA_TOPIC='pageviews-avro-topic',
+    VALUE_FORMAT='AVRO'
+  );
+```
+
+### Declaring a derived view
+
+The following statement shows how to create a materialized view derived from an
+existing source. The {{ site.ak }} topic that the view is materialized to
+inherits the value format of the source, unless it's overridden explicitly in
+the `WITH` clause, as shown. The value schema is registered with {{ site.sr }}
+if the value format supports the integration, with the exception of the `JSON`
+format, which only _reads_ from {{ site.sr }}.
+
+```sql
+CREATE TABLE pageviews_by_url 
+  WITH (
+    VALUE_FORMAT='AVRO'
+  ) AS 
+  SELECT
+    url,
+    COUNT(*) AS VIEW_COUNT
+  FROM pageviews
+  GROUP BY url;
+```
+
+!!! note
+    The schema will be registered in {{ site.sr }} under the subject
+    `PAGEVIEWS_BY_URL-value`.
+
+### Converting formats
+
+ksqlDB enables you to change the underlying value format of streams and tables. 
+This means that you can easily mix and match streams and tables with different
+data formats and also convert between value formats. For example, you can join
+a stream backed by Avro data with a table backed by JSON data.
+
+The example below converts a JSON-formatted topic into Avro. Only the
+`VALUE_FORMAT` is required to achieve the data conversion. ksqlDB generates an
+appropriate Avro schema for the new `PAGEVIEWS_AVRO` stream automatically and
+registers the schema with {{ site.sr }}.
+
+```sql
+CREATE STREAM pageviews_json (
+    pageid VARCHAR KEY, 
+    viewtime BIGINT, 
+    userid VARCHAR
+  ) WITH (
+    KAFKA_TOPIC='pageviews_kafka_topic_json', 
+    VALUE_FORMAT='JSON'
+  );
+
+CREATE STREAM pageviews_avro
+  WITH (VALUE_FORMAT = 'AVRO') AS
+  SELECT * FROM pageviews_json;
+```
+
+!!! note
+    The schema will be registered in {{ site.sr }} under the subject
+    `PAGEVIEWS_AVRO-value`.
+
+For more information, see
+[Changing Data Serialization Format from JSON to Avro](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/changing-data-serialization-format-json-avro)
+in the [Stream Processing Cookbook](https://www.confluent.io/product/ksql/stream-processing-cookbook).
 
 ## Valid Identifiers
 

--- a/docs/developer-guide/create-a-stream.md
+++ b/docs/developer-guide/create-a-stream.md
@@ -17,6 +17,11 @@ query results from other streams.
 !!! note
       Creating tables is similar to creating streams. For more information,
       see [Create a ksqlDB Table](create-a-table.md).
+      
+ksqlDB can't infer the topic value's data format, so you must provide the
+format of the values that are stored in the topic. In this example, the
+data format is `DELIMITED`. 
+For all supported formats, see [Serialization Formats](serialization.md#serialization-formats).
 
 Create a Stream from an existing Kafka topic
 --------------------------------------------
@@ -33,11 +38,6 @@ The following example creates a stream that has three columns from the
 `pageviews` topic: `viewtime`, `userid`, and `pageid`. All of these columns are loaded from the 
 {{ site.ak }} topic message value. To access data in your message key, see 
 [Create a Stream with a Specified Key](#create-a-stream-with-a-specified-key), below.
-
-ksqlDB can't infer the topic value's data format, so you must provide the
-format of the values that are stored in the topic. In this example, the
-data format is `DELIMITED`. Other options are `Avro`, `JSON`, `JSON_SR`, `PROTOBUF`, and `KAFKA`.
-See [Serialization Formats](serialization.md#serialization-formats) for more details.
 
 In the ksqlDB CLI, paste the following CREATE STREAM statement:
 
@@ -102,9 +102,9 @@ The previous SQL statement doesn't define a column to represent the data in the
 is serialized in a key format that ksqlDB supports, you can specify the key in the column list of 
 the CREATE STREAM statement.
 
-ksqlDB requires keys to have been serialized using {{ site.ak }}'s own serializers or compatible
-serializers. ksqlDB supports `INT`, `BIGINT`, `DOUBLE`, and `STRING` key types. If the data in your
-{{ site.ak }} topics does not have a suitable key format, 
+ksqlDB requires keys to be serialized using {{ site.ak }}'s own serializers or compatible
+serializers. For supported data types, see the [`KAFKA` format](./serialization.md#kafka). 
+If the data in your {{ site.ak }} topics doesn't have a suitable key format, 
 see [Key Requirements](syntax-reference.md#key-requirements).
 
 For example, the {{ site.ak }}  message key of the `pageviews` topic is a `BIGINT` containing the 
@@ -189,6 +189,25 @@ Value format         : DELIMITED
 Kafka topic          : pageviews (partitions: 1, replication: 1)
 [...]
 ```
+
+### Creating a Table using Schema Inference
+
+For supported [serialization formats](../developer-guide/serialization.md),
+ksqlDB can integrate with [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
+ksqlDB can use [Schema Inference](../concepts/schemas.md#schema-inference) to
+spare you from defining columns manually in your `CREATE STREAM` statements.
+
+The following example creates a stream over an existing topic, loading the
+value column definitions from {{ site.sr }}.
+
+```sql
+CREATE STREAM pageviews WITH (
+    KAFKA_TOPIC='pageviews',
+    VALUE_FORMAT='PROTOBUF'
+  );
+```
+
+For more information, see [Schema Inference](../concepts/schemas.md#schema-inference).
 
 Create a Stream backed by a new Kafka Topic
 -------------------------------------------

--- a/docs/developer-guide/create-a-table.md
+++ b/docs/developer-guide/create-a-table.md
@@ -17,6 +17,16 @@ query results from other tables or streams.
 !!! note
       Creating streams is similar to creating tables. For more information,
       see [Create a ksqlDB Stream](create-a-stream.md).
+      
+ksqlDB can't infer the topic value's data format, so you must provide the
+format of the values that are stored in the topic. In this example, the
+data format is `JSON`. For all supported formats, see
+[Serialization Formats](serialization.md#serialization-formats).
+
+ksqlDB requires keys to be serialized using {{ site.ak }}'s own serializers or
+compatible serializers. For supported data types, see the [`KAFKA` format](./serialization.md#kafka). 
+If the data in your {{ site.ak }} topics doesn't have a suitable key format, 
+see [Key Requirements](syntax-reference.md#key-requirements).
 
 Create a Table from an existing Kafka Topic
 -------------------------------------------
@@ -33,16 +43,6 @@ The following example creates a table that has four columns from the
 `users` topic: `registertime`, `userid`, `gender`, and `regionid`. 
 The `userid` column is the primary key of the table. This means that it's loaded from the {{ site.ak }} message
 key. Primary key columns can't be `NULL`.
-
-ksqlDB can't infer the topic value's data format, so you must provide the
-format of the values that are stored in the topic. In this example, the
-data format is `JSON`. Other options are `Avro`, `DELIMITED`, `JSON_SR`, `PROTOBUF`, and `KAFKA`. 
-For more information, see [Serialization Formats](serialization.md#serialization-formats).
-
-ksqlDB requires keys to have been serialized using {{ site.ak }}'s own serializers or compatible
-serializers. ksqlDB supports `INT`, `BIGINT`, `DOUBLE`, and `STRING` key types. If the data in your
-{{ site.ak }} topics does not have a suitable key format, 
-see [Key Requirements](syntax-reference.md#key-requirements).
 
 In the ksqlDB CLI, paste the following CREATE TABLE statement:
 
@@ -126,6 +126,27 @@ Press Ctrl+C to stop printing the query results.
 
 The table values update continuously with the most recent records,
 because the underlying `users` topic receives new messages continuously.
+
+### Creating a Table using Schema Inference
+
+For supported [serialization formats](../developer-guide/serialization.md),
+ksqlDB can integrate with [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
+ksqlDB can use [Schema Inference](../concepts/schemas.md#schema-inference) to
+spare you from defining columns manually in your `CREATE TABLE` statements.
+
+The following example creates a table over an existing topic, loading the
+value column definitions from {{ site.sr }}.
+
+```sql
+CREATE TABLE users (
+    userid VARCHAR PRIMARY KEY
+  ) WITH (
+    KAFKA_TOPIC = 'users',
+    VALUE_FORMAT='AVRO'
+);
+```
+
+For more information, see [Schema Inference](../concepts/schemas.md#schema-inference).
 
 Create a Table backed by a new Kafka Topic
 ------------------------------------------

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -17,7 +17,7 @@ These topics show how to develop ksqlDB applications.
 - [Implement a User-defined Function (UDF, UDAF, and UDTF)](implement-a-udf)
 - [Partition Data to Enable Joins](joins/partition-data.md)
 - [Syntax Reference](syntax-reference.md)
-- [Serialization](serialization.md)
+- [Serialization Formats](serialization.md)
 - [Testing Tool](test-and-debug/ksqldb-testing-tool.md)
 - [ksqlDB REST API Reference](api.md)
 - [Processing Log](test-and-debug/processing-log.md)

--- a/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
@@ -65,12 +65,17 @@ The key of the resulting stream is determined by the following rules, in order o
 
 The projection must include all columns required in the result, including any key columns.
 
+For supported [serialization formats](../developer-guide/serialization.md),
+ksqlDB can integrate with [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
+ksqlDB registers the value schema of the new stream with {{ site.sr }} automatically. 
+The schema is registered under the subject `<topic-name>-value`.
+
 The WITH clause for the result supports the following properties:
 
 |     Property      |                                             Description                                              |
 | ----------------- | ---------------------------------------------------------------------------------------------------- |
 | KAFKA_TOPIC       | The name of the Kafka topic that backs this stream. If this property is not set, then the name of the stream in upper case will be used as default. |
-| VALUE_FORMAT      | Specifies the serialization format of the message value in the topic. Supported formats: `JSON`, `DELIMITED` (comma-separated value), `AVRO`, `KAFKA`, and `PROTOBUF`. If this property is not set, the format of the input stream/table is used. For more information, see [Serialization Formats](../serialization.md#serialization-formats). |
+| VALUE_FORMAT      | Specifies the serialization format of the message value in the topic. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats). If this property is not set, the format of the input stream/table is used. |
 | VALUE_DELIMITER   | Used when VALUE_FORMAT='DELIMITED'. Supports single character to be a delimiter, defaults to ','. For space and tab delimited values you must use the special values 'SPACE' or 'TAB', not an actual space or tab character. |
 | PARTITIONS        | The number of partitions in the backing topic. If this property is not set, then the number of partitions of the input stream/table will be used. In join queries, the property values are taken from the left-side stream or table. |
 | REPLICAS          | The replication factor for the topic. If this property is not set, then the number of replicas of the input stream or table will be used. In join queries, the property values are taken from the left-side stream or table. |

--- a/docs/developer-guide/ksqldb-reference/create-stream.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream.md
@@ -45,7 +45,12 @@ Each column is defined by:
    If a column is not marked as a `KEY` column, ksqlDB loads it from the Kafka message's value.
    Unlike a table's `PRIMARY KEY`, a stream's keys can be NULL.
    
-Each row within the table has a `ROWTIME` pseudo column, which represents the _event time_ 
+For supported [serialization formats](../developer-guide/serialization.md),
+ksqlDB can integrate with [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
+ksqlDB can use [Schema Inference](../concepts/schemas.md#schema-inference) to
+spare you from defining columns manually in your `CREATE STREAM` statements.
+   
+Each row within the stream has a `ROWTIME` pseudo column, which represents the _event time_ 
 of the row. The timestamp has milliseconds accuracy. The timestamp is used by ksqlDB during any
 windowing operations and during joins, where data from each side of a join is generally processed
 in time order.  
@@ -59,7 +64,7 @@ The WITH clause supports the following properties:
 |        Property         |                                            Description                                            |
 | ----------------------- | ------------------------------------------------------------------------------------------------- |
 | KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this source. The topic must either already exist in Kafka, or PARTITIONS must be specified to create the topic. Command will fail if the topic exists with different partition/replica counts. |
-| VALUE_FORMAT (required) | Specifies the serialization format of the message value in the topic. Supported formats: `JSON`, `JSON_SR`, `DELIMITED` (comma-separated value), `AVRO`, `KAFKA`, and `PROTOBUF`. For more information, see [Serialization Formats](../serialization.md#serialization-formats). |
+| VALUE_FORMAT (required) | Specifies the serialization format of the message value in the topic. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats). |
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a STREAM without an existing topic (the command will fail if the topic does not exist). |
 | REPLICAS                | The number of replicas in the backing topic. If this property is not set but PARTITIONS is set, then the default Kafka cluster configuration for replicas will be used for creating a new topic. |
 | VALUE_DELIMITER         | Used when VALUE_FORMAT='DELIMITED'. Supports single character to be a delimiter, defaults to ','. For space and tab delimited values you must use the special values 'SPACE' or 'TAB', not an actual space or tab character. |
@@ -102,5 +107,18 @@ CREATE STREAM pageviews (
     KAFKA_TOPIC = 'keyed-pageviews-topic',
     VALUE_FORMAT = 'JSON'
   );
-```
 
+-- keyless stream, with value columns loaded from Schema Registry:
+CREATE STREAM pageviews WITH (
+    KAFKA_TOPIC = 'keyless-pageviews-topic',
+    VALUE_FORMAT = 'JSON'
+  );
+
+-- keyed stream, with value columns loaded from Schema Registry:
+CREATE STREAM pageviews (
+    page_id BIGINT KEY
+  ) WITH (
+    KAFKA_TOPIC = 'keyed-pageviews-topic',
+    VALUE_FORMAT = 'JSON'
+  );
+```

--- a/docs/developer-guide/ksqldb-reference/create-table-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-table-as-select.md
@@ -66,12 +66,17 @@ The primary key of the resulting table is determined by the following rules, in 
  
 The projection must include all columns required in the result, including any primary key columns.
 
+For supported [serialization formats](../developer-guide/serialization.md),
+ksqlDB can integrate with the [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
+ksqlDB registers the value schema of the new table with {{ site.sr }} automatically. 
+The schema is registered under the subject `<topic-name>-value`.
+
 The WITH clause supports the following properties:
 
 |     Property      |                                             Description                                              |
 | ----------------- | ---------------------------------------------------------------------------------------------------- |
 | KAFKA_TOPIC       | The name of the Kafka topic that backs this table. If this property is not set, then the name of the table will be used as default. |
-| VALUE_FORMAT      | Specifies the serialization format of the message value in the topic. Supported formats: `JSON`, `JSON_SR`, `DELIMITED` (comma-separated value), `AVRO`, `KAFKA`, and `PROTOBUF`. If this property is not set, then the format of the input stream/table is used. For more information, see [Serialization Formats](../serialization.md#serialization-formats). |
+| VALUE_FORMAT      | Specifies the serialization format of the message value in the topic. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats). If this property is not set, then the format of the input stream/table is used. |
 | VALUE_DELIMITER   | Used when VALUE_FORMAT='DELIMITED'. Supports single character to be a delimiter, defaults to ','. For space and tab delimited values you must use the special values 'SPACE' or 'TAB', not an actual space or tab character. |
 | PARTITIONS        | The number of partitions in the backing topic. If this property is not set, then the number of partitions of the input stream/table will be used. In join queries, the property values are taken from the left-side stream or table. |
 | REPLICAS          | The replication factor for the topic. If this property is not set, then the number of replicas of the input stream or table will be used. In join queries, the property values are taken from the left-side stream or table. |

--- a/docs/developer-guide/ksqldb-reference/create-table.md
+++ b/docs/developer-guide/ksqldb-reference/create-table.md
@@ -45,6 +45,11 @@ Each column is defined by:
    from the {{ site.ak }} message's value. Unlike a stream's `KEY` column, a table's `PRIMARY KEY` column(s)
    are NON NULL. Any records in the Kafka topic with NULL key columns are dropped.
    
+For supported [serialization formats](../developer-guide/serialization.md),
+ksqlDB can integrate with [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
+ksqlDB can use [Schema Inference](../concepts/schemas.md#schema-inference) to
+spare you from defining columns manually in your `CREATE TABLE` statements.
+   
 Each row within the table has a `ROWTIME` pseudo column, which represents the _last modified time_ 
 of the row. The timestamp has milliseconds accuracy. The timestamp is used by ksqlDB when updating
 a row, during any windowing operations and during joins, where data from each side of a join is 
@@ -58,7 +63,7 @@ The WITH clause supports the following properties:
 |        Property         |                                            Description                                            |
 | ----------------------- | ------------------------------------------------------------------------------------------------- |
 | KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this source. The topic must either already exist in Kafka, or PARTITIONS must be specified to create the topic. Command will fail if the topic exists with different partition/replica counts. |
-| VALUE_FORMAT (required) | Specifies the serialization format of message values in the topic. Supported formats: `JSON`, `JSON_SR`, `DELIMITED` (comma-separated value), `AVRO`, `KAFKA`, and `PROTOBUF`. For more information, see [Serialization Formats](../serialization.md#serialization-formats). |
+| VALUE_FORMAT (required) | Specifies the serialization format of message values in the topic. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats). |
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a TABLE without an existing topic (the command will fail if the topic does not exist). |
 | REPLICAS                | The number of replicas in the backing topic. If this property is not set but PARTITIONS is set, then the default Kafka cluster configuration for replicas will be used for creating a new topic. |
 | VALUE_DELIMITER         | Used when VALUE_FORMAT='DELIMITED'. Supports single character to be a delimiter, defaults to ','. For space and tab delimited values you must use the special values 'SPACE' or 'TAB', not an actual space or tab character. |
@@ -78,11 +83,20 @@ Example
 -------
 
 ```sql
+-- table with declared columns: 
 CREATE TABLE users (
      id BIGINT PRIMARY KEY,
      usertimestamp BIGINT,
      gender VARCHAR,
      region_id VARCHAR
+   ) WITH (
+     KAFKA_TOPIC = 'my-users-topic', 
+     VALUE_FORMAT = 'JSON'
+   );
+
+-- table with value columns loaded from Schema Registry: 
+CREATE TABLE users (
+     id BIGINT PRIMARY KEY
    ) WITH (
      KAFKA_TOPIC = 'my-users-topic', 
      VALUE_FORMAT = 'JSON'

--- a/docs/operate-and-deploy/installation/server-config/avro-schema.md
+++ b/docs/operate-and-deploy/installation/server-config/avro-schema.md
@@ -2,204 +2,27 @@
 layout: page
 title: Configure ksqlDB for Avro, Protobuf, and JSON schemas
 tagline: Set up Schema Registry to enable reading and writing messages in Avro, Protobuf, and JSON formats
-description: Learn how read and write messages in Avro, Protobuf, and JSON by integrating ksqlDB with Confluent Schema Registry
+description: Learn how integrate ksqlDB with Confluent Schema Registry
 keywords: ksqldb, schema, avro, protobuf, json, json_sr
 ---
 
-ksqlDB can read and write messages that have Avro, Protobuf, or JSON schemas
-by integrating with [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
-ksqlDB automatically retrieves (reads) and registers (writes) schemas as
-needed, which saves you from having to manually define columns
-and data types in SQL and from manual interaction with {{ site.sr }}.
-
-Supported functionality
-=======================
-
-ksqlDB supports Avro, Protobuf, and JSON data in the {{ site.aktm }} message
-values.
-
-Schemas with nested fields are supported. You can read nested data,
-in Avro, Protobuf, and JSON formats, by using the STRUCT type. Also, you can
-create new nested STRUCT data as the result of a query. For more info, see
-[STRUCT](../../../developer-guide/syntax-reference.md#struct).
-
-The following functionality is not supported:
-
--   Message *keys* in Avro, Protobuf, or JSON formats are not supported. Message
-    keys in ksqlDB are always interpreted as `KAFKA` format, which means ksqlDB
-    ignores schemas that have been registered for message keys.
-
-Although ksqlDB doesn't support loading the message key's schema from {{ site.sr }},
-you can provide the key column definition within the `CREATE TABLE` or `CREATE STREAM`
-statement. 
-
-Tables require a `PRIMARY KEY`, so you must supply one in your `CREATE TABLE` statement. 
-`KEY` columns are optional for streams, so if you do not supply one the stream will be created 
-without any key columns.
+For supported [serialization formats](../developer-guide/serialization.md),
+ksqlDB can integrate with [Confluent Schema Registry](https://docs.confluent.io/current/schema-registry/index.html).
+ksqlDB automatically retrieves (reads) and registers (writes) schemas as needed,
+which spares you from defining columns and data types  manually in `CREATE`
+statements and from manual interaction with {{ site.sr }}. For more information,
+see [Schema Inference](../../../concepts/schemas.md#schema-inference).
 
 Configure ksqlDB for Avro, Protobuf, and JSON
 =============================================
 
 You must configure the REST endpoint of {{ site.sr }} by setting
-`ksql.schema.registry.url` (default: `http://localhost:8081`) in the
-ksqlDB Server configuration file
+`ksql.schema.registry.url` in the ksqlDB Server configuration file
 (`<path-to-confluent>/etc/ksqldb/ksql-server.properties`). For more
-information, see
-[Installation Instructions](../installing.md#installation-instructions).
+information, see [Installation Instructions](../installing.md#installation-instructions).
+{{ site.sr }} is [included by default](https://docs.confluent.io/current/quickstart/index.html) with
+{{ site.cp }}.
 
 !!! important
       Don't use the SET statement in the ksqlDB CLI to configure the registry
       endpoint.
-
-Use Avro, Protobuf, or JSON in ksqlDB
-=====================================
-
-Before using Avro, Protobuf, or JSON in ksqlDB, make sure that {{ site.sr }} is up and
-running and that `ksql.schema.registry.url` is set correctly in the ksqlDB
-properties file (defaults to `http://localhost:8081`). {{ site.sr }} is
-[included by default](https://docs.confluent.io/current/quickstart/index.html) with
-{{ site.cp }}.
-
-!!! important
-      By default, ksqlDB-registered schemas have the same name
-      (`KsqlDataSourceSchema`) and the same namespace
-      (`io.confluent.ksql.avro_schemas`). You can override this behavior by
-      providing a `VALUE_AVRO_SCHEMA_FULL_NAME` property in the `WITH` clause,
-      where you set the `VALUE_FORMAT` to `'AVRO'`. As the name suggests, this
-      property overrides the default name/namespace with the provided one.
-      For example, `com.mycompany.MySchema` registers a schema with the
-      `MySchema` name and the `com.mycompany` namespace.
-
-Here's what you can do with Avro, Protobuf, and JSON in ksqlDB:
-
--   Declare streams and tables on {{ site.ak }} topics with Avro- or Protobuf-
-    formatted data by using `CREATE STREAM` and `CREATE TABLE` statements.
--   Read from and write into Avro- or Protobuf-formatted data by using
-    `CREATE STREAM AS SELECT` and `CREATE TABLE AS SELECT` statements.
--   Create derived streams and tables from existing streams and tables
-    with `CREATE STREAM AS SELECT` and `CREATE TABLE AS SELECT`
-    statements.
--   Convert data to different formats with `CREATE STREAM AS SELECT` and
-    `CREATE TABLE AS SELECT` statements. For example, you can convert a
-    stream from Avro to JSON.
-
-Example SQL statements with Avro
---------------------------------
-
-The following statements show how to create streams and tables that have 
-Avro-formatted data. If you want to use Protobuf- or JSON-formatted data,
-substitute `PROTOBUF` or `JSON_SR` for `AVRO` in each statement.
-
-!!! note
-    ksqlDB handles the `JSON` and `JSON_SR` formats differently. Use `JSON_SR`
-    when you need schema validation by {{ site.sr }}. If you don't need schema
-    validation, you can use `JSON`.
-
-### Create a new stream by reading Avro-formatted data
-
-#### Without a key column
-
-The following statement shows how to create a new `pageviews` stream by
-reading from a {{ site.ak }} topic that has Avro-formatted message values.
-
-```sql
-CREATE STREAM pageviews
-  WITH (
-    KAFKA_TOPIC='pageviews-avro-topic',
-    VALUE_FORMAT='AVRO'
-  );
-```
-
-#### With a key column
-
-The following statement shows how to create a new `pageviews` stream by
-reading from a {{ site.ak }} topic that has Avro-formatted message values and
-a `KAFKA`-formatted `INT` message key.
-
-```sql
-CREATE STREAM pageviews (
-    pageId INT KEY
-  ) WITH (
-    KAFKA_TOPIC='pageviews-avro-topic',
-    VALUE_FORMAT='AVRO'
-  );
-```
-
-### Create a new table by reading Avro-formatted data
-
-The following statement shows how to create a new `users` table by
-reading from a {{ site.ak }} topic that has Avro-formatted message values 
-and a `KAFKA`-formatted `BIGINT` message key.
-
-```sql
-CREATE TABLE users (
-    userId BIGINT PRIMARY KEY
-  ) WITH (
-    KAFKA_TOPIC='users-avro-topic',
-    VALUE_FORMAT='AVRO'
-  );
-```
-
-In this example, you don't need to define any value columns or data types in
-the CREATE statement. ksqlDB infers this information automatically from
-the latest registered schema for the `pageviews-avro-topic` topic.
-ksqlDB uses the most recent schema at the time the statement is first
-executed.
-
-!!! note
-    The schema must be registered in {{ site.sr }} under the subject
-    `users-avro-topic-value`.
-
-### Create a new stream with selected fields of Avro-formatted data
-
-If you want to create a STREAM or TABLE with only a subset of all the
-available fields in the Avro schema, you must explicitly define the
-columns and data types.
-
-The following statement shows how to create a new `pageviews_reduced`
-stream, which is similar to the previous example, but with only a few of
-the available fields in the Avro data. In this example, only the
-`viewtime` and `pageid` columns are picked.
-
-```sql
-CREATE STREAM pageviews_reduced (
-    pageid VARCHAR KEY, 
-    viewtime BIGINT
-  ) WITH (
-    KAFKA_TOPIC='pageviews-avro-topic',
-    VALUE_FORMAT='AVRO'
-  );
-```
-
-### Convert a JSON Stream to an Avro stream
-
-ksqlDB enables you to work with streams and tables regardless of their
-underlying data format. This means that you can easily mix and match
-streams and tables with different data formats and also convert between
-data formats. For example, you can join a stream backed by Avro data
-with a table backed by JSON data.
-
-In this example, only the `VALUE_FORMAT` is required for Avro to achieve
-the data conversion. ksqlDB automatically generates an appropriate Avro
-schema for the new `pageviews_avro` stream, and it registers the schema
-with {{ site.sr }}.
-
-```sql
-CREATE STREAM pageviews_json (
-    pageid VARCHAR KEY, 
-    viewtime BIGINT, 
-    userid VARCHAR
-  ) WITH (
-    KAFKA_TOPIC='pageviews_kafka_topic_json', 
-    VALUE_FORMAT='JSON'
-  );
-
-CREATE STREAM pageviews_avro
-  WITH (VALUE_FORMAT = 'AVRO') AS
-  SELECT * FROM pageviews_json
-  EMIT CHANGES;
-```
-
-For more information, see
-[Changing Data Serialization Format from JSON to Avro](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/changing-data-serialization-format-json-avro)
-in the [Stream Processing Cookbook](https://www.confluent.io/product/ksql/stream-processing-cookbook).


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/6006.

* docs: improve documentation around schema inference

fixes: https://github.com/confluentinc/ksql/issues/5220

* docs: copy edit new schema inference content

Co-authored-by: Andy Coates <big-andy-coates@users.noreply.github.com>

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

