### PR TITLE
fix: protobuf format does not support unwrapping

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -116,6 +116,16 @@
       }
     },
     {
+      "name": "WRAP_SINGLE_VALUE=false",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='input_topic', value_format='PROTOBUF');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "'WRAP_SINGLE_VALUE' can not be set to 'false' for 'PROTOBUF' as it does not support unwrapping"
+      }
+    },
+    {
       "name": "should convert enum to STRING",
       "statements": [
         "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='PROTOBUF');",

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.serde.protobuf;
 import io.confluent.connect.protobuf.ProtobufConverter;
 import io.confluent.connect.protobuf.ProtobufConverterConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.schema.connect.SchemaWalker;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.serde.KsqlSerdeFactory;
@@ -41,6 +42,12 @@ public class ProtobufSerdeFactory implements KsqlSerdeFactory {
 
   @Override
   public void validate(final PersistenceSchema schema) {
+    if (schema.isUnwrapped()) {
+      throw new KsqlException("'" + CommonCreateConfigs.WRAP_SINGLE_VALUE
+          + "' can not be set to 'false' for '" + ProtobufFormat.NAME
+          + "' as it does not support unwrapping");
+    }
+
     SchemaWalker.visit(schema.serializedSchema(), new SchemaValidator());
   }
 


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/5994

Fixes a unintuitive error should user set `WRAP_SINGLE_VALUE=false` with `PROTOBUF` format.
