### PR TITLE
feat: Support for IF EXISTS on CREATE CONNECTOR

### DIFF
--- a/docs/developer-guide/ksqldb-reference/create-connector.md
+++ b/docs/developer-guide/ksqldb-reference/create-connector.md
@@ -13,7 +13,7 @@ Synopsis
 --------
 
 ```sql
-CREATE SOURCE | SINK CONNECTOR connector_name WITH( property_name = expression [, ...]);
+CREATE SOURCE | SINK CONNECTOR [IF NOT EXISTS] connector_name WITH( property_name = expression [, ...]);
 ```
 
 Description
@@ -23,6 +23,9 @@ Create a new connector in the {{ site.kconnectlong }} cluster with the
 configuration passed in the WITH clause. Some connectors have ksqlDB templates
 that simplify configuring them. For more information, see
 [Natively Supported Connectors](../../concepts/connectors.md#natively-supported-connectors).
+
+If the IF NOT EXISTS clause is present, the statement does not fail if a connector with the supplied name
+already exists
 
 !!! note
     CREATE CONNECTOR works only in interactive mode. 

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -72,7 +72,8 @@ statement
                     (WITH tableProperties)?                                 #createTable
     | CREATE (OR REPLACE)? TABLE (IF NOT EXISTS)? sourceName
             (WITH tableProperties)? AS query                                #createTableAs
-    | CREATE (SINK | SOURCE) CONNECTOR identifier WITH tableProperties      #createConnector
+    | CREATE (SINK | SOURCE) CONNECTOR (IF NOT EXISTS)? identifier
+             WITH tableProperties                                           #createConnector
     | INSERT INTO sourceName query                                          #insertInto
     | INSERT INTO sourceName (columns)? VALUES values                       #insertValues
     | DROP STREAM (IF EXISTS)? sourceName (DELETE TOPIC)?                   #dropStream

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -335,7 +335,8 @@ public class AstBuilder {
           getLocation(context),
           name,
           properties,
-          type
+          type,
+          context.EXISTS() != null
       );
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateConnector.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateConnector.java
@@ -34,30 +34,39 @@ public class CreateConnector extends Statement {
   private final String name;
   private final ImmutableMap<String, Literal> config;
   private final Type type;
+  private final boolean notExists;
 
   public CreateConnector(
       final Optional<NodeLocation> location,
       final String name,
       final Map<String, Literal> config,
-      final Type type
+      final Type type,
+      final boolean notExists
   ) {
     super(location);
     this.name = Objects.requireNonNull(name, "name");
     this.config = ImmutableMap.copyOf(Objects.requireNonNull(config, "config"));
     this.type = Objects.requireNonNull(type, "type");
+    this.notExists = notExists;
+
   }
 
   public CreateConnector(
       final String name,
       final Map<String, Literal> config,
-      final Type type
+      final Type type,
+      final boolean notExisits
   ) {
-    this(Optional.empty(), name, config, type);
+    this(Optional.empty(), name, config, type, notExisits);
   }
 
 
   public String getName() {
     return name;
+  }
+
+  public boolean ifNotExists() {
+    return notExists;
   }
 
   public Map<String, Literal> getConfig() {
@@ -81,12 +90,13 @@ public class CreateConnector extends Statement {
     final CreateConnector that = (CreateConnector) o;
     return Objects.equals(name, that.name)
         && Objects.equals(config, that.config)
+        && Objects.equals(notExists, that.notExists)
         && Objects.equals(type, that.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, config, type);
+    return Objects.hash(name, config, type, notExists);
   }
 
   @Override
@@ -95,6 +105,7 @@ public class CreateConnector extends Statement {
         + "name='" + name + '\''
         + ", config=" + config
         + ", type=" + type
+        + ", notExists" + notExists
         + '}';
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateConnectorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateConnectorTest.java
@@ -39,18 +39,21 @@ public class CreateConnectorTest {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new CreateConnector(Optional.of(SOME_LOCATION), NAME, CONFIG, CreateConnector.Type.SOURCE),
-            new CreateConnector(Optional.of(OTHER_LOCATION), NAME, CONFIG, CreateConnector.Type.SOURCE),
-            new CreateConnector(NAME, CONFIG, CreateConnector.Type.SOURCE)
+            new CreateConnector(Optional.of(SOME_LOCATION), NAME, CONFIG, CreateConnector.Type.SOURCE, false),
+            new CreateConnector(Optional.of(OTHER_LOCATION), NAME, CONFIG, CreateConnector.Type.SOURCE, false),
+            new CreateConnector(NAME, CONFIG, CreateConnector.Type.SOURCE, false)
         )
         .addEqualityGroup(
-            new CreateConnector(OTHER_NAME, CONFIG, CreateConnector.Type.SOURCE)
+            new CreateConnector(OTHER_NAME, CONFIG, CreateConnector.Type.SOURCE, false)
         )
         .addEqualityGroup(
-            new CreateConnector(NAME, OTHER_CONFIG, CreateConnector.Type.SOURCE)
+            new CreateConnector(NAME, OTHER_CONFIG, CreateConnector.Type.SOURCE, false)
         )
         .addEqualityGroup(
-            new CreateConnector(NAME, CONFIG, CreateConnector.Type.SINK)
+            new CreateConnector(NAME, CONFIG, CreateConnector.Type.SINK, false)
+        )
+        .addEqualityGroup(
+            new CreateConnector(NAME, CONFIG, CreateConnector.Type.SOURCE, true)
         )
         .testEquals();
   }


### PR DESCRIPTION
Fixes #5992 

### Description 
Added IF EXISTS to the create connector portion of the grammar and made necessary code changes ,
Basically added a check in `ConnectExecutor` , to call /connectors endpoint and find if connector is already created

### Testing done 
Added unit tests and did manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

