### PR TITLE
feat: add Ksql warning to KsqlResource response when CommandRunner degraded

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -99,6 +99,7 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
@@ -570,6 +571,34 @@ public class KsqlResourceTest {
     assertThat(descriptionList.getQueryDescriptions(), containsInAnyOrder(
         QueryDescriptionFactory.forQueryMetadata(queryMetadata.get(0), queryHostState),
         QueryDescriptionFactory.forQueryMetadata(queryMetadata.get(1), queryHostState)));
+  }
+
+  @Test
+  public void shouldHaveKsqlWarningIfCommandRunnerDegraded() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(SystemColumns.ROWKEY_NAME, SqlTypes.STRING)
+        .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BOOLEAN)
+        .valueColumn(ColumnName.of("FIELD2"), SqlTypes.STRING)
+        .build();
+
+    givenSource(
+        DataSourceType.KSTREAM, "new_stream", "new_topic",
+        schema);
+
+    // When:
+    when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.DEGRADED);
+    when(errorsHandler.commandRunnerDegradedErrorMessage()).thenReturn(DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_ERROR_MESSAGE);
+
+    final SourceDescriptionList descriptionList1 = makeSingleRequest(
+        "SHOW STREAMS EXTENDED;", SourceDescriptionList.class);
+    when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.RUNNING);
+    final SourceDescriptionList descriptionList2 = makeSingleRequest(
+        "SHOW STREAMS EXTENDED;", SourceDescriptionList.class);
+
+    assertThat(descriptionList1.getWarnings().size(), is(1));
+    assertThat(descriptionList1.getWarnings().get(0).getMessage(), is(DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_ERROR_MESSAGE));
+    assertThat(descriptionList2.getWarnings().size(), is(0));
   }
 
   @Test

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
@@ -19,7 +19,7 @@ import io.confluent.ksql.util.ErrorMessageUtil;
 
 public class DefaultErrorMessages implements ErrorMessages {
 
-  static String COMMAND_RUNNER_DEGRADED_ERROR_MESSAGE =
+  public static final String COMMAND_RUNNER_DEGRADED_ERROR_MESSAGE =
       "The server has encountered an incompatible entry in its log "
           + "and cannot process further DDL statements."
           + System.lineSeparator()

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -18,7 +18,8 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -60,7 +61,7 @@ public abstract class KsqlEntity {
 
   public KsqlEntity(final String statementText, final List<KsqlWarning> warnings) {
     this.statementText = statementText;
-    this.warnings = warnings == null ? Collections.emptyList() : ImmutableList.copyOf(warnings);
+    this.warnings = warnings == null ? new ArrayList<>() : new ArrayList<>(warnings);
   }
 
   public String getStatementText() {
@@ -69,5 +70,9 @@ public abstract class KsqlEntity {
 
   public List<KsqlWarning> getWarnings() {
     return warnings;
+  }
+  
+  public void updateWarnings(final List<KsqlWarning> warnings) {
+    this.warnings.addAll(warnings);
   }
 }


### PR DESCRIPTION
```
ksql> show streams;

 Stream Name         | Kafka Topic                 | Format 
------------------------------------------------------------
 KSQL_PROCESSING_LOG | default_ksql_processing_log | JSON   
 TEST                | TEST                        | JSON   
 TEST1               | TEST1                       | JSON   
------------------------------------------------------------
WARNING: The server has encountered an incompatible entry in its log and cannot process further DDL statements.
This is most likely due to the service being rolled back to an earlier version.
```

Done by adding a KsqlWarning to the existing warnings list for each `KsqlEntity` returned from the server.

Alternatively, we could just add a separate `WarningEntity` to the `KsqlEntityList` returned from the server instead of modifying each KsqlEntity.
https://github.com/confluentinc/ksql/blob/453125c87f8538f80029278f323c2c193870fa85/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/WarningEntity.java


### Testing done 
Manual and unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

