### PR TITLE
feat: introduce the sql-based testing tool (YATT)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -84,7 +84,7 @@ public class InsertValuesExecutor {
   }
 
   @VisibleForTesting
-  InsertValuesExecutor(
+  public InsertValuesExecutor(
       final boolean canBeDisabledByConfig,
       final RecordProducer producer
   ) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -234,11 +234,23 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     }
   }
 
-  @Override
-  public void close() {
-    allLiveQueries.forEach(QueryMetadata::stop);
+  /**
+   * @param closeQueries whether or not to clean up the local state for any running queries
+   */
+  public void close(final boolean closeQueries) {
+    if (closeQueries) {
+      allLiveQueries.forEach(QueryMetadata::close);
+    } else {
+      allLiveQueries.forEach(QueryMetadata::stop);
+    }
+
     engineMetrics.close();
     aggregateMetricsCollector.shutdown();
+  }
+
+  @Override
+  public void close() {
+    close(false);
   }
 
   /**

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -145,6 +145,10 @@ public class PersistentQueryMetadata extends QueryMetadata {
     return physicalPlan;
   }
 
+  public DataSource getSink() {
+    return sinkDataSource;
+  }
+
   @VisibleForTesting
   Optional<MaterializationProvider> getMaterializationProvider() {
     return materializationProvider;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -58,7 +58,7 @@ public abstract class QueryMetadata {
   private final KafkaStreamsBuilder kafkaStreamsBuilder;
   private final Map<String, Object> streamsProperties;
   private final Map<String, Object> overriddenProperties;
-  private final Consumer<QueryMetadata> closeCallback;
+  private Consumer<QueryMetadata> closeCallback;
   private final Set<SourceName> sourceNames;
   private final LogicalSchema logicalSchema;
   private final Long closeTimeout;
@@ -140,6 +140,10 @@ public abstract class QueryMetadata {
     this.queryStateListener = Optional.of(queryStateListener);
     kafkaStreams.setStateListener(queryStateListener);
     queryStateListener.onChange(kafkaStreams.state(), kafkaStreams.state());
+  }
+
+  public void closeAndThen(final Consumer<QueryMetadata> andThen) {
+    this.closeCallback = closeCallback.andThen(andThen);
   }
 
   private void uncaughtHandler(final Thread t, final Throwable e) {

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
@@ -89,7 +89,7 @@ public class KsqlTestException extends KsqlException {
       final Path file
   ) {
     return String.format(
-        "Test failure for assert `%s` (%s):\n\t%s\n\t%s",
+        "Test failure for assert `%s` (%s):%n\t%s%n\t%s",
         SqlFormatter.formatSql(assertStatement),
         assertStatement.getLocation().map(Objects::toString).orElse("unknown"),
         message,
@@ -105,7 +105,7 @@ public class KsqlTestException extends KsqlException {
       final Path file
   ) {
     return String.format(
-        "Test failure during directive evaluation `%s` (%s):\n\t%s\t%s",
+        "Test failure during directive evaluation `%s` (%s):%n\t%s%n\t%s",
         directive,
         directive.getLocation(),
         message,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.parser.tree.AssertStatement;
 import io.confluent.ksql.test.model.LocationWithinFile;
 import io.confluent.ksql.test.parser.TestDirective;
 import io.confluent.ksql.test.parser.TestStatement;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.ParserUtil;
 import java.nio.file.Path;
 import java.util.Objects;
@@ -33,7 +34,7 @@ import java.util.Optional;
  * to automatically populate the statement that produced it as well as the
  * location in the file.
  */
-public class KsqlTestException extends AssertionError {
+public class KsqlTestException extends KsqlException {
 
   public KsqlTestException(
       final TestStatement statement,
@@ -72,7 +73,7 @@ public class KsqlTestException extends AssertionError {
         parsedStatement.getStatement());
 
     return String.format(
-        "Test failure for statement `%s` (%s):\n\t%s\n\t%s",
+        "Test failure for statement `%s` (%s):%n\t%s%n\t%s",
         parsedStatement.getStatementText(),
         loc.map(NodeLocation::toString).orElse("unknown"),
         message,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/KsqlTestException.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test;
+
+import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
+import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.SqlFormatter;
+import io.confluent.ksql.parser.tree.AssertStatement;
+import io.confluent.ksql.test.model.LocationWithinFile;
+import io.confluent.ksql.test.parser.TestDirective;
+import io.confluent.ksql.test.parser.TestStatement;
+import io.confluent.ksql.util.ParserUtil;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Indicates a test exception as well as where it occurred. All sql-driven
+ * tests should throw this exception at the top-level if possible in order
+ * to automatically populate the statement that produced it as well as the
+ * location in the file.
+ */
+public class KsqlTestException extends AssertionError {
+
+  public KsqlTestException(
+      final TestStatement statement,
+      final Path file,
+      final Throwable cause
+  ) {
+    super(getMessage(statement, cause.getMessage(), file), cause);
+  }
+
+  public KsqlTestException(
+      final TestStatement statement,
+      final Path file,
+      final String message
+  ) {
+    super(getMessage(statement, message, file));
+  }
+
+  private static String getMessage(
+      final TestStatement stmt,
+      final String message,
+      final Path file
+  ) {
+    return stmt.apply(
+        parsed -> engineMessage(parsed, message, file),
+        assertStatement -> assertMessage(assertStatement, message, file),
+        directive -> directiveMessage(directive, message, file)
+    );
+  }
+
+  private static String engineMessage(
+      final ParsedStatement parsedStatement,
+      final String message,
+      final Path file
+  ) {
+    final Optional<NodeLocation> loc = ParserUtil.getLocation(
+        parsedStatement.getStatement());
+
+    return String.format(
+        "Test failure for statement `%s` (%s):\n\t%s\n\t%s",
+        parsedStatement.getStatementText(),
+        loc.map(NodeLocation::toString).orElse("unknown"),
+        message,
+        new LocationWithinFile(
+            file,
+            loc.map(NodeLocation::getLineNumber).orElse(1))
+    );
+  }
+
+  private static String assertMessage(
+      final AssertStatement assertStatement,
+      final String message,
+      final Path file
+  ) {
+    return String.format(
+        "Test failure for assert `%s` (%s):\n\t%s\n\t%s",
+        SqlFormatter.formatSql(assertStatement),
+        assertStatement.getLocation().map(Objects::toString).orElse("unknown"),
+        message,
+        new LocationWithinFile(
+            file,
+            assertStatement.getLocation().map(NodeLocation::getLineNumber).orElse(1))
+    );
+  }
+
+  private static String directiveMessage(
+      final TestDirective directive,
+      final String message,
+      final Path file
+  ) {
+    return String.format(
+        "Test failure during directive evaluation `%s` (%s):\n\t%s\t%s",
+        directive,
+        directive.getLocation(),
+        message,
+        new LocationWithinFile(
+            file,
+            directive.getLocation().getLineNumber())
+    );
+  }
+
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.driver;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.engine.generic.GenericRecordFactory;
+import io.confluent.ksql.engine.generic.KsqlGenericRecord;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.parser.AssertTable;
+import io.confluent.ksql.parser.tree.AssertStream;
+import io.confluent.ksql.parser.tree.AssertValues;
+import io.confluent.ksql.parser.tree.InsertValues;
+import io.confluent.ksql.schema.ksql.SystemColumns;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Iterator;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.test.TestRecord;
+
+/**
+ * {@code AssertExecutor} handles the assertion statements for the Sql-based
+ * testing tool.
+ */
+public final class AssertExecutor {
+
+  private AssertExecutor() {
+  }
+
+  public static void assertValues(
+      final KsqlExecutionContext engine,
+      final KsqlConfig config,
+      final AssertValues assertValues,
+      final TestDriverPipeline driverPipeline
+  ) {
+    final InsertValues values = assertValues.getStatement();
+    final boolean compareTimestamp = values
+        .getColumns()
+        .stream()
+        .anyMatch(SystemColumns.ROWTIME_NAME::equals);
+
+    final DataSource dataSource = engine.getMetaStore().getSource(values.getTarget());
+    final KsqlGenericRecord expected = new GenericRecordFactory(
+        config, engine.getMetaStore(), System::currentTimeMillis
+    ).build(
+        values.getColumns(),
+        values.getValues(),
+        dataSource.getSchema(),
+        dataSource.getDataSourceType()
+    );
+
+    final Iterator<TestRecord<Struct, GenericRow>> records = driverPipeline
+        .getRecordsForTopic(dataSource.getKafkaTopicName());
+    if (!records.hasNext()) {
+      throw new KsqlException(
+          String.format(
+              "Expected another record (%s) for %s but already read all records: %s",
+              expected,
+              dataSource.getName(),
+              driverPipeline.getAllRecordsForTopic(dataSource.getKafkaTopicName())
+          )
+      );
+    }
+
+    final TestRecord<Struct, GenericRow> actualTestRecord = records.next();
+    final KsqlGenericRecord actual = KsqlGenericRecord.of(
+        actualTestRecord.key(),
+        actualTestRecord.value(),
+        compareTimestamp ? actualTestRecord.timestamp() : expected.ts
+    );
+
+    if (!actual.equals(expected)) {
+      throw new KsqlException(
+          String.format(
+              "Expected record does not match actual. Expected: %s vs. Actual: %s",
+              expected,
+              actual
+          )
+      );
+    }
+  }
+
+  public static void assertStream(final AssertStream assertStatement) {
+    throw new UnsupportedOperationException();
+  }
+
+  public static void assertTable(final AssertTable assertStatement) {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/loader/TestLoader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/loader/TestLoader.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.test.loader;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.test.tools.Test;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
@@ -34,7 +35,7 @@ public interface TestLoader<T extends Test> {
   //   mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.files=test1.json,test2,json
   String KSQL_TEST_FILES = "ksql.test.files";
 
-  Stream<T> load();
+  Stream<T> load() throws IOException;
 
   static List<String> getWhiteList() {
     final String ksqlTestFiles = System.getProperty(KSQL_TEST_FILES, "").trim();

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestLoader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestLoader.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.parser;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.test.KsqlTestException;
+import io.confluent.ksql.test.parser.TestDirective.Type;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * The {@code SqlTestLoader} loads the test files that should be run
+ * by the Ksql testing tool based on a path and optional filters.
+ */
+public class SqlTestLoader {
+
+  private final Predicate<Test> shouldRun;
+
+  public SqlTestLoader() {
+    this(t -> true);
+  }
+
+  /**
+   * @param testFilter filters out which tests to run
+   */
+  public SqlTestLoader(final Predicate<Test> testFilter) {
+    this.shouldRun = Objects.requireNonNull(testFilter, "testFilter");
+  }
+
+  /**
+   * @param path a directory containing all test files to run
+   *
+   * @return a list of tests to run
+   */
+  public List<Test> loadDirectory(final Path path) throws IOException {
+    final SqlTestLoader loader = new SqlTestLoader();
+    final List<Path> files = Files
+        .find(path, Integer.MAX_VALUE, (filePath, fileAttr) -> fileAttr.isRegularFile())
+        .collect(Collectors.toList());
+
+    final ImmutableList.Builder<Test> builder = ImmutableList.builder();
+    for (final Path file : files) {
+      builder.addAll(loader.loadTest(file));
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * @param path a single sql test file, containing possibly many tests
+   *
+   * @return the list of tests to run
+   */
+  public List<Test> loadTest(final Path path) throws IOException {
+    final ImmutableList.Builder<Test> builder = ImmutableList.builder();
+
+    List<TestStatement> statements = null;
+    String name = null;
+
+    final SqlTestReader reader = SqlTestReader.of(path);
+    while (reader.hasNext()) {
+      final TestStatement statement = reader.next();
+      final Optional<String> nextName = statement.consumeDirective(
+          directive -> directive.getType() == Type.TEST ? directive.getContents() : null
+      );
+
+      if (nextName.isPresent()) {
+        // flush the previous test
+        if (statements != null) {
+          builder.add(new Test(path, name, statements));
+        }
+
+        statements = new ArrayList<>();
+        name = nextName.get();
+      } else if (statements == null) {
+        throw new KsqlTestException(statement, path, "Exepcted test to start with --@test.");
+      }
+
+      statements.add(statement);
+    }
+
+    builder.add(new Test(path, name, statements));
+    return builder.build().stream().filter(shouldRun).collect(ImmutableList.toImmutableList());
+  }
+
+  /**
+   * Represents a tuple of (test name, file, test statements) that constitute a ksql
+   * test.
+   */
+  public static class Test {
+
+    private final Path file;
+    private final String name;
+    private final List<TestStatement> statements;
+
+    public Test(final Path file, final String name, final List<TestStatement> statements) {
+      this.file = file;
+      this.name = name;
+      this.statements = statements;
+    }
+
+    public Path getFile() {
+      return file;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public List<TestStatement> getStatements() {
+      return statements;
+    }
+
+    /**
+     * @return an {@code Object[]} representation of this class used for Parameterized
+     *         JUnit testing. The representation is [name, file, statements]
+     */
+    public Object[] asObjectArray() {
+      return new Object[]{name, file, statements};
+    }
+  }
+
+}

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
@@ -78,7 +78,7 @@ public final class SqlTestReader implements Iterator<TestStatement> {
   }
 
   /**
-   * @param file     the test file
+   * @param file the test file
    */
   public static SqlTestReader of(
       final Path file
@@ -128,7 +128,8 @@ public final class SqlTestReader implements Iterator<TestStatement> {
       cachedStatement = true;
     }
 
-    // if there's no cachedStatement at this point, we've hit EOF
+    // if there's no cachedStatement at this point, then all that's left is the directives
+    // so we can just use EOF (tks.size()) as our stopping point
     final int currIdx = cachedStatement ? testStatement.getStart().getTokenIndex() : tks.size();
     while (directiveIdx < currIdx) {
       final Token tok = tks.get(directiveIdx++);

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestDirective.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/TestDirective.java
@@ -57,6 +57,10 @@ public class TestDirective {
     return contents;
   }
 
+  public NodeLocation getLocation() {
+    return location;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -79,21 +83,13 @@ public class TestDirective {
 
   @Override
   public String toString() {
-    return "TestDirective{"
-        + "type=" + type
-        + ", contents='" + contents + '\''
-        + '}';
-  }
-
-  public NodeLocation getLocation() {
-    return location;
+    return "--@" + type.getTypeName() + ": " + contents;
   }
 
   public enum Type {
     TEST("test"),
     EXPECTED_ERROR("expected.error"),
     EXPECTED_MESSAGE("expected.message"),
-    ENABLED("enabled"),
     UNKNOWN("UNKNOWN")
     ;
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.driver;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
+import io.confluent.ksql.ServiceInfo;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.engine.generic.GenericRecordFactory;
+import io.confluent.ksql.engine.generic.KsqlGenericRecord;
+import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
+import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.parser.AssertTable;
+import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.AssertStatement;
+import io.confluent.ksql.parser.tree.AssertStream;
+import io.confluent.ksql.parser.tree.AssertValues;
+import io.confluent.ksql.parser.tree.CreateAsSelect;
+import io.confluent.ksql.parser.tree.CreateSource;
+import io.confluent.ksql.parser.tree.InsertValues;
+import io.confluent.ksql.parser.tree.SetProperty;
+import io.confluent.ksql.parser.tree.UnsetProperty;
+import io.confluent.ksql.properties.PropertyOverrider;
+import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
+import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.utils.FormatOptions;
+import io.confluent.ksql.serde.GenericRowSerDe;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.services.FakeKafkaTopicClient;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.services.TestServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.test.KsqlTestException;
+import io.confluent.ksql.test.driver.TestDriverPipeline.TopicInfo;
+import io.confluent.ksql.test.parser.SqlTestLoader;
+import io.confluent.ksql.test.parser.TestDirective;
+import io.confluent.ksql.test.parser.TestStatement;
+import io.confluent.ksql.test.tools.TestFunctionRegistry;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class KsqlTesterTest {
+
+  private static final String TEST_DIR = "/sql-tests";
+
+  private static final ImmutableMap<String, Object> BASE_CONFIG = ImmutableMap
+      .<String, Object>builder()
+      .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:0")
+      .put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 0)
+      .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+      .put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0)
+      .put(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, 0L)
+      .put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "some.ksql.service.id")
+      .build();
+
+  // parameterized
+  private final Path file;
+  private final List<TestStatement> statements;
+
+  // initialized in setUp
+  private ServiceContext serviceContext;
+  private KsqlEngine engine;
+  private KsqlConfig config;
+  private TestDriverPipeline driverPipeline;
+  private FakeKafkaTopicClient topicClient;
+
+  // populated during run
+  private Map<String, Object> overrides;
+
+  // populated during execution to handle the expected exception
+  // scenario - don't use Matchers because they do not create very
+  // user friendly error messages
+  private Class<? extends Exception> expectedException;
+  private String expectedMessage;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Object[][] data() throws IOException {
+    final Path testDir = Paths.get(KsqlTesterTest.class.getResource(TEST_DIR).getFile());
+    final SqlTestLoader loader = new SqlTestLoader();
+    return loader.loadDirectory(testDir)
+        .stream()
+        .map(SqlTestLoader.Test::asObjectArray)
+        .toArray(Object[][]::new);
+  }
+
+  public KsqlTesterTest(final String testCase, final Path file, final List<TestStatement> statements) {
+    this.file = Objects.requireNonNull(file, "file");
+    this.statements = statements;
+  }
+
+  @Before
+  public void setUp() {
+    final MockSchemaRegistryClient srClient = new MockSchemaRegistryClient();
+    this.topicClient = new FakeKafkaTopicClient();
+    this.serviceContext = TestServiceContext.create(topicClient, () -> srClient);
+    this.config = new KsqlConfig(BASE_CONFIG);
+
+    final MetaStoreImpl metaStore = new MetaStoreImpl(TestFunctionRegistry.INSTANCE.get());
+    this.engine = new KsqlEngine(
+        serviceContext,
+        NoopProcessingLogContext.INSTANCE,
+        metaStore,
+        ServiceInfo.create(config),
+        new SequentialQueryIdGenerator()
+    );
+
+    this.expectedException = null;
+    this.expectedMessage = null;
+
+    this.overrides = new HashMap<>();
+    this.driverPipeline = new TestDriverPipeline();
+  }
+
+  @After
+  public void close() {
+    engine.close(true);
+    serviceContext.close();
+  }
+
+  @Test
+  public void test() {
+    for (final TestStatement testStatement : statements) {
+      try {
+        testStatement.consume(this::execute, this::doAssert, this::directive);
+      } catch (final Exception e) {
+        handleExpectedException(testStatement, e);
+        return;
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void execute(final ParsedStatement parsedStatement) {
+    final PreparedStatement<?> engineStatement = engine.prepare(parsedStatement);
+    final ConfiguredStatement<?> configured = ConfiguredStatement.of(
+        engineStatement, overrides, config);
+
+    createTopics(engineStatement);
+
+    if (engineStatement.getStatement() instanceof InsertValues) {
+      pipeInput((ConfiguredStatement<InsertValues>) configured);
+      return;
+    } else if (engineStatement.getStatement() instanceof SetProperty) {
+      PropertyOverrider.set((ConfiguredStatement<SetProperty>) configured, overrides);
+      return;
+    } else if (engineStatement.getStatement() instanceof UnsetProperty) {
+      PropertyOverrider.unset((ConfiguredStatement<UnsetProperty>) configured, overrides);
+      return;
+    }
+
+    final ExecuteResult result = engine.execute(
+        serviceContext,
+        configured);
+
+    // is DDL statement
+    if (!result.getQuery().isPresent()) {
+      return;
+    }
+
+    final PersistentQueryMetadata query = (PersistentQueryMetadata) result.getQuery().get();
+    final Topology topology = query.getTopology();
+    final Properties properties = new Properties();
+    properties.putAll(query.getStreamsProperties());
+
+    final TopologyTestDriver driver = new TopologyTestDriver(topology, properties);
+    query.closeAndThen(qm -> driver.close());
+
+    final List<TopicInfo> inputTopics = query
+        .getSourceNames()
+        .stream()
+        .map(sn -> engine.getMetaStore().getSource(sn))
+        .map(ds -> new TopicInfo(ds.getKafkaTopicName(), keySerde(ds), valueSerde(ds)))
+        .collect(Collectors.toList());
+
+    final DataSource output = engine.getMetaStore().getSource(query.getSinkName());
+    final TopicInfo outputInfo = new TopicInfo(
+        output.getKafkaTopicName(),
+        keySerde(output),
+        valueSerde(output)
+    );
+
+    driverPipeline.addDriver(driver, inputTopics, outputInfo);
+  }
+
+  private void createTopics(final PreparedStatement<?> engineStatement) {
+    if (engineStatement.getStatement() instanceof CreateSource) {
+      final CreateSource statement = (CreateSource) engineStatement.getStatement();
+      topicClient.preconditionTopicExists(
+          statement.getProperties().getKafkaTopic(),
+          statement.getProperties().getPartitions().orElse(1),
+          statement.getProperties().getReplicas().orElse((short) 1),
+          ImmutableMap.of()
+      );
+    } else if (engineStatement.getStatement() instanceof CreateAsSelect) {
+      final CreateAsSelect statement = (CreateAsSelect) engineStatement.getStatement();
+      topicClient.preconditionTopicExists(
+          statement.getProperties().getKafkaTopic()
+              .orElse(statement.getName().toString(FormatOptions.noEscape()).toUpperCase()),
+          statement.getProperties().getPartitions().orElse(1),
+          statement.getProperties().getReplicas().orElse((short) 1),
+          ImmutableMap.of()
+      );
+    }
+  }
+
+  private void pipeInput(final ConfiguredStatement<InsertValues> statement) {
+    final InsertValues insertValues = statement.getStatement();
+    final DataSource dataSource = engine.getMetaStore().getSource(insertValues.getTarget());
+    if (dataSource == null) {
+      throw new KsqlException("Unknown data source " + insertValues.getTarget());
+    }
+
+    final KsqlGenericRecord record = new GenericRecordFactory(
+        config, engine.getMetaStore(), System::currentTimeMillis
+    ).build(
+        insertValues.getColumns(),
+        insertValues.getValues(),
+        dataSource.getSchema(),
+        dataSource.getDataSourceType()
+    );
+    driverPipeline.pipeInput(
+        dataSource.getKafkaTopicName(),
+        record.key,
+        record.value,
+        record.ts
+    );
+  }
+
+  private void doAssert(final AssertStatement assertStatement) {
+    if (assertStatement instanceof AssertValues) {
+      AssertExecutor.assertValues(engine, config, (AssertValues) assertStatement, driverPipeline);
+    } else if (assertStatement instanceof AssertStream) {
+      AssertExecutor.assertStream(((AssertStream) assertStatement));
+    } else if (assertStatement instanceof AssertTable) {
+      AssertExecutor.assertTable(((AssertTable) assertStatement));
+    }
+  }
+
+  private Serde<Struct> keySerde(final DataSource sinkSource) {
+    return sinkSource.getKsqlTopic().getKeyFormat()
+        .getFormat()
+        .getSerdeFactory(
+            sinkSource.getKsqlTopic().getKeyFormat().getFormatInfo()
+        ).createSerde(
+            PersistenceSchema.from(
+                sinkSource.getSchema().keyConnectSchema(),
+                sinkSource.getSerdeOptions().contains(SerdeOption.UNWRAP_SINGLE_VALUES)),
+            config,
+            serviceContext.getSchemaRegistryClientFactory(),
+            Struct.class
+        );
+  }
+
+  private Serde<GenericRow> valueSerde(final DataSource sinkSource) {
+    return GenericRowSerDe.from(
+        sinkSource.getKsqlTopic().getValueFormat().getFormatInfo(),
+        PersistenceSchema.from(
+            sinkSource.getSchema().valueConnectSchema(),
+            sinkSource.getSerdeOptions().contains(SerdeOption.UNWRAP_SINGLE_VALUES)),
+        config,
+        serviceContext.getSchemaRegistryClientFactory(),
+        "",
+        NoopProcessingLogContext.INSTANCE
+    );
+  }
+
+  private void directive(final TestDirective directive) {
+    try {
+      switch (directive.getType()) {
+        case EXPECTED_ERROR:
+          handleExpectedClass(directive);
+          break;
+        case EXPECTED_MESSAGE:
+          handleExpectedMessage(directive);
+          break;
+        default:
+      }
+    } catch (final Exception e) {
+      throw new KsqlException("Failed to handle directive " + directive, e);
+    }
+  }
+
+  private void handleExpectedException(final TestStatement testStatement, final Exception e) {
+    if (expectedException == null && expectedMessage == null) {
+      throw new KsqlTestException(testStatement, file, e);
+    }
+
+    if (!e.getMessage().contains(expectedMessage)) {
+      throw new KsqlTestException(
+          testStatement,
+          file,
+          "Expected exception with message \"" + expectedMessage + "\" but got " + e);
+    }
+
+    if (!expectedException.isInstance(e)) {
+      throw new KsqlTestException(
+          testStatement,
+          file,
+          "Expected exception with class " + expectedException + " but got " + e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void handleExpectedClass(final TestDirective directive) throws ClassNotFoundException {
+    expectedException = (Class<? extends Exception>) Class.forName(directive.getContents());
+  }
+
+  private void handleExpectedMessage(final TestDirective directive) {
+    expectedMessage = directive.getContents();
+  }
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.test.KsqlTestException;
 import io.confluent.ksql.test.driver.TestDriverPipeline.TopicInfo;
 import io.confluent.ksql.test.parser.SqlTestLoader;
+import io.confluent.ksql.test.parser.SqlTestLoader.SqlTest;
 import io.confluent.ksql.test.parser.TestDirective;
 import io.confluent.ksql.test.parser.TestStatement;
 import io.confluent.ksql.test.tools.TestFunctionRegistry;
@@ -115,10 +116,9 @@ public class KsqlTesterTest {
   @Parameterized.Parameters(name = "{0}")
   public static Object[][] data() throws IOException {
     final Path testDir = Paths.get(KsqlTesterTest.class.getResource(TEST_DIR).getFile());
-    final SqlTestLoader loader = new SqlTestLoader();
-    return loader.loadDirectory(testDir)
-        .stream()
-        .map(SqlTestLoader.Test::asObjectArray)
+    final SqlTestLoader loader = new SqlTestLoader(testDir);
+    return loader.load()
+        .map(SqlTest::asObjectArray)
         .toArray(Object[][]::new);
   }
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
@@ -50,28 +50,28 @@ public class SqlTestReaderTest {
     assertThat(reader.next(), is(TestStatement.of(new TestDirective(Type.TEST, "test1", LOC))));
 
     assertThat(reader.hasNext(), is(true));
-    reader.next().handle(
+    reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
         s -> assertThat("unexpected statement " + s, false),
         s -> assertThat("unexpected statement " + s, false)
     );
 
     assertThat(reader.hasNext(), is(true));
-    reader.next().handle(
+    reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM bar")),
         s -> assertThat("unexpected statement " + s, false),
         s -> assertThat("unexpected statement " + s, false)
     );
 
     assertThat(reader.hasNext(), is(true));
-    reader.next().handle(
+    reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("INSERT INTO")),
         s -> assertThat("unexpected statement " + s, false),
         s -> assertThat("unexpected statement " + s, false)
     );
 
     assertThat(reader.hasNext(), is(true));
-    reader.next().handle(
+    reader.next().consume(
         s -> assertThat("unexpected statement " + s, false),
         s -> assertThat(s, instanceOf(AssertValues.class)),
         s -> assertThat("unexpected statement " + s, false)
@@ -93,14 +93,14 @@ public class SqlTestReaderTest {
     assertThat(reader.next(), is(TestStatement.of(new TestDirective(Type.TEST, "test1", LOC))));
 
     assertThat(reader.hasNext(), is(true));
-    reader.next().handle(
+    reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
         s -> assertThat("unexpected statement " + s, false),
         s -> assertThat("unexpected statement " + s, false)
     );
 
     assertThat(reader.hasNext(), is(true));
-    reader.next().handle(
+    reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM bar")),
         s -> assertThat("unexpected statement " + s, false),
         s -> assertThat("unexpected statement " + s, false)
@@ -124,7 +124,7 @@ public class SqlTestReaderTest {
     assertThat(reader.next(), is(TestStatement.of(new TestDirective(Type.TEST, "test1", LOC))));
 
     assertThat(reader.hasNext(), is(true));
-    reader.next().handle(
+    reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
         s -> assertThat("unexpected statement " + s, false),
         s -> assertThat("unexpected statement " + s, false)
@@ -151,7 +151,7 @@ public class SqlTestReaderTest {
     assertThat(reader.next(), is(TestStatement.of(new TestDirective(Type.TEST, "test1", LOC))));
 
     assertThat(reader.hasNext(), is(true));
-    reader.next().handle(
+    reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
         s -> assertThat("unexpected statement " + s, false),
         s -> assertThat("unexpected statement " + s, false)

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/TestDirectiveTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/TestDirectiveTest.java
@@ -52,7 +52,6 @@ public class TestDirectiveTest {
 
     // Then:
     assertThat(directive, Matchers.is(new TestDirective(Type.TEST, "bar", LOC)));
-    assertThat(directive.getLocation(), Matchers.is(new NodeLocation(1, 10)));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/asserts.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/asserts.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "name": "should not parse ASSERT",
+      "statements": [
+        "ASSERT VALUES foo (id INT) VALUES (123);"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "mismatched input 'ASSERT'"
+      }
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -1,0 +1,119 @@
+-- this test file is a "meta-test" that tests the basic functionality of the KsqlTester
+-- eventually, we plan to remove this test in favor of migrating the QTTs over to use this format
+-- directly
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test with tables
+----------------------------------------------------------------------------------------------------
+CREATE TABLE foo (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE TABLE bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test without rowtime comparison
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (id, col1) VALUES (1, 1);
+ASSERT VALUES bar (id, col1) VALUES (1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test with aggregation
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE TABLE bar AS SELECT id, COUNT(*) as count FROM foo GROUP BY id;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, count) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic test (format AVRO)
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='AVRO');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic chained test
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+CREATE STREAM baz AS SELECT * FROM bar;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES baz (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic join test
+----------------------------------------------------------------------------------------------------
+CREATE STREAM s (id INT KEY, foo INT) WITH (kafka_topic='s', value_format='JSON');
+CREATE TABLE t (id INT PRIMARY KEY, bar INT) WITH (kafka_topic='t', value_format='JSON');
+
+CREATE STREAM j AS SELECT s.id, s.foo, t.bar FROM s JOIN t ON s.id = t.id;
+
+INSERT INTO t (rowtime, id, bar) VALUES (1, 1, 1);
+INSERT INTO s (rowtime, id, foo) VALUES (1, 1, 2);
+
+ASSERT VALUES j (rowtime, s_id, foo, bar) VALUES (1, 1, 2, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: basic create or replace test
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+SET 'ksql.create.or.replace.enabled'='true';
+CREATE OR REPLACE STREAM bar AS SELECT id, col1 + 1 as col1 FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 2);
+
+----------------------------------------------------------------------------------------------------
+--@test: make sure properties do not carry over
+--@expected.error: io.confluent.ksql.util.KsqlStatementException
+--@expected.message: Cannot add stream 'BAR': A stream with the same name already exists
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+CREATE OR REPLACE STREAM bar AS SELECT id, col1 + 1 as col1 FROM foo;
+
+----------------------------------------------------------------------------------------------------
+--@test: bad assert statement should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected record does not match actual
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (2, 2, 2);
+
+----------------------------------------------------------------------------------------------------
+--@test: bad engine statement should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Exception while preparing statement: FOO does not exist.
+----------------------------------------------------------------------------------------------------
+CREATE STREAM bar AS SELECT * FROM foo;


### PR DESCRIPTION
### Description 

First draft at the fully implemented `KsqlTester` (see #5965). Review guide:

* Start by looking at `test.sql` to see how the testing tool works end-to-end
* Then look at `KsqlTesterTest` to see the full test in action. I'm planning on refactoring this further when I make it a standalone tool, but given that I want this to test query upgrades I'm leaving this in a little bit of a rougher state for now
* Look at `SqlTestLoader` to see how we load tests
* Look at `AssertExecutor` to look at asserting mechanism. I'm planning on improving the assertion mechanism to leverage the `SELECT` formatting of rows when I make this tool public, but for now it just compares the Generic representation of rows directy
* The rest is piping/formatting exceptions/etc...

### Testing done 

- `test.sql` tests this end to end

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

