### PR TITLE
test: fix flaky test due to static state

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsMutualAuthTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsMutualAuthTest.java
@@ -18,12 +18,8 @@ package io.confluent.ksql.api.client;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import java.util.Map;
 import org.apache.kafka.common.config.SslConfigs;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ClientTlsMutualAuthTest extends ClientTlsTest {
-
-  protected static final Logger log = LoggerFactory.getLogger(ClientTlsMutualAuthTest.class);
 
   @Override
   protected KsqlRestConfig createServerConfig() {

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsTest.java
@@ -22,26 +22,23 @@ import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.test.util.secure.ServerKeyStore;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import javax.net.ssl.SSLHandshakeException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ClientTlsTest extends ClientTest {
 
-  protected static final Logger log = LoggerFactory.getLogger(ClientTlsTest.class);
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
 
-  protected static final String TRUST_STORE_PATH = ServerKeyStore.keyStoreProps()
+  protected static final String TRUST_STORE_PATH = SERVER_KEY_STORE.keyStoreProps()
       .get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
-  protected static final String TRUST_STORE_PASSWORD = ServerKeyStore.keyStoreProps()
+  protected static final String TRUST_STORE_PASSWORD = SERVER_KEY_STORE.keyStoreProps()
       .get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
-  protected static final String KEY_STORE_PATH = ServerKeyStore.keyStoreProps()
+  protected static final String KEY_STORE_PATH = SERVER_KEY_STORE.keyStoreProps()
       .get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
-  protected static final String KEY_STORE_PASSWORD = ServerKeyStore.keyStoreProps()
+  protected static final String KEY_STORE_PASSWORD = SERVER_KEY_STORE.keyStoreProps()
       .get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
 
   @Override

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -54,6 +54,8 @@ import org.junit.rules.RuleChain;
 @Category({IntegrationTest.class})
 public class SslClientAuthFunctionalTest {
 
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
+
   private static final String TOPIC_NAME = new OrderDataProvider().topicName();
 
   private static final String JSON_KSQL_REQUEST = UrlEscapers.urlFormParameterEscaper()
@@ -63,10 +65,9 @@ public class SslClientAuthFunctionalTest {
 
   public static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
-  @SuppressWarnings("deprecation")
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
-      .withProperties(ServerKeyStore.keyStoreProps())
+      .withProperties(SERVER_KEY_STORE.keyStoreProps())
       .withProperty(KsqlRestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
           KsqlRestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED)
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "https://localhost:0")
@@ -94,15 +95,13 @@ public class SslClientAuthFunctionalTest {
 
   @Test
   public void shouldNotBeAbleToUseCliIfClientDoesNotProvideCertificate() {
-
     // Given:
     givenClientConfiguredWithoutCertificate();// Then:
-
 
     // When:
     final Exception e = assertThrows(
         KsqlRestClientException.class,
-        () -> canMakeCliRequest()
+        this::canMakeCliRequest
     );
 
     // Then:
@@ -123,7 +122,7 @@ public class SslClientAuthFunctionalTest {
   }
 
   @Test
-  public void shouldNotBeAbleToUseWssIfClientDoesNotTrustServerCert() throws Exception {
+  public void shouldNotBeAbleToUseWssIfClientDoesNotTrustServerCert() {
     // Given:
     givenClientConfiguredWithoutCertificate();
 
@@ -147,9 +146,9 @@ public class SslClientAuthFunctionalTest {
 
   private void givenClientConfiguredWithCertificate() {
 
-    String clientCertPath = ServerKeyStore.keyStoreProps()
+    String clientCertPath = SERVER_KEY_STORE.keyStoreProps()
         .get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
-    String clientCertPassword = ServerKeyStore.keyStoreProps()
+    String clientCertPassword = SERVER_KEY_STORE.keyStoreProps()
         .get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
 
     // HTTP:

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -54,6 +54,7 @@ import org.junit.rules.RuleChain;
 public class SslFunctionalTest {
 
   private static final String TOPIC_NAME = new OrderDataProvider().topicName();
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
 
   private static final String JSON_KSQL_REQUEST = UrlEscapers.urlFormParameterEscaper()
       .escape("{"
@@ -64,7 +65,7 @@ public class SslFunctionalTest {
 
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
-      .withProperties(ServerKeyStore.keyStoreProps())
+      .withProperties(SERVER_KEY_STORE.keyStoreProps())
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "https://localhost:0")
       .build();
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -44,12 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ApiTest extends BaseApiTest {
-
-  protected static final Logger log = LoggerFactory.getLogger(ApiTest.class);
 
   protected static final List<JsonObject> DEFAULT_INSERT_ROWS = generateInsertRows();
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ListenersTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ListenersTest.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 
 public class ListenersTest extends BaseApiTest {
 
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
+
   @Test
   public void shouldSupportOneListener() {
     //Given:
@@ -129,15 +131,15 @@ public class ListenersTest extends BaseApiTest {
         "Invalid listener URI"));
   }
 
-  private KsqlRestConfig createConfig(String listeners, boolean tls) {
+  private static KsqlRestConfig createConfig(String listeners, boolean tls) {
     Map<String, Object> config = new HashMap<>();
     config.put(KsqlRestConfig.LISTENERS_CONFIG, listeners);
     config.put(KsqlRestConfig.VERTICLE_INSTANCES, 4);
 
     if (tls) {
-      String keyStorePath = ServerKeyStore.keyStoreProps()
+      String keyStorePath = SERVER_KEY_STORE.keyStoreProps()
           .get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
-      String keyStorePassword = ServerKeyStore.keyStoreProps()
+      String keyStorePassword = SERVER_KEY_STORE.keyStoreProps()
           .get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
 
       config.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keyStorePath);
@@ -151,5 +153,4 @@ public class ListenersTest extends BaseApiTest {
     stopServer();
     stopClient();
   }
-
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
@@ -42,6 +42,8 @@ import org.junit.rules.RuleChain;
 @Category({IntegrationTest.class})
 public class ShowQueriesMultiNodeWithTlsFunctionalTest {
 
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
+
   private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
   private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
   private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.kstreamName();
@@ -51,14 +53,14 @@ public class ShowQueriesMultiNodeWithTlsFunctionalTest {
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG,
           "http://localhost:8088,https://localhost:8189")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "https://localhost:8189")
-      .withProperties(ServerKeyStore.keyStoreProps())
+      .withProperties(SERVER_KEY_STORE.keyStoreProps())
       .build();
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG,
           "http://localhost:8098,https://localhost:8199")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "https://localhost:8199")
-      .withProperties(ServerKeyStore.keyStoreProps())
+      .withProperties(SERVER_KEY_STORE.keyStoreProps())
       .build();
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
@@ -76,6 +76,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(Enclosed.class)
 public class SystemAuthenticationFunctionalTest {
 
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
   private static final TemporaryFolder TMP = new TemporaryFolder();
 
   static {
@@ -111,7 +112,7 @@ public class SystemAuthenticationFunctionalTest {
       .put(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir())
       .put(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1)
       .put(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
-      .putAll(ServerKeyStore.keyStoreProps())
+      .putAll(SERVER_KEY_STORE.keyStoreProps())
       .build();
 
   private static Map<String, String> internalKeyStoreProps(boolean node1) {

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -44,7 +44,6 @@ import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.TopicDescription;
 import io.confluent.ksql.test.util.secure.ClientTrustStore;
 import io.confluent.ksql.test.util.secure.ServerKeyStore;
-import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
@@ -71,6 +70,8 @@ import org.junit.Test;
 import org.reactivestreams.Subscription;
 
 public class KsqlClientTest {
+
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
 
   private Vertx vertx;
   private FakeApiServer server;
@@ -731,9 +732,9 @@ public class KsqlClientTest {
         .setHost("localhost")
         .setSsl(true)
         .setKeyStoreOptions(new JksOptions()
-            .setPath(ServerKeyStore.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
+            .setPath(SERVER_KEY_STORE.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
             .setPassword(
-                ServerKeyStore.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)));
+                SERVER_KEY_STORE.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)));
 
     startServer(serverOptions);
     serverUri = URI.create("https://localhost:" + server.getPort());

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -96,6 +96,7 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
   private static final Logger log = LoggerFactory.getLogger(EmbeddedSingleNodeKafkaCluster.class);
   private static final Duration PRODUCE_TIMEOUT = Duration.ofSeconds(30);
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
 
   public static final String JAAS_KAFKA_PROPS_NAME = "KafkaServer";
 
@@ -674,7 +675,7 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
       brokerConfig.put(KafkaConfig.InterBrokerSecurityProtocolProp(),
           SecurityProtocol.SASL_SSL.name());
       brokerConfig.put(KafkaConfig.SaslMechanismInterBrokerProtocolProp(), "PLAIN");
-      brokerConfig.putAll(ServerKeyStore.keyStoreProps());
+      brokerConfig.putAll(SERVER_KEY_STORE.keyStoreProps());
       brokerConfig.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
 
       clientConfig.putAll(SecureKafkaHelper.getSecureCredentialsConfig(VALID_USER1));

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/secure/KeyStoreUtil.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/secure/KeyStoreUtil.java
@@ -28,7 +28,7 @@ import org.apache.kafka.test.TestUtils;
 /**
  * Util class for working with test key & trust stores.
  */
-final class KeyStoreUtil {
+public final class KeyStoreUtil {
   private KeyStoreUtil() {
   }
 
@@ -57,7 +57,7 @@ final class KeyStoreUtil {
    * @param path                the path to write to.
    * @param base64EncodedStore  the base64 encoded store content.
    */
-  static void putStore(final Path path, final String base64EncodedStore) {
+  public static void putStore(final Path path, final String base64EncodedStore) {
     try {
       final byte[] decoded = Base64.getDecoder().decode(base64EncodedStore);
       Files.write(path, decoded);

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/secure/ServerKeyStore.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/secure/ServerKeyStore.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ServerKeyStore {
 
-  protected static final Logger log = LoggerFactory.getLogger(ServerKeyStore.class);
+  private static final Logger log = LoggerFactory.getLogger(ServerKeyStore.class);
 
   private static final String BASE64_ENCODED_STORE =
       "/u3+7QAAAAIAAAACAAAAAgAGY2Fyb290AAABYgp9KI4ABVguNTA5AAADLDCCAygwggIQAgkAvZW/3jNCgKgwDQYJKoZI"
@@ -129,10 +129,11 @@ public final class ServerKeyStore {
   private static final String KEY_PASSWORD = "password";
   private static final String KEYSTORE_PASSWORD = "password";
   private static final String TRUSTSTORE_PASSWORD = "password";
-  private static final AtomicReference<Path> keyStorePath = new AtomicReference<>();
-  private static final AtomicReference<Path> clientKeyStorePath = new AtomicReference<>();
 
-  private ServerKeyStore() {
+  private final AtomicReference<Path> keyStorePath = new AtomicReference<>();
+  private final AtomicReference<Path> clientKeyStorePath = new AtomicReference<>();
+
+  public ServerKeyStore() {
   }
 
   /**
@@ -140,7 +141,7 @@ public final class ServerKeyStore {
    *         The store at this path may be replaced with an expired store via the method
    *         {@link #loadExpiredServerKeyStore}.
    */
-  public static Map<String, String> keyStoreProps() {
+  public Map<String, String> keyStoreProps() {
     return ImmutableMap.of(
         SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keyStorePath(),
         SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, KEYSTORE_PASSWORD,
@@ -155,7 +156,7 @@ public final class ServerKeyStore {
    *         In contrast to {@link #keyStoreProps}, the store at this path will not replaced
    *         with an expired store when the method {@link #loadExpiredServerKeyStore} is called.
    */
-  public static Map<String, String> clientKeyStoreProps() {
+  public Map<String, String> clientKeyStoreProps() {
     return ImmutableMap.of(
         SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, clientKeyStorePath(),
         SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, KEYSTORE_PASSWORD,
@@ -165,17 +166,17 @@ public final class ServerKeyStore {
     );
   }
 
-  public static void loadExpiredServerKeyStore() {
+  public void loadExpiredServerKeyStore() {
     KeyStoreUtil.putStore(Paths.get(keyStorePath()), EXPIRED_BASE64_ENCODED_STORE);
     log.info("Loaded expired store");
   }
 
-  public static void loadValidServerKeyStore() {
+  public void loadValidServerKeyStore() {
     KeyStoreUtil.putStore(Paths.get(keyStorePath()), BASE64_ENCODED_STORE);
     log.info("Loaded valid store");
   }
 
-  private static String keyStorePath() {
+  private String keyStorePath() {
     final Path path = keyStorePath.updateAndGet(existing -> {
       if (existing != null) {
         return existing;
@@ -187,7 +188,7 @@ public final class ServerKeyStore {
     return path.toAbsolutePath().toString();
   }
 
-  private static String clientKeyStorePath() {
+  private String clientKeyStorePath() {
     final Path path = clientKeyStorePath.updateAndGet(existing -> {
       if (existing != null) {
         return existing;


### PR DESCRIPTION
### Description 

The `TlsTest` tended to fail locally when running other tests in parallel. Investigation showed this is due to shared state in `ServerKeyStore`: the path to the key store.  The test needed to write a bad cert and then assert requests failed, but if another test ran it would override the bad cert with a good one.
