### PR TITLE
test: add filters.sql and assert tombstone

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -21,13 +21,16 @@ import io.confluent.ksql.engine.generic.GenericRecordFactory;
 import io.confluent.ksql.engine.generic.KsqlGenericRecord;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.AssertTable;
+import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.AssertStream;
+import io.confluent.ksql.parser.tree.AssertTombstone;
 import io.confluent.ksql.parser.tree.AssertValues;
 import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Iterator;
+import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.test.TestRecord;
 
@@ -47,13 +50,33 @@ public final class AssertExecutor {
       final TestDriverPipeline driverPipeline
   ) {
     final InsertValues values = assertValues.getStatement();
+    assertContent(engine, config, values, driverPipeline, false);
+  }
+
+  public static void assertTombstone(
+      final KsqlExecutionContext engine,
+      final KsqlConfig config,
+      final AssertTombstone assertTombstone,
+      final TestDriverPipeline driverPipeline
+  ) {
+    final InsertValues values = assertTombstone.getStatement();
+    assertContent(engine, config, values, driverPipeline, true);
+  }
+
+  private static void assertContent(
+      final KsqlExecutionContext engine,
+      final KsqlConfig config,
+      final InsertValues values,
+      final TestDriverPipeline driverPipeline,
+      final boolean isTombstone
+  ) {
     final boolean compareTimestamp = values
         .getColumns()
         .stream()
         .anyMatch(SystemColumns.ROWTIME_NAME::equals);
 
     final DataSource dataSource = engine.getMetaStore().getSource(values.getTarget());
-    final KsqlGenericRecord expected = new GenericRecordFactory(
+    KsqlGenericRecord expected = new GenericRecordFactory(
         config, engine.getMetaStore(), System::currentTimeMillis
     ).build(
         values.getColumns(),
@@ -61,6 +84,13 @@ public final class AssertExecutor {
         dataSource.getSchema(),
         dataSource.getDataSourceType()
     );
+
+    if (isTombstone) {
+      if (expected.value.values().stream().anyMatch(Objects::nonNull)) {
+        throw new KsqlException("Unexpected value columns specified in ASSERT NULL VALUES.");
+      }
+      expected = KsqlGenericRecord.of(expected.key, null, expected.ts);
+    }
 
     final Iterator<TestRecord<Struct, GenericRow>> records = driverPipeline
         .getRecordsForTopic(dataSource.getKafkaTopicName());

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.engine.generic.GenericRecordFactory;
 import io.confluent.ksql.engine.generic.KsqlGenericRecord;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.AssertTable;
-import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.AssertStream;
 import io.confluent.ksql.parser.tree.AssertTombstone;
 import io.confluent.ksql.parser.tree.AssertValues;

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.AssertStatement;
 import io.confluent.ksql.parser.tree.AssertStream;
+import io.confluent.ksql.parser.tree.AssertTombstone;
 import io.confluent.ksql.parser.tree.AssertValues;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.CreateSource;
@@ -265,13 +266,15 @@ public class KsqlTesterTest {
     );
   }
 
-  private void doAssert(final AssertStatement assertStatement) {
-    if (assertStatement instanceof AssertValues) {
-      AssertExecutor.assertValues(engine, config, (AssertValues) assertStatement, driverPipeline);
-    } else if (assertStatement instanceof AssertStream) {
-      AssertExecutor.assertStream(((AssertStream) assertStatement));
-    } else if (assertStatement instanceof AssertTable) {
-      AssertExecutor.assertTable(((AssertTable) assertStatement));
+  private void doAssert(final AssertStatement statement) {
+    if (statement instanceof AssertValues) {
+      AssertExecutor.assertValues(engine, config, (AssertValues) statement, driverPipeline);
+    } else if (statement instanceof AssertTombstone) {
+      AssertExecutor.assertTombstone(engine, config, (AssertTombstone) statement, driverPipeline);
+    } else if (statement instanceof AssertStream) {
+      AssertExecutor.assertStream(((AssertStream) statement));
+    } else if (statement instanceof AssertTable) {
+      AssertExecutor.assertTable(((AssertTable) statement));
     }
   }
 

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/query-upgrades/filters.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/query-upgrades/filters.sql
@@ -1,0 +1,191 @@
+-- this file tests adding/removing/changing filters
+
+----------------------------------------------------------------------------------------------------
+--@test: add filter to basic STREAM without filter
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE STREAM a (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE STREAM b AS SELECT * FROM a;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+ASSERT VALUES b (id, col1) VALUES (1, 0);
+
+CREATE OR REPLACE STREAM b AS SELECT * FROM a WHERE col1 > 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+INSERT INTO a (id, col1) VALUES (1, 1);
+
+ASSERT VALUES b (id, col1) VALUES (1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: remove filter from basic STREAM with filter
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE STREAM a (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE STREAM b AS SELECT * FROM a WHERE col1 > 0;
+
+INSERT INTO a (id, col1) VALUES (2, 0);
+
+CREATE OR REPLACE STREAM b AS SELECT * FROM a;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+
+ASSERT VALUES b (id, col1) VALUES (1, 0);
+
+----------------------------------------------------------------------------------------------------
+--@test: modify filter from basic STREAM with filter
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE STREAM a (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE STREAM b AS SELECT * FROM a WHERE col1 > 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+INSERT INTO a (id, col1) VALUES (1, 1);
+
+CREATE OR REPLACE STREAM b AS SELECT * FROM a WHERE col1 < 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+INSERT INTO a (id, col1) VALUES (1, -1);
+
+ASSERT VALUES b (id, col1) VALUES (1, 1);
+ASSERT VALUES b (id, col1) VALUES (1, -1);
+
+----------------------------------------------------------------------------------------------------
+-- note that each insert that is filtered out corresponds with a tombstone emitted into
+-- the topic
+--@test: add filter to basic TABLE without filter
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE TABLE a (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE TABLE b AS SELECT * FROM a;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+ASSERT VALUES b (id, col1) VALUES (1, 0);
+
+CREATE OR REPLACE TABLE b AS SELECT * FROM a WHERE col1 > 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+INSERT INTO a (id, col1) VALUES (1, 1);
+
+ASSERT NULL VALUES b (id) KEY (1);
+ASSERT VALUES b (id, col1) VALUES (1, 1);
+
+----------------------------------------------------------------------------------------------------
+--@test: remove filter from basic TABLE with filter
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE TABLE a (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE TABLE b AS SELECT * FROM a WHERE col1 > 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+
+CREATE OR REPLACE TABLE b AS SELECT * FROM a;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+
+ASSERT NULL VALUES b (id) KEY (1);
+ASSERT VALUES b (id, col1) VALUES (1, 0);
+
+----------------------------------------------------------------------------------------------------
+--@test: modify filter from basic TABLE with filter
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE TABLE a (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE TABLE b AS SELECT * FROM a WHERE col1 > 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+INSERT INTO a (id, col1) VALUES (1, 1);
+
+CREATE OR REPLACE TABLE b AS SELECT * FROM a WHERE col1 < 0;
+
+INSERT INTO a (id, col1) VALUES (1, 0);
+INSERT INTO a (id, col1) VALUES (1, -1);
+
+ASSERT NULL VALUES b (id) KEY (1);
+ASSERT VALUES b (id, col1) VALUES (1, 1);
+ASSERT NULL VALUES b (id) KEY (1);
+ASSERT VALUES b (id, col1) VALUES (1, -1);
+
+----------------------------------------------------------------------------------------------------
+-- following tests are here to ensure that a subset of what we expect to fail actually fails      --
+-- they are not intended to be exhaustive, as those tests will come when we being to implement    --
+-- more complicated upgrades                                                                      --
+----------------------------------------------------------------------------------------------------
+
+----------------------------------------------------------------------------------------------------
+--@test: add filter to StreamTableJoin
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Upgrades not yet supported for StreamTableJoin
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+CREATE STREAM s (id INT KEY, foo INT) WITH (kafka_topic='s', value_format='JSON');
+CREATE TABLE t (id INT PRIMARY KEY, bar INT) WITH (kafka_topic='t', value_format='JSON');
+
+CREATE STREAM j AS SELECT s.id, s.foo, t.bar FROM s JOIN t ON s.id = t.id;
+CREATE OR REPLACE STREAM j AS SELECT s.id, s.foo, t.bar FROM s JOIN t ON s.id = t.id WHERE s.foo > 0;
+
+----------------------------------------------------------------------------------------------------
+--@test: add filter to StreamAggregate
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Upgrades not yet supported for StreamAggregate
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+
+CREATE TABLE bar AS SELECT id, COUNT(*) as count FROM foo GROUP BY id;
+CREATE OR REPLACE TABLE bar AS SELECT id, COUNT(*) as count FROM foo WHERE col1 > 0 GROUP BY id;
+
+----------------------------------------------------------------------------------------------------
+--@test: add filter to PartitionBy
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Upgrades not yet supported for StreamSelectKey
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE STREAM a (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE STREAM b AS SELECT * FROM a PARTITION BY col1;
+
+CREATE OR REPLACE STREAM b AS SELECT * FROM a WHERE col1 > 0 PARTITION BY col1;
+
+----------------------------------------------------------------------------------------------------
+--@test: add filter to windowed aggregation
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Upgrades not yet supported for StreamWindowedAggregate
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE STREAM a (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE TABLE b AS SELECT id, COUNT(*)
+  FROM a WINDOW TUMBLING (SIZE 30 SECONDS)
+  GROUP BY id;
+
+CREATE OR REPLACE TABLE b AS SELECT id, COUNT(*)
+  FROM a WINDOW TUMBLING (SIZE 30 SECONDS)
+  WHERE col1 > 0
+  GROUP BY id;
+
+----------------------------------------------------------------------------------------------------
+--@test: add filter to Suppress
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Upgrades not yet supported for TableSuppress
+----------------------------------------------------------------------------------------------------
+SET 'ksql.create.or.replace.enabled' = 'true';
+
+CREATE STREAM a (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='JSON');
+CREATE TABLE b AS SELECT id, COUNT(*)
+  FROM a WINDOW TUMBLING (SIZE 30 SECONDS)
+  GROUP BY id
+  EMIT FINAL;
+
+CREATE OR REPLACE TABLE b AS SELECT id, COUNT(*)
+  FROM a WINDOW TUMBLING (SIZE 30 SECONDS)
+  WHERE col1 > 0
+  GROUP BY id
+  EMIT FINAL;

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -85,6 +85,7 @@ statement
 
 assertStatement
     : ASSERT VALUES sourceName (columns)? VALUES values                     #assertValues
+    | ASSERT NULL VALUES sourceName (columns)? KEY values                   #assertTombstone
     | ASSERT STREAM sourceName (tableElements)? (WITH tableProperties)?     #assertStream
     | ASSERT TABLE sourceName (tableElements)? (WITH tableProperties)?      #assertTable
     ;

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.AssertStream;
+import io.confluent.ksql.parser.tree.AssertTombstone;
 import io.confluent.ksql.parser.tree.AssertValues;
 import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.AstVisitor;
@@ -368,6 +369,21 @@ public final class SqlFormatter {
       visitColumns(node.getStatement().getColumns());
 
       builder.append("VALUES ");
+
+      visitExpressionList(node.getStatement().getValues());
+
+      return null;
+    }
+
+    @Override
+    public Void visitAssertTombstone(final AssertTombstone node, final Integer context) {
+      builder.append("ASSERT NULL VALUES ");
+      builder.append(escapedName(node.getStatement().getTarget()));
+      builder.append(" ");
+
+      visitColumns(node.getStatement().getColumns());
+
+      builder.append("KEY ");
 
       visitExpressionList(node.getStatement().getValues());
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertTombstone.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertTombstone.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Objects;
+import java.util.Optional;
+
+public class AssertTombstone extends AssertStatement {
+
+  private final InsertValues statement;
+
+  public AssertTombstone(
+      final Optional<NodeLocation> location,
+      final InsertValues statement
+  ) {
+    super(location);
+    this.statement = Objects.requireNonNull(statement, "statement");
+  }
+
+  public InsertValues getStatement() {
+    return statement;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getStatement());
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final AssertTombstone that = (AssertTombstone) o;
+    return Objects.equals(getStatement(), that.getStatement());
+  }
+
+  @Override
+  public String toString() {
+    return "AssertTombstone{"
+        + "statement=" + getStatement()
+        + '}';
+  }
+
+  @Override
+  protected <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitAssertTombstone(this, context);
+  }
+}

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -193,4 +193,8 @@ public abstract class AstVisitor<R, C> {
   public R visitAssertTable(final AssertTable node, final C context) {
     return visitStatement(node.getStatement(), context);
   }
+
+  public R visitAssertTombstone(final AssertTombstone node, final C context) {
+    return visitStatement(node.getStatement(), context);
+  }
 }


### PR DESCRIPTION
### Description 

This PR does two things:
- add support for tombstone assertions (`ASSERT NULL VALUES ... KEY`) to the sql testing tool
- add `filters.json` to test creating or replacing with regards to filters

### Testing done 

- `filters.json` is self-testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

