### PR TITLE
feat: hard delete schemas for push queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -273,8 +273,11 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     }
 
     if (query.hasEverBeenStarted()) {
-      SchemaRegistryUtil
-          .cleanupInternalTopicSchemas(applicationId, serviceContext.getSchemaRegistryClient());
+      SchemaRegistryUtil.cleanupInternalTopicSchemas(
+          applicationId,
+          serviceContext.getSchemaRegistryClient(),
+          query instanceof TransientQueryMetadata);
+
       serviceContext.getTopicClient().deleteInternalTopics(applicationId);
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/DefaultSchemaRegistryClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/DefaultSchemaRegistryClient.java
@@ -149,6 +149,11 @@ public class DefaultSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
+  public List<Integer> deleteSubject(final String s, final boolean b) {
+    return ImmutableList.of();
+  }
+
+  @Override
   public List<Integer> deleteSubject(final Map<String, String> map, final String s) {
     return ImmutableList.of();
   }


### PR DESCRIPTION
### Description 
Address https://github.com/confluentinc/ksql/issues/5714
Push queries can be used frequently for testing before making a CSAS/CTAS query which can lead to too many accumulated subjects over time. Hard deleting any internal topics generated by push queries to prevent this.

https://docs.confluent.io/current/schema-registry/schema-deletion-guidelines.html#hard-delete-a-schema
SR API says to soft delete then hard delete.

### Testing done 
unit test
manual testing with a SR

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

