### PR TITLE
feat: Support IF EXISTS keyword on DROP CONNECTOR

### DIFF
--- a/docs/developer-guide/ksqldb-reference/drop-connector.md
+++ b/docs/developer-guide/ksqldb-reference/drop-connector.md
@@ -13,7 +13,7 @@ Synopsis
 --------
 
 ```sql
-DROP CONNECTOR connector_name;
+DROP CONNECTOR [IF EXISTS] connector_name;
 ```
 
 Description
@@ -21,3 +21,6 @@ Description
 
 Drop a connector and delete it from the {{ site.kconnect }} cluster. The
 topics associated with this cluster are not deleted by this command.
+
+If the IF EXISTS clause is present, the statement doesn't fail if the
+connector doesn't exist.

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.cli.console.table.builder.TableBuilder;
 import io.confluent.ksql.cli.console.table.builder.TablesListTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.TopicDescriptionTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.TypeListTableBuilder;
+import io.confluent.ksql.cli.console.table.builder.WarningEntityTableBuilder;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.rest.ApiJsonMapper;
@@ -81,6 +82,7 @@ import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.entity.TopicDescription;
 import io.confluent.ksql.rest.entity.TypeList;
+import io.confluent.ksql.rest.entity.WarningEntity;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.CmdLineUtil;
 import io.confluent.ksql.util.HandlerMaps;
@@ -173,6 +175,8 @@ public class Console implements Closeable {
               tablePrinter(TypeList.class, TypeListTableBuilder::new))
           .put(ErrorEntity.class,
               tablePrinter(ErrorEntity.class, ErrorEntityTableBuilder::new))
+          .put(WarningEntity.class,
+              tablePrinter(WarningEntity.class, WarningEntityTableBuilder::new))
           .build();
 
   private static <T extends KsqlEntity> Handler1<KsqlEntity, Console> tablePrinter(

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/WarningEntityTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/WarningEntityTableBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.cli.console.table.builder;
+
+import io.confluent.ksql.cli.console.table.Table;
+import io.confluent.ksql.rest.entity.WarningEntity;
+
+public class WarningEntityTableBuilder implements TableBuilder<WarningEntity> {
+  @Override
+  public Table buildTable(final WarningEntity entity) {
+    return new Table.Builder()
+        .withColumnHeaders("Message")
+        .withRow(entity.getMessage())
+        .build();
+  }
+}

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -77,7 +77,7 @@ statement
     | INSERT INTO sourceName (columns)? VALUES values                       #insertValues
     | DROP STREAM (IF EXISTS)? sourceName (DELETE TOPIC)?                   #dropStream
     | DROP TABLE (IF EXISTS)? sourceName (DELETE TOPIC)?                    #dropTable
-    | DROP CONNECTOR identifier                                             #dropConnector
+    | DROP CONNECTOR (IF EXISTS)? identifier                                #dropConnector
     | EXPLAIN  (statement | identifier)                                     #explain
     | CREATE TYPE identifier AS type                                        #registerType
     | DROP TYPE (IF EXISTS)? identifier                                     #dropType

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -394,6 +394,7 @@ public class AstBuilder {
     public Node visitDropConnector(final DropConnectorContext context) {
       return new DropConnector(
           getLocation(context),
+          context.EXISTS() != null,
           ParserUtil.getIdentifierText(context.identifier())
       );
     }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/DropConnector.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/DropConnector.java
@@ -15,17 +15,29 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
 import java.util.Optional;
 
 public class DropConnector extends Statement {
 
+  private final boolean ifExists;
   private final String connectorName;
 
-  public DropConnector(final Optional<NodeLocation> location, final String connectorName) {
+  public DropConnector(
+      final Optional<NodeLocation> location,
+      final boolean ifExists,
+      final String connectorName
+  ) {
     super(location);
+    this.ifExists = ifExists;
     this.connectorName = connectorName;
+  }
+
+  public boolean getIfExists() {
+    return ifExists;
   }
 
   public String getConnectorName() {
@@ -41,18 +53,19 @@ public class DropConnector extends Statement {
       return false;
     }
     final DropConnector that = (DropConnector) o;
-    return Objects.equals(connectorName, that.connectorName);
+    return Objects.equals(connectorName, that.connectorName) && ifExists == that.ifExists;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(connectorName);
+    return Objects.hash(ifExists, connectorName);
   }
 
   @Override
   public String toString() {
-    return "DropConnector{"
-        + "connectorName='" + connectorName + '\''
-        + '}';
+    return toStringHelper(this)
+            .add("ifExists", ifExists)
+            .add("connectorName", connectorName)
+            .toString();
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Optional;
+import org.apache.hc.core5.http.HttpStatus;
 
 public final class DropConnectorExecutor {
 
@@ -43,7 +44,7 @@ public final class DropConnectorExecutor {
         serviceContext.getConnectClient().delete(connectorName);
 
     if (response.error().isPresent()) {
-      if (ifExists && response.httpCode() == 404) {
+      if (ifExists && response.httpCode() == HttpStatus.SC_NOT_FOUND) {
         return Optional.of(new WarningEntity(statement.getStatementText(),
                 "Connector '" + connectorName + "' does not exist."));
       } else {

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -48,7 +48,8 @@ import java.util.List;
     @JsonSubTypes.Type(value = ConnectorList.class, name = "connector_list"),
     @JsonSubTypes.Type(value = ConnectorDescription.class, name = "connector_description"),
     @JsonSubTypes.Type(value = TypeList.class, name = "type_list"),
-    @JsonSubTypes.Type(value = ErrorEntity.class, name = "error_entity")
+    @JsonSubTypes.Type(value = ErrorEntity.class, name = "error_entity"),
+    @JsonSubTypes.Type(value = WarningEntity.class, name = "warning_entity")
 })
 public abstract class KsqlEntity {
   private final String statementText;

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/WarningEntity.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/WarningEntity.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.Immutable;
+
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Immutable
+public class WarningEntity extends KsqlEntity {
+  private final String message;
+
+  @JsonCreator
+  public WarningEntity(
+       @JsonProperty("statementText") final String statementText,
+       @JsonProperty("message") final String message
+  ) {
+    super(statementText);
+    this.message = Objects.requireNonNull(message, "message");
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final WarningEntity that = (WarningEntity) o;
+    return Objects.equals(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message);
+  }
+
+  @Override
+  public String toString() {
+    return "ErrorEntity{"
+            + "message='" + message + '\''
+            + '}';
+  }
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/WarningEntity.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/WarningEntity.java
@@ -60,7 +60,7 @@ public class WarningEntity extends KsqlEntity {
 
   @Override
   public String toString() {
-    return "ErrorEntity{"
+    return "WarningEntity{"
             + "message='" + message + '\''
             + '}';
   }


### PR DESCRIPTION
### Description 

Fixes #5988

Added `IF EXISTS` keyword to the `DROP CONNECTOR` command. 

Previously, this error message would have shown if the connector does not exist:

```
 Error                                   
-----------------------------------------
 {
  "error_code" : 404,
  "message" : "Connector FOO not found"
} 
-----------------------------------------
```

With this change, if the `IF EXISTS` keyword is used, the response is:

```
 Message                         
---------------------------------
 Connector 'FOO' does not exist. 
---------------------------------
```
If the `IF EXISTS` keyword is not used, the response is the original error response.

I added a new `Entity` class called `WarningEntity` that prints a message without the Error header. It could also be used in other similar situations, such as #5992.

### Testing done 
Added tests to `DropConnectorExecutorTest.java`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

