### PR TITLE
docs: use correct AVRO format in AVRO serialization example

### DIFF
--- a/docs/developer-guide/serialization.md
+++ b/docs/developer-guide/serialization.md
@@ -199,7 +199,7 @@ Avro records can be deserialized into matching ksqlDB schemas.
 For example, given a SQL statement such as:
 
 ```sql
-CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT) WITH (VALUE_FORMAT='JSON', ...);
+CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT) WITH (VALUE_FORMAT='AVRO', ...);
 ```
 
 And an Avro record serialized with the schema:


### PR DESCRIPTION
### Description 
The example in https://docs.ksqldb.io/en/latest/developer-guide/serialization/#serialization-formats has a `JSON` format in the AVRO records section. This should be `AVRO` instead.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

