### PR TITLE
feat: add serialization exceptions to processing logger

### DIFF
--- a/docs/developer-guide/test-and-debug/processing-log.md
+++ b/docs/developer-guide/test-and-debug/processing-log.md
@@ -18,7 +18,7 @@ writing the processing log to {{ site.ak }} and consuming it as ksqlDB stream.
 
 !!! important
 	The processing log is not for server logging, but rather for per-record
-    logging on ksqlDB applications. If you want to configure a Kafka appender
+    logging on ksqlDB applications. If you want to configure an {{ site.ak }} appender
     for the server logs, assign the `log4j.appender.kafka_appender.Topic`
     and `log4j.logger.io.confluent.ksql` configuration settings in the ksqlDB
     Server config file. For more information, see
@@ -119,7 +119,7 @@ message.type (INT)
 message.deserializationError (STRUCT)
 
 :   The contents of a message with type 0 (DESERIALIZATION_ERROR).
-    Logged when a deserializer fails to deserialize a Kafka record.
+    Logged when a deserializer fails to deserialize an {{ site.ak }} record.
 
 message.deserializationError.errorMessage (STRING)
 
@@ -128,7 +128,7 @@ message.deserializationError.errorMessage (STRING)
 
 message.deserializationError.recordB64 (STRING)
 
-:   The Kafka record, encoded in Base64.
+:   The {{ site.ak }} record, encoded in Base64.
 
 message.deserializationError.cause (LIST<STRING>)
 
@@ -137,7 +137,7 @@ message.deserializationError.cause (LIST<STRING>)
 
 message.deserializationError.topic (STRING)
 
-:   The Kafka topic of the record for which deserialization failed.
+:   The {{ site.ak }} topic of the record for which deserialization failed.
 
 message.recordProcessingError (STRUCT)
 
@@ -163,7 +163,7 @@ message.recordProcessingError.cause (LIST<STRING>)
 message.productionError (STRUCT)
 
 :   The contents of a message with type 2 (PRODUCTION_ERROR). Logged
-    when a producer fails to publish a Kafka record.
+    when a producer fails to publish an {{ site.ak }} record.
 
 message.productionError.errorMessage (STRING)
 
@@ -191,14 +191,14 @@ message.serializationError.cause (LIST<STRING>)
 
 message.serializationError.topic (STRING)
 
-:   The Kafka topic to which the ksqlDB row that failed to serialize
+:   The {{ site.ak }} topic to which the ksqlDB row that failed to serialize
     would have been produced.
 
 Log Stream
 ----------
 
 We recommend configuring the query processing log to write entries back
-to Kafka. This way, you can configure ksqlDB to set up a stream over the
+to {{ site.ak }}. This way, you can configure ksqlDB to set up a stream over the
 topic automatically.
 
 To log to Kafka, set up a Kafka appender and a special layout for

--- a/ksqldb-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogMessageSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogMessageSchema.java
@@ -58,10 +58,25 @@ public final class ProcessingLogMessageSchema {
       .optional()
       .build();
 
+  public static final String SERIALIZATION_ERROR_FIELD_MESSAGE = "errorMessage";
+  public static final String SERIALIZATION_ERROR_FIELD_RECORD = "record";
+  public static final String SERIALIZATION_ERROR_FIELD_CAUSE = "cause";
+  public static final String SERIALIZATION_ERROR_FIELD_TOPIC = "topic";
+
+  private static final Schema SERIALIZATION_ERROR_SCHEMA = SchemaBuilder.struct()
+      .name(NAMESPACE + "SerializationError")
+      .field(SERIALIZATION_ERROR_FIELD_MESSAGE, Schema.OPTIONAL_STRING_SCHEMA)
+      .field(SERIALIZATION_ERROR_FIELD_RECORD, Schema.OPTIONAL_STRING_SCHEMA)
+      .field(SERIALIZATION_ERROR_FIELD_CAUSE, CAUSE_SCHEMA)
+      .field(SERIALIZATION_ERROR_FIELD_TOPIC, Schema.OPTIONAL_STRING_SCHEMA)
+      .optional()
+      .build();
+
   public enum MessageType {
     DESERIALIZATION_ERROR(0, DESERIALIZATION_ERROR_SCHEMA),
     RECORD_PROCESSING_ERROR(1, RECORD_PROCESSING_ERROR_SCHEMA),
-    PRODUCTION_ERROR(2, PRODUCTION_ERROR_SCHEMA);
+    PRODUCTION_ERROR(2, PRODUCTION_ERROR_SCHEMA),
+    SERIALIZATION_ERROR(3, SERIALIZATION_ERROR_SCHEMA);
 
     private final int typeId;
     private final Schema schema;
@@ -84,6 +99,7 @@ public final class ProcessingLogMessageSchema {
   public static final String DESERIALIZATION_ERROR = "deserializationError";
   public static final String RECORD_PROCESSING_ERROR = "recordProcessingError";
   public static final String PRODUCTION_ERROR = "productionError";
+  public static final String SERIALIZATION_ERROR = "serializationError";
 
   public static final Schema PROCESSING_LOG_SCHEMA = SchemaBuilder.struct()
       .name(NAMESPACE + "ProcessingLogRecord")
@@ -91,6 +107,7 @@ public final class ProcessingLogMessageSchema {
       .field(DESERIALIZATION_ERROR, DESERIALIZATION_ERROR_SCHEMA)
       .field(RECORD_PROCESSING_ERROR, RECORD_PROCESSING_ERROR_SCHEMA)
       .field(PRODUCTION_ERROR, PRODUCTION_ERROR_SCHEMA)
+      .field(SERIALIZATION_ERROR, SERIALIZATION_ERROR_SCHEMA)
       .optional()
       .build();
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/logging/processing/ProcessingLogServerUtilsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/logging/processing/ProcessingLogServerUtilsTest.java
@@ -188,7 +188,8 @@ public class ProcessingLogServerUtilsTest {
             + "type INT, "
             + "deserializationError STRUCT<errorMessage VARCHAR, recordB64 VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>, "
             + "recordProcessingError STRUCT<errorMessage VARCHAR, record VARCHAR, cause ARRAY<VARCHAR>>, "
-            + "productionError STRUCT<errorMessage VARCHAR>"
+            + "productionError STRUCT<errorMessage VARCHAR>, "
+            + "serializationError STRUCT<errorMessage VARCHAR, record VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>"
             + ">"
             + ") WITH(KAFKA_TOPIC='processing_log_topic', VALUE_FORMAT='JSON');"));
   }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingSerializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingSerializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.logging.processing;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.serialization.Serializer;
+
+public final class LoggingSerializer<T> implements Serializer<T> {
+
+  private final Serializer<T> delegate;
+  private final ProcessingLogger processingLogger;
+
+  public LoggingSerializer(
+      final Serializer<T> delegate,
+      final ProcessingLogger processingLogger
+  ) {
+    this.delegate = requireNonNull(delegate, "delegate");
+    this.processingLogger = requireNonNull(processingLogger, "processingLogger");
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs, final boolean isKey) {
+    delegate.configure(configs, isKey);
+  }
+
+  @Override
+  public byte[] serialize(final String topic, final T data) {
+    try {
+      return delegate.serialize(topic, data);
+    } catch (final RuntimeException e) {
+      processingLogger.error(new SerializationError<>(e, Optional.of(data), topic));
+      throw e;
+    }
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+}

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/SerializationError.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/SerializationError.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.logging.processing;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.MessageType;
+import io.confluent.ksql.util.ErrorMessageUtil;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+
+public class SerializationError<T> implements ProcessingLogger.ErrorMessage {
+
+  private final Throwable exception;
+  private final Optional<T> record;
+  private final String topic;
+
+  public SerializationError(
+      final Throwable exception,
+      final Optional<T> record,
+      final String topic
+  ) {
+    this.exception = requireNonNull(exception, "exception");
+    this.record = requireNonNull(record, "record");
+    this.topic = requireNonNull(topic, "topic");
+  }
+
+  @Override
+  public SchemaAndValue get(final ProcessingLogConfig config) {
+    final Struct struct = new Struct(ProcessingLogMessageSchema.PROCESSING_LOG_SCHEMA)
+        .put(ProcessingLogMessageSchema.TYPE, MessageType.SERIALIZATION_ERROR.getTypeId())
+        .put(ProcessingLogMessageSchema.SERIALIZATION_ERROR, serializationError(config));
+
+    return new SchemaAndValue(ProcessingLogMessageSchema.PROCESSING_LOG_SCHEMA, struct);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SerializationError<?> that = (SerializationError) o;
+    return Objects.equals(exception, that.exception)
+        && Objects.equals(record, that.record)
+        && Objects.equals(topic, that.topic);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(exception, record, topic);
+  }
+
+  private Struct serializationError(final ProcessingLogConfig config) {
+    final Struct serializationError = new Struct(MessageType.SERIALIZATION_ERROR.getSchema())
+        .put(
+            ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_MESSAGE,
+            exception.getMessage())
+        .put(
+            ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_CAUSE,
+            getCause()
+        )
+        .put(
+            ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_TOPIC,
+            topic
+        );
+
+    if (config.getBoolean(ProcessingLogConfig.INCLUDE_ROWS)) {
+      serializationError.put(
+          ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_RECORD,
+          record.map(Object::toString).orElse(null)
+      );
+    }
+
+    return serializationError;
+  }
+
+  private List<String> getCause() {
+    final List<String> cause = ErrorMessageUtil.getErrorMessages(exception);
+    cause.remove(0);
+    return cause;
+  }
+}

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericKeySerDe.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericKeySerDe.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.SchemaNotSupportedException;
 import io.confluent.ksql.logging.processing.LoggingDeserializer;
+import io.confluent.ksql.logging.processing.LoggingSerializer;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
@@ -138,7 +139,7 @@ public final class GenericKeySerDe implements KeySerdeFactory {
         : wrapped(serde, targetType);
 
     final Serde<Struct> result = Serdes.serdeFrom(
-        inner.serializer(),
+        new LoggingSerializer<>(inner.serializer(), processingLogger),
         new LoggingDeserializer<>(inner.deserializer(), processingLogger)
     );
 
@@ -172,7 +173,7 @@ public final class GenericKeySerDe implements KeySerdeFactory {
       final Class<T> type
   ) {
     if (type != Struct.class) {
-      throw new IllegalArgumentException("Unwrapped must be of type Struct");
+      throw new IllegalArgumentException("Wrapped must be of type Struct");
     }
 
     return (Serde) innerSerde;

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
@@ -23,6 +23,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.SchemaNotSupportedException;
 import io.confluent.ksql.logging.processing.LoggingDeserializer;
+import io.confluent.ksql.logging.processing.LoggingSerializer;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
@@ -147,7 +148,7 @@ public final class GenericRowSerDe implements ValueSerdeFactory {
           : wrapped(serde, schema, targetType);
 
     final Serde<GenericRow> result = Serdes.serdeFrom(
-        genericRowSerde.serializer(),
+        new LoggingSerializer<>(genericRowSerde.serializer(), processingLogger),
         new LoggingDeserializer<>(genericRowSerde.deserializer(), processingLogger)
     );
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingDeserializerTest.java
@@ -47,9 +47,6 @@ public class LoggingDeserializerTest {
 
   private static final GenericRow SOME_ROW = genericRow("some", "fields");
   private static final byte[] SOME_BYTES = "some bytes".getBytes(StandardCharsets.UTF_8);
-  private static final ProcessingLogConfig LOG_CONFIG = new ProcessingLogConfig(ImmutableMap.of(
-      ProcessingLogConfig.INCLUDE_ROWS, true
-  ));
 
   @Mock
   private Deserializer<GenericRow> delegate;

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingSerializerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.logging.processing;
+
+import static io.confluent.ksql.GenericRow.genericRow;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.NullPointerTester;
+import io.confluent.ksql.GenericRow;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoggingSerializerTest {
+
+  private static final GenericRow SOME_ROW = genericRow("some", "fields");
+  private static final byte[] SOME_BYTES = "some bytes".getBytes(StandardCharsets.UTF_8);
+
+  @Mock
+  private Serializer<GenericRow> delegate;
+  @Mock
+  private ProcessingLogger processingLogger;
+
+  private LoggingSerializer<GenericRow> serializer;
+
+  @Before
+  public void setUp() {
+    serializer = new LoggingSerializer<>(delegate, processingLogger);
+  }
+
+  @Test
+  public void shouldThrowNPEs() {
+    new NullPointerTester().testAllPublicConstructors(LoggingSerializer.class);
+  }
+
+  @Test
+  public void shouldConfigureDelegate() {
+    // Given:
+    final Map<String, ?> configs = ImmutableMap.of("some", "thing");
+
+    // When:
+    serializer.configure(configs, true);
+
+    // Then:
+    verify(delegate).configure(configs, true);
+  }
+
+  @Test
+  public void shouldCloseDelegate() {
+    // When:
+    serializer.close();
+
+    // Then:
+    verify(delegate).close();
+  }
+
+  @Test
+  public void shouldSerializeWithDelegate() {
+    // Given:
+    when(delegate.serialize(any(), any())).thenReturn(SOME_BYTES);
+
+    // When:
+    serializer.serialize("some topic", SOME_ROW);
+
+    // Then:
+    verify(delegate).serialize("some topic", SOME_ROW);
+  }
+
+  @Test(expected = ArithmeticException.class)
+  public void shouldThrowIfDelegateThrows() {
+    // Given:
+    when(delegate.serialize(any(), any())).thenThrow(new ArithmeticException());
+
+    // When:
+    serializer.serialize("t", SOME_ROW);
+
+    // Then: throws
+  }
+
+  @Test
+  public void shouldLogOnException() {
+    // Given:
+    when(delegate.serialize(any(), any()))
+        .thenThrow(new RuntimeException("outer",
+            new RuntimeException("inner", new RuntimeException("cause"))));
+
+    // When:
+    final RuntimeException e = assertThrows(
+        RuntimeException.class,
+        () -> serializer.serialize("t", SOME_ROW)
+    );
+
+    // Then:
+    verify(processingLogger).error(new SerializationError<>(e, Optional.of(SOME_ROW), "t"));
+  }
+
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/SerializationErrorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/SerializationErrorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.logging.processing;
+
+import static io.confluent.ksql.GenericRow.genericRow;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.PROCESSING_LOG_SCHEMA;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_CAUSE;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_MESSAGE;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_RECORD;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_TOPIC;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.TYPE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Test;
+
+public class SerializationErrorTest {
+
+  private static final String TOPIC = "topic";
+  private static final GenericRow RECORD = genericRow("some", "fields");
+  private static final Exception CAUSE = new Exception("cause1", new Exception("cause2"));
+  private static final Exception ERROR = new Exception("error message", CAUSE);
+  private static final List<String> CAUSE_LIST = ImmutableList.of("cause1", "cause2");
+
+  private static final ProcessingLogConfig LOGGING_CONFIG = new ProcessingLogConfig(
+      Collections.singletonMap(ProcessingLogConfig.INCLUDE_ROWS, true)
+  );
+
+  @Test
+  public void shouldBuildSerializationError() {
+    // Given:
+    final SerializationError<GenericRow> serError = new SerializationError<>(
+        ERROR,
+        Optional.of(RECORD),
+        TOPIC
+    );
+
+    // When:
+    final SchemaAndValue msg = serError.get(LOGGING_CONFIG);
+
+    // Then:
+    final Schema schema = msg.schema();
+    assertThat(schema, equalTo(PROCESSING_LOG_SCHEMA));
+    final Struct struct = (Struct) msg.value();
+    assertThat(
+        struct.get(ProcessingLogMessageSchema.TYPE),
+        equalTo(ProcessingLogMessageSchema.MessageType.SERIALIZATION_ERROR.getTypeId()));
+    final Struct serializationError = struct.getStruct(SERIALIZATION_ERROR);
+    assertThat(
+        serializationError.get(SERIALIZATION_ERROR_FIELD_MESSAGE),
+        equalTo(ERROR.getMessage())
+    );
+    assertThat(
+        serializationError.get(SERIALIZATION_ERROR_FIELD_CAUSE),
+        equalTo(CAUSE_LIST)
+    );
+    assertThat(
+        serializationError.get(SERIALIZATION_ERROR_FIELD_RECORD),
+        equalTo(RECORD.toString())
+    );
+    assertThat(
+        serializationError.get(SERIALIZATION_ERROR_FIELD_TOPIC),
+        equalTo(TOPIC)
+    );
+    schema.fields().forEach(
+        f -> {
+          if (!ImmutableList.of(TYPE, SERIALIZATION_ERROR).contains(f.name())) {
+            assertThat(struct.get(f), is(nullValue()));
+          }
+        }
+    );
+  }
+
+  @Test
+  public void shouldSetEmptyRecordToNull() {
+    // Given:
+    final SerializationError<GenericRow> serError =
+        new SerializationError<>(ERROR, Optional.empty(), TOPIC);
+
+    // When:
+    final SchemaAndValue msg = serError.get(LOGGING_CONFIG);
+
+    // Then:
+    final Struct struct = (Struct) msg.value();
+    assertThat(
+        struct.get(ProcessingLogMessageSchema.TYPE),
+        equalTo(ProcessingLogMessageSchema.MessageType.SERIALIZATION_ERROR.getTypeId()));
+    final Struct serializationError = struct.getStruct(SERIALIZATION_ERROR);
+    assertThat(serializationError.get(SERIALIZATION_ERROR_FIELD_RECORD), is(nullValue()));
+  }
+
+  @Test
+  public void shouldBuildSerializationErrorWithNullRecordIfIncludeRowFalse() {
+    // Given:
+    final ProcessingLogConfig config = new ProcessingLogConfig(
+        Collections.singletonMap(ProcessingLogConfig.INCLUDE_ROWS, false)
+    );
+
+    final SerializationError<GenericRow> serError = new SerializationError<>(
+        ERROR,
+        Optional.of(RECORD),
+        TOPIC
+    );
+
+    // When:
+    final SchemaAndValue msg = serError.get(config);
+
+    // Then:
+    final Struct struct = (Struct) msg.value();
+    assertThat(
+        struct.get(ProcessingLogMessageSchema.TYPE),
+        equalTo(ProcessingLogMessageSchema.MessageType.SERIALIZATION_ERROR.getTypeId()));
+    final Struct serializationError = struct.getStruct(SERIALIZATION_ERROR);
+    assertThat(serializationError.get(SERIALIZATION_ERROR_FIELD_RECORD), is(nullValue()));
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
@@ -29,12 +29,12 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.SchemaNotSupportedException;
 import io.confluent.ksql.logging.processing.LoggingDeserializer;
+import io.confluent.ksql.logging.processing.LoggingSerializer;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
-import io.confluent.ksql.serde.GenericKeySerDe.UnwrappedKeySerializer;
 import io.confluent.ksql.util.KsqlConfig;
 import java.time.Duration;
 import java.util.Collections;
@@ -202,7 +202,7 @@ public class GenericKeySerDeTest {
   }
 
   @Test
-  public void shouldUseInnerSerializerForWrappedSchema() {
+  public void shouldUseLoggingSerializer() {
     // When:
     final Serde<Struct> result = factory.create(
         FORMAT,
@@ -214,23 +214,7 @@ public class GenericKeySerDeTest {
     );
 
     // Then:
-    assertThat(result.serializer(), is(innerSerializer));
-  }
-
-  @Test
-  public void shouldUseUnwrappingSerializerForUnwrappedSchema() {
-    // When:
-    final Serde<Struct> result = factory.create(
-        FORMAT,
-        UNWRAPPED_SCHEMA,
-        CONFIG,
-        srClientFactory,
-        LOGGER_NAME_PREFIX,
-        processingLogCxt
-    );
-
-    // Then:
-    assertThat(result.serializer(), is(instanceOf(UnwrappedKeySerializer.class)));
+    assertThat(result.serializer(), is(instanceOf(LoggingSerializer.class)));
   }
 
   @Test

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
@@ -95,7 +95,7 @@ public class GenericRowSerDeTest {
   @Mock
   private ProcessingLoggerFactory loggerFactory;
   @Mock
-  private Serde<Object> deletageSerde;
+  private Serde<Object> delegateSerde;
   @Mock
   private Serializer<Object> delegateSerializer;
   @Mock
@@ -107,9 +107,9 @@ public class GenericRowSerDeTest {
 
   @Before
   public void setUp() {
-    when(serdesFactories.create(any(), any(), any(), any(), any())).thenReturn(deletageSerde);
-    when(deletageSerde.serializer()).thenReturn(delegateSerializer);
-    when(deletageSerde.deserializer()).thenReturn(delegateDeserializer);
+    when(serdesFactories.create(any(), any(), any(), any(), any())).thenReturn(delegateSerde);
+    when(delegateSerde.serializer()).thenReturn(delegateSerializer);
+    when(delegateSerde.deserializer()).thenReturn(delegateDeserializer);
 
     when(delegateSerializer.serialize(any(), any())).thenReturn(SOME_BYTES);
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -81,6 +82,15 @@ public class GenericRowSerDeTest {
               .field("f0", Schema.OPTIONAL_STRING_SCHEMA)
               .build(),
           true);
+
+  private static final PersistenceSchema STRUCT_FIELD_SCHEMA =
+      PersistenceSchema.from(
+          (ConnectSchema) SchemaBuilder.struct()
+              .field("f0", SchemaBuilder.struct().optional()
+                  .field("g0", Schema.OPTIONAL_STRING_SCHEMA)
+                  .build())
+              .build(),
+          false);
 
   private static final String SOME_TOPIC = "fred";
   private static final byte[] SOME_BYTES = "Vic".getBytes(StandardCharsets.UTF_8);
@@ -436,6 +446,62 @@ public class GenericRowSerDeTest {
 
     // Then:
     assertThat(e.getMessage(), containsString("Expected single-field value. got: 2"));
+  }
+
+  @Test
+  public void shouldThrowInformativeErrorOnNonOptionalStruct() {
+    // Given:
+    final Serializer<GenericRow> serializer = givenSerdeForSchema(STRUCT_FIELD_SCHEMA)
+        .serializer();
+
+    final Schema nonOptionalSchema = SchemaBuilder.struct()
+        .field("g0", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    final GenericRow row = GenericRow.genericRow(
+        new Struct(nonOptionalSchema).put("g0", "foo"));
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> serializer.serialize(SOME_TOPIC, row)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Failed to prepare Struct value field 'f0' for serialization."));
+    assertThat(e.getMessage(), containsString(
+        "This could happen if the value was produced by a user-defined function "
+        + "where the schema has non-optional return types. ksqlDB requires all "
+        + "schemas to be optional at all levels of the Struct: the Struct itself, "
+        + "schemas for all fields within the Struct, and so on."));
+  }
+
+  @Test
+  public void shouldThrowInformativeErrorOnStructWithNonOptionalField() {
+    // Given:
+    final Serializer<GenericRow> serializer = givenSerdeForSchema(STRUCT_FIELD_SCHEMA)
+        .serializer();
+
+    final Schema schemaWithNonOptionalField = SchemaBuilder.struct().optional()
+        .field("g0", Schema.STRING_SCHEMA)
+        .build();
+    final GenericRow row = GenericRow.genericRow(
+        new Struct(schemaWithNonOptionalField).put("g0", "foo"));
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> serializer.serialize(SOME_TOPIC, row)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Failed to prepare Struct value field 'f0' for serialization."));
+    assertThat(e.getMessage(), containsString(
+        "This could happen if the value was produced by a user-defined function "
+            + "where the schema has non-optional return types. ksqlDB requires all "
+            + "schemas to be optional at all levels of the Struct: the Struct itself, "
+            + "schemas for all fields within the Struct, and so on."));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5364

Two changes in this PR (corresponding to the first two commits):
- add serialization exceptions to the processing log: currently deserialization exceptions are logged but serialization exceptions aren't
- throw a more informative error message in the event that serialization exceptions are caused by UDFs with return types with non-optional schemas, since the error message from Connect (`Struct schemas do not match.`) isn't particularly actionable by users.

### Testing done 

Added unit tests. Manual testing underway.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

