### PR TITLE
docs: update example curl commands (DOCS-5203)

### DIFF
--- a/docs/developer-guide/api.md
+++ b/docs/developer-guide/api.md
@@ -55,7 +55,7 @@ Here's an example request that returns the results from the
 
 ```bash
 curl -X "POST" "http://localhost:8088/ksql" \
-     -H "Content-Type: application/vnd.ksql.v1+json; charset=utf-8" \
+     -H "Accept: application/vnd.ksql.v1+json" \
      -d $'{
   "ksql": "LIST STREAMS;",
   "streamsProperties": {}
@@ -67,9 +67,22 @@ Here's an example request that retrieves streaming data from
 
 ```bash
 curl -X "POST" "http://localhost:8088/query" \
-     -H "Content-Type: application/vnd.ksql.v1+json; charset=utf-8" \
+     -H "Accept: application/vnd.ksql.v1+json" \
      -d $'{
-  "ksql": "SELECT * FROM TEST_STREAM EMIT CHANGES;",
+  "sql": "SELECT * FROM TEST_STREAM EMIT CHANGES;",
+  "streamsProperties": {}
+}'
+```
+
+Provide the `--basic` and `--user` options if basic HTTPS authentication is
+enabled on the cluster, as shown in the following command.
+
+```bash hl_lines="3"
+curl -X "POST" "https://localhost:8088/ksql" \
+     -H "Accept: application/vnd.ksql.v1+json" \
+     --basic --user "<API key>:<secret>" \
+     -d $'{
+  "ksql": "LIST STREAMS;",
   "streamsProperties": {}
 }'
 ```

--- a/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
@@ -16,11 +16,11 @@ SELECT statements use the `/query` endpoint.
       request. In contrast, SET and UNSET assignments in the ksqlDB CLI persist
       throughout the CLI session.
 
-POST /ksql
+## POST /ksql
 
 :   Run a sequence of SQL statements.
 
-JSON Parameters:
+## JSON Parameters
 
 - **ksql** (string): A semicolon-delimited sequence of SQL statements to run.
 - **streamsProperties** (map): Property overrides to run the statements with.
@@ -40,7 +40,7 @@ The response JSON is an array of result objects. The result object contents
 depend on the statement that it is returning results for. The following
 sections detail the contents of the result objects by statement.
 
-**Common Fields**
+## Common Fields
 
 The following fields are common to all responses.
 
@@ -164,7 +164,7 @@ Response JSON Object:
 - **queryDescription.topology** (string): The Kafka Streams topology that the query is running.
 - **overriddenProperties** (map): The property overrides that the query is running with.
 
-**Errors**
+## Errors
 
 If ksqlDB fails to execute a statement, it returns a response with an error
 status code (4xx/5xx). Even if an error is returned, the server may have been
@@ -183,7 +183,20 @@ The ``/ksql`` endpoint may return the following error codes in the ``error_code`
 - 40001 (BAD_STATEMENT): The request contained an invalid SQL statement.
 - 40002 (QUERY_ENDPOINT): The request contained a statement that should be issued to the ``/query`` endpoint.
 
-**Example request**
+## Examples
+
+### Example curl command
+
+```bash
+curl -X "POST" "http://<ksqldb-host-name>:8088/ksql" \
+     -H "Accept: application/vnd.ksql.v1+json" \
+     -d $'{
+  "ksql": "LIST STREAMS;",
+  "streamsProperties": {}
+}'
+```
+
+### Example request
 
 ```http
 POST /ksql HTTP/1.1
@@ -198,7 +211,7 @@ Content-Type: application/vnd.ksql.v1+json
 }
 ```
 
-**Example response**
+### Example response
 
 ```http
 HTTP/1.1 200 OK
@@ -226,8 +239,7 @@ Content-Type: application/vnd.ksql.v1+json
 ]
 ```
 
-Coordinate Multiple Requests
-----------------------------
+## Coordinate Multiple Requests
 
 To submit multiple, interdependent requests, there are two options. The
 first is to submit them as a single request, similar to the example

--- a/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
@@ -12,11 +12,11 @@ until the `LIMIT` specified in the statement is reached, or the client
 closes the connection. If no `LIMIT` is specified in the statement, then
 the response is streamed until the client closes the connection.
 
-POST /query
+## POST /query
 
 :   Run a ``SELECT`` statement and stream back the results.
 
-JSON Parameters:
+## JSON Parameters:
 
 - **ksql** (string): The SELECT statement to run.
 - **streamsProperties** (map): Property overrides to run the statements with.
@@ -34,7 +34,20 @@ Response JSON Object:
 - **finalMessage** (string): If this field is non-null, it contains a final message from the server. No additional rows will be returned and the server will end the response.
 - **errorMessage** (string): If this field is non-null, an error has been encountered while running the statement. No additional rows are returned and the server will end the response.
 
-**Example request**
+## Examples 
+
+### Example curl command
+
+```bash
+curl -X "POST" "http://<ksqldb-host-name>:8088/query" \
+     -d $'{
+  "ksql": "SELECT * FROM USERS;",
+  "streamsProperties": {}
+}'
+
+```
+
+### Example request
 
 ```http
 POST /query HTTP/1.1
@@ -42,14 +55,14 @@ Accept: application/vnd.ksql.v1+json
 Content-Type: application/vnd.ksql.v1+json
 
 {
-  "ksql": "SELECT * FROM pageviews;",
+  "sql": "SELECT * FROM pageviews;",
   "streamsProperties": {
     "ksql.streams.auto.offset.reset": "earliest"
   }
 }
 ```
 
-**Example response**
+### Example response
 
 ```http
 HTTP/1.1 200 OK

--- a/docs/developer-guide/ksqldb-rest-api/streaming-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/streaming-endpoint.md
@@ -152,4 +152,15 @@ In case of error, an error response (see below) is sent. For an error response f
 
 !!!note
     
-    Please note that acks can be returned in a different sequence to which the inserts were submitted. 
+    Acks can be returned in a different sequence compared with the order in
+    which inserts were submitted. 
+
+## Example curl command
+
+```bash
+curl -X "POST" "http://<ksqldb-host-name>:8088/query-stream" \
+     -d $'{
+  "sql": "SELECT * FROM PAGEVIEWS EMIT CHANGES;",
+  "streamsProperties": {}
+}'
+```


### PR DESCRIPTION
This came up while I was updating the [CCloud/ksqlDB quickstart](https://docs.confluent.io/current/quickstart/cloud-quickstart/ksql.html#access-a-ksql-cloud-application-in-ccloud-with-an-api-key).