### PR TITLE
chore: update response code on pull queries disabled to be 4xx (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -180,12 +180,13 @@ public final class PullQueryExecutor {
     }
 
     if (!statement.getConfig().getBoolean(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG)) {
-      throw new KsqlException(
+      throw new KsqlStatementException(
           "Pull queries are disabled."
               + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
               + System.lineSeparator()
               + "Please set " + KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG + "=true to enable "
-              + "this feature.");
+              + "this feature.",
+          statement.getStatementText());
     }
 
     try {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.rest.server.validation.CustomValidators;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlStatementException;
 import java.util.Optional;
 import org.apache.kafka.common.utils.Time;
 import org.junit.Rule;
@@ -79,7 +80,7 @@ public class PullQueryExecutorTest {
 
       // When:
       final Exception e = assertThrows(
-          KsqlException.class,
+          KsqlStatementException.class,
           () -> pullQueryExecutor.execute(query, engine.getServiceContext(), Optional.empty(), 0L)
       );
 


### PR DESCRIPTION
### Description 

Currently, if a user tries to issue a pull query to a server for which `ksql.pull.queries.enable=false`, a 500 is returned when the response code should actually be 4xx. This PR changes the error code to 400 by switching the type of exception thrown. 

### Testing done 

The usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

