### PR TITLE
chore: temporarily split CP dep version into maven and docker deps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,8 @@ def baseConfig = {
     owner = 'ksql'
     slackChannel = '#ksql-alerts'
     ksql_db_version = "0.12.0"  // next version to be released
-    cp_version = "6.1.0-beta200825192044"  // must be a beta version from the packaging build
+    cp_version = "v6.1.0-beta200812055546"  // must be a beta version from the packaging build
+    cp_version_docker = "6.1.0-beta200825192044"  // temporary hack for 0.12.0 release
     packaging_build_number = "1"
     default_git_revision = 'refs/heads/master'
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
@@ -205,7 +206,7 @@ def job = {
                             '''
 
                             config.dockerPullDeps.each { dockerRepo ->
-                                sh "docker pull ${config.dockerRegistry}${dockerRepo}:${config.cp_version}-latest"
+                                sh "docker pull ${config.dockerRegistry}${dockerRepo}:${config.cp_version_docker}-latest"
                             }
 
                             // Set the project versions in the pom files
@@ -221,7 +222,7 @@ def job = {
                             cmd += "-Dcheckstyle.skip "
                             cmd += "-Ddocker.tag=${config.docker_tag} "
                             cmd += "-Ddocker.registry=${config.dockerRegistry} "
-                            cmd += "-Ddocker.upstream-tag=${config.cp_version}-latest "
+                            cmd += "-Ddocker.upstream-tag=${config.cp_version_docker}-latest "
                             cmd += "-Dskip.docker.build=false "
 
                             withEnv(['MAVEN_OPTS=-XX:MaxPermSize=128M']) {
@@ -234,7 +235,7 @@ def job = {
                             if (!config.isPrJob) {
                                 def git_tag = "v${config.ksql_db_artifact_version}-ksqldb"
                                 sh "git add ."
-                                sh "git commit -m \"build: Setting project version ${config.ksql_db_artifact_version} and parent version ${config.cp_version}.\""
+                                sh "git commit -m \"build: Setting project version ${config.ksql_db_artifact_version} and parent version ${config.cp_version}. Using ${config.cp_version_docker} for upstream docker tag.\""
                                 sh "git tag ${git_tag}"
                                 sshagent (credentials: ['ConfluentJenkins Github SSH Key']) {
                                     sh "git push origin ${git_tag}"


### PR DESCRIPTION
### Description 

Temporary change for 0.12.0 release since the Maven artifact version we'd like to use for our Streams dependency doesn't have associated base docker images. This change will be reverted after the 0.12.0 release as the value of having separate variables is low.

### Testing done 

PR builder will verify images build. The only thing not covered by the PR builder in terms of testing is the downstream CCloud image build. Manual inspection shows the Maven artifact dependency version is the correct one to pass to the job.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

