### PR TITLE
feat: clarify key or value in (de)serialization processing log messages

### DIFF
--- a/docs/developer-guide/test-and-debug/processing-log.md
+++ b/docs/developer-guide/test-and-debug/processing-log.md
@@ -121,6 +121,11 @@ message.deserializationError (STRUCT)
 :   The contents of a message with type 0 (DESERIALIZATION_ERROR).
     Logged when a deserializer fails to deserialize an {{ site.ak }} record.
 
+message.deserializationError.component (STRING)
+
+:   Either "key" or "value" representing the component of the row that
+    failed to deserialize.
+
 message.deserializationError.errorMessage (STRING)
 
 :   A string containing a human-readable error message detailing the
@@ -174,6 +179,11 @@ message.serializationError (STRUCT)
 
 :   The contents of a message with type 3 (SERIALIZATION_ERROR).
     Logged when a serializer fails to serialize a ksqlDB row.
+    
+message.serializationError.component (STRING)
+
+:   Either "key" or "value" representing the component of the row that
+    failed to serialize.
 
 message.serializationError.errorMessage (STRING)
 
@@ -265,7 +275,7 @@ Field   | Type
  LOGGER  | VARCHAR(STRING)
  LEVEL   | VARCHAR(STRING)
  TIME    | BIGINT
- MESSAGE | STRUCT<type INTEGER, deserializationError STRUCT<errorMessage VARCHAR(STRING), recordB64 VARCHAR(STRING), cause ARRAY<VARCHAR(STRING)>, topic VARCHAR(STRING)>, ...> 
+ MESSAGE | STRUCT<type INTEGER, deserializationError STRUCT<component VARCHAR(STRING), errorMessage VARCHAR(STRING), recordB64 VARCHAR(STRING), cause ARRAY<VARCHAR(STRING)>, topic VARCHAR(STRING)>, ...> 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
@@ -281,6 +291,7 @@ ksql> CREATE STREAM PROCESSING_LOG_STREAM (
          MESSAGE STRUCT<
              `TYPE` INTEGER,
              deserializationError STRUCT<
+                 component STRING,
                  errorMessage STRING,
                  recordB64 STRING,
                  cause ARRAY<STRING>,
@@ -292,6 +303,7 @@ ksql> CREATE STREAM PROCESSING_LOG_STREAM (
              productionError STRUCT<
                  errorMessage STRING>,
              serializationError STRUCT<
+                 component STRING,
                  errorMessage STRING,
                  record STRING,
                  cause ARRAY<STRING>,

--- a/docs/developer-guide/test-and-debug/processing-log.md
+++ b/docs/developer-guide/test-and-debug/processing-log.md
@@ -121,9 +121,9 @@ message.deserializationError (STRUCT)
 :   The contents of a message with type 0 (DESERIALIZATION_ERROR).
     Logged when a deserializer fails to deserialize an {{ site.ak }} record.
 
-message.deserializationError.component (STRING)
+message.deserializationError.target (STRING)
 
-:   Either "key" or "value" representing the component of the row that
+:   Either "key" or "value" representing the target component of the row that
     failed to deserialize.
 
 message.deserializationError.errorMessage (STRING)
@@ -180,9 +180,9 @@ message.serializationError (STRUCT)
 :   The contents of a message with type 3 (SERIALIZATION_ERROR).
     Logged when a serializer fails to serialize a ksqlDB row.
     
-message.serializationError.component (STRING)
+message.serializationError.target (STRING)
 
-:   Either "key" or "value" representing the component of the row that
+:   Either "key" or "value" representing the target component of the row that
     failed to serialize.
 
 message.serializationError.errorMessage (STRING)
@@ -275,7 +275,7 @@ Field   | Type
  LOGGER  | VARCHAR(STRING)
  LEVEL   | VARCHAR(STRING)
  TIME    | BIGINT
- MESSAGE | STRUCT<type INTEGER, deserializationError STRUCT<component VARCHAR(STRING), errorMessage VARCHAR(STRING), recordB64 VARCHAR(STRING), cause ARRAY<VARCHAR(STRING)>, topic VARCHAR(STRING)>, ...> 
+ MESSAGE | STRUCT<type INTEGER, deserializationError STRUCT<target VARCHAR(STRING), errorMessage VARCHAR(STRING), recordB64 VARCHAR(STRING), cause ARRAY<VARCHAR(STRING)>, topic VARCHAR(STRING)>, ...> 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
@@ -291,7 +291,7 @@ ksql> CREATE STREAM PROCESSING_LOG_STREAM (
          MESSAGE STRUCT<
              `TYPE` INTEGER,
              deserializationError STRUCT<
-                 component STRING,
+                 target STRING,
                  errorMessage STRING,
                  recordB64 STRING,
                  cause ARRAY<STRING>,
@@ -303,7 +303,7 @@ ksql> CREATE STREAM PROCESSING_LOG_STREAM (
              productionError STRUCT<
                  errorMessage STRING>,
              serializationError STRUCT<
-                 component STRING,
+                 target STRING,
                  errorMessage STRING,
                  record STRING,
                  cause ARRAY<STRING>,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogMessageSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogMessageSchema.java
@@ -24,6 +24,7 @@ public final class ProcessingLogMessageSchema {
   private static final Schema CAUSE_SCHEMA =
       SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
 
+  public static final String DESERIALIZATION_ERROR_FIELD_COMPONENT = "component";
   public static final String DESERIALIZATION_ERROR_FIELD_MESSAGE = "errorMessage";
   public static final String DESERIALIZATION_ERROR_FIELD_RECORD_B64 = "recordB64";
   public static final String DESERIALIZATION_ERROR_FIELD_CAUSE = "cause";
@@ -31,6 +32,7 @@ public final class ProcessingLogMessageSchema {
 
   private static final Schema DESERIALIZATION_ERROR_SCHEMA = SchemaBuilder.struct()
       .name(NAMESPACE + "DeserializationError")
+      .field(DESERIALIZATION_ERROR_FIELD_COMPONENT, Schema.OPTIONAL_STRING_SCHEMA)
       .field(DESERIALIZATION_ERROR_FIELD_MESSAGE, Schema.OPTIONAL_STRING_SCHEMA)
       .field(DESERIALIZATION_ERROR_FIELD_RECORD_B64, Schema.OPTIONAL_STRING_SCHEMA)
       .field(DESERIALIZATION_ERROR_FIELD_CAUSE, CAUSE_SCHEMA)
@@ -58,6 +60,7 @@ public final class ProcessingLogMessageSchema {
       .optional()
       .build();
 
+  public static final String SERIALIZATION_ERROR_FIELD_COMPONENT = "component";
   public static final String SERIALIZATION_ERROR_FIELD_MESSAGE = "errorMessage";
   public static final String SERIALIZATION_ERROR_FIELD_RECORD = "record";
   public static final String SERIALIZATION_ERROR_FIELD_CAUSE = "cause";
@@ -65,6 +68,7 @@ public final class ProcessingLogMessageSchema {
 
   private static final Schema SERIALIZATION_ERROR_SCHEMA = SchemaBuilder.struct()
       .name(NAMESPACE + "SerializationError")
+      .field(SERIALIZATION_ERROR_FIELD_COMPONENT, Schema.OPTIONAL_STRING_SCHEMA)
       .field(SERIALIZATION_ERROR_FIELD_MESSAGE, Schema.OPTIONAL_STRING_SCHEMA)
       .field(SERIALIZATION_ERROR_FIELD_RECORD, Schema.OPTIONAL_STRING_SCHEMA)
       .field(SERIALIZATION_ERROR_FIELD_CAUSE, CAUSE_SCHEMA)

--- a/ksqldb-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogMessageSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogMessageSchema.java
@@ -24,7 +24,7 @@ public final class ProcessingLogMessageSchema {
   private static final Schema CAUSE_SCHEMA =
       SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
 
-  public static final String DESERIALIZATION_ERROR_FIELD_COMPONENT = "component";
+  public static final String DESERIALIZATION_ERROR_FIELD_TARGET = "target";
   public static final String DESERIALIZATION_ERROR_FIELD_MESSAGE = "errorMessage";
   public static final String DESERIALIZATION_ERROR_FIELD_RECORD_B64 = "recordB64";
   public static final String DESERIALIZATION_ERROR_FIELD_CAUSE = "cause";
@@ -32,7 +32,7 @@ public final class ProcessingLogMessageSchema {
 
   private static final Schema DESERIALIZATION_ERROR_SCHEMA = SchemaBuilder.struct()
       .name(NAMESPACE + "DeserializationError")
-      .field(DESERIALIZATION_ERROR_FIELD_COMPONENT, Schema.OPTIONAL_STRING_SCHEMA)
+      .field(DESERIALIZATION_ERROR_FIELD_TARGET, Schema.OPTIONAL_STRING_SCHEMA)
       .field(DESERIALIZATION_ERROR_FIELD_MESSAGE, Schema.OPTIONAL_STRING_SCHEMA)
       .field(DESERIALIZATION_ERROR_FIELD_RECORD_B64, Schema.OPTIONAL_STRING_SCHEMA)
       .field(DESERIALIZATION_ERROR_FIELD_CAUSE, CAUSE_SCHEMA)
@@ -60,7 +60,7 @@ public final class ProcessingLogMessageSchema {
       .optional()
       .build();
 
-  public static final String SERIALIZATION_ERROR_FIELD_COMPONENT = "component";
+  public static final String SERIALIZATION_ERROR_FIELD_TARGET = "target";
   public static final String SERIALIZATION_ERROR_FIELD_MESSAGE = "errorMessage";
   public static final String SERIALIZATION_ERROR_FIELD_RECORD = "record";
   public static final String SERIALIZATION_ERROR_FIELD_CAUSE = "cause";
@@ -68,7 +68,7 @@ public final class ProcessingLogMessageSchema {
 
   private static final Schema SERIALIZATION_ERROR_SCHEMA = SchemaBuilder.struct()
       .name(NAMESPACE + "SerializationError")
-      .field(SERIALIZATION_ERROR_FIELD_COMPONENT, Schema.OPTIONAL_STRING_SCHEMA)
+      .field(SERIALIZATION_ERROR_FIELD_TARGET, Schema.OPTIONAL_STRING_SCHEMA)
       .field(SERIALIZATION_ERROR_FIELD_MESSAGE, Schema.OPTIONAL_STRING_SCHEMA)
       .field(SERIALIZATION_ERROR_FIELD_RECORD, Schema.OPTIONAL_STRING_SCHEMA)
       .field(SERIALIZATION_ERROR_FIELD_CAUSE, CAUSE_SCHEMA)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/logging/processing/ProcessingLogServerUtilsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/logging/processing/ProcessingLogServerUtilsTest.java
@@ -186,10 +186,10 @@ public class ProcessingLogServerUtilsTest {
             + "time BIGINT, "
             + "message STRUCT<"
             + "type INT, "
-            + "deserializationError STRUCT<component VARCHAR, errorMessage VARCHAR, recordB64 VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>, "
+            + "deserializationError STRUCT<target VARCHAR, errorMessage VARCHAR, recordB64 VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>, "
             + "recordProcessingError STRUCT<errorMessage VARCHAR, record VARCHAR, cause ARRAY<VARCHAR>>, "
             + "productionError STRUCT<errorMessage VARCHAR>, "
-            + "serializationError STRUCT<component VARCHAR, errorMessage VARCHAR, record VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>"
+            + "serializationError STRUCT<target VARCHAR, errorMessage VARCHAR, record VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>"
             + ">"
             + ") WITH(KAFKA_TOPIC='processing_log_topic', VALUE_FORMAT='JSON');"));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/logging/processing/ProcessingLogServerUtilsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/logging/processing/ProcessingLogServerUtilsTest.java
@@ -186,10 +186,10 @@ public class ProcessingLogServerUtilsTest {
             + "time BIGINT, "
             + "message STRUCT<"
             + "type INT, "
-            + "deserializationError STRUCT<errorMessage VARCHAR, recordB64 VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>, "
+            + "deserializationError STRUCT<component VARCHAR, errorMessage VARCHAR, recordB64 VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>, "
             + "recordProcessingError STRUCT<errorMessage VARCHAR, record VARCHAR, cause ARRAY<VARCHAR>>, "
             + "productionError STRUCT<errorMessage VARCHAR>, "
-            + "serializationError STRUCT<errorMessage VARCHAR, record VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>"
+            + "serializationError STRUCT<component VARCHAR, errorMessage VARCHAR, record VARCHAR, cause ARRAY<VARCHAR>, `topic` VARCHAR>"
             + ">"
             + ") WITH(KAFKA_TOPIC='processing_log_topic', VALUE_FORMAT='JSON');"));
   }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/DeserializationError.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/DeserializationError.java
@@ -75,7 +75,7 @@ public class DeserializationError implements ProcessingLogger.ErrorMessage {
   private Struct deserializationError(final ProcessingLogConfig config) {
     final Struct deserializationError = new Struct(MessageType.DESERIALIZATION_ERROR.getSchema())
         .put(
-            ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_COMPONENT,
+            ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_TARGET,
             LoggingSerdeUtil.getRecordComponent(isKey))
         .put(
             ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_MESSAGE,

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/DeserializationError.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/DeserializationError.java
@@ -18,9 +18,7 @@ package io.confluent.ksql.logging.processing;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.MessageType;
-import io.confluent.ksql.util.ErrorMessageUtil;
 import java.util.Base64;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -31,15 +29,18 @@ public class DeserializationError implements ProcessingLogger.ErrorMessage {
   private final Throwable exception;
   private final Optional<byte[]> record;
   private final String topic;
+  private final boolean isKey;
 
   public DeserializationError(
       final Throwable exception,
       final Optional<byte[]> record,
-      final String topic
+      final String topic,
+      final boolean isKey
   ) {
     this.exception = requireNonNull(exception, "exception");
     this.record = requireNonNull(record, "record");
     this.topic = requireNonNull(topic, "topic");
+    this.isKey = isKey;
   }
 
   @Override
@@ -62,27 +63,29 @@ public class DeserializationError implements ProcessingLogger.ErrorMessage {
     final DeserializationError that = (DeserializationError) o;
     return Objects.equals(exception, that.exception)
         && Objects.equals(record, that.record)
-        && Objects.equals(topic, that.topic);
+        && Objects.equals(topic, that.topic)
+        && isKey == that.isKey;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(exception, record, topic);
+    return Objects.hash(exception, record, topic, isKey);
   }
 
   private Struct deserializationError(final ProcessingLogConfig config) {
     final Struct deserializationError = new Struct(MessageType.DESERIALIZATION_ERROR.getSchema())
         .put(
+            ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_COMPONENT,
+            LoggingSerdeUtil.getRecordComponent(isKey))
+        .put(
             ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_MESSAGE,
             exception.getMessage())
         .put(
             ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_CAUSE,
-            getCause()
-        )
+            LoggingSerdeUtil.getCause(exception))
         .put(
             ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_TOPIC,
-            topic
-        );
+            topic);
 
     if (config.getBoolean(ProcessingLogConfig.INCLUDE_ROWS)) {
       deserializationError.put(
@@ -92,11 +95,5 @@ public class DeserializationError implements ProcessingLogger.ErrorMessage {
     }
 
     return deserializationError;
-  }
-
-  private List<String> getCause() {
-    final List<String> cause = ErrorMessageUtil.getErrorMessages(exception);
-    cause.remove(0);
-    return cause;
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingDeserializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingDeserializer.java
@@ -26,6 +26,7 @@ public final class LoggingDeserializer<T> implements Deserializer<T> {
 
   private final Deserializer<T> delegate;
   private final ProcessingLogger processingLogger;
+  private boolean isKey;
 
   public LoggingDeserializer(
       final Deserializer<T> delegate,
@@ -37,6 +38,7 @@ public final class LoggingDeserializer<T> implements Deserializer<T> {
 
   @Override
   public void configure(final Map<String, ?> configs, final boolean isKey) {
+    this.isKey = isKey;
     delegate.configure(configs, isKey);
   }
 
@@ -59,7 +61,7 @@ public final class LoggingDeserializer<T> implements Deserializer<T> {
     } catch (final RuntimeException e) {
       return new DelayedResult<T>(
           e,
-          new DeserializationError(e, Optional.ofNullable(bytes), topic),
+          new DeserializationError(e, Optional.ofNullable(bytes), topic, isKey),
           processingLogger
       );
     }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingSerdeUtil.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingSerdeUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.logging.processing;
+
+import io.confluent.ksql.util.ErrorMessageUtil;
+import java.util.List;
+
+final class LoggingSerdeUtil {
+
+  private LoggingSerdeUtil() {
+  }
+
+  static List<String> getCause(final Throwable exception) {
+    final List<String> cause = ErrorMessageUtil.getErrorMessages(exception);
+    cause.remove(0);
+    return cause;
+  }
+
+  static String getRecordComponent(final boolean isKey) {
+    return isKey ? "key" : "value";
+  }
+}

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingSerializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/LoggingSerializer.java
@@ -25,6 +25,7 @@ public final class LoggingSerializer<T> implements Serializer<T> {
 
   private final Serializer<T> delegate;
   private final ProcessingLogger processingLogger;
+  private boolean isKey;
 
   public LoggingSerializer(
       final Serializer<T> delegate,
@@ -36,6 +37,7 @@ public final class LoggingSerializer<T> implements Serializer<T> {
 
   @Override
   public void configure(final Map<String, ?> configs, final boolean isKey) {
+    this.isKey = isKey;
     delegate.configure(configs, isKey);
   }
 
@@ -44,7 +46,7 @@ public final class LoggingSerializer<T> implements Serializer<T> {
     try {
       return delegate.serialize(topic, data);
     } catch (final RuntimeException e) {
-      processingLogger.error(new SerializationError<>(e, Optional.of(data), topic));
+      processingLogger.error(new SerializationError<>(e, Optional.of(data), topic, isKey));
       throw e;
     }
   }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/SerializationError.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/SerializationError.java
@@ -74,7 +74,7 @@ public class SerializationError<T> implements ProcessingLogger.ErrorMessage {
   private Struct serializationError(final ProcessingLogConfig config) {
     final Struct serializationError = new Struct(MessageType.SERIALIZATION_ERROR.getSchema())
         .put(
-            ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_COMPONENT,
+            ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_TARGET,
             LoggingSerdeUtil.getRecordComponent(isKey))
         .put(
             ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_MESSAGE,

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/SerializationError.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/logging/processing/SerializationError.java
@@ -18,8 +18,6 @@ package io.confluent.ksql.logging.processing;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.MessageType;
-import io.confluent.ksql.util.ErrorMessageUtil;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -30,15 +28,18 @@ public class SerializationError<T> implements ProcessingLogger.ErrorMessage {
   private final Throwable exception;
   private final Optional<T> record;
   private final String topic;
+  private final boolean isKey;
 
   public SerializationError(
       final Throwable exception,
       final Optional<T> record,
-      final String topic
+      final String topic,
+      final boolean isKey
   ) {
     this.exception = requireNonNull(exception, "exception");
     this.record = requireNonNull(record, "record");
     this.topic = requireNonNull(topic, "topic");
+    this.isKey = isKey;
   }
 
   @Override
@@ -58,30 +59,32 @@ public class SerializationError<T> implements ProcessingLogger.ErrorMessage {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final SerializationError<?> that = (SerializationError) o;
+    final SerializationError<?> that = (SerializationError<?>) o;
     return Objects.equals(exception, that.exception)
         && Objects.equals(record, that.record)
-        && Objects.equals(topic, that.topic);
+        && Objects.equals(topic, that.topic)
+        && isKey == that.isKey;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(exception, record, topic);
+    return Objects.hash(exception, record, topic, isKey);
   }
 
   private Struct serializationError(final ProcessingLogConfig config) {
     final Struct serializationError = new Struct(MessageType.SERIALIZATION_ERROR.getSchema())
         .put(
+            ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_COMPONENT,
+            LoggingSerdeUtil.getRecordComponent(isKey))
+        .put(
             ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_MESSAGE,
             exception.getMessage())
         .put(
             ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_CAUSE,
-            getCause()
-        )
+            LoggingSerdeUtil.getCause(exception))
         .put(
             ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_TOPIC,
-            topic
-        );
+            topic);
 
     if (config.getBoolean(ProcessingLogConfig.INCLUDE_ROWS)) {
       serializationError.put(
@@ -91,11 +94,5 @@ public class SerializationError<T> implements ProcessingLogger.ErrorMessage {
     }
 
     return serializationError;
-  }
-
-  private List<String> getCause() {
-    final List<String> cause = ErrorMessageUtil.getErrorMessages(exception);
-    cause.remove(0);
-    return cause;
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
@@ -164,7 +164,7 @@ public class KafkaSerdeFactory implements KsqlSerdeFactory {
         return struct;
       } catch (final Exception e) {
         throw new SerializationException(
-            "Error deserializing DELIMITED message from topic: " + topic, e);
+            "Error deserializing KAFKA message from topic: " + topic, e);
       }
     }
   }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/DeserializationErrorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/DeserializationErrorTest.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.logging.processing;
 
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_CAUSE;
-import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_COMPONENT;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_TARGET;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_MESSAGE;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_RECORD_B64;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_TOPIC;
@@ -93,7 +93,7 @@ public class DeserializationErrorTest {
         equalTo(MessageType.DESERIALIZATION_ERROR.getTypeId()));
     final Struct deserializationError = struct.getStruct(DESERIALIZATION_ERROR);
     assertThat(
-        deserializationError.get(DESERIALIZATION_ERROR_FIELD_COMPONENT),
+        deserializationError.get(DESERIALIZATION_ERROR_FIELD_TARGET),
         equalTo("value")
     );
     assertThat(
@@ -164,7 +164,7 @@ public class DeserializationErrorTest {
     final Struct struct = (Struct) msg.value();
     final Struct deserializationError = struct.getStruct(DESERIALIZATION_ERROR);
     assertThat(
-        deserializationError.get(DESERIALIZATION_ERROR_FIELD_COMPONENT),
+        deserializationError.get(DESERIALIZATION_ERROR_FIELD_TARGET),
         equalTo("key")
     );
   }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/DeserializationErrorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/DeserializationErrorTest.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.logging.processing;
 
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_CAUSE;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_COMPONENT;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_MESSAGE;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_RECORD_B64;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_TOPIC;
@@ -40,7 +56,8 @@ public class DeserializationErrorTest {
     final DeserializationError deserError = new DeserializationError(
         error,
         Optional.empty(),
-        "topic"
+        "topic",
+        false
     );
 
     // When:
@@ -59,7 +76,8 @@ public class DeserializationErrorTest {
     final DeserializationError deserError = new DeserializationError(
         error,
         Optional.of(record),
-        "topic"
+        "topic",
+        false
     );
 
     // When:
@@ -73,6 +91,10 @@ public class DeserializationErrorTest {
         struct.get(ProcessingLogMessageSchema.TYPE),
         equalTo(MessageType.DESERIALIZATION_ERROR.getTypeId()));
     final Struct deserializationError = struct.getStruct(DESERIALIZATION_ERROR);
+    assertThat(
+        deserializationError.get(DESERIALIZATION_ERROR_FIELD_COMPONENT),
+        equalTo("value")
+    );
     assertThat(
         deserializationError.get(DESERIALIZATION_ERROR_FIELD_MESSAGE),
         equalTo(error.getMessage())
@@ -108,7 +130,8 @@ public class DeserializationErrorTest {
     final DeserializationError deserError = new DeserializationError(
         error,
         Optional.of(record),
-        "topic"
+        "topic",
+        false
     );
 
     // When:
@@ -121,5 +144,27 @@ public class DeserializationErrorTest {
         equalTo(MessageType.DESERIALIZATION_ERROR.getTypeId()));
     final Struct deserializationError = struct.getStruct(DESERIALIZATION_ERROR);
     assertThat(deserializationError.get(DESERIALIZATION_ERROR_FIELD_RECORD_B64), nullValue());
+  }
+
+  @Test
+  public void shouldBuildErrorWithKeyComponent() {
+    // Given:
+    final DeserializationError deserError = new DeserializationError(
+        error,
+        Optional.of(record),
+        "topic",
+        true
+    );
+
+    // When:
+    final SchemaAndValue msg = deserError.get(config);
+
+    // Then:
+    final Struct struct = (Struct) msg.value();
+    final Struct deserializationError = struct.getStruct(DESERIALIZATION_ERROR);
+    assertThat(
+        deserializationError.get(DESERIALIZATION_ERROR_FIELD_COMPONENT),
+        equalTo("key")
+    );
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/DeserializationErrorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/DeserializationErrorTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.MessageType;
 import java.util.Base64;
 import java.util.Collections;
@@ -166,5 +167,34 @@ public class DeserializationErrorTest {
         deserializationError.get(DESERIALIZATION_ERROR_FIELD_COMPONENT),
         equalTo("key")
     );
+  }
+
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    final Exception error1 = new Exception("error");
+    final Exception error2 = new Exception("different error");
+    final byte[] record1 = new byte[256];
+    final byte[] record2 = new byte[512];
+    new EqualsTester()
+        .addEqualityGroup(
+            new DeserializationError(error1, Optional.of(record1), "topic", false),
+            new DeserializationError(error1, Optional.of(record1), "topic", false)
+        )
+        .addEqualityGroup(
+            new DeserializationError(error2, Optional.of(record1), "topic", false)
+        )
+        .addEqualityGroup(
+            new DeserializationError(error1, Optional.of(record2), "topic", false)
+        )
+        .addEqualityGroup(
+            new DeserializationError(error1, Optional.empty(), "topic", false)
+        )
+        .addEqualityGroup(
+            new DeserializationError(error1, Optional.of(record1), "other_topic", false)
+        )
+        .addEqualityGroup(
+            new DeserializationError(error1, Optional.of(record1), "topic", true)
+        )
+        .testEquals();
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingDeserializerTest.java
@@ -48,6 +48,8 @@ public class LoggingDeserializerTest {
 
   private static final GenericRow SOME_ROW = genericRow("some", "fields");
   private static final byte[] SOME_BYTES = "some bytes".getBytes(StandardCharsets.UTF_8);
+  private static final Exception ERROR = new RuntimeException("outer",
+      new RuntimeException("inner", new RuntimeException("cause")));
 
   @Mock
   private Deserializer<GenericRow> delegate;
@@ -116,23 +118,10 @@ public class LoggingDeserializerTest {
     assertThat(result.get(), is(SOME_ROW));
   }
 
-  @Test(expected = ArithmeticException.class)
+  @Test
   public void shouldThrowIfDelegateThrows() {
     // Given:
-    when(delegate.deserialize(any(), any())).thenThrow(new ArithmeticException());
-
-    // When:
-    deserializer.deserialize("t", SOME_BYTES);
-
-    // Then: throws
-  }
-
-  @Test
-  public void shouldLogOnException() {
-    // Given:
-    when(delegate.deserialize(any(), any()))
-        .thenThrow(new RuntimeException("outer",
-            new RuntimeException("inner", new RuntimeException("cause"))));
+    when(delegate.deserialize(any(), any())).thenThrow(ERROR);
 
     // When:
     final RuntimeException e = assertThrows(
@@ -141,15 +130,28 @@ public class LoggingDeserializerTest {
     );
 
     // Then:
-    verify(processingLogger).error(new DeserializationError(e, Optional.of(SOME_BYTES), "t", false));
+    assertThat(e, is(ERROR));
+  }
+
+  @Test
+  public void shouldLogOnException() {
+    // Given:
+    when(delegate.deserialize(any(), any())).thenThrow(ERROR);
+
+    // When:
+    assertThrows(
+        RuntimeException.class,
+        () -> deserializer.deserialize("t", SOME_BYTES)
+    );
+
+    // Then:
+    verify(processingLogger).error(new DeserializationError(ERROR, Optional.of(SOME_BYTES), "t", false));
   }
 
   @Test
   public void shouldDelayLogOnException() {
     // Given:
-    when(delegate.deserialize(any(), any()))
-        .thenThrow(new RuntimeException("outer",
-            new RuntimeException("inner", new RuntimeException("cause"))));
+    when(delegate.deserialize(any(), any())).thenThrow(ERROR);
 
     // When:
     final DelayedResult<GenericRow> result = deserializer.tryDeserialize("t", SOME_BYTES);
@@ -159,5 +161,22 @@ public class LoggingDeserializerTest {
     assertThrows(RuntimeException.class, result::get);
     verify(processingLogger)
         .error(new DeserializationError(result.getError(), Optional.of(SOME_BYTES), "t", false));
+  }
+
+  @Test
+  public void shouldLogExceptionForKey() {
+    // Given:
+    deserializer.configure(Collections.emptyMap(), true);
+
+    when(delegate.deserialize(any(), any())).thenThrow(ERROR);
+
+    // When:
+    assertThrows(
+        RuntimeException.class,
+        () -> deserializer.deserialize("t", SOME_BYTES)
+    );
+
+    // Then:
+    verify(processingLogger).error(new DeserializationError(ERROR, Optional.of(SOME_BYTES), "t", true));
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingDeserializerTest.java
@@ -29,6 +29,7 @@ import com.google.common.testing.NullPointerTester;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.logging.processing.LoggingDeserializer.DelayedResult;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -60,6 +61,7 @@ public class LoggingDeserializerTest {
   @Before
   public void setUp() {
     deserializer = new LoggingDeserializer<>(delegate, processingLogger);
+    deserializer.configure(Collections.emptyMap(), false);
   }
 
   @Test
@@ -139,7 +141,7 @@ public class LoggingDeserializerTest {
     );
 
     // Then:
-    verify(processingLogger).error(new DeserializationError(e, Optional.of(SOME_BYTES), "t"));
+    verify(processingLogger).error(new DeserializationError(e, Optional.of(SOME_BYTES), "t", false));
   }
 
   @Test
@@ -156,6 +158,6 @@ public class LoggingDeserializerTest {
     assertTrue(result.isError());
     assertThrows(RuntimeException.class, result::get);
     verify(processingLogger)
-        .error(new DeserializationError(result.getError(), Optional.of(SOME_BYTES), "t"));
+        .error(new DeserializationError(result.getError(), Optional.of(SOME_BYTES), "t", false));
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingSerializerTest.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.logging.processing;
 
 import static io.confluent.ksql.GenericRow.genericRow;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -40,6 +42,8 @@ public class LoggingSerializerTest {
 
   private static final GenericRow SOME_ROW = genericRow("some", "fields");
   private static final byte[] SOME_BYTES = "some bytes".getBytes(StandardCharsets.UTF_8);
+  private static final Exception ERROR = new RuntimeException("outer",
+      new RuntimeException("inner", new RuntimeException("cause")));
 
   @Mock
   private Serializer<GenericRow> delegate;
@@ -92,23 +96,10 @@ public class LoggingSerializerTest {
     verify(delegate).serialize("some topic", SOME_ROW);
   }
 
-  @Test(expected = ArithmeticException.class)
+  @Test
   public void shouldThrowIfDelegateThrows() {
     // Given:
-    when(delegate.serialize(any(), any())).thenThrow(new ArithmeticException());
-
-    // When:
-    serializer.serialize("t", SOME_ROW);
-
-    // Then: throws
-  }
-
-  @Test
-  public void shouldLogOnException() {
-    // Given:
-    when(delegate.serialize(any(), any()))
-        .thenThrow(new RuntimeException("outer",
-            new RuntimeException("inner", new RuntimeException("cause"))));
+    when(delegate.serialize(any(), any())).thenThrow(ERROR);
 
     // When:
     final RuntimeException e = assertThrows(
@@ -117,7 +108,39 @@ public class LoggingSerializerTest {
     );
 
     // Then:
-    verify(processingLogger).error(new SerializationError<>(e, Optional.of(SOME_ROW), "t", false));
+    assertThat(e, is(ERROR));
+  }
+
+  @Test
+  public void shouldLogOnException() {
+    // Given:
+    when(delegate.serialize(any(), any())).thenThrow(ERROR);
+
+    // When:
+    assertThrows(
+        RuntimeException.class,
+        () -> serializer.serialize("t", SOME_ROW)
+    );
+
+    // Then:
+    verify(processingLogger).error(new SerializationError<>(ERROR, Optional.of(SOME_ROW), "t", false));
+  }
+
+  @Test
+  public void shouldLogExceptionForKey() {
+    // Given:
+    serializer.configure(Collections.emptyMap(), true);
+
+    when(delegate.serialize(any(), any())).thenThrow(ERROR);
+
+    // When:
+    assertThrows(
+        RuntimeException.class,
+        () -> serializer.serialize("t", SOME_ROW)
+    );
+
+    // Then:
+    verify(processingLogger).error(new SerializationError<>(ERROR, Optional.of(SOME_ROW), "t", true));
   }
 
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/LoggingSerializerTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.NullPointerTester;
 import io.confluent.ksql.GenericRow;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.common.serialization.Serializer;
@@ -50,6 +51,7 @@ public class LoggingSerializerTest {
   @Before
   public void setUp() {
     serializer = new LoggingSerializer<>(delegate, processingLogger);
+    serializer.configure(Collections.emptyMap(), false);
   }
 
   @Test
@@ -115,7 +117,7 @@ public class LoggingSerializerTest {
     );
 
     // Then:
-    verify(processingLogger).error(new SerializationError<>(e, Optional.of(SOME_ROW), "t"));
+    verify(processingLogger).error(new SerializationError<>(e, Optional.of(SOME_ROW), "t", false));
   }
 
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/SerializationErrorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/SerializationErrorTest.java
@@ -19,7 +19,7 @@ import static io.confluent.ksql.GenericRow.genericRow;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.PROCESSING_LOG_SCHEMA;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_CAUSE;
-import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_COMPONENT;
+import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_TARGET;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_MESSAGE;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_RECORD;
 import static io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.SERIALIZATION_ERROR_FIELD_TOPIC;
@@ -74,7 +74,7 @@ public class SerializationErrorTest {
         equalTo(ProcessingLogMessageSchema.MessageType.SERIALIZATION_ERROR.getTypeId()));
     final Struct serializationError = struct.getStruct(SERIALIZATION_ERROR);
     assertThat(
-        serializationError.get(SERIALIZATION_ERROR_FIELD_COMPONENT),
+        serializationError.get(SERIALIZATION_ERROR_FIELD_TARGET),
         equalTo("value")
     );
     assertThat(
@@ -159,7 +159,7 @@ public class SerializationErrorTest {
     final Struct struct = (Struct) msg.value();
     final Struct serializationError = struct.getStruct(SERIALIZATION_ERROR);
     assertThat(
-        serializationError.get(SERIALIZATION_ERROR_FIELD_COMPONENT),
+        serializationError.get(SERIALIZATION_ERROR_FIELD_TARGET),
         equalTo("key")
     );
   }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/SerializationErrorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/logging/processing/SerializationErrorTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.GenericRow;
 import java.util.Collections;
 import java.util.List;
@@ -161,5 +162,32 @@ public class SerializationErrorTest {
         serializationError.get(SERIALIZATION_ERROR_FIELD_COMPONENT),
         equalTo("key")
     );
+  }
+
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    final Exception error1 = new Exception("error");
+    final Exception error2 = new Exception("different error");
+    new EqualsTester()
+        .addEqualityGroup(
+            new SerializationError<>(error1, Optional.of(genericRow("some", "fields")), "topic", false),
+            new SerializationError<>(error1, Optional.of(genericRow("some", "fields")), "topic", false)
+        )
+        .addEqualityGroup(
+            new SerializationError<>(error2, Optional.of(genericRow("some", "fields")), "topic", false)
+        )
+        .addEqualityGroup(
+            new SerializationError<>(error1, Optional.of(genericRow("other", "fields")), "topic", false)
+        )
+        .addEqualityGroup(
+            new SerializationError<>(error1, Optional.empty(), "topic", false)
+        )
+        .addEqualityGroup(
+            new SerializationError<>(error1, Optional.of(genericRow("some", "fields")), "other_topic", false)
+        )
+        .addEqualityGroup(
+            new SerializationError<>(error1, Optional.of(genericRow("some", "fields")), "topic", true)
+        )
+        .testEquals();
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/StaticTopicSerdeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/StaticTopicSerdeTest.java
@@ -159,7 +159,7 @@ public class StaticTopicSerdeTest {
         () -> staticSerde.deserializer().deserialize(SOURCE_TOPIC, SOME_BYTES));
 
     // Then:
-    verify(logger).error(new DeserializationError(err, Optional.of(SOME_BYTES), STATIC_TOPIC));
+    verify(logger).error(new DeserializationError(err, Optional.of(SOME_BYTES), STATIC_TOPIC, false));
     verifyZeroInteractions(callback);
   }
 


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5627

Currently, there's nothing in the processing log message for (de)serialization errors to indicate whether it was the record key or value that failed to serialize/deserialize. This PR adds a new field to the relevant processing log message schemas called "component" with value "key" or "value" to indicate so.

Not in love with the name "component" but couldn't think of anything better. Suggestions appreciated!

Also fixes a typo in the Kafka deserializer error message that indicated the wrong format (delimited).

### Testing done 

Unit + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

