### PR TITLE
chore: support ASSERT STREAM and ASSERT TABLE in KsqlTester

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -42,7 +42,7 @@ public final class CommonCreateConfigs {
 
   public static final String VALUE_DELIMITER_PROPERTY = "VALUE_DELIMITER";
 
-  static void addToConfigDef(
+  public static void addToConfigDef(
       final ConfigDef configDef,
       final boolean topicNameRequired,
       final boolean valueFormatRequired

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -56,39 +56,41 @@ public final class AssertExecutor {
 
 
   private static final List<SourceProperty> MUST_MATCH = ImmutableList.<SourceProperty>builder()
-      .add(new SourceProperty(
-          DataSource::getSchema,
-          cs -> cs.getElements().toLogicalSchema(),
-          "schema"
-      ))
-      .add(new SourceProperty(
-          DataSource::getDataSourceType,
-          cs -> cs instanceof CreateTable ? DataSourceType.KTABLE : DataSourceType.KSTREAM,
-          "type"
-      )).add(new SourceProperty(
-          DataSource::getKafkaTopicName,
-          cs -> cs.getProperties().getKafkaTopic(),
-          "kafka topic"
+      .add(
+          new SourceProperty(
+              DataSource::getSchema,
+              cs -> cs.getElements().toLogicalSchema(),
+              "schema"
+      )).add(
+          new SourceProperty(
+              DataSource::getDataSourceType,
+              cs -> cs instanceof CreateTable ? DataSourceType.KTABLE : DataSourceType.KSTREAM,
+              "type"
+      )).add(
+          new SourceProperty(
+              DataSource::getKafkaTopicName,
+              cs -> cs.getProperties().getKafkaTopic(),
+              "kafka topic"
       )).add(
           new SourceProperty(
               ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getFormat(),
               cs -> cs.getProperties().getValueFormat().name(),
               "value format"
           )).add(new SourceProperty(
-          DataSource::getSerdeOptions,
-          cs -> cs.getProperties().getSerdeOptions(),
-          "serde options"
+              DataSource::getSerdeOptions,
+              cs -> cs.getProperties().getSerdeOptions(),
+              "serde options"
       )).add(
           new SourceProperty(
               ds -> ds.getTimestampColumn().map(TimestampColumn::getColumn),
               cs -> cs.getProperties().getTimestampColumnName(),
               "timestamp column"
-          )).add(
+      )).add(
           new SourceProperty(
               ds -> ds.getTimestampColumn().flatMap(TimestampColumn::getFormat),
               cs -> cs.getProperties().getTimestampFormat(),
               "timestamp format"
-          )).build();
+      )).build();
 
   private AssertExecutor() {
   }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/AssertExecutorMetaTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/AssertExecutorMetaTest.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.test.driver;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.config.ConfigDef;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Most test coverage for the AssertExecutor is in the sql-tests/test.sql file
+ * which is run through the KsqlTesterTest tool. This class is here to ensure
+ * that the class evolves properly.
+ */
+public class AssertExecutorMetaTest {
+
+  /**
+   * These are excluded from coverage
+   */
+  private final Set<String> excluded = ImmutableSet.of(
+      CommonCreateConfigs.SOURCE_NUMBER_OF_PARTITIONS, // testing tool does not support partitions
+      CommonCreateConfigs.SOURCE_NUMBER_OF_REPLICAS    // testing tool does not support replicas
+  );
+
+  @Test
+  public void shouldCoverAllWithClauses() {
+    // Given:
+    final ConfigDef def = new ConfigDef();
+    CommonCreateConfigs.addToConfigDef(def, true, true);
+    final Set<String> allValidProps = def.names();
+
+    // When:
+    final Set<String> coverage = AssertExecutor.MUST_MATCH
+        .stream()
+        .map(sp -> sp.withClauseName)
+        .flatMap(Arrays::stream)
+        .collect(Collectors.toSet());
+
+    // Then:
+    assertThat(Sets.difference(allValidProps, coverage), Matchers.is(excluded));
+  }
+
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -118,7 +118,7 @@ public class KsqlTesterTest {
   // populated during execution to handle the expected exception
   // scenario - don't use Matchers because they do not create very
   // user friendly error messages
-  private Class<? extends Exception> expectedException;
+  private Class<? extends Throwable> expectedException;
   private String expectedMessage;
 
   @Parameterized.Parameters(name = "{0}")
@@ -174,7 +174,7 @@ public class KsqlTesterTest {
     for (final TestStatement testStatement : statements) {
       try {
         testStatement.consume(this::execute, this::doAssert, this::directive);
-      } catch (final Exception e) {
+      } catch (final Throwable e) {
         handleExpectedException(testStatement, e);
         return;
       }
@@ -377,7 +377,7 @@ public class KsqlTesterTest {
     }
   }
 
-  private void handleExpectedException(final TestStatement testStatement, final Exception e) {
+  private void handleExpectedException(final TestStatement testStatement, final Throwable e) {
     if (expectedException == null && expectedMessage == null) {
       throw new KsqlTestException(testStatement, file, e);
     }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -327,9 +327,9 @@ public class KsqlTesterTest {
     } else if (statement instanceof AssertTombstone) {
       AssertExecutor.assertTombstone(engine, config, (AssertTombstone) statement, driverPipeline);
     } else if (statement instanceof AssertStream) {
-      AssertExecutor.assertStream(((AssertStream) statement));
+      AssertExecutor.assertStream(engine, ((AssertStream) statement));
     } else if (statement instanceof AssertTable) {
-      AssertExecutor.assertTable(((AssertTable) statement));
+      AssertExecutor.assertTable(engine, ((AssertTable) statement));
     }
   }
 

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -124,7 +124,7 @@ CREATE STREAM bar AS SELECT * FROM foo;
 --@test: assert stream with wrong schema should fail
 
 --@expected.error: io.confluent.ksql.util.KsqlException
---@expected.message: Expected schema does not match actual.
+--@expected.message: Expected schema does not match actual
 ----------------------------------------------------------------------------------------------------
 CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
 CREATE STREAM bar AS SELECT * FROM foo;
@@ -135,7 +135,7 @@ ASSERT STREAM bar (id INT KEY, col1 VARCHAR) WITH (kafka_topic='BAR', value_form
 --@test: assert stream with wrong schema (key) should fail
 
 --@expected.error: io.confluent.ksql.util.KsqlException
---@expected.message: Expected schema does not match actual.
+--@expected.message: Expected schema does not match actual
 ----------------------------------------------------------------------------------------------------
 CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
 CREATE STREAM bar AS SELECT * FROM foo;
@@ -146,7 +146,7 @@ ASSERT STREAM bar (id INT, col1 VARCHAR) WITH (kafka_topic='BAR', value_format='
 --@test: assert stream with wrong type should fail
 
 --@expected.error: io.confluent.ksql.util.KsqlException
---@expected.message: Expected source `BAR` to be a TABLE but was KSTREAM
+--@expected.message: Expected type does not match actual for source BAR
 ----------------------------------------------------------------------------------------------------
 CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
 CREATE STREAM bar AS SELECT * FROM foo;
@@ -157,7 +157,7 @@ ASSERT TABLE bar (id INT PRIMARY KEY, col1 INT) WITH (kafka_topic='BAR', value_f
 --@test: assert stream with wrong topic should fail
 
 --@expected.error: io.confluent.ksql.util.KsqlException
---@expected.message: Expected source `BAR` to have kafka topic BAR but was BAZ
+--@expected.message: Expected kafka topic does not match actual for source BAR
 ----------------------------------------------------------------------------------------------------
 CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
 CREATE STREAM bar AS SELECT * FROM foo;
@@ -168,9 +168,42 @@ ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAZ', value_format='
 --@test: assert stream with wrong topic format should fail
 
 --@expected.error: io.confluent.ksql.util.KsqlException
---@expected.message: Expected source `BAR` to have value format of FormatInfo{format=JSON, properties={}} but got FormatInfo{format=AVRO, properties={}}
+--@expected.message: Expected value format does not match actual for source BAR
 ----------------------------------------------------------------------------------------------------
 CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
 CREATE STREAM bar AS SELECT * FROM foo;
 
 ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='AVRO');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong timestamp column
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected timestamp column does not match actual for source BAR.
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 BIGINT, col2 BIGINT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar WITH(timestamp='col1') AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 BIGINT, col2 BIGINT) WITH (kafka_topic='BAR', value_format='JSON', timestamp='col2');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong timestamp format
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected timestamp format does not match actual for source BAR.
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 VARCHAR) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar WITH(timestamp='col1', timestamp_format='yyyy') AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 VARCHAR) WITH (kafka_topic='BAR', value_format='JSON', timestamp='col1', timestamp_format='mm');
+
+----------------------------------------------------------------------------------------------------
+--@test: assert stream with wrong topic should fail
+
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: Expected serde options does not match actual for source BAR
+----------------------------------------------------------------------------------------------------
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON', wrap_single_value=false);

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -103,7 +103,7 @@ ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
 ----------------------------------------------------------------------------------------------------
 --@test: bad assert statement should fail
 
---@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.error: java.lang.AssertionError
 --@expected.message: Expected record does not match actual
 ----------------------------------------------------------------------------------------------------
 CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');


### PR DESCRIPTION
### Description 

fixes #6112 - implements this functionality into the KsqlTester

### Testing done 

added tests in `test.sql`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

