### PR TITLE
chore: support RUN SCRIPT in KsqlTester

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/parser/SqlTestReader.java
@@ -19,13 +19,21 @@ import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.parser.AstBuilder;
 import io.confluent.ksql.parser.CaseInsensitiveStream;
 import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.ParsingException;
 import io.confluent.ksql.parser.SqlBaseLexer;
 import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.SqlBaseParser.TestStatementContext;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.ParserUtil;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Deque;
 import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStream;
@@ -63,6 +71,9 @@ public final class SqlTestReader implements Iterator<TestStatement> {
 
   private final SqlBaseParser parser;
   private final CommonTokenStream tks;
+
+  /* used to evaluate RunScript statements one at a time*/
+  private final Deque<ParsedStatement> cachedRunScript = new LinkedList<>();
 
   /* indicates the latest index in tks that has been scanned for directives */
   private int directiveIdx = 0;
@@ -104,6 +115,7 @@ public final class SqlTestReader implements Iterator<TestStatement> {
   @Override
   public boolean hasNext() {
     return cachedStatement
+        || !cachedRunScript.isEmpty()
         || !parser.isMatchedEOF()
         || hasMoreDirectives();
   }
@@ -119,6 +131,10 @@ public final class SqlTestReader implements Iterator<TestStatement> {
 
   @Override
   public TestStatement next() {
+    if (!cachedRunScript.isEmpty()) {
+      return TestStatement.of(cachedRunScript.removeFirst());
+    }
+
     // because the parser skips over non-default (SqlBaseLexer.DIRECTIVES) channels,
     // we need to first get the next test statement and then check if we "skipped"
     // over any comments that contain directives. if we find any directives, we
@@ -143,9 +159,9 @@ public final class SqlTestReader implements Iterator<TestStatement> {
       return TestStatement.of(
           DefaultKsqlParser.parsedStatement(testStatement.singleStatement())
       );
-    }
-
-    if (testStatement.assertStatement() != null) {
+    } else if (testStatement.runScript() != null) {
+      return handleRunScript();
+    } else if (testStatement.assertStatement() != null) {
       return TestStatement.of(
           new AstBuilder(TypeRegistry.EMPTY)
               .buildAssertStatement(testStatement.assertStatement())
@@ -153,6 +169,23 @@ public final class SqlTestReader implements Iterator<TestStatement> {
     }
 
     throw new IllegalStateException("Unexpected parse tree for statement " + testStatement);
+  }
+
+  private TestStatement handleRunScript() {
+    final String script = ParserUtil.unquote(testStatement.runScript().STRING().getText(), "'");
+    try {
+      final List<String> lines = Files.readAllLines(
+          Paths.get(ParserUtil.getIdentifierText(script)));
+      cachedRunScript.addAll(new DefaultKsqlParser().parse(String.join("", lines)));
+    } catch (IOException e) {
+      throw new KsqlException(e);
+    }
+
+    if (cachedRunScript.isEmpty()) {
+      throw new IllegalArgumentException("Empty run script: " + script);
+    }
+
+    return TestStatement.of(cachedRunScript.removeFirst());
   }
 
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
@@ -20,12 +20,12 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
 
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.ParsingException;
 import io.confluent.ksql.parser.tree.AssertValues;
 import io.confluent.ksql.test.parser.TestDirective.Type;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -61,29 +61,29 @@ public class SqlTestReaderTest {
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM bar")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("INSERT INTO")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
-        s -> assertThat("unexpected statement " + s, false),
+        s -> fail("unexpected statement " + s),
         s -> assertThat(s, instanceOf(AssertValues.class)),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s)
     );
   }
 
@@ -104,15 +104,15 @@ public class SqlTestReaderTest {
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM bar")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(false));
@@ -135,8 +135,8 @@ public class SqlTestReaderTest {
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
@@ -162,8 +162,8 @@ public class SqlTestReaderTest {
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(false));
@@ -202,15 +202,15 @@ public class SqlTestReaderTest {
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM foo")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(true));
     reader.next().consume(
         s -> assertThat(s.getStatementText(), containsString("CREATE STREAM bar")),
-        s -> assertThat("unexpected statement " + s, false),
-        s -> assertThat("unexpected statement " + s, false)
+        s -> fail("unexpected statement " + s),
+        s -> fail("unexpected statement " + s)
     );
 
     assertThat(reader.hasNext(), is(false));

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
+import com.google.common.base.Charsets;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.ParsingException;
 import io.confluent.ksql.parser.tree.AssertValues;
@@ -187,7 +188,7 @@ public class SqlTestReaderTest {
     final String fileContents =
         "CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='a', value_format='json');\n"
         + "CREATE STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='b', value_format='json');";
-    final Path runScript = Files.write(temporaryFolder.newFile().toPath(), fileContents.getBytes());
+    final Path runScript = Files.write(temporaryFolder.newFile().toPath(), fileContents.getBytes(Charsets.UTF_8));
     final String contents = ""
         + "--@test: test1\n"
         + "RUN SCRIPT '" + runScript.toString() + "';";

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/asserts.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/asserts.json
@@ -9,6 +9,16 @@
         "type": "io.confluent.ksql.parser.exception.ParseFailedException",
         "message": "mismatched input 'ASSERT'"
       }
+    },
+    {
+      "name": "should not parse RUN SCRIPT",
+      "statements": [
+        "RUN SCRIPT 'foo';"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "mismatched input 'RUN'"
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test-script.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test-script.sql
@@ -1,0 +1,2 @@
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test-script.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test-script.sql
@@ -1,2 +1,0 @@
-CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
-CREATE STREAM bar AS SELECT * FROM foo;

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -86,6 +86,19 @@ INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
 ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 2);
 
 ----------------------------------------------------------------------------------------------------
+--@test: basic test with run script
+----------------------------------------------------------------------------------------------------
+-- contents of script:
+-- CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+-- CREATE STREAM bar AS SELECT * FROM foo;
+RUN SCRIPT './src/test/resources/sql-tests/test-script.sql';
+
+ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON');
+
+INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
+ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);
+
+----------------------------------------------------------------------------------------------------
 --@test: bad assert statement should fail
 
 --@expected.error: io.confluent.ksql.util.KsqlException

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -91,7 +91,7 @@ ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 2);
 -- contents of script:
 -- CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
 -- CREATE STREAM bar AS SELECT * FROM foo;
-RUN SCRIPT './src/test/resources/sql-tests/test-script.sql';
+RUN SCRIPT './src/test/resources/test-script.sql';
 
 ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON');
 

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/test.sql
@@ -91,9 +91,7 @@ ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 2);
 -- contents of script:
 -- CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
 -- CREATE STREAM bar AS SELECT * FROM foo;
-RUN SCRIPT './src/test/resources/test-script.sql';
-
-ASSERT STREAM bar (id INT KEY, col1 INT) WITH (kafka_topic='BAR', value_format='JSON');
+RUN SCRIPT '/test-script.sql';
 
 INSERT INTO foo (rowtime, id, col1) VALUES (1, 1, 1);
 ASSERT VALUES bar (rowtime, id, col1) VALUES (1, 1, 1);

--- a/ksqldb-functional-tests/src/test/resources/test-script.sql
+++ b/ksqldb-functional-tests/src/test/resources/test-script.sql
@@ -1,0 +1,5 @@
+-- a test script used in sql-tests/test.sql
+-- NOTE: do not move this test to within the sql-tests dir because it will be
+-- picked up and attempted to execute as a full test by the test framework
+CREATE STREAM foo (id INT KEY, col1 INT) WITH (kafka_topic='foo', value_format='JSON');
+CREATE STREAM bar AS SELECT * FROM foo;

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -33,7 +33,7 @@ statements
     ;
 
 testStatement
-    : (singleStatement | assertStatement ';') EOF?
+    : (singleStatement | assertStatement ';' | runScript ';') EOF?
     ;
 
 singleStatement
@@ -88,6 +88,10 @@ assertStatement
     | ASSERT NULL VALUES sourceName (columns)? KEY values                   #assertTombstone
     | ASSERT STREAM sourceName (tableElements)? (WITH tableProperties)?     #assertStream
     | ASSERT TABLE sourceName (tableElements)? (WITH tableProperties)?      #assertTable
+    ;
+
+runScript
+    : RUN SCRIPT STRING
     ;
 
 query


### PR DESCRIPTION
fixes #6114 

### Description 
Allows the testing tool to accept `RUN SCRIPT`, which allows advanced CI/CD use cases where the scripts get deployed directly to production.

### Testing done 
- Unit testing
- a new test case in `test.sql` using `test-script.sql`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

