### PR TITLE
fix: create /var/lib/kafka-streams directory on RPM installation

### DIFF
--- a/debian/confluent-ksqldb.postinst
+++ b/debian/confluent-ksqldb.postinst
@@ -11,35 +11,35 @@ case "$1" in
         adduser --system --disabled-password --disabled-login --home /var/empty \
                 --no-create-home --quiet --force-badname --ingroup $_group $_user
                 
-  # Set explicit kafka-streams directory if not set
-  ksqldb_config=/etc/ksqldb/ksql-server.properties
-  if [ -f $ksqldb_config ]; then
-    if ! grep '^state.dir=' $ksqldb_config >/dev/null 2>&1; then
-      echo "state.dir=/var/lib/kafka-streams" >> $ksqldb_config
-    fi
-  fi                
+	# Set explicit kafka-streams directory if not set
+	ksqldb_config=/etc/ksqldb/ksql-server.properties
+	if [ -f $ksqldb_config ]; then
+		if ! grep '^state.dir=' $ksqldb_config >/dev/null 2>&1; then
+			echo "state.dir=/var/lib/kafka-streams" >> $ksqldb_config
+		fi
+	fi
 
 	_permwarn=
 	for dir in /var/log/confluent /var/lib/kafka-streams ; do
 		# Confluent log and kafka-streams directories should be writable by group
 		_perm="chown ${_user}:${_group} $dir && chmod u+wx,g+wx,o= $dir"
 
-    if [ ! -d $dir ]; then
-      echo "Creating directory $dir with owner $_user:$_group"
-      mkdir -p $dir
-      eval $_perm
-    else
-      echo "Notice: Not creating existing directory $dir, ensure proper permissions for user $_user group $_group"
-      _permwarn="${_permwarn}${_perm}\n"
-    fi
+		if [ ! -d $dir ]; then
+			echo "Creating directory $dir with owner $_user:$_group"
+			mkdir -p $dir
+			eval $_perm
+		else
+			echo "Notice: Not creating existing directory $dir, ensure proper permissions for user $_user group $_group"
+			_permwarn="${_permwarn}${_perm}\n"
+		fi
 	done
 
 	if [ -n "$_permwarn" ]; then
-	    echo "Notice: If you are planning to use the provided systemd service units for"
-	    echo "Notice: confluent-ksql, make sure that read-write permissions"
-	    echo "Notice: for user $_user and group $_group are set up according to the"
-	    echo "Notice: following commands:"
-	    /bin/echo -e "$_permwarn"
+		echo "Notice: If you are planning to use the provided systemd service units for"
+		echo "Notice: confluent-ksql, make sure that read-write permissions"
+		echo "Notice: for user $_user and group $_group are set up according to the"
+		echo "Notice: following commands:"
+		/bin/echo -e "$_permwarn"
 	fi
         ;;
 esac

--- a/debian/confluent-ksqldb.postinst
+++ b/debian/confluent-ksqldb.postinst
@@ -10,25 +10,28 @@ case "$1" in
 	(getent group $_group 2>&1 >/dev/null) || addgroup --quiet --system $_group
         adduser --system --disabled-password --disabled-login --home /var/empty \
                 --no-create-home --quiet --force-badname --ingroup $_group $_user
+                
+  # Set explicit kafka-streams directory if not set
+  ksqldb_config=/etc/ksqldb/ksql-server.properties
+  if [ -f $ksqldb_config ]; then
+    if ! grep '^state.dir=' $ksqldb_config >/dev/null 2>&1; then
+      echo "state.dir=/var/lib/kafka-streams" >> $ksqldb_config
+    fi
+  fi                
 
 	_permwarn=
-	for dir in /var/log/confluent ; do
-	    if [ $dir = /var/log/confluent ]; then
-		# Confluent log directory should be writable by group
+	for dir in /var/log/confluent /var/lib/kafka-streams ; do
+		# Confluent log and kafka-streams directories should be writable by group
 		_perm="chown ${_user}:${_group} $dir && chmod u+wx,g+wx,o= $dir"
-	    else
-		# Other dirs are only readable by group
-		_perm="chown ${_user}:${_group} $dir && chmod u+wx,g+r,o= $dir"
-	    fi
 
-	    if [ ! -d $dir ]; then
-		echo "Creating directory $dir with owner $_user:$_group"
-		mkdir -p $dir
-		eval $_perm
-	    else
-		echo "Notice: Not creating existing directory $dir, ensure proper permissions for user $_user group $_group"
-		_permwarn="${_permwarn}${_perm}\n"
-	    fi
+    if [ ! -d $dir ]; then
+      echo "Creating directory $dir with owner $_user:$_group"
+      mkdir -p $dir
+      eval $_perm
+    else
+      echo "Notice: Not creating existing directory $dir, ensure proper permissions for user $_user group $_group"
+      _permwarn="${_permwarn}${_perm}\n"
+    fi
 	done
 
 	if [ -n "$_permwarn" ]; then

--- a/debian/confluent-ksqldb.spec.in
+++ b/debian/confluent-ksqldb.spec.in
@@ -27,16 +27,19 @@ _group=confluent
 getent group $_group 2>&1 >/dev/null || groupadd -r $_group
 getent passwd $_user 2>&1 >/dev/null || \
     useradd -r -g $_group --home-dir /tmp --no-create-home -s /sbin/nologin -c "Confluent KSQL" $_user
+    
+# Set explicit kafka-streams directory if not set
+ksqldb_config=/etc/ksqldb/ksql-server.properties
+if [ -f $ksqldb_config ]; then
+  if ! grep '^state.dir=' $ksqldb_config >/dev/null 2>&1; then
+    echo "state.dir=/var/lib/kafka-streams" >> $ksqldb_config
+  fi
+fi    
 
 _permwarn=
-for dir in /var/log/confluent ; do
-    if [ $dir = /var/log/confluent ]; then
-        # Confluent log directory should be writable by group
-        _perm="chown ${_user}:${_group} $dir && chmod u+wx,g+wx,o= $dir"
-    else
-        # Other dirs are only readable by group
-        _perm="chown ${_user}:${_group} $dir && chmod u+wx,g+r,o= $dir"
-    fi
+for dir in /var/log/confluent /var/lib/kafka-streams ; do
+    # Confluent log and kafka-streams directories should be writable by group
+    _perm="chown ${_user}:${_group} $dir && chmod u+wx,g+wx,o= $dir"
 
     if [ ! -d $dir ]; then
         echo "Creating directory $dir with owner $_user:$_group"
@@ -79,6 +82,7 @@ fi
 %{__rm} %{buildroot}/confluent-ksqldb.spec
 
 %{__mkdir_p} %{buildroot}/var/log/confluent
+%{__mkdir_p} %{buildroot}/var/lib/kafka-streams
 
 
 %files


### PR DESCRIPTION
### Description 
When installing ksqlDB using RPM/DEB packages, the `/var/lib/kafka-streams` directory cannot be created because lack of write permissions in `/var/lib`. To fix this, this PR creates the streams directory during the RPM installation.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

