### PR TITLE
 fix: wrong value schema being registered for unwrapped primitives 

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -523,6 +523,7 @@ public class KsqlConfig extends AbstractConfig {
             SCHEMA_REGISTRY_URL_PROPERTY,
             ConfigDef.Type.STRING,
             "",
+            new ConfigDef.NonNullValidator(),
             ConfigDef.Importance.MEDIUM,
             "The URL for the schema registry"
         ).define(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -15,16 +15,15 @@
 
 package io.confluent.ksql.util;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
 import io.confluent.ksql.execution.plan.Formats;
-import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.avro.AvroFormat;
-import io.confluent.ksql.serde.avro.AvroSchemas;
 import java.io.IOException;
 import org.apache.hc.core5.http.HttpStatus;
 
@@ -44,26 +43,22 @@ public final class AvroUtil {
       return;
     }
 
-    final PhysicalSchema physicalSchema = PhysicalSchema.from(
-        ddl.getSchema(),
-        formats.getOptions()
-    );
-    final org.apache.avro.Schema avroSchema = AvroSchemas.getAvroSchema(
-        physicalSchema.valueSchema(),
-        format.getProperties()
-            .getOrDefault(AvroFormat.FULL_SCHEMA_NAME, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME)
+    final AvroSchema parsedSchema = (AvroSchema) new AvroFormat().toParsedSchema(
+        ddl.getSchema().value(),
+        formats.getOptions(),
+        formats.getValueFormat()
     );
 
     final String topicName = ddl.getTopicName();
 
-    if (!isValidAvroSchemaForTopic(topicName, avroSchema, schemaRegistryClient)) {
+    if (!isValidAvroSchemaForTopic(topicName, parsedSchema, schemaRegistryClient)) {
       throw new KsqlStatementException(String.format(
           "Cannot register avro schema for %s as the schema is incompatible with the current "
               + "schema version registered for the topic.%n"
               + "KSQL schema: %s%n"
               + "Registered schema: %s",
           topicName,
-          avroSchema,
+          parsedSchema,
           getRegisteredSchema(topicName, schemaRegistryClient)
       ), statementText);
     }
@@ -83,12 +78,12 @@ public final class AvroUtil {
 
   private static boolean isValidAvroSchemaForTopic(
       final String topicName,
-      final org.apache.avro.Schema avroSchema,
+      final ParsedSchema schema,
       final SchemaRegistryClient schemaRegistryClient
   ) {
     try {
       return schemaRegistryClient.testCompatibility(
-          topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, new AvroSchema(avroSchema));
+          topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, schema);
     } catch (final IOException e) {
       throw new KsqlException(String.format(
           "Could not check Schema compatibility: %s", e.getMessage()

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -131,10 +131,7 @@ public class TestExecutor implements Closeable {
   ) {
     topicInfoCache.clear();
 
-    final KsqlConfig currentConfigs = new KsqlConfig(config);
-    final Map<String, String> persistedConfigs = testCase.persistedProperties();
-    final KsqlConfig ksqlConfig = persistedConfigs.isEmpty() ? currentConfigs :
-        currentConfigs.overrideBreakingConfigsWithOriginalValues(persistedConfigs);
+    final KsqlConfig ksqlConfig = testCase.applyPersistedProperties(new KsqlConfig(config));
 
     try {
       final List<TopologyTestDriverContainer> topologyTestDrivers = topologyBuilder

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanLoader.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanLoader.java
@@ -217,7 +217,7 @@ public final class TestCasePlanLoader {
   ) {
     final TestInfoGatherer testInfo = executeTestCaseAndGatherInfo(testCase);
 
-    final List<TopicNode> allTopicNodes = getTopicsFromTestCase(testCase);
+    final List<TopicNode> allTopicNodes = getTopicsFromTestCase(testCase, configs);
 
     final TestCaseNode testCodeNode = new TestCaseNode(
         simpleTestName,
@@ -251,13 +251,17 @@ public final class TestCasePlanLoader {
     );
   }
 
-  private static List<TopicNode> getTopicsFromTestCase(final TestCase testCase) {
+  private static List<TopicNode> getTopicsFromTestCase(
+      final TestCase testCase,
+      final Map<?, ?> configs
+  ) {
     final Collection<Topic> allTopics = TestCaseBuilderUtil.getAllTopics(
         testCase.statements(),
         testCase.getTopics(),
         testCase.getOutputRecords(),
         testCase.getInputRecords(),
-        TestFunctionRegistry.INSTANCE.get()
+        TestFunctionRegistry.INSTANCE.get(),
+        new KsqlConfig(configs)
     );
 
     return allTopics.stream()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.TopicInfoCache;
 import io.confluent.ksql.test.tools.TopicInfoCache.TopicInfo;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.RetryUtil;
@@ -165,7 +166,8 @@ public class RestTestExecutor implements Closeable {
         testCase.getTopics(),
         testCase.getOutputRecords(),
         testCase.getInputRecords(),
-        TestFunctionRegistry.INSTANCE.get()
+        TestFunctionRegistry.INSTANCE.get(),
+        new KsqlConfig(testCase.getProperties())
     );
 
     topics.forEach(topic -> {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_serialization_should_produce_primitive_schema_for_unwrapped/6.1.0_1599053522062/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_serialization_should_produce_primitive_schema_for_unwrapped/6.1.0_1599053522062/plan.json
@@ -1,0 +1,142 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, FOO STRING) WITH (KAFKA_TOPIC='input_topic', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `FOO` STRING",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `FOO` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        },
+        "options" : [ "UNWRAP_SINGLE_VALUES" ]
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `FOO` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "FOO AS FOO" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "options" : [ "UNWRAP_SINGLE_VALUES" ]
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_serialization_should_produce_primitive_schema_for_unwrapped/6.1.0_1599053522062/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_serialization_should_produce_primitive_schema_for_unwrapped/6.1.0_1599053522062/spec.json
@@ -1,0 +1,98 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1599053522062,
+  "path" : "query-validation-tests/serdes.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `FOO` STRING",
+      "serdeOptions" : [ ]
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `FOO` STRING",
+      "serdeOptions" : [ "UNWRAP_SINGLE_VALUES" ]
+    }
+  },
+  "testCase" : {
+    "name" : "serialization should produce primitive schema for unwrapped",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "foo" : "bar"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : "bar"
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "schema" : "string",
+      "format" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "input_topic",
+      "schema" : {
+        "type" : "record",
+        "name" : "KsqlDataSourceSchema",
+        "namespace" : "io.confluent.ksql.avro_schemas",
+        "fields" : [ {
+          "name" : "FOO",
+          "type" : [ "null", "string" ],
+          "default" : null
+        } ],
+        "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+      },
+      "format" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, foo STRING) WITH (kafka_topic='input_topic', value_format='AVRO');", "CREATE STREAM OUTPUT WITH (wrap_single_value=false) AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `FOO` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ "UNWRAP_SINGLE_VALUES" ]
+      }, {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `FOO` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_serialization_should_produce_primitive_schema_for_unwrapped/6.1.0_1599053522062/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_serialization_should_produce_primitive_schema_for_unwrapped/6.1.0_1599053522062/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/serdes.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/serdes.json
@@ -25,6 +25,41 @@
       }
     },
     {
+      "name": "serialization should produce primitive schema for unwrapped",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, foo STRING) WITH (kafka_topic='input_topic', value_format='AVRO');",
+        "CREATE STREAM OUTPUT WITH (wrap_single_value=false) AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {"name": "OUTPUT", "schema": "string"}
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": "bar"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": "bar"}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "K STRING KEY, FOO STRING", "serdeOptions": ["UNWRAP_SINGLE_VALUES"]}
+        ]
+      }
+    },
+    {
+      "name": "serialization should fail if primitive schema not compatible with existing value schema - AVRO",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, foo STRING) WITH (kafka_topic='input_topic', value_format='AVRO');",
+        "CREATE STREAM OUTPUT WITH (wrap_single_value=false) AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {"name": "OUTPUT", "schema": {"name": "KsqlRecord", "type": "record", "fields": [{"name": "FOO", "type": "string"}]}}
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Cannot register avro schema for OUTPUT as the schema is incompatible with the current schema version registered for the topic."
+      }
+    },
+    {
       "name": "C* should throw for multi-field schema if WRAP_SINGLE_VALUE=true",
       "statements": [
         "CREATE STREAM INPUT (K STRING KEY, f0 STRING, f1 STRING) WITH (WRAP_SINGLE_VALUE=true, kafka_topic='input_topic', value_format='JSON');"

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
@@ -95,10 +95,14 @@ public interface Format {
    * {@link ParsedSchema} with which to populate the Schema Registry.
    *
    * @param columns the list of columns
+   * @param serdeOptions the serde options
    * @param formatInfo the format info potentially containing additional info required to convert
    * @return the {@code ParsedSchema} which will be added to the Schema Registry
    */
-  default ParsedSchema toParsedSchema(List<? extends SimpleColumn> columns, FormatInfo formatInfo) {
+  default ParsedSchema toParsedSchema(
+      List<? extends SimpleColumn> columns,
+      SerdeOptions serdeOptions,
+      FormatInfo formatInfo) {
     throw new KsqlException("Format does not implement Schema Registry support: " + name());
   }
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroSchemas.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroSchemas.java
@@ -19,27 +19,17 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import io.confluent.connect.avro.AvroData;
-import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
-public final class AvroSchemas {
+final class AvroSchemas {
+
   private AvroSchemas() {
   }
 
-  public static org.apache.avro.Schema getAvroSchema(
-      final PersistenceSchema schema,
-      final String name
-  ) {
-    return new AvroData(0).fromConnectSchema(
-        getAvroCompatibleConnectSchema(schema.serializedSchema(), name)
-    );
-  }
-
-  public static Schema getAvroCompatibleConnectSchema(
+  static Schema getAvroCompatibleConnectSchema(
       final Schema schema,
       final String schemaFullName
   ) {


### PR DESCRIPTION
### Description 

fixes: #6134

Fixes an issue where the wrong schema is registered for unwrapped primitive values. The registered schema  incorrectly still has the value column wrapping in a record.

As part of this work `AvroSchemas` is now package private, and `AvroFormat` is used in its place in the code.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

