### PR TITLE
test: stabilise TlsTest

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
@@ -117,20 +117,6 @@ public class FileWatcherTest {
     assertThatEventually(watcher::isAlive, is(false));
   }
 
-  @Test
-  public void willStopIfDirectoryRenamed() throws Exception {
-    // Given:
-    watcher = new FileWatcher(filePath, callback);
-    watcher.start();
-
-    // When:
-    Files.move(filePath.getParent(), filePath.getParent().getParent().resolve("new"));
-
-    // Then:
-    verify(callback, never()).run();
-    assertThatEventually(watcher::isAlive, is(false));
-  }
-
   /**
    * Resolution of {@link FileTime} on some OS / JDKs can have only second resolution. This can mean
    * the watcher 'misses' an update to a file that was <i>created</i> before the watcher was started

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.server;
+
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import io.confluent.ksql.api.server.FileWatcher.Callback;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FileWatcherTest {
+
+  @ClassRule
+  public static final TemporaryFolder TMP = new TemporaryFolder();
+
+  @Mock
+  private Callback callback;
+  public Path filePath;
+  private FileWatcher watcher;
+  private byte[] someBytes;
+
+  @Before
+  public void setUp() throws Exception {
+    filePath = TMP.newFolder().toPath().resolve(UUID.randomUUID().toString());
+    someBytes = "data".getBytes(UTF_8);
+  }
+
+  @After
+  public void tearDown() {
+    watcher.shutdown();
+  }
+
+  @Test
+  public void shouldDetectFileCreated() throws Exception {
+    // Given:
+    watcher = new FileWatcher(filePath, callback);
+    watcher.start();
+
+    // When:
+    Files.write(filePath, someBytes, StandardOpenOption.CREATE_NEW);
+
+    // Then:
+    verify(callback, timeout(TimeUnit.MINUTES.toMillis(1))).run();
+  }
+
+  @Test
+  public void shouldDetectFileUpdated() throws Exception {
+    // Given:
+    Files.write(filePath, someBytes, StandardOpenOption.CREATE_NEW);
+
+    waitForLastModifiedTick();
+
+    watcher = new FileWatcher(filePath, callback);
+    watcher.start();
+
+    // When:
+    Files.write(filePath, someBytes);
+
+    // Then:
+    verify(callback, timeout(TimeUnit.MINUTES.toMillis(1))).run();
+  }
+
+  @Test
+  public void shouldShutdownAsync() throws Exception {
+    watcher = new FileWatcher(filePath, callback);
+    watcher.start();
+
+    // When:
+    watcher.shutdown();
+
+    // Then:
+    assertThatEventually(watcher::isAlive, is(false));
+  }
+
+  @Test
+  public void willStopIfDirectoryDeleted() throws Exception {
+    // Given:
+    watcher = new FileWatcher(filePath, callback);
+    watcher.start();
+
+    // When:
+    Files.delete(filePath.getParent());
+
+    // Then:
+    verify(callback, never()).run();
+    assertThatEventually(watcher::isAlive, is(false));
+  }
+
+  @Test
+  public void willStopIfDirectoryRenamed() throws Exception {
+    // Given:
+    watcher = new FileWatcher(filePath, callback);
+    watcher.start();
+
+    // When:
+    Files.move(filePath.getParent(), filePath.getParent().getParent().resolve("new"));
+
+    // Then:
+    verify(callback, never()).run();
+    assertThatEventually(watcher::isAlive, is(false));
+  }
+
+  /**
+   * Resolution of {@link FileTime} on some OS / JDKs can have only second resolution. This can mean
+   * the watcher 'misses' an update to a file that was <i>created</i> before the watcher was started
+   * and <i>updated</i> after, if the update results in the same last modified time.
+   *
+   * <p>To ensure we stable test we must therefore wait for a second to ensure a different last
+   * modified time.
+   *
+   * https://stackoverflow.com/questions/24804618/get-file-mtime-with-millisecond-resolution-from-java
+   */
+  private static void waitForLastModifiedTick() throws Exception {
+    Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+  }
+}

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/secure/KeyStoreUtil.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/secure/KeyStoreUtil.java
@@ -43,9 +43,8 @@ public final class KeyStoreUtil {
       final File tempFile = TestUtils.tempFile();
       final Path path = tempFile.toPath();
 
-      putStore(path, base64EncodedStore);
+      putStore(name, path, base64EncodedStore);
 
-      System.out.println("Wrote temporary " + name + " for testing: " + path);
       return path;
     } catch (final Exception e) {
       throw new RuntimeException("Failed to create temporary store", e);
@@ -57,10 +56,13 @@ public final class KeyStoreUtil {
    * @param path                the path to write to.
    * @param base64EncodedStore  the base64 encoded store content.
    */
-  public static void putStore(final Path path, final String base64EncodedStore) {
+  public static void putStore(final String name, final Path path, final String base64EncodedStore) {
     try {
       final byte[] decoded = Base64.getDecoder().decode(base64EncodedStore);
+
       Files.write(path, decoded);
+      System.out.println("Wrote temporary " + name + " for testing: " + path);
+
     } catch (final Exception e) {
       throw new RuntimeException("Failed to put store", e);
     }

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/secure/ServerKeyStore.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/secure/ServerKeyStore.java
@@ -21,15 +21,11 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.common.config.SslConfigs;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Helper for creating a client key store to enable SSL in tests.
  */
 public final class ServerKeyStore {
-
-  private static final Logger log = LoggerFactory.getLogger(ServerKeyStore.class);
 
   private static final String BASE64_ENCODED_STORE =
       "/u3+7QAAAAIAAAACAAAAAgAGY2Fyb290AAABYgp9KI4ABVguNTA5AAADLDCCAygwggIQAgkAvZW/3jNCgKgwDQYJKoZI"
@@ -139,7 +135,7 @@ public final class ServerKeyStore {
   /**
    * @return props brokers will need to connect to support SSL connections.
    *         The store at this path may be replaced with an expired store via the method
-   *         {@link #loadExpiredServerKeyStore}.
+   *         {@link #writeExpiredServerKeyStore}.
    */
   public Map<String, String> keyStoreProps() {
     return ImmutableMap.of(
@@ -154,7 +150,7 @@ public final class ServerKeyStore {
   /**
    * @return props clients may use to connect to support SSL connections.
    *         In contrast to {@link #keyStoreProps}, the store at this path will not replaced
-   *         with an expired store when the method {@link #loadExpiredServerKeyStore} is called.
+   *         with an expired store when the method {@link #writeExpiredServerKeyStore} is called.
    */
   public Map<String, String> clientKeyStoreProps() {
     return ImmutableMap.of(
@@ -166,14 +162,20 @@ public final class ServerKeyStore {
     );
   }
 
-  public void loadExpiredServerKeyStore() {
-    KeyStoreUtil.putStore(Paths.get(keyStorePath()), EXPIRED_BASE64_ENCODED_STORE);
-    log.info("Loaded expired store");
+  public void writeExpiredServerKeyStore() {
+    KeyStoreUtil.putStore(
+        "expired-server-key-store",
+        Paths.get(keyStorePath()),
+        EXPIRED_BASE64_ENCODED_STORE
+    );
   }
 
-  public void loadValidServerKeyStore() {
-    KeyStoreUtil.putStore(Paths.get(keyStorePath()), BASE64_ENCODED_STORE);
-    log.info("Loaded valid store");
+  public void writeValidServerKeyStore() {
+    KeyStoreUtil.putStore(
+        "valid-server-key-store",
+        Paths.get(keyStorePath()),
+        BASE64_ENCODED_STORE
+    );
   }
 
   private String keyStorePath() {


### PR DESCRIPTION
### Description 

fixes an issue where the TlsTest was failing because the file watcher wasn't detecting the change of the Tls cert from valid to invalid.  This was because of a limitation of JDK 8, which has only second resolution for `FileTime`, meaning the `WatchService` can miss updated made to files that existed before the watch was registered, if the update happened after the watch was started and the updated didn't change the last modified time, i.e. the last modified time both before and after the update was in the second second.

The fix is to insert a sleep to ensure at least one whole second has elapsed.

In production code, this one second window of bad behaviour is highly unlikely to be hit, and there's no real way to solve it, except upgrading to JDK 9.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

