### PR TITLE
test: avoid noise in test logs (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -115,6 +115,7 @@ public class BaseApiTest {
     if (server != null) {
       try {
         server.stop();
+        server = null;
       } catch (Exception e) {
         log.error("Failed to shutdown server", e);
       }
@@ -125,6 +126,7 @@ public class BaseApiTest {
     if (client != null) {
       try {
         client.close();
+        client = null;
       } catch (Exception e) {
         log.error("Failed to close client", e);
       }
@@ -134,7 +136,13 @@ public class BaseApiTest {
   protected void createServer(KsqlRestConfig serverConfig) {
     server = new Server(vertx, serverConfig, testEndpoints,
         new KsqlDefaultSecurityExtension(), Optional.empty(), serverState);
-    server.start();
+
+    try {
+      server.start();
+    } catch (final Exception e) {
+      server = null;
+      throw e;
+    }
   }
 
   protected KsqlRestConfig createServerConfig() {

--- a/ksqldb-test-util/src/main/resources/log4j.properties
+++ b/ksqldb-test-util/src/main/resources/log4j.properties
@@ -18,31 +18,32 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-# Disable INFO logs from Config classes, which log out their config on each creation:
-log4j.logger.io.confluent.connect.avro.AvroConverterConfig=WARN
-log4j.logger.io.confluent.connect.avro.AvroDataConfig=WARN
-log4j.logger.io.confluent.kafka.serializers.KafkaAvroDeserializerConfig=WARN
-log4j.logger.io.confluent.kafka.serializers.KafkaAvroSerializerConfig=WARN
-log4j.logger.io.confluent.kafka.serializers.KafkaJsonDeserializerConfig=WARN
-log4j.logger.io.confluent.kafka.serializers.KafkaJsonSerializerConfig=WARN
-log4j.logger.io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerConfig=WARN
-log4j.logger.io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializerConfig=WARN
-log4j.logger.io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig=WARN
-log4j.logger.io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig=WARN
-log4j.logger.io.confluent.ksql.logging.processing.ProcessingLogConfig=WARN
-log4j.logger.io.confluent.ksql.rest.server.KsqlRestConfig=WARN
-log4j.logger.io.confluent.ksql.util.KsqlConfig=WARN
-log4j.logger.io.confluent.ksql.cli.console.CliConfig=WARN
-log4j.logger.kafka.server.KafkaConfig=WARN
-log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=WARN
-log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=WARN
-log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=WARN
-log4j.logger.org.apache.kafka.connect.json.JsonConverterConfig=WARN
-log4j.logger.io.confluent.connect.json.JsonSchemaConverterConfig=WARN
-log4j.logger.io.confluent.connect.json.JsonSchemaDataConfig=WARN
-log4j.logger.io.confluent.connect.protobuf.ProtobufDataConfig=WARN
-log4j.logger.io.confluent.connect.protobuf.ProtobufConverterConfig=WARN
-log4j.logger.org.apache.kafka.streams.StreamsConfig=WARN
+# Disable INFO and WARN logs from Config classes, which log out their config on each creation
+# and warnings for any unknown config:
+log4j.logger.io.confluent.connect.avro.AvroConverterConfig=ERROR
+log4j.logger.io.confluent.connect.avro.AvroDataConfig=ERROR
+log4j.logger.io.confluent.kafka.serializers.KafkaAvroDeserializerConfig=ERROR
+log4j.logger.io.confluent.kafka.serializers.KafkaAvroSerializerConfig=ERROR
+log4j.logger.io.confluent.kafka.serializers.KafkaJsonDeserializerConfig=ERROR
+log4j.logger.io.confluent.kafka.serializers.KafkaJsonSerializerConfig=ERROR
+log4j.logger.io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerConfig=ERROR
+log4j.logger.io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializerConfig=ERROR
+log4j.logger.io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig=ERROR
+log4j.logger.io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig=ERROR
+log4j.logger.io.confluent.ksql.logging.processing.ProcessingLogConfig=ERROR
+log4j.logger.io.confluent.ksql.rest.server.KsqlRestConfig=ERROR
+log4j.logger.io.confluent.ksql.util.KsqlConfig=ERROR
+log4j.logger.io.confluent.ksql.cli.console.CliConfig=ERROR
+log4j.logger.kafka.server.KafkaConfig=ERROR
+log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=ERROR
+log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=ERROR
+log4j.logger.org.apache.kafka.connect.json.JsonConverterConfig=ERROR
+log4j.logger.io.confluent.connect.json.JsonSchemaConverterConfig=ERROR
+log4j.logger.io.confluent.connect.json.JsonSchemaDataConfig=ERROR
+log4j.logger.io.confluent.connect.protobuf.ProtobufDataConfig=ERROR
+log4j.logger.io.confluent.connect.protobuf.ProtobufConverterConfig=ERROR
+log4j.logger.org.apache.kafka.streams.StreamsConfig=ERROR
 
 # Disable INFO logging from the UDF loader, which logs every UDF ever time it runs:
 log4j.logger.io.confluent.ksql.function.UdfLoader=WARN


### PR DESCRIPTION
### Description 

Tests derived from `BaseApiTest` can generate multiple exceptions in the logs unnecessarily, making it harder to debug issues, because they attempt to close `server` and `client` multiple times.  This change resolves this.

Additionally, our test logs are full of log lines about unknown configs being passed to `XxxxConfig` classes. This warning can be safely ignored (and is), so we shouldn't need to see it in the logs.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

