### PR TITLE
fix: delete zombie consumer groups 🧟

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.engine;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.ServiceInfo;
@@ -47,6 +48,7 @@ import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +61,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   private final ScheduledExecutorService aggregateMetricsCollector;
   private final String serviceId;
   private final EngineContext primaryContext;
+  private final QueryCleanupService cleanupService;
 
   public KsqlEngine(
       final ServiceContext serviceContext,
@@ -89,11 +92,13 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       final Function<KsqlEngine, KsqlEngineMetrics> engineMetricsFactory,
       final QueryIdGenerator queryIdGenerator
   ) {
+    this.cleanupService = new QueryCleanupService();
     this.primaryContext = EngineContext.create(
         serviceContext,
         processingLogContext,
         metaStore,
-        queryIdGenerator
+        queryIdGenerator,
+        cleanupService
     );
     this.serviceId = Objects.requireNonNull(serviceId, "serviceId");
     this.engineMetrics = engineMetricsFactory.apply(this);
@@ -110,6 +115,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
         1000,
         TimeUnit.MILLISECONDS
     );
+
+    cleanupService.startAsync();
   }
 
   public int numberOfLiveQueries() {
@@ -152,6 +159,11 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
   public String getServiceId() {
     return serviceId;
+  }
+
+  @VisibleForTesting
+  QueryCleanupService getCleanupService() {
+    return cleanupService;
   }
 
   @Override
@@ -234,6 +246,15 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   public void close(final boolean closeQueries) {
     primaryContext.getAllLiveQueries()
       .forEach(closeQueries ? QueryMetadata::close : QueryMetadata::stop);
+
+    try {
+      cleanupService.stopAsync().awaitTerminated(30, TimeUnit.SECONDS);
+    } catch (TimeoutException e) {
+      log.warn("Timed out while closing cleanup service. "
+              + "External resources for the following applications may be orphaned: {}",
+          cleanupService.pendingApplicationIds()
+      );
+    }
 
     engineMetrics.close();
     aggregateMetricsCollector.shutdown();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import io.confluent.ksql.schema.registry.SchemaRegistryUtil;
+import io.confluent.ksql.services.ServiceContext;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@code QueryCleanupService} helps cleanup external resources from queries
+ * out of the main line of query execution. This ensures that tasks that might
+ * take a long time don't happen on the CLI feedback path (such as cleaning up
+ * consumer groups).
+ *
+ * <p>NOTE: this cleanup service is intended to be used across threads and across
+ * real/sandboxed engines.</p>
+ */
+@SuppressWarnings("UnstableApiUsage")
+class QueryCleanupService extends AbstractExecutionThreadService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(QueryCleanupService.class);
+  private static final Runnable SHUTDOWN_SENTINEL = () -> { };
+
+  private final BlockingQueue<Runnable> cleanupTasks;
+
+  QueryCleanupService() {
+    cleanupTasks = new LinkedBlockingDeque<>();
+  }
+
+  @Override
+  protected void run() {
+    try {
+      while (true) {
+        final Runnable task = cleanupTasks.take();
+        if (task == SHUTDOWN_SENTINEL) {
+          return;
+        }
+
+        task.run();
+      }
+    } catch (final InterruptedException e) {
+      // gracefully exit if this method was interrupted and reset
+      // the interrupt flag
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  protected void triggerShutdown() {
+    cleanupTasks.add(SHUTDOWN_SENTINEL);
+  }
+
+  public Set<String> pendingApplicationIds() {
+    return cleanupTasks.stream()
+        .filter(QueryCleanupTask.class::isInstance)
+        .map(QueryCleanupTask.class::cast)
+        .map(t -> t.appId).collect(ImmutableSet.toImmutableSet());
+  }
+
+  public void addCleanupTask(final QueryCleanupTask task) {
+    cleanupTasks.add(task);
+  }
+
+  @VisibleForTesting
+  void awaitAllPreviousProcessed() {
+    // add a task to the end of the queue to make sure that
+    // we've finished processing everything up until this point
+    cleanupTasks.add(() -> { });
+
+    // busy wait is fine here because this should only be
+    // used in tests - if we ever have the need to make this
+    // production ready, then we should properly implement this
+    // with a condition variable wait/notify pattern
+    while (!cleanupTasks.isEmpty()) {
+      Thread.yield();
+    }
+  }
+
+  static class QueryCleanupTask implements Runnable {
+    private final String appId;
+    private final boolean isTransient;
+    private final ServiceContext serviceContext;
+
+    QueryCleanupTask(
+        final ServiceContext serviceContext,
+        final String appId,
+        final boolean isTransient
+    ) {
+      this.appId = appId;
+      this.isTransient = isTransient;
+      this.serviceContext = serviceContext;
+    }
+
+    @Override
+    public void run() {
+      tryRun(
+          () -> SchemaRegistryUtil.cleanupInternalTopicSchemas(
+              appId,
+              serviceContext.getSchemaRegistryClient(),
+              isTransient),
+          "internal topic schemas"
+      );
+
+      tryRun(() -> serviceContext.getTopicClient().deleteInternalTopics(appId), "internal topics");
+      tryRun(
+          () -> serviceContext
+              .getConsumerGroupClient()
+              .deleteConsumerGroups(ImmutableSet.of(appId)),
+          "internal consumer groups");
+    }
+
+    private void tryRun(final Runnable runnable, final String resource) {
+      try {
+        runnable.run();
+      } catch (final Exception e) {
+        LOG.warn("Failed to cleanup {} for {}", resource, appId, e);
+      }
+    }
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedKafkaConsumerGroupClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedKafkaConsumerGroupClient.java
@@ -18,46 +18,22 @@ package io.confluent.ksql.services;
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.confluent.ksql.services.KafkaConsumerGroupClient.ConsumerGroupSummary;
 import io.confluent.ksql.util.LimitedProxyBuilder;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.TopicPartition;
+import java.util.Set;
 
 @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD") // Methods invoked via reflection.
 @SuppressWarnings("unused")  // Methods invoked via reflection.
 public final class SandboxedKafkaConsumerGroupClient {
 
   static KafkaConsumerGroupClient createProxy(final KafkaConsumerGroupClient delegate) {
-    final SandboxedKafkaConsumerGroupClient sandbox =
-        new SandboxedKafkaConsumerGroupClient(delegate);
-
     return LimitedProxyBuilder.forClass(KafkaConsumerGroupClient.class)
-        .forward("describeConsumerGroup", methodParams(String.class), sandbox)
-        .forward("listGroups", methodParams(), sandbox)
-        .forward("listConsumerGroupOffsets", methodParams(String.class), sandbox)
+        .forward("describeConsumerGroup", methodParams(String.class), delegate)
+        .forward("listGroups", methodParams(), delegate)
+        .forward("listConsumerGroupOffsets", methodParams(String.class), delegate)
+        .swallow("deleteConsumerGroups", methodParams(Set.class))
         .build();
   }
 
-  private final KafkaConsumerGroupClient delegate;
-
-  private SandboxedKafkaConsumerGroupClient(final KafkaConsumerGroupClient delegate) {
-    this.delegate = Objects.requireNonNull(delegate, "delegate");
-  }
-
-
-
-  public ConsumerGroupSummary describeConsumerGroup(final String groupId) {
-    return delegate.describeConsumerGroup(groupId);
-  }
-
-  public List<String> listGroups() {
-    return delegate.listGroups();
-  }
-
-  public Map<TopicPartition, OffsetAndMetadata> listConsumerGroupOffsets(final String groupId) {
-    return delegate.listConsumerGroupOffsets(groupId);
+  private SandboxedKafkaConsumerGroupClient() {
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
@@ -92,7 +92,7 @@ public final class ExecutorUtil {
       } catch (final Exception e) {
         final Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
         if (shouldRetry.test(cause)) {
-          log.info("Retrying request. Retry no: " + retries, e);
+          log.info("Retrying request. Retry no: {} Cause: '{}'", retries, e.getMessage());
           lastException = e;
         } else if (cause instanceof Exception) {
           throw (Exception) cause;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/FakeKafkaConsumerGroupClient.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/FakeKafkaConsumerGroupClient.java
@@ -3,6 +3,7 @@ package io.confluent.ksql.services;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,8 @@ import org.apache.kafka.common.TopicPartition;
 public class FakeKafkaConsumerGroupClient implements KafkaConsumerGroupClient {
 
   private static final List<String> groups = ImmutableList.of("cg1", "cg2");
+
+  private Set<String> deletedConsumerGroups = new HashSet<>();
 
   @Override
   public List<String> listGroups() {
@@ -48,5 +51,14 @@ public class FakeKafkaConsumerGroupClient implements KafkaConsumerGroupClient {
           new RuntimeException()
       );
     }
+  }
+
+  @Override
+  public void deleteConsumerGroups(final Set<String> groups) {
+    deletedConsumerGroups.addAll(groups);
+  }
+
+  public Set<String> getDeletedConsumerGroups() {
+    return ImmutableSet.copyOf(deletedConsumerGroups);
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/KafkaConsumerGroupClient.java
@@ -33,6 +33,8 @@ public interface KafkaConsumerGroupClient {
 
   Map<TopicPartition, OffsetAndMetadata> listConsumerGroupOffsets(String group);
 
+  void deleteConsumerGroups(Set<String> groups);
+
   /**
    * API POJOs
    */

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaConsumerGroupClient.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaConsumerGroupClient.java
@@ -65,4 +65,9 @@ public class StubKafkaConsumerGroupClient implements KafkaConsumerGroupClient {
       );
     }
   }
+
+  @Override
+  public void deleteConsumerGroups(final Set<String> groups) {
+    // do nothing
+  }
 }


### PR DESCRIPTION
fixes #1283

### Description 

Before this PR, we don't clean up consumer groups that are leftover which makes it really annoying for users to look into their existing consumer groups. This PR adds cleanup on close for persistent and transient queries.

The unfortunate part, is that the consumer group API takes a while to update when the last consumer has left the group (specifically, the `heartbeat.interval.ms` which is default to 3 seconds, needs to pass after the last consumer leaves the group). To account for this, I've taken the external resource cleanup out of the main execution path so that the UI doesn't hang when we terminate a query.

### Testing done 

Unit testing, and manual testing to make sure the resources are cleaned up.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

