### PR TITLE
chore: update healthcheck behavior when command topic is missing

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -36,9 +36,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
 public class HealthCheckAgent {
   private static final Logger log = LoggerFactory.getLogger(HealthCheckAgent.class);
@@ -146,7 +149,8 @@ public class HealthCheckAgent {
         isHealthy = true;
       } catch (final Exception e) {
         log.error("Error describing command topic during health check", e);
-        isHealthy = false;
+        isHealthy = e instanceof UnknownTopicOrPartitionException
+            || ExceptionUtils.getRootCause(e) instanceof UnknownTopicOrPartitionException;
       }
 
       return new HealthCheckResponseDetail(isHealthy);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -39,9 +39,9 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
 public class HealthCheckAgent {
   private static final Logger log = LoggerFactory.getLogger(HealthCheckAgent.class);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -44,7 +44,6 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -44,9 +44,12 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -146,6 +149,32 @@ public class HealthCheckAgentTest {
   public void shouldReturnHealthyIfKafkaCheckFailsWithAuthorizationException() {
     // Given:
     doThrow(KsqlTopicAuthorizationException.class).when(adminClient).describeTopics(any(), any());
+
+    // When:
+    final HealthCheckResponse response = healthCheckAgent.checkHealth();
+
+    // Then:
+    assertThat(response.getDetails().get(KAFKA_CHECK_NAME).getIsHealthy(), is(true));
+    assertThat(response.getIsHealthy(), is(true));
+  }
+
+  @Test
+  public void shouldReturnHealthyIfKafkaCheckFailsWithUnknownTopicOrPartitionExceptionAsRootCause() {
+    // Given:
+    when(adminClient.describeTopics(any(), any())).thenThrow(new RuntimeException(new UnknownTopicOrPartitionException()));
+
+    // When:
+    final HealthCheckResponse response = healthCheckAgent.checkHealth();
+
+    // Then:
+    assertThat(response.getDetails().get(KAFKA_CHECK_NAME).getIsHealthy(), is(true));
+    assertThat(response.getIsHealthy(), is(true));
+  }
+
+  @Test
+  public void shouldReturnHealthyIfKafkaCheckFailsWithUnknownTopicOrPartitionException() {
+    // Given:
+    when(adminClient.describeTopics(any(), any())).thenThrow(new UnknownTopicOrPartitionException());
 
     // When:
     final HealthCheckResponse response = healthCheckAgent.checkHealth();


### PR DESCRIPTION
### Description 
I deleted the command topic and checked to see what exception is returned when the describe topic operation is done with the AdminClient for the healthcheck agent. Updated catch blocks to account for this

```
java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.
	at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45)
	at org.apache.kafka.common.internals.KafkaFutureImpl.access$000(KafkaFutureImpl.java:32)
	at org.apache.kafka.common.internals.KafkaFutureImpl$SingleWaiter.await(KafkaFutureImpl.java:89)
	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:260)
	at io.confluent.ksql.rest.healthcheck.HealthCheckAgent$KafkaBrokerCheck.check(HealthCheckAgent.java:141)
	at io.confluent.ksql.rest.healthcheck.HealthCheckAgent.lambda$checkHealth$0(HealthCheckAgent.java:76)
	at java.util.stream.Collectors.lambda$toMap$58(Collectors.java:1321)
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at io.confluent.ksql.rest.healthcheck.HealthCheckAgent.checkHealth(HealthCheckAgent.java:74)
	at io.confluent.ksql.rest.server.resources.HealthCheckResource$1.load(HealthCheckResource.java:87)
	at io.confluent.ksql.rest.server.resources.HealthCheckResource$1.load(HealthCheckResource.java:81)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3524)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2273)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2156)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2046)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3943)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3967)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4952)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4958)
	at io.confluent.ksql.rest.server.resources.HealthCheckResource.getResponse(HealthCheckResource.java:58)
	at io.confluent.ksql.rest.server.resources.HealthCheckResource.checkHealth(HealthCheckResource.java:53)
	at io.confluent.ksql.rest.server.KsqlServerEndpoints.lambda$executeCheckHealth$17(KsqlServerEndpoints.java:231)
	at io.confluent.ksql.rest.server.KsqlServerEndpoints.executeOldApiEndpoint(KsqlServerEndpoints.java:298)
	at io.confluent.ksql.rest.server.KsqlServerEndpoints.executeCheckHealth(KsqlServerEndpoints.java:230)
	at io.confluent.ksql.api.server.ServerVerticle.lambda$handleHealthcheckRequest$12(ServerVerticle.java:290)
	at io.confluent.ksql.api.server.OldApiUtils.handleOldApiRequest(OldApiUtils.java:69)
	at io.confluent.ksql.api.server.ServerVerticle.handleHealthcheckRequest(ServerVerticle.java:288)
	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1034)
	at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:131)
	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:133)
	at io.confluent.ksql.api.server.ServerStateHandler.handle(ServerStateHandler.java:46)
	at io.confluent.ksql.api.server.ServerStateHandler.handle(ServerStateHandler.java:28)
	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1034)
	at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:131)
	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:133)
	at io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:54)
	at io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:36)
	at io.vertx.core.http.impl.WebSocketRequestHandler.handle(WebSocketRequestHandler.java:50)
	at io.vertx.core.http.impl.WebSocketRequestHandler.handle(WebSocketRequestHandler.java:32)
	at io.vertx.core.http.impl.Http1xServerConnection.handleMessage(Http1xServerConnection.java:136)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:229)
	at io.vertx.core.net.impl.VertxHandler.channelRead(VertxHandler.java:173)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler.channelRead(WebSocketServerExtensionHandler.java:101)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:311)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:425)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:714)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:576)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.
```

### Testing done 
Unit test and manual test (Kafka healthcheck still reports healthy after command topic is deleted)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

