### PR TITLE
chore: fix master findbugs issue (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
@@ -30,6 +30,7 @@ import java.nio.file.attribute.FileTime;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -110,7 +111,12 @@ public class FileWatcherTest {
     watcher.start();
 
     // When:
-    Files.delete(filePath.getParent());
+    final Path parent = filePath.getParent();
+    if (parent != null) {
+      Files.delete(parent);
+    } else {
+      Assert.fail("Expected parent for " + filePath);
+    }
 
     // Then:
     verify(callback, never()).run();


### PR DESCRIPTION
### Description 
Fixes the following:
```
[2020-09-10T20:28:42.115Z] [ERROR] Possible null pointer dereference in io.confluent.ksql.api.server.FileWatcherTest.willStopIfDirectoryDeleted() due to return value of called method [io.confluent.ksql.api.server.FileWatcherTest, io.confluent.ksql.api.server.FileWatcherTest] Method invoked at FileWatcherTest.java:[line 113]Known null at FileWatcherTest.java:[line 113] NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE
```

### Testing done 
n/a

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

