### PR TITLE
fix: ssl.keystore.type=pkcs12

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -328,10 +328,10 @@ public class Server {
             Optional.ofNullable(Strings.emptyToNull(keyStorePassword.value())),
             keyStoreAlias))
             .setPassword(keyStorePassword.value()));
-      } else if (keyStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_JKS)) {
+      } else if (keyStoreType.equalsIgnoreCase(KsqlRestConfig.SSL_STORE_TYPE_JKS)) {
         options.setKeyStoreOptions(
             new JksOptions().setPath(keyStorePath).setPassword(keyStorePassword.value()));
-      } else if (keyStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_PKCS12)) {
+      } else if (keyStoreType.equalsIgnoreCase(KsqlRestConfig.SSL_STORE_TYPE_PKCS12)) {
         options.setPfxKeyCertOptions(
             new PfxOptions().setPath(keyStorePath).setPassword(keyStorePassword.value()));
       }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -114,8 +114,8 @@ public class KsqlRestConfig extends AbstractConfig {
 
   public static final String SSL_STORE_TYPE_JKS = "JKS";
   public static final String SSL_STORE_TYPE_PKCS12 = "PKCS12";
-  public static final ConfigDef.ValidString SSL_STORE_TYPE_VALIDATOR =
-      ConfigDef.ValidString.in(
+    public static final ConfigDef.CaseInsensitiveValidString SSL_STORE_TYPE_VALIDATOR =
+            ConfigDef.CaseInsensitiveValidString.in(
           SSL_STORE_TYPE_JKS,
           SSL_STORE_TYPE_PKCS12
       );


### PR DESCRIPTION
### Description 
This PR fixes #6064 KSQLDB fails to start if ssl.keystore.type=pkcs12 instead of ssl.keystore.type=PKCS12

### Testing done 
mvn clean package

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

