### PR TITLE
chore: make sure unclean leader election is set to false

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
@@ -40,7 +40,8 @@ public final class KsqlInternalTopicUtils {
 
   private static final ImmutableMap<String, ?> INTERNAL_TOPIC_CONFIG = ImmutableMap.of(
       TopicConfig.RETENTION_MS_CONFIG, INTERNAL_TOPIC_RETENTION_MS,
-      TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE
+      TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE,
+      TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, false
   );
 
   private KsqlInternalTopicUtils() {
@@ -85,7 +86,6 @@ public final class KsqlInternalTopicUtils {
         ImmutableMap.<String, Object>builder()
             .putAll(INTERNAL_TOPIC_CONFIG)
             .put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minInSyncReplicas)
-            .put(TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, false)
             .build()
     );
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
@@ -120,7 +120,8 @@ public class KsqlInternalTopicUtilsTest {
     // Then:
     verify(topicClient).addTopicConfig(TOPIC_NAME, ImmutableMap.of(
         TopicConfig.RETENTION_MS_CONFIG, -1L,
-        TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE
+        TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE,
+        TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, false
     ));
   }
 


### PR DESCRIPTION
### Description 
We'll set config overrides for internal topics
```
if (topicClient.addTopicConfig(name, INTERNAL_TOPIC_CONFIG)) 
```
if the topic already exists and the configs don't match.

`unclean.leader.election.enable` wasn't being set to false in the event the topic is already present

NOTE: `min.insync.replicas` isn't being set if the topic already exists, only when the server creates the internal topic, should we add code to also set this value?

### Testing done 
Created command topic without setting any configs.
```
/kafka-topics --zookeeper localhost:2181 --describe --topic _confluent-ksql-default__command_topic
Topic: _confluent-ksql-default__command_topic	PartitionCount: 1	ReplicationFactor: 1	Configs: 
	Topic: _confluent-ksql-default__command_topic	Partition: 0	Leader: 0	Replicas: 0	Isr: 0	Offline: 
```
Start up server
```
/kafka-topics --zookeeper localhost:2181 --describe --topic _confluent-ksql-default__command_topic
Topic: _confluent-ksql-default__command_topic	PartitionCount: 1	ReplicationFactor: 1	Configs: cleanup.policy=delete,retention.ms=-1,unclean.leader.election.enable=false
	Topic: _confluent-ksql-default__command_topic	Partition: 0	Leader: 0	Replicas: 0	Isr: 0	Offline: 
```
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

