### PR TITLE
chore: set auto.offset.reset to none for command topic consumer

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -95,6 +95,10 @@ public class CommandStore implements CommandQueue, Closeable {
           ConsumerConfig.ISOLATION_LEVEL_CONFIG,
           IsolationLevel.READ_COMMITTED.toString().toLowerCase(Locale.ROOT)
       );
+      kafkaConsumerProperties.put(
+          ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+          "none"
+      );
       kafkaProducerProperties.put(
           ProducerConfig.TRANSACTIONAL_ID_CONFIG,
           ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)


### PR DESCRIPTION
### Description 
If the server is running and we delete the command topic, we should throw an exception from the command consumer when it tries to poll the new command topic. Previously the value was set to `LATEST` since it was default

### Testing done 
Delete command topic after server is up.
Recreate the command topic
```
Exception in thread "CommandRunner" org.apache.kafka.clients.consumer.OffsetOutOfRangeException: Fetch position FetchPosition{offset=4, offsetEpoch=Optional[0], currentLeader=LeaderAndEpoch{leader=Optional[stevenz-mbp13.lan:9092 (id: 0 rack: null)], epoch=0}} is out of range for partition _confluent-ksql-default__command_topic-0
	at org.apache.kafka.clients.consumer.internals.Fetcher.handleOffsetOutOfRange(Fetcher.java:1358)
	at org.apache.kafka.clients.consumer.internals.Fetcher.initializeCompletedFetch(Fetcher.java:1310)
	at org.apache.kafka.clients.consumer.internals.Fetcher.fetchedRecords(Fetcher.java:611)
	at org.apache.kafka.clients.consumer.KafkaConsumer.pollForFetches(KafkaConsumer.java:1304)
	at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1233)
	at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1206)
	at io.confluent.ksql.rest.server.CommandTopic.getNewCommands(CommandTopic.java:81)
	at io.confluent.ksql.rest.server.computation.CommandStore.getNewCommands(CommandStore.java:243)
	at io.confluent.ksql.rest.server.computation.CommandRunner.fetchAndRunCommands(CommandRunner.java:243)
	at io.confluent.ksql.rest.server.computation.CommandRunner$Runner.run(CommandRunner.java:362)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

