### PR TITLE
test: extend serde benchmark to include all formats and key serde

### DIFF
--- a/ksqldb-benchmark/README.md
+++ b/ksqldb-benchmark/README.md
@@ -5,10 +5,10 @@ This module is for JMH micro-benchmarking of pieces of the KSQL code.
 ## `SerdeBenchmark.java`
 
 For example, `SerdeBenchmark.java`
-benchmarks the performance of the Avro and JSON serdes used by KSQL, since the serdes have been
+benchmarks the performance of the serdes used by KSQL, since the serdes have been
 shown to be a performance bottleneck in the past. The benchmarks use the schema files found in
-`src/main/resources/schemas`. A serialization and deserialization benchmark is run for each schema
-(e.g., `impressions` or `metrics`) and each serialization format (Avro or JSON).  
+`src/main/resources/schemas`. A serialization and deserialization benchmark is run for each 
+configured combination of schema and format.  
 
 ### How to run
 
@@ -24,17 +24,12 @@ java -jar ./target/benchmarks.jar
 To run only a subset of the benchmarks, you can specify parameters to run with. For example,
 to run only Avro benchmarks:
 ```
-java -jar ./target/benchmarks.jar -p serializationFormat=Avro
+java -jar ./target/benchmarks.jar -p params=impressions/Avro,metrics/Avro,single-key/Avro
 ```
 
 Or to run only JSON (serialization and deserialization) benchmarks using the `metrics` schema:
 ```
-java -jar ./target/benchmarks.jar -p serializationFormat=JSON -p schemaName=metrics
-```
-
-Or to run only the deserialization benchmarks on both the `impressions` and `metrics` schemas:
-```
-java -jar ./target/benchmarks.jar SerdeBenchmark.deserialize -p schemaName=impressions,metrics
+java -jar ./target/benchmarks.jar -p params=metrics/JSON
 ```
 
 ### Running with non-default parameters
@@ -78,3 +73,37 @@ Time per operation is quite consistent from run to run, and from iteration to it
 instance for many of the benchmarks.)
 Don't be surprised if running on your laptop produces better results than those reported here for
 an r5.xlarge EC2 instance, since that is consistently the case.
+
+Results from 2019 Macbook Pro (2.3 Ghz cores), run with:
+
+```java
+@Warmup(iterations = 1, time = 30)
+@Measurement(iterations = 2, time = 30)
+@Threads(4)
+@Fork(1)
+```
+
+| Benchmark   | schemaName & serialisationFormat | time (us/op) |
+|:-----------:|:--------------------------------:|:------------:| 
+| deserialize | single-key/Delimited  | 2.784 |
+| deserialize |      single-key/Kafka  | 0.045 |
+| deserialize |       single-key/JSON  | 0.200 |
+| deserialize |       single-key/Avro  | 0.550 |
+| deserialize | impressions/Delimited  | 2.840 |
+| deserialize |  impressions/Protobuf  | 1.928 |
+| deserialize |      impressions/JSON  | 1.218 |
+| deserialize |      impressions/Avro  | 1.474 |
+| deserialize |      metrics/Protobuf  | 5.259 |
+| deserialize |          metrics/JSON  | 5.687 |
+| deserialize |          metrics/Avro  | 4.674 |
+| serialize   |  single-key/Delimited  | 0.200 |
+| serialize   |      single-key/Kafka  | 0.010 |
+| serialize   |       single-key/JSON  | 0.170 |
+| serialize   |       single-key/Avro  | 0.245 |
+| serialize   | impressions/Delimited  | 0.521 |
+| serialize   |  impressions/Protobuf  | 1.471 |
+| serialize   |      impressions/JSON  | 0.683 |
+| serialize   |      impressions/Avro  | 1.374 |
+| serialize   |      metrics/Protobuf  | 6.321 |
+| serialize   |         metrics/JSON  | 3.336 |
+| serialize   |          metrics/Avro  | 5.179 |

--- a/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -103,7 +103,7 @@ public class SerdeBenchmark {
       final String[] parts = text.split(SEPARATOR);
       if (parts.length != 2) {
         throw new IllegalArgumentException("Param should be in form "
-            + "'<format-name>|<schema-name>', got: " + text);
+            + "'<format-name>" + SEPARATOR + "<schema-name>', got: " + text);
       }
 
       return new Params(parts[0], parts[1]);

--- a/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -27,21 +27,24 @@ import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.serde.EnabledSerdeFeatures;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.GenericKeySerDe;
 import io.confluent.ksql.serde.GenericRowSerDe;
+import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Pair;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Struct;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -79,100 +82,166 @@ public class SerdeBenchmark {
   private static final String SCHEMA_FILE_SUFFIX = ".avro";
   private static final String TOPIC_NAME = "serde_benchmark";
 
-  @State(Scope.Thread)
-  public static class SchemaAndGenericRowState {
-    LogicalSchema schema;
-    GenericRow row;
+  private static final String IMPRESSIONS_SCHEMA = "impressions";
+  private static final String METRICS_SCHEMA = "metrics";
+  private static final String SINGLE_KEY_SCHEMA = "single-key";
 
-    @Param({"impressions", "metrics"})
-    public String schemaName;
+  private static final String SEPARATOR = "/";
 
-    @Setup(Level.Iteration)
-    public void setUp() throws Exception {
-      final Generator generator = new Generator(getSchemaStream(), new Random());
+  private static final String JSON_FORMAT = "JSON";
+  private static final String AVRO_FORMAT = "Avro";
+  private static final String PROTOBUF_FORMAT = "Protobuf";
+  private static final String DELIMITED_FORMAT = "Delimited";
+  private static final String KAFKA_FORMAT = "Kafka";
 
-      // choose arbitrary key
-      final String key = generator.schema().getFields().get(0).name();
+  private static final class Params {
 
-      final RowGenerator rowGenerator = new RowGenerator(generator, key, Optional.empty());
+    final String schemaName;
+    final String formatName;
 
-      final Pair<Struct, GenericRow> genericRowPair = rowGenerator.generateRow();
-      row = genericRowPair.getRight();
-      schema = rowGenerator.schema();
+    static Params parse(final String text) {
+      final String[] parts = text.split(SEPARATOR);
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("Param should be in form "
+            + "'<format-name>|<schema-name>', got: " + text);
+      }
+
+      return new Params(parts[0], parts[1]);
     }
 
-    private InputStream getSchemaStream() {
-      return SerdeBenchmark.class.getClassLoader().getResourceAsStream(
-          SCHEMA_DIR.resolve(schemaName + SCHEMA_FILE_SUFFIX).toString());
+    private Params(final String schemaName, final String formatName) {
+      this.schemaName = Objects.requireNonNull(schemaName, "schemaName");
+      this.formatName = Objects.requireNonNull(formatName, "formatName").toUpperCase();
     }
   }
 
   @State(Scope.Thread)
   public static class SerdeState {
 
-    Serializer<GenericRow> serializer;
-    Deserializer<GenericRow> deserializer;
-    GenericRow row;
+    Serializer<Object> serializer;
+    Deserializer<Object> deserializer;
+    Object data;
     byte[] bytes;
 
-    @Param({"JSON", "Avro"})
-    public String serializationFormat;
+    @Param({
+        SINGLE_KEY_SCHEMA + SEPARATOR + DELIMITED_FORMAT,
+        SINGLE_KEY_SCHEMA + SEPARATOR + KAFKA_FORMAT,
+        // SINGLE_KEY + PROTOBUF excluded as PB isn't yet supported for single key schemas
+        SINGLE_KEY_SCHEMA + SEPARATOR + JSON_FORMAT,
+        SINGLE_KEY_SCHEMA + SEPARATOR + AVRO_FORMAT,
 
+        IMPRESSIONS_SCHEMA + SEPARATOR + DELIMITED_FORMAT,
+        // IMPRESSIONS + KAFKA excluded as KAFKA does not support multiple columns
+        IMPRESSIONS_SCHEMA + SEPARATOR + PROTOBUF_FORMAT,
+        IMPRESSIONS_SCHEMA + SEPARATOR + JSON_FORMAT,
+        IMPRESSIONS_SCHEMA + SEPARATOR + AVRO_FORMAT,
+
+        // METRICS + DELIMITED_FORMAT excluded as DELIMITED does not support complex types
+        // METRICS + KAFKA excluded as KAFKA does not support multiple columns
+        METRICS_SCHEMA + SEPARATOR + PROTOBUF_FORMAT,
+        METRICS_SCHEMA + SEPARATOR + JSON_FORMAT,
+        METRICS_SCHEMA + SEPARATOR + AVRO_FORMAT
+    })
+    public String params;
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Setup(Level.Iteration)
-    public void setUp(final SchemaAndGenericRowState rowState) {
-      final Serde<GenericRow> serde;
-      switch (serializationFormat) {
-        case "JSON":
-          serde = getJsonSerde(rowState.schema);
-          break;
-        case "Avro":
-          serde = getAvroSerde(rowState.schema);
-          break;
-        default:
-          throw new RuntimeException("Invalid format: " + serializationFormat);
+    public void setUp() throws IOException {
+      final Params params = Params.parse(this.params);
+
+      final RowGenerator generator = getRowGenerator(params.schemaName);
+
+      final LogicalSchema schema = generator.schema();
+      final Pair<Struct, GenericRow> row = generator.generateRow();
+
+      if (params.schemaName.equals(SINGLE_KEY_SCHEMA)) {
+        // Benchmark the key serde:
+        final Serde<Struct> serde = getGenericKeySerde(schema, params.formatName);
+
+        serializer = (Serializer) serde.serializer();
+        deserializer = (Deserializer) serde.deserializer();
+        data = row.getLeft();
+      } else {
+
+        // Benchmark the value serde:
+        final Serde<GenericRow> serde = getGenericRowSerde(schema, params.formatName);
+
+        serializer = (Serializer) serde.serializer();
+        deserializer = (Deserializer) serde.deserializer();
+        data = row.getRight();
       }
-      serializer = serde.serializer();
-      deserializer = serde.deserializer();
-      row = rowState.row;
-      bytes = serializer.serialize(TOPIC_NAME, row);
+
+      bytes = serializer.serialize(TOPIC_NAME, data);
     }
 
-    private static Serde<GenericRow> getJsonSerde(final LogicalSchema schema) {
-      final Serializer<GenericRow> serializer = getJsonSerdeHelper(schema).serializer();
-      final Deserializer<GenericRow> deserializer = getJsonSerdeHelper(schema).deserializer();
-      return Serdes.serdeFrom(serializer, deserializer);
+    private static RowGenerator getRowGenerator(final String schemaName) throws IOException {
+      final Generator generator = getGenerator(schemaName);
+
+      // choose arbitrary key
+      final String keyField = generator.schema().getFields().get(0).name();
+
+      return new RowGenerator(generator, keyField, Optional.empty());
     }
 
-    private static Serde<GenericRow> getJsonSerdeHelper(final LogicalSchema schema) {
-      return getGenericRowSerde(
-          FormatInfo.of(FormatFactory.JSON.name()),
-          schema,
-          () -> null
-      );
+    private static Generator getGenerator(final String schemaName) throws IOException {
+      final Path schemaPath = SCHEMA_DIR.resolve(schemaName + SCHEMA_FILE_SUFFIX);
+
+      try (InputStream schemaResource = SerdeBenchmark.class.getClassLoader()
+          .getResourceAsStream(schemaPath.toString())) {
+
+        if (schemaResource == null) {
+          throw new FileNotFoundException("Schema file not found: " + schemaName);
+        }
+
+        return new Generator(schemaResource, new Random());
+      }
     }
 
-    private static Serde<GenericRow> getAvroSerde(final LogicalSchema schema) {
-      final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    private static FormatInfo getFormatInfo(final String formatName) {
+      if (AvroFormat.NAME.equals(formatName)) {
+        return FormatInfo.of(
+            FormatFactory.AVRO.name(),
+            ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "benchmarkSchema")
+        );
+      }
 
-      return getGenericRowSerde(
-          FormatInfo.of(
-              FormatFactory.AVRO.name(),
-              ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "benchmarkSchema")),
-          schema,
-          () -> schemaRegistryClient
+      return FormatInfo.of(formatName);
+    }
+
+    private static Serde<Struct> getGenericKeySerde(
+        final LogicalSchema schema,
+        final String formatName
+    ) {
+      final FormatInfo formatInfo = getFormatInfo(formatName);
+
+      final SchemaRegistryClient srClient = new MockSchemaRegistryClient();
+
+      final PersistenceSchema persistenceSchema = PersistenceSchema
+          .from(schema.key(), EnabledSerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+
+      return new GenericKeySerDe().create(
+          formatInfo,
+          persistenceSchema,
+          new KsqlConfig(Collections.emptyMap()),
+          () -> srClient,
+          "benchmark",
+          ProcessingLogContext.create()
       );
     }
 
     private static Serde<GenericRow> getGenericRowSerde(
-        final FormatInfo format,
         final LogicalSchema schema,
-        final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
+        final String formatName
     ) {
+      final FormatInfo format = getFormatInfo(formatName);
+
+      final SchemaRegistryClient srClient = new MockSchemaRegistryClient();
+
       return GenericRowSerDe.from(
           format,
           PersistenceSchema.from(schema.value(), EnabledSerdeFeatures.of()),
           new KsqlConfig(Collections.emptyMap()),
-          schemaRegistryClientFactory,
+          () -> srClient,
           "benchmark",
           ProcessingLogContext.create()
       );
@@ -182,12 +251,20 @@ public class SerdeBenchmark {
   @SuppressWarnings("MethodMayBeStatic") // Tests can not be static
   @Benchmark
   public byte[] serialize(final SerdeState serdeState) {
-    return serdeState.serializer.serialize(TOPIC_NAME, serdeState.row);
+    if (serdeState.serializer == null) {
+      return null;
+    }
+
+    return serdeState.serializer.serialize(TOPIC_NAME, serdeState.data);
   }
 
   @SuppressWarnings("MethodMayBeStatic") // Tests can not be static
   @Benchmark
-  public GenericRow deserialize(final SerdeState serdeState) {
+  public Object deserialize(final SerdeState serdeState) {
+    if (serdeState.deserializer == null) {
+      return null;
+    }
+
     return serdeState.deserializer.deserialize(TOPIC_NAME, serdeState.bytes);
   }
 

--- a/ksqldb-benchmark/src/main/resources/schemas/single-key.avro
+++ b/ksqldb-benchmark/src/main/resources/schemas/single-key.avro
@@ -1,0 +1,16 @@
+{
+  "namespace": "streams",
+  "name": "single",
+  "type": "record",
+  "fields": [
+    {
+      "name": "col0",
+      "type": {
+        "type": "long",
+        "arg.properties": {
+          "range": {"min": 0, "max": 100000}
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/6211

Enhances the serde benchmarks beyond just testing `AVRO` and `JSON` formats via the `GenericRowSerde` to include `KAFKA`, `DELIMITED` and `PROTOBUF` formats and test key serde via the `GenericKeySerde`.

```
Benchmark                                (params)  Mode  Cnt  Score   Error  Units
SerdeBenchmark.deserialize   single-key/Delimited  avgt    2  2.784          us/op
SerdeBenchmark.deserialize       single-key/Kafka  avgt    2  0.045          us/op
SerdeBenchmark.deserialize        single-key/JSON  avgt    2  0.200          us/op
SerdeBenchmark.deserialize        single-key/Avro  avgt    2  0.550          us/op
SerdeBenchmark.deserialize  impressions/Delimited  avgt    2  2.840          us/op
SerdeBenchmark.deserialize   impressions/Protobuf  avgt    2  1.928          us/op
SerdeBenchmark.deserialize       impressions/JSON  avgt    2  1.218          us/op
SerdeBenchmark.deserialize       impressions/Avro  avgt    2  1.474          us/op
SerdeBenchmark.deserialize       metrics/Protobuf  avgt    2  5.259          us/op
SerdeBenchmark.deserialize           metrics/JSON  avgt    2  5.687          us/op
SerdeBenchmark.deserialize           metrics/Avro  avgt    2  4.674          us/op
SerdeBenchmark.serialize     single-key/Delimited  avgt    2  0.200          us/op
SerdeBenchmark.serialize         single-key/Kafka  avgt    2  0.010          us/op
SerdeBenchmark.serialize          single-key/JSON  avgt    2  0.170          us/op
SerdeBenchmark.serialize          single-key/Avro  avgt    2  0.245          us/op
SerdeBenchmark.serialize    impressions/Delimited  avgt    2  0.521          us/op
SerdeBenchmark.serialize     impressions/Protobuf  avgt    2  1.471          us/op
SerdeBenchmark.serialize         impressions/JSON  avgt    2  0.683          us/op
SerdeBenchmark.serialize         impressions/Avro  avgt    2  1.374          us/op
SerdeBenchmark.serialize         metrics/Protobuf  avgt    2  6.321          us/op
SerdeBenchmark.serialize             metrics/JSON  avgt    2  3.336          us/op
SerdeBenchmark.serialize             metrics/Avro  avgt    2  5.179          us/op
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

