### PR TITLE
fix: format cast arguments with passed context

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -312,7 +312,8 @@ public final class ExpressionFormatter {
     @Override
     public String visitCast(final Cast node, final Context context) {
       return "CAST"
-          + "(" + process(node.getExpression(), context) + " AS " + node.getType() + ")";
+          + "(" + process(node.getExpression(), context) + " AS "
+          + process(node.getType(), context) + ")";
     }
 
     @Override

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -297,6 +297,22 @@ public class ExpressionFormatterTest {
   }
 
   @Test
+  public void shouldFormatCastToStruct() {
+    // Given:
+    final Cast cast = new Cast(
+        new StringLiteral("foo"),
+        new Type(SqlStruct.builder()
+            .field("field", SqlTypes.STRING).build())
+    );
+
+    // When:
+    final String result = ExpressionFormatter.formatExpression(cast, FormatOptions.none());
+
+    // Then:
+    assertThat(result, equalTo("CAST('foo' AS STRUCT<`field` STRING>)"));
+  }
+
+  @Test
   public void shouldFormatSearchedCaseExpression() {
     final SearchedCaseExpression expression = new SearchedCaseExpression(
         Collections.singletonList(

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/cast_-_struct_to_struct_with_same_schema/6.1.0_1600377904990/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/cast_-_struct_to_struct_with_same_schema/6.1.0_1600377904990/plan.json
@@ -1,0 +1,140 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, F0 STRUCT<F0 INTEGER, `f1` INTEGER>) WITH (KAFKA_TOPIC='test_topic', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `F0` STRUCT<`F0` INTEGER, `f1` INTEGER>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.ID ID,\n  CAST(TEST.F0 AS STRUCT<F0 INTEGER, `f1` INTEGER>) KSQL_COL_0\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `KSQL_COL_0` STRUCT<`F0` INTEGER, `f1` INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `F0` STRUCT<`F0` INTEGER, `f1` INTEGER>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "CAST(F0 AS STRUCT<F0 INTEGER, `f1` INTEGER>) AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.streams.max.task.idle.ms" : "0",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.enable.metastore.backup" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/cast_-_struct_to_struct_with_same_schema/6.1.0_1600377904990/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/cast_-_struct_to_struct_with_same_schema/6.1.0_1600377904990/spec.json
@@ -1,0 +1,92 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1600377904990,
+  "path" : "query-validation-tests/cast.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `F0` STRUCT<`F0` INTEGER, `f1` INTEGER>",
+      "serdeOptions" : [ ]
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `KSQL_COL_0` STRUCT<`F0` INTEGER, `f1` INTEGER>",
+      "serdeOptions" : [ ]
+    }
+  },
+  "testCase" : {
+    "name" : "struct to struct with same schema",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "f0" : {
+          "f0" : 1,
+          "f1" : 3
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "KSQL_COL_0" : {
+          "F0" : 1,
+          "f1" : 3
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, f0 STRUCT<F0 INT, `f1` INT>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, cast(f0 as STRUCT<F0 INTEGER, `f1` INTEGER>) FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `F0` STRUCT<`F0` INTEGER, `f1` INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `KSQL_COL_0` STRUCT<`F0` INTEGER, `f1` INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "serdeOptions" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "formatInfo" : {
+              "format" : "KAFKA"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/cast_-_struct_to_struct_with_same_schema/6.1.0_1600377904990/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/cast_-_struct_to_struct_with_same_schema/6.1.0_1600377904990/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/cast.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/cast.json
@@ -87,14 +87,14 @@
     {
       "name": "struct to struct with same schema",
       "statements": [
-        "CREATE STREAM TEST (ID STRING KEY, f0 STRUCT<F0 INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT ID, cast(f0 as STRUCT<F0 INTEGER>) FROM TEST;"
+        "CREATE STREAM TEST (ID STRING KEY, f0 STRUCT<F0 INT, `f1` INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, cast(f0 as STRUCT<F0 INTEGER, `f1` INTEGER>) FROM TEST;"
       ],
       "inputs": [
-        {"topic": "test_topic", "value": {"f0": {"f0": 1}}}
+        {"topic": "test_topic", "value": {"f0": {"f0": 1, "f1": 3}}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "value": {"KSQL_COL_0": {"F0": 1}}}
+        {"topic": "OUTPUT", "value": {"KSQL_COL_0": {"F0": 1, "f1": 3}}}
       ]
     },
     {


### PR DESCRIPTION
### Description 

Previously, the second argument in `CAST` was not getting fully processed in the `ExpressionFormatter`, causing field cases to not be preserved when casting to structs. This PR fixes that.

Fixes #5973 

### Testing done 
Manually tested, added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

