### PR TITLE
chore: example wiring up of KEY_FORMAT

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -37,6 +37,7 @@ public final class CommonCreateConfigs {
 
   // Persistence Props:
   public static final String VALUE_AVRO_SCHEMA_FULL_NAME = "VALUE_AVRO_SCHEMA_FULL_NAME";
+  public static final String KEY_FORMAT_PROPERTY = "KEY_FORMAT";
   public static final String VALUE_FORMAT_PROPERTY = "VALUE_FORMAT";
   public static final String WRAP_SINGLE_VALUE = "WRAP_SINGLE_VALUE";
 
@@ -75,6 +76,13 @@ public final class CommonCreateConfigs {
                 + "' is set, then the default "
                 + "Kafka cluster configuration for replicas will be used for creating a new "
                 + "topic."
+        )
+        .define(
+            KEY_FORMAT_PROPERTY,
+            ConfigDef.Type.STRING,
+            null,
+            Importance.HIGH,
+            "The format of the serialized key"
         )
         .define(
             VALUE_FORMAT_PROPERTY,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/serde/SerdeOption.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/serde/SerdeOption.java
@@ -28,7 +28,7 @@ public enum SerdeOption {
    *
    * @see SerdeOption#UNWRAP_SINGLE_VALUES
    */
-  WRAP_SINGLE_VALUES(SerdeFeature.WRAP_SINGLES),
+  WRAP_SINGLE_VALUES(SerdeFeature.WRAP_SINGLES, false),
 
   /**
    * If the value schema contains only a single field, persist it as an anonymous value.
@@ -38,17 +38,23 @@ public enum SerdeOption {
    *
    * @see SerdeOption#WRAP_SINGLE_VALUES
    */
-  UNWRAP_SINGLE_VALUES(SerdeFeature.UNWRAP_SINGLES),
+  UNWRAP_SINGLE_VALUES(SerdeFeature.UNWRAP_SINGLES, false),
 
   /**
    * Key version of {@link #UNWRAP_SINGLE_VALUES}.
    */
-  UNWRAP_SINGLE_KEYS(SerdeFeature.UNWRAP_SINGLES);
+  UNWRAP_SINGLE_KEYS(SerdeFeature.UNWRAP_SINGLES, true);
 
+  private final boolean isKey;
   private final SerdeFeature requiredFeature;
 
-  SerdeOption(final SerdeFeature requiredFeature) {
+  SerdeOption(final SerdeFeature requiredFeature, final boolean isKey) {
+    this.isKey = isKey;
     this.requiredFeature = Objects.requireNonNull(requiredFeature, "requiredFeature");
+  }
+
+  public boolean isKeyOption() {
+    return isKey;
   }
 
   public SerdeFeature requiredFeature() {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/serde/SerdeOptions.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/serde/SerdeOptions.java
@@ -60,17 +60,12 @@ public final class SerdeOptions {
     validate(this.options);
   }
 
-  @SuppressWarnings("MethodMayBeStatic")
   public EnabledSerdeFeatures keyFeatures() {
-    // Currently there are no key features:
-    return EnabledSerdeFeatures.of();
+    return features(true);
   }
 
   public EnabledSerdeFeatures valueFeatures() {
-    // Currently there are no key features, so all are value features:
-    return EnabledSerdeFeatures.from(options.stream()
-        .map(SerdeOption::requiredFeature)
-        .collect(Collectors.toSet()));
+    return features(false);
   }
 
   public Set<SerdeOption> all() {
@@ -109,6 +104,13 @@ public final class SerdeOptions {
   @Override
   public String toString() {
     return options.toString();
+  }
+
+  private EnabledSerdeFeatures features(final boolean key) {
+    return EnabledSerdeFeatures.from(options.stream()
+        .filter(option -> option.isKeyOption() == key)
+        .map(SerdeOption::requiredFeature)
+        .collect(Collectors.toSet()));
   }
 
   private static void validate(final Set<SerdeOption> options) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -135,6 +135,12 @@ public class KsqlConfig extends AbstractConfig {
       + "in interactive mode. Once this limit is reached, any further persistent queries will not "
       + "be accepted.";
 
+  public static final String KSQL_DEFAULT_KEY_FORMAT_CONFIG = "ksql.persistence.default.format.key";
+  private static final String KSQL_DEFAULT_KEY_FORMAT_DEFAULT = "KAFKA";
+  private static final String KSQL_DEFAULT_KEY_FORMAT_DOC =
+      "Key format that will be used by default if none is specified in the WITH properties of "
+          + "CREATE STREAM/TABLE statements.";
+
   public static final String KSQL_WRAP_SINGLE_VALUES =
       "ksql.persistence.wrap.single.values";
 
@@ -624,6 +630,12 @@ public class KsqlConfig extends AbstractConfig {
             null,
             ConfigDef.Importance.LOW,
             KSQL_CUSTOM_METRICS_EXTENSION_DOC
+        ).define(
+            KSQL_DEFAULT_KEY_FORMAT_CONFIG,
+            Type.STRING,
+            KSQL_DEFAULT_KEY_FORMAT_DEFAULT,
+            ConfigDef.Importance.LOW,
+            KSQL_DEFAULT_KEY_FORMAT_DOC
         ).define(
             KSQL_ENABLE_TOPIC_ACCESS_VALIDATOR,
             Type.STRING,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -82,7 +82,7 @@ public final class CreateSourceFactory {
       final KsqlConfig ksqlConfig
   ) {
     final SourceName sourceName = statement.getName();
-    final KsqlTopic topic = buildTopic(statement.getProperties(), serviceContext);
+    final KsqlTopic topic = buildTopic(statement.getProperties(), ksqlConfig, serviceContext);
     final LogicalSchema schema = buildSchema(statement.getElements());
     final Optional<TimestampColumn> timestampColumn = buildTimestampColumn(
         ksqlConfig,
@@ -116,7 +116,7 @@ public final class CreateSourceFactory {
       final KsqlConfig ksqlConfig
   ) {
     final SourceName sourceName = statement.getName();
-    final KsqlTopic topic = buildTopic(statement.getProperties(), serviceContext);
+    final KsqlTopic topic = buildTopic(statement.getProperties(), ksqlConfig, serviceContext);
     final LogicalSchema schema = buildSchema(statement.getElements());
     if (schema.key().isEmpty()) {
       final boolean usingSchemaInference = statement.getProperties().getSchemaId().isPresent();
@@ -177,6 +177,7 @@ public final class CreateSourceFactory {
 
   private static KsqlTopic buildTopic(
       final CreateSourceProperties properties,
+      final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext
   ) {
     final String kafkaTopicName = properties.getKafkaTopic();
@@ -184,7 +185,7 @@ public final class CreateSourceFactory {
       throw new KsqlException("Kafka topic does not exist: " + kafkaTopicName);
     }
 
-    return TopicFactory.create(properties);
+    return TopicFactory.create(properties, ksqlConfig);
   }
 
   private static Optional<TimestampColumn> buildTimestampColumn(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -91,6 +91,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
 
     return schemaKStream.into(
         getKsqlTopic().getKafkaTopicName(),
+        getKsqlTopic().getKeyFormat(),
         getKsqlTopic().getValueFormat(),
         serdeOptions,
         contextStacker,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -20,6 +20,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.Statement;
@@ -34,6 +35,7 @@ import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
+import io.confluent.ksql.topic.TopicFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlSchemaRegistryNotConfiguredException;
@@ -76,10 +78,15 @@ public class SchemaRegisterInjector implements Injector {
 
     final LogicalSchema schema = cs.getStatement().getElements().toLogicalSchema();
 
+    final KsqlConfig ksqlConfig = cs.getConfig()
+        .cloneWithPropertyOverwrite(cs.getConfigOverrides());
+
+    final KsqlTopic ksqlTopic = TopicFactory.create(cs.getStatement().getProperties(), ksqlConfig);
+
     final SerdeOptions serdeOptions = SerdeOptionsFactory.buildForCreateStatement(
         schema,
-        FormatFactory.KAFKA,
-        cs.getStatement().getProperties().getValueFormat(),
+        ksqlTopic.getKeyFormat().getFormat(),
+        ksqlTopic.getValueFormat().getFormat(),
         cs.getStatement().getProperties().getSerdeOptions(),
         cs.getConfig()
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -86,9 +86,10 @@ public class SchemaKStream<K> {
 
   public SchemaKStream<K> into(
       final String kafkaTopicName,
+      final KeyFormat keyFormat,
       final ValueFormat valueFormat,
       final SerdeOptions options,
-      final QueryContext.Stacker contextStacker,
+      final Stacker contextStacker,
       final Optional<TimestampColumn> timestampColumn
   ) {
     final StreamSink<K> step = ExecutionStepFactory.streamSink(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -71,9 +71,10 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   @Override
   public SchemaKTable<K> into(
       final String kafkaTopicName,
+      final KeyFormat keyFormat,
       final ValueFormat valueFormat,
       final SerdeOptions options,
-      final QueryContext.Stacker contextStacker,
+      final Stacker contextStacker,
       final Optional<TimestampColumn> timestampColumn
   ) {
     final TableSink<K> step = ExecutionStepFactory.tableSink(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -66,6 +66,7 @@ import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.EnabledSerdeFeatures;
+import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeySerdeFactory;
 import io.confluent.ksql.serde.SerdeOption;
@@ -460,7 +461,7 @@ public class CreateSourceFactoryTest {
     verify(serdeOptionsSupplier).build(
         schema,
         KAFKA,
-        statement.getProperties().getValueFormat(),
+        FormatFactory.of(statement.getProperties().getFormatInfo()),
         statement.getProperties().getSerdeOptions(),
         ksqlConfig
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.avro.AvroFormat;
@@ -68,6 +69,7 @@ public class KsqlStructuredDataOutputNodeTest {
       .build();
 
   private static final PlanNodeId PLAN_NODE_ID = new PlanNodeId("0");
+  private static final KeyFormat PROTOBUF_KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.PROTOBUF.name()));
   private static final ValueFormat JSON_FORMAT = ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()));
 
   @Mock
@@ -95,13 +97,14 @@ public class KsqlStructuredDataOutputNodeTest {
     when(sourceNode.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
     when(sourceNode.buildStream(ksqlStreamBuilder)).thenReturn((SchemaKStream) sourceStream);
 
-    when(sourceStream.into(any(), any(), any(), any(), any()))
+    when(sourceStream.into(any(), any(), any(), any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStream);
 
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
     when(ksqlTopic.getKafkaTopicName()).thenReturn(SINK_KAFKA_TOPIC_NAME);
+    when(ksqlTopic.getKeyFormat()).thenReturn(PROTOBUF_KEY_FORMAT);
     when(ksqlTopic.getValueFormat()).thenReturn(JSON_FORMAT);
 
     buildNode();
@@ -143,26 +146,39 @@ public class KsqlStructuredDataOutputNodeTest {
     // Given:
     givenInsertIntoNode();
 
-    final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name(), ImmutableMap
-        .of(AvroFormat.FULL_SCHEMA_NAME, "name")));
+    final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(
+        FormatFactory.AVRO.name(),
+        ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "key-name")
+    ));
 
+    final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(
+        FormatFactory.AVRO.name(),
+        ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "name")
+    ));
+
+    when(ksqlTopic.getKeyFormat()).thenReturn(keyFormat);
     when(ksqlTopic.getValueFormat()).thenReturn(valueFormat);
 
-    // When/Then (should not throw):
+    // When:
     outputNode.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(sourceStream).into(any(), eq(valueFormat), any(), any(), any());
+    verify(sourceStream).into(any(), eq(keyFormat), eq(valueFormat), any(), any(), any());
   }
 
   @Test
   public void shouldCallInto() {
+    // Given:
+    when(ksqlTopic.getKeyFormat()).thenReturn(PROTOBUF_KEY_FORMAT);
+    when(ksqlTopic.getValueFormat()).thenReturn(JSON_FORMAT);
+
     // When:
     final SchemaKStream<?> result = outputNode.buildStream(ksqlStreamBuilder);
 
     // Then:
     verify(sourceStream).into(
         eq(SINK_KAFKA_TOPIC_NAME),
+        eq(PROTOBUF_KEY_FORMAT),
         eq(JSON_FORMAT),
         eq(SerdeOptions.of()),
         stackerCaptor.capture(),

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -73,7 +73,7 @@ public final class AssertExecutor {
           CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY
       )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getFormat(),
-          cs -> cs.getProperties().getValueFormat().name(),
+          cs -> cs.getProperties().getFormatInfo().getFormat(),
           "value format",
           CommonCreateConfigs.VALUE_FORMAT_PROPERTY
       )).add(new SourceProperty(

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -33,7 +33,6 @@ import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.RegisterType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
-import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.serde.SerdeOptionsFactory;
 import io.confluent.ksql.serde.ValueFormat;
@@ -139,7 +138,7 @@ public final class TestCaseBuilderUtil {
     final Function<PreparedStatement<?>, Topic> extractTopic = (PreparedStatement<?> stmt) -> {
       final CreateSource statement = (CreateSource) stmt.getStatement();
 
-      final KsqlTopic ksqlTopic = TopicFactory.create(statement.getProperties());
+      final KsqlTopic ksqlTopic = TopicFactory.create(statement.getProperties(), ksqlConfig);
 
       final ValueFormat valueFormat = ksqlTopic.getValueFormat();
       final Optional<ParsedSchema> valueSchema;
@@ -150,8 +149,8 @@ public final class TestCaseBuilderUtil {
         try {
           serdeOptions = SerdeOptionsFactory.buildForCreateStatement(
               logicalSchema,
-              FormatFactory.KAFKA,
-              statement.getProperties().getValueFormat(),
+              ksqlTopic.getKeyFormat().getFormat(),
+              ksqlTopic.getValueFormat().getFormat(),
               statement.getProperties().getSerdeOptions(),
               ksqlConfig
           );

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
@@ -17,6 +17,44 @@
       },
       "inputs": [],
       "outputs": []
+    },
+    {
+      "name": "explicit key format - C*",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, VAL STRING) WITH (kafka_topic='input', key_format='JSON', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": "1", "value": {"VAL": "v"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"VAL": "v"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INPUT", "type": "stream", "schema": "ID STRING KEY, VAL STRING", "keyFormat": {"format": "JSON"}},
+          {"name": "OUTPUT", "type": "stream", "schema": "ID STRING KEY, VAL STRING", "keyFormat": {"format": "JSON"}}
+        ]
+      }
+    },
+    {
+      "name": "explicit key format - C*AS",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, VAL STRING) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT WITH (key_format='JSON', value_format='AVRO') AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": "1", "value": {"VAL": "v"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"VAL": "v"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INPUT", "type": "stream", "schema": "ID STRING KEY, VAL STRING", "keyFormat": {"format": "KAFKA"}},
+          {"name": "OUTPUT", "type": "stream", "schema": "ID STRING KEY, VAL STRING", "keyFormat": {"format": "JSON"}}
+        ]
+      }
     }
   ]
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -25,8 +25,6 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.ColumnReferenceParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateAsConfigs;
-import io.confluent.ksql.serde.Format;
-import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.SerdeOptions;
@@ -69,10 +67,6 @@ public final class CreateSourceAsProperties {
     props.validateDateTimeFormat(CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY);
   }
 
-  public Optional<Format> getValueFormat() {
-    return getFormatInfo().map(FormatFactory::of);
-  }
-
   public Optional<String> getKafkaTopic() {
     return Optional.ofNullable(props.getString(CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY));
   }
@@ -103,6 +97,11 @@ public final class CreateSourceAsProperties {
     }
 
     return SerdeOptions.of(builder.build());
+  }
+
+  public Optional<FormatInfo> getKeyFormatInfo() {
+    return Optional.ofNullable(props.getString(CommonCreateConfigs.KEY_FORMAT_PROPERTY))
+        .map(format -> FormatInfo.of(format, ImmutableMap.of()));
   }
 
   public Optional<FormatInfo> getFormatInfo() {

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -27,8 +27,6 @@ import io.confluent.ksql.parser.ColumnReferenceParser;
 import io.confluent.ksql.parser.DurationParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateConfigs;
-import io.confluent.ksql.serde.Format;
-import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.SerdeOptions;
@@ -78,10 +76,6 @@ public final class CreateSourceProperties {
     validateWindowInfo();
   }
 
-  public Format getValueFormat() {
-    return FormatFactory.of(getFormatInfo());
-  }
-
   public String getKafkaTopic() {
     return props.getString(CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY);
   }
@@ -129,6 +123,11 @@ public final class CreateSourceProperties {
 
   public Optional<Integer> getSchemaId() {
     return Optional.ofNullable(props.getInt(CreateConfigs.SCHEMA_ID));
+  }
+
+  public Optional<FormatInfo> getKeyFormatInfo() {
+    return Optional.ofNullable(props.getString(CommonCreateConfigs.KEY_FORMAT_PROPERTY))
+        .map(format -> FormatInfo.of(format, ImmutableMap.of()));
   }
 
   public FormatInfo getFormatInfo() {

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -547,7 +547,7 @@ public class KsqlParserTest {
     assertThat(Iterables.get(result.getElements(), 0).getName(), equalTo(ColumnName.of("ORDERTIME")));
     assertThat(Iterables.get(result.getElements(), 6).getType().getSqlType().baseType(), equalTo(SqlBaseType.STRUCT));
     assertThat(result.getProperties().getKafkaTopic(), equalTo("orders_topic"));
-    assertThat(result.getProperties().getValueFormat(), equalTo(FormatFactory.AVRO));
+    assertThat(result.getProperties().getFormatInfo().getFormat(), equalTo(FormatFactory.AVRO.name()));
   }
 
   @Test
@@ -562,7 +562,7 @@ public class KsqlParserTest {
     assertThat(Iterables.size(result.getElements()), equalTo(4));
     assertThat(Iterables.get(result.getElements(), 0).getName(), equalTo(ColumnName.of("USERTIME")));
     assertThat(result.getProperties().getKafkaTopic(), equalTo("foo"));
-    assertThat(result.getProperties().getValueFormat(), equalTo(FormatFactory.JSON));
+    assertThat(result.getProperties().getFormatInfo().getFormat(), equalTo(FormatFactory.JSON.name()));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -53,7 +53,6 @@ public class CreateSourceAsPropertiesTest {
 
     // Then:
     assertThat(properties.getKafkaTopic(), is(Optional.empty()));
-    assertThat(properties.getValueFormat(), is(Optional.empty()));
     assertThat(properties.getTimestampColumnName(), is(Optional.empty()));
     assertThat(properties.getTimestampFormat(), is(Optional.empty()));
     assertThat(properties.getFormatInfo(), is(Optional.empty()));

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -73,7 +73,7 @@ public class CreateSourcePropertiesTest {
 
     // Then:
     assertThat(properties.getKafkaTopic(), is("foo"));
-    assertThat(properties.getValueFormat(), is(FormatFactory.AVRO));
+    assertThat(properties.getFormatInfo().getFormat(), is(FormatFactory.AVRO.name()));
   }
 
   @Test


### PR DESCRIPTION
Just raising as an example of how we can wire in KEY_FORMAT and default key format config without an injector. 

Very rough code only.  Doesn't handle default value format, doesn't include any tests, doesn't add `FORMAT` etc etc.

Basically, we need to worry about:

1. What formats the user supplied in C* statements and the defaults in the config:  this is handled by `TopicFactory`.
2. What formats the user supplied in C*AS statements: this is handled by `Analyzer`.

These changes are inline with the general design of the code (as its always been), and don't require an injector or reformatting of the SQL

