### PR TITLE
chore: remove junit5 references

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -59,7 +60,6 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -326,10 +326,13 @@ public class EndToEndIntegrationTest {
   ) throws Exception {
     final BlockingRowQueue rowQueue = queryMetadata.getRowQueue();
 
-    TestUtils.waitForCondition(
+    assertThatEventually(
+        expectedRows + " rows were not available after 30 seconds",
         () -> rowQueue.size() >= expectedRows,
-        30_000,
-        expectedRows + " rows were not available after 30 seconds");
+        is(true),
+        30,
+        TimeUnit.SECONDS
+    );
 
     final List<GenericRow> rows = new ArrayList<>();
     rowQueue.drainTo(rows);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.integration;
 
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.test.util.ConsumerTestUtil.hasUniqueRecords;
 import static io.confluent.ksql.test.util.ConsumerTestUtil.toUniqueRecords;
 import static io.confluent.ksql.test.util.MapMatchers.mapHasSize;
@@ -54,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -556,7 +558,8 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param topicNames the names of the topics to await existence for.
    */
   public void waitForTopicsToBePresent(final String... topicNames) throws Exception {
-    TestUtils.waitForCondition(
+    assertThatEventually(
+        "topics not all present after 30 seconds. topics: " + Arrays.toString(topicNames),
         () -> {
           try {
             final KafkaTopicClient topicClient = serviceContext.get().getTopicClient();
@@ -566,8 +569,9 @@ public final class IntegrationTestHarness extends ExternalResource {
             throw new RuntimeException("could not get subjects");
           }
         },
-        30_000,
-        "topics not all present after 30 seconds. topics: " + Arrays.toString(topicNames));
+        is(true),
+        30, TimeUnit.SECONDS
+    );
   }
 
   /**
@@ -576,7 +580,8 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param subjectName the name of the subject to await existence for.
    */
   public void waitForSubjectToBePresent(final String subjectName) throws Exception {
-    TestUtils.waitForCondition(
+    assertThatEventually(
+        "subject not present after 30 seconds. subject: " + subjectName,
         () -> {
           try {
             return getSchemaRegistryClient().getAllSubjects().contains(subjectName);
@@ -584,8 +589,10 @@ public final class IntegrationTestHarness extends ExternalResource {
             throw new RuntimeException("could not get subjects");
           }
         },
-        30_000,
-        "subject not present after 30 seconds. subject: " + subjectName);
+        is(true),
+        30,
+        TimeUnit.SECONDS
+    );
   }
 
   /**
@@ -594,7 +601,8 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param subjectName the name of the subject to await absence for.
    */
   public void waitForSubjectToBeAbsent(final String subjectName) throws Exception {
-    TestUtils.waitForCondition(
+    assertThatEventually(
+        "subject still present after 30 seconds. subject: " + subjectName,
         () -> {
           try {
             return !getSchemaRegistryClient().getAllSubjects().contains(subjectName);
@@ -602,8 +610,10 @@ public final class IntegrationTestHarness extends ExternalResource {
             throw new RuntimeException("could not get subjects");
           }
         },
-        30_000,
-        "subject still present after 30 seconds. subject: " + subjectName);
+        is(true),
+        30,
+        TimeUnit.SECONDS
+    );
   }
 
   public ParsedSchema getSchema(final String subjectName) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.integration;
 import static io.confluent.ksql.GenericRow.genericRow;
 import static io.confluent.ksql.serde.FormatFactory.AVRO;
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -125,7 +126,7 @@ public class JoinIntTest {
     );
 
     final Map<String, GenericRow> results = new HashMap<>();
-    TestUtils.waitForCondition(() -> {
+    assertThatEventually("failed to complete join correctly", () -> {
           results.putAll(TEST_HARNESS.verifyAvailableUniqueRows(
               testStreamName,
               1,
@@ -145,8 +146,7 @@ public class JoinIntTest {
         }
       }
       return success;
-        }, MAX_WAIT_MS,
-        "failed to complete join correctly");
+        }, is(true), MAX_WAIT_MS, TimeUnit.MILLISECONDS);
   }
 
   @Test
@@ -185,7 +185,7 @@ public class JoinIntTest {
     );
 
     final Map<String, GenericRow> results = new HashMap<>();
-    TestUtils.waitForCondition(() -> {
+    assertThatEventually("failed to complete join correctly", () -> {
       results.putAll(TEST_HARNESS.verifyAvailableUniqueRows(
           testStreamName,
           1,
@@ -204,7 +204,7 @@ public class JoinIntTest {
         }
       }
       return success;
-    }, MAX_WAIT_MS, "failed to complete join correctly");
+    }, is(true), MAX_WAIT_MS, TimeUnit.MILLISECONDS);
   }
 
   @Test
@@ -259,7 +259,7 @@ public class JoinIntTest {
 
     final AtomicInteger attempts = new AtomicInteger();
     final Map<String, GenericRow> results = new HashMap<>();
-    TestUtils.waitForCondition(() -> {
+    assertThatEventually("failed to complete join correctly", () -> {
       results.putAll(TEST_HARNESS.verifyAvailableUniqueRows(
           outputStream,
           1,
@@ -282,7 +282,7 @@ public class JoinIntTest {
         }
       }
       return success;
-    }, 120000, "failed to complete join correctly");
+    }, is(true), 120000, TimeUnit.MILLISECONDS);
 
     assertThat(results, is(expectedResults));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/HealthCheckResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/HealthCheckResourceTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -26,6 +27,7 @@ import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.healthcheck.HealthCheckAgent;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -83,10 +85,12 @@ public class HealthCheckResourceTest {
     healthCheckResource.checkHealth();
 
     // When / Then:
-    TestUtils.waitForCondition(
-        () -> healthCheckResource.checkHealth().getEntity() == response2,
+    assertThatEventually(
+        "Should receive response2 once response1 expires.",
+        () -> healthCheckResource.checkHealth().getEntity(),
+        is(response2),
         1000,
-        "Should receive response2 once response1 expires."
+        TimeUnit.MILLISECONDS
     );
   }
 }

--- a/ksqldb-udf-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/ksqldb-udf-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -29,10 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ksql.version>@{project.version}</ksql.version>
-        <junit.jupiter.version>5.4.1</junit.jupiter.version>
-        <maven.shade.version>3.2.1</maven.shade.version>
-        <!-- JUnit 5 requires Surefire version 2.22.1 or higher -->
-        <maven.surefire.version>2.22.1</maven.surefire.version>
+        <maven.surefire.version>3.0.0-M4</maven.surefire.version>
     </properties>
 
     <repositories>
@@ -73,19 +70,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${maven.shade.version}</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>
             </plugin>
@@ -101,9 +85,9 @@
         </dependency>
         <!-- Test dependencies -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ksqldb-udf-quickstart/src/main/resources/archetype-resources/src/test/java/ReverseUdfTests.java
+++ b/ksqldb-udf-quickstart/src/main/resources/archetype-resources/src/test/java/ReverseUdfTests.java
@@ -15,24 +15,23 @@
 
 package ${package};
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Example class that demonstrates how to unit test UDFs.
  */
 public class ReverseUdfTests {
 
-  @ParameterizedTest(name = "reverse({0})= {1}")
-  @CsvSource({
-      "hello, olleh",
-      "world, dlrow",
-  })
-  void reverseString(final String source, final String expectedResult) {
+  @Test
+  public void shouldReverseString() {
+    // Given:
     final ReverseUdf reverse = new ReverseUdf();
-    final String actualResult = reverse.reverseString(source);
-    assertEquals(expectedResult, actualResult, source + " reversed should equal " + expectedResult);
+
+    // When:
+    final String actualResult = reverse.reverseString("foo");
+
+    // Then:
+    Assert.assertEquals("oof", actualResult);
   }
 }

--- a/ksqldb-udf-quickstart/src/main/resources/archetype-resources/src/test/java/SummaryStatsUdafTests.java
+++ b/ksqldb-udf-quickstart/src/main/resources/archetype-resources/src/test/java/SummaryStatsUdafTests.java
@@ -15,17 +15,12 @@
 
 package ${package};
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import io.confluent.ksql.function.udaf.Udaf;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.Assert;
+import org.junit.Test;
 
 
 /**
@@ -34,53 +29,36 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class SummaryStatsUdafTests {
 
   @Test
-  void mergeAggregates() {
+  public void mergeAggregates() {
+    // Given:
     final Udaf<Double, Map<String, Double>, Map<String, Double>> udaf =
         SummaryStatsUdaf.createUdaf();
 
+    // When:
     final Map<String, Double> mergedAggregate = udaf.merge(
         // (sample_size, sum, mean)
         aggregate(3.0, 3300.0, 1100.0),
         aggregate(7.0, 6700.0, 957.143)
     );
 
+    // Then:
     final Map<String, Double> expectedResult = aggregate(10.0, 10000.0, 1000.0);
-    assertEquals(expectedResult, mergedAggregate);
+    Assert.assertEquals(expectedResult, mergedAggregate);
   }
 
-  @ParameterizedTest
-  @MethodSource("aggSources")
-  void calculateSummaryStats(
-      final Double newValue,
-      final Map<String, Double> currentAggregate,
-      final Map<String, Double> expectedResult
-  ) {
+  @Test
+  public void shouldComputeNewAggregate() {
+    // Given:
     final Udaf<Double, Map<String, Double>, Map<String, Double>> udaf =
         SummaryStatsUdaf.createUdaf();
 
-    assertEquals(expectedResult, udaf.aggregate(newValue, currentAggregate));
-  }
+    // When:
+    Map<String, Double> newAggregate = udaf.aggregate(900.0, aggregate(1.0, 400.0, 400.0));
 
-  static Stream<Arguments> aggSources() {
-    return Stream.of(
-      // sample: 400
-      arguments(
-        // new value
-        400.0,
-        // current aggregate
-        aggregate(0.0, 0.0, 0.0),
-        // expected new aggregate
-        aggregate(1.0, 400.0, 400.0)
-      ),
-      // sample: 400, 900
-      arguments(
-        // new value
-        900.0,
-        // current aggregate
-        aggregate(1.0, 400.0, 400.0),
-        // expected new aggregate
-        aggregate(2.0, 1300.0, 650.0)
-      )
+    // Then:
+    Assert.assertEquals(
+        aggregate(2.0, 1300.0, 650.0),
+        newAggregate
     );
   }
 
@@ -88,7 +66,7 @@ public class SummaryStatsUdafTests {
    * Helper method for building an aggregate that mimics what KSQL would pass
    * to our UDAF instance.
    */
-  static Map<String, Double> aggregate(
+  private static Map<String, Double> aggregate(
       final Double sampleSize,
       final Double sum,
       final Double mean

--- a/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
+++ b/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
@@ -15,13 +15,14 @@
 
 package io.confluent.ksql.version.metrics;
 
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
+import static org.hamcrest.Matchers.is;
 import static org.mockserver.model.HttpRequest.request;
 
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 import io.confluent.support.metrics.BaseSupportConfig;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.test.TestUtils;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class VersionCheckerIntegrationTest {
     );
     versionCheckerAgent.start(KsqlModuleType.SERVER, versionCheckProps);
 
-    TestUtils.waitForCondition(() -> {
+    assertThatEventually("Version not submitted", () -> {
           try {
             clientAndProxy.verify(request().withPath("/ksql/anon").withMethod("POST"));
             return true;
@@ -69,7 +70,9 @@ public class VersionCheckerIntegrationTest {
             return false;
           }
         },
-        30000, "Version not submitted"
+        is(true),
+        30000,
+        TimeUnit.MILLISECONDS
     );
   }
 }


### PR DESCRIPTION
### Description 

Some of our dependencies require Junit5 to run (namely usage of Kafka's `TestUtil`) as of https://github.com/confluentinc/kafka/commit/7d0086e0c35d827a46e82956f42af57f6a6539f1. While I was at it, I cleaned up the maven architype as well.

### Testing done 
`mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

