### PR TITLE
test: support source value format in QTT post conditions (MINOR)

### DIFF
--- a/ksqldb-functional-tests/README.md
+++ b/ksqldb-functional-tests/README.md
@@ -308,6 +308,7 @@ A post condition can define the list of sources that must exist in the metastore
   "type": "table",
   "schema": "ID BIGINT KEY, FOO STRING, KSQL_COL_1 BIGINT",
   "keyFormat": {"format": "KAFKA"},
+  "valueFormat": "JSON",
   "serdeOptions": ["UNWRAP_SINGLE_VALUES"]
 }
 ```
@@ -320,6 +321,7 @@ Each source can define the following attributes:
 | type         | (Required) Specifies if the source is a STREAM or TABLE. |
 | schema       | (Optional) Specifies the SQL schema for the source. |
 | keyFormat    | (Optional) Key serialization format for the source. |
+| valueFormat  | (Optional) Value serialization format for the source. |
 | serdeOptions | (Optional) List of expected serde options for the source. |
 
 #### Topics

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/matchers/MetaStoreMatchers.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/matchers/MetaStoreMatchers.java
@@ -73,6 +73,20 @@ public final class MetaStoreMatchers {
     };
   }
 
+  public static Matcher<DataSource> hasValueFormat(
+      final Matcher<? super String> matcher
+  ) {
+    return new FeatureMatcher<DataSource, String>(
+        matcher,
+        "source with value format",
+        "value format") {
+      @Override
+      protected String featureValueOf(final DataSource actual) {
+        return actual.getKsqlTopic().getValueFormat().getFormatInfo().getFormat();
+      }
+    };
+  }
+
   public static Matcher<DataSource> hasSerdeOptions(
       final Matcher<? super Iterable<? super SerdeOption>> matcher
   ) {

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/SourceNodeTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/SourceNodeTest.java
@@ -28,6 +28,7 @@ public class SourceNodeTest {
       "stream",
       Optional.of("ROWKEY INT KEY, NAME STRING"),
       Optional.of(KeyFormatNodeTest.INSTANCE),
+      Optional.of("JSON"),
       Optional.of(ImmutableSet.of(SerdeOption.UNWRAP_SINGLE_VALUES))
   );
   static final SourceNode INSTANCE_WITHOUT_SERDE_OPTIONS = new SourceNode(
@@ -35,6 +36,7 @@ public class SourceNodeTest {
       "stream",
       Optional.of("ROWKEY INT KEY, NAME STRING"),
       Optional.of(KeyFormatNodeTest.INSTANCE),
+      Optional.of("JSON"),
       Optional.empty()
   );
   static final SourceNode INSTANCE_WITH_EMPTY_SERDE_OPTIONS = new SourceNode(
@@ -42,6 +44,7 @@ public class SourceNodeTest {
       "stream",
       Optional.of("ROWKEY INT KEY, NAME STRING"),
       Optional.of(KeyFormatNodeTest.INSTANCE),
+      Optional.of("JSON"),
       Optional.of(Collections.emptySet())
   );
 

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
@@ -37,22 +37,20 @@
         {"topic": "OUTPUT", "value": {"FOO": 10}}
       ],
       "post": {
-        "topics": {
-          "topics": [
-            {
-              "name" : "input_topic",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "JSON"},
-              "partitions": 4
-            },
-            {
-              "name" : "OUTPUT",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "JSON"},
-              "partitions": 4
-            }
-          ]
-        }
+        "sources": [
+          {
+            "name" : "INPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "JSON"
+          },
+          {
+            "name" : "OUTPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "JSON"
+          }
+        ]
       }
     },
     {
@@ -72,22 +70,20 @@
         {"topic": "OUTPUT", "value": {"FOO": 10}}
       ],
       "post": {
-        "topics": {
-          "topics": [
-            {
-              "name" : "input_topic",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "JSON"},
-              "partitions": 4
-            },
-            {
-              "name" : "OUTPUT",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "JSON"},
-              "partitions": 4
-            }
-          ]
-        }
+        "sources": [
+          {
+            "name" : "INPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "JSON"
+          },
+          {
+            "name" : "OUTPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "JSON"
+          }
+        ]
       }
     },
     {
@@ -132,22 +128,20 @@
         {"topic": "OUTPUT", "value": {"FOO": 10}}
       ],
       "post": {
-        "topics": {
-          "topics": [
-            {
-              "name" : "input_topic",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "JSON"},
-              "partitions": 4
-            },
-            {
-              "name" : "OUTPUT",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "JSON"},
-              "partitions": 4
-            }
-          ]
-        }
+        "sources": [
+          {
+            "name" : "INPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "JSON"
+          },
+          {
+            "name" : "OUTPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "JSON"
+          }
+        ]
       }
     },
     {
@@ -167,22 +161,20 @@
         {"topic": "OUTPUT", "value": {"FOO": 10}}
       ],
       "post": {
-        "topics": {
-          "topics": [
-            {
-              "name" : "input_topic",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "JSON"},
-              "partitions": 4
-            },
-            {
-              "name" : "OUTPUT",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "JSON"},
-              "partitions": 4
-            }
-          ]
-        }
+        "sources": [
+          {
+            "name" : "INPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "JSON"
+          },
+          {
+            "name" : "OUTPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "JSON"
+          }
+        ]
       }
     },
     {
@@ -197,22 +189,20 @@
       "input": [{"topic": "input", "key": "foo", "value": "bar"}],
       "output": [{"topic": "OUTPUT", "key": "foo", "value": "bar"}],
       "post": {
-        "topics": {
-          "topics": [
-            {
-              "name" : "input",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "KAFKA"},
-              "partitions": 4
-            },
-            {
-              "name" : "OUTPUT",
-              "keyFormat" : {"formatInfo" : {"format" : "KAFKA"}},
-              "valueFormat" : {"format" : "KAFKA"},
-              "partitions": 4
-            }
-          ]
-        }
+        "sources": [
+          {
+            "name" : "INPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "KAFKA"
+          },
+          {
+            "name" : "OUTPUT",
+            "type" : "stream",
+            "keyFormat" : {"format": "KAFKA"},
+            "valueFormat" : "KAFKA"
+          }
+        ]
       }
     },
     {


### PR DESCRIPTION
### Description 

Addresses https://github.com/confluentinc/ksql/pull/6194#discussion_r490670303 by adding value format into the sources post-condition check of QTT, and updating the new tests to use the sources post-condition check rather than the topics post-condition check.

### Testing done 

Test-only change. Verified that tests fail if the specified source value format does not match what's expected.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

