### PR TITLE
test: add RQTT for non-KAFKA key format (MINOR)

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -383,6 +383,21 @@
       "responses": [
         {"admin": {"@type": "currentStatus"}}
       ]
+    },
+    {
+      "name": "non-KAFKA key format",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "INSERT INTO TEST (ID, ROWTIME, K) VALUES (10, 1234, 'key');"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "timestamp": 1234, "key": "key", "value": {"ID": 10}}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1513,6 +1513,33 @@
           {"row":{"columns":["10",1]}}
         ]}
       ]
+    },
+    {
+      "name": "non-windowed single key lookup - non-KAFKA key format",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', key_format='JSON', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID=10;",
+        "SELECT * FROM AGGREGATE WHERE ID=123369;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 10, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}}
+        ]}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -729,6 +729,29 @@
           {"finalMessage":"Limit Reached"}
         ]}
       ]
+    },
+    {
+      "name": "non-windowed stream - non-KAFKA key format",
+      "statements": [
+        "CREATE STREAM INPUT (K INT KEY, ID INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "SELECT * FROM INPUT EMIT CHANGES LIMIT 2;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {"id": 100}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 11, "value": {"id": 101}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER, `ID` INTEGER"}},
+          {"row":{"columns":[11, 100]}},
+          {"row":{"columns":[11, 101]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/6216

Add RQTT tests with non-Kafka formats. No changes were needed to the RQTT framework. This PR just adds a few tests as sanity checks going forward.

The tests aren't super useful as sanity checks since RQTT doesn't support the post-conditions check that QTT does which would allow us to verify the key and value formats of the created sources. This means an (unlikely) bug could be introduced into the RQTT executor which always hardcodes a particular key format and these tests would still pass. I don't think it's worth introducing a post-conditions check to RQTT, though, since that's the job of QTT not RQTT.

### Testing done 

Tests pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

