### PR TITLE
docs: bump docs version to 0.13.0 (DOCS-5440)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,9 +218,9 @@ extra:
         # Build-related string tokens
         kafkaversion: 2.6
         kafkarelease: 5.5.0-ccs
-        ksqldbversion: 0.12.0
+        ksqldbversion: 0.13.0
         ksqldbcpversion: 6.1.0-beta200715032424
-        release: 0.12.0
+        release: 0.13.0
         cprelease: 5.5.0
         releasepostbranch: 5.5.0-post
         scalaversion: 2.12


### PR DESCRIPTION
Prep for the 0.13.x-ksqldb branch cut.