### PR TITLE
test: correct bug in QTT that meant some tests were ignored

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TestCaseNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TestCaseNode.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.test.TestFrameworkException;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.tools.exceptions.MissingFieldException;
 import java.util.List;
@@ -133,12 +134,22 @@ public class TestCaseNode {
   }
 
   private void validate() {
-    if (this.name.isEmpty()) {
+    if (name.isEmpty()) {
       throw new MissingFieldException("name");
     }
 
-    if (this.statements.isEmpty()) {
-      throw new InvalidFieldException("statements", "was empty");
+    try {
+      if (statements.isEmpty()) {
+        throw new InvalidFieldException("statements", "was empty");
+      }
+
+      if (!expectedException.isPresent() && inputs.isEmpty() && outputs.isEmpty()) {
+        throw new InvalidFieldException(
+            "outputs", "no inputs, outputs or expectedException provided");
+      }
+    } catch (final Exception e) {
+      throw new TestFrameworkException(
+          "Invalid test case: '" + name + "'. cause: " + e.getMessage(), e);
     }
   }
 

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/delimited_-_deserialize_DELIMITED_with_WRAP_SINGLE_VALUE_false/6.1.0_1599861951568/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/delimited_-_deserialize_DELIMITED_with_WRAP_SINGLE_VALUE_false/6.1.0_1599861951568/spec.json
@@ -20,6 +20,8 @@
       "numPartitions" : 4
     } ],
     "statements" : [ "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='input_topic', value_format='DELIMITED');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "inputs": [{"topic": "input_topic", "key": "foo", "value": "1"}],
+    "outputs": [{"topic": "OUTPUT", "key": "foo", "value": "1"}],
     "post" : {
       "sources" : [ {
         "name" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/formats_-_explicit_format/6.1.0_1600714522363/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/formats_-_explicit_format/6.1.0_1600714522363/spec.json
@@ -20,6 +20,8 @@
       "numPartitions" : 4
     } ],
     "statements" : [ "CREATE STREAM INPUT (K STRING KEY, foo STRING) WITH (kafka_topic='input', format='KAFKA');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "inputs": [{"topic": "input", "key": "foo", "value": "bar"}],
+    "outputs": [{"topic": "OUTPUT", "key": "foo", "value": "bar"}],
     "properties" : {
       "ksql.persistence.default.format.value" : "JSON"
     },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_BIGINT/6.1.0_1597874026416/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_BIGINT/6.1.0_1597874026416/spec.json
@@ -20,6 +20,8 @@
       "numPartitions" : 4
     } ],
     "statements" : [ "CREATE STREAM INPUT (K BIGINT KEY, foo BIGINT) WITH (kafka_topic='input', value_format='KAFKA');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "inputs": [{"topic": "input", "key": 1, "value": 2}],
+    "outputs": [{"topic": "OUTPUT", "key": 1, "value": 2}],
     "post" : {
       "sources" : [ {
         "name" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_DOUBLE/6.1.0_1597874026426/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_DOUBLE/6.1.0_1597874026426/spec.json
@@ -20,6 +20,8 @@
       "numPartitions" : 4
     } ],
     "statements" : [ "CREATE STREAM INPUT (K DOUBLE KEY, foo DOUBLE) WITH (kafka_topic='input', value_format='KAFKA');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "inputs": [{"topic": "input", "key": 1.1, "value": 2.2}],
+    "outputs": [{"topic": "OUTPUT", "key": 1.1, "value": 2.2}],
     "post" : {
       "sources" : [ {
         "name" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_Default_single_value_wrapping/6.1.0_1597874026383/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_Default_single_value_wrapping/6.1.0_1597874026383/spec.json
@@ -20,6 +20,8 @@
       "numPartitions" : 4
     } ],
     "statements" : [ "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (kafka_topic='input', value_format='KAFKA');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "inputs": [{"topic": "input", "key": "foo", "value": 1}],
+    "outputs": [{"topic": "OUTPUT", "key": "foo", "value": 1}],
     "post" : {
       "sources" : [ {
         "name" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_INT/6.1.0_1597874026407/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_INT/6.1.0_1597874026407/spec.json
@@ -20,6 +20,8 @@
       "numPartitions" : 4
     } ],
     "statements" : [ "CREATE STREAM INPUT (K INT KEY, foo INT) WITH (kafka_topic='input', value_format='KAFKA');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "inputs": [{"topic": "input", "key": 1, "value": 2}],
+    "outputs": [{"topic": "OUTPUT", "key": 1, "value": 2}],
     "post" : {
       "sources" : [ {
         "name" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_STRING/6.1.0_1597874026396/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_STRING/6.1.0_1597874026396/spec.json
@@ -20,6 +20,8 @@
       "numPartitions" : 4
     } ],
     "statements" : [ "CREATE STREAM INPUT (K STRING KEY, foo STRING) WITH (kafka_topic='input', value_format='KAFKA');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "inputs": [{"topic": "input", "key": "foo", "value": "bar"}],
+    "outputs": [{"topic": "OUTPUT", "key": "foo", "value": "bar"}],
     "post" : {
       "sources" : [ {
         "name" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_Unwrapped_single_values/6.1.0_1599861974669/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/kafka_-_Unwrapped_single_values/6.1.0_1599861974669/spec.json
@@ -20,6 +20,8 @@
       "numPartitions" : 4
     } ],
     "statements" : [ "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='input', value_format='KAFKA');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "inputs": [{"topic": "input", "key": "foo", "value": 1}],
+    "outputs": [{"topic": "OUTPUT", "key": "foo", "value": 1}],
     "post" : {
       "sources" : [ {
         "name" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/delimited.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/delimited.json
@@ -35,8 +35,8 @@
         "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='input_topic', value_format='DELIMITED');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "input": [{"topic": "input", "key": "foo", "value": "1"}],
-      "output": [{"topic": "OUTPUT", "key": "foo", "value": "1"}]
+      "inputs": [{"topic": "input_topic", "key": "foo", "value": "1"}],
+      "outputs": [{"topic": "OUTPUT", "key": "foo", "value": "1"}]
     },
     {
       "name": "select delimited value_format",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
@@ -194,8 +194,8 @@
       "properties": {
         "ksql.persistence.default.format.value": "JSON"
       },
-      "input": [{"topic": "input", "key": "foo", "value": "bar"}],
-      "output": [{"topic": "OUTPUT", "key": "foo", "value": "bar"}],
+      "inputs": [{"topic": "input", "key": "foo", "value": "bar"}],
+      "outputs": [{"topic": "OUTPUT", "key": "foo", "value": "bar"}],
       "post": {
         "topics": {
           "topics": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/kafka.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/kafka.json
@@ -17,8 +17,8 @@
         "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='input', value_format='KAFKA');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "input": [{"topic": "input", "key": "foo", "value": 1}],
-      "output": [{"topic": "OUTPUT", "key": "foo", "value": 1}]
+      "inputs": [{"topic": "input", "key": "foo", "value": 1}],
+      "outputs": [{"topic": "OUTPUT", "key": "foo", "value": 1}]
     },
     {
       "name": "Default single value wrapping",
@@ -26,8 +26,8 @@
         "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (kafka_topic='input', value_format='KAFKA');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "input": [{"topic": "input", "key": "foo", "value": 1}],
-      "output": [{"topic": "OUTPUT", "key": "foo", "value": 1}]
+      "inputs": [{"topic": "input", "key": "foo", "value": 1}],
+      "outputs": [{"topic": "OUTPUT", "key": "foo", "value": 1}]
     },
     {
       "name": "STRING",
@@ -35,8 +35,8 @@
         "CREATE STREAM INPUT (K STRING KEY, foo STRING) WITH (kafka_topic='input', value_format='KAFKA');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "input": [{"topic": "input", "key": "foo", "value": "bar"}],
-      "output": [{"topic": "OUTPUT", "key": "foo", "value": "bar"}]
+      "inputs": [{"topic": "input", "key": "foo", "value": "bar"}],
+      "outputs": [{"topic": "OUTPUT", "key": "foo", "value": "bar"}]
     },
     {
       "name": "INT",
@@ -44,8 +44,8 @@
         "CREATE STREAM INPUT (K INT KEY, foo INT) WITH (kafka_topic='input', value_format='KAFKA');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "input": [{"topic": "input", "key": 1, "value": 2}],
-      "output": [{"topic": "OUTPUT", "key": 1, "value": 2}]
+      "inputs": [{"topic": "input", "key": 1, "value": 2}],
+      "outputs": [{"topic": "OUTPUT", "key": 1, "value": 2}]
     },
     {
       "name": "BIGINT",
@@ -53,8 +53,8 @@
         "CREATE STREAM INPUT (K BIGINT KEY, foo BIGINT) WITH (kafka_topic='input', value_format='KAFKA');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "input": [{"topic": "input", "key": 1, "value": 2}],
-      "output": [{"topic": "OUTPUT", "key": 1, "value": 2}]
+      "inputs": [{"topic": "input", "key": 1, "value": 2}],
+      "outputs": [{"topic": "OUTPUT", "key": 1, "value": 2}]
     },
     {
       "name": "DOUBLE",
@@ -62,8 +62,8 @@
         "CREATE STREAM INPUT (K DOUBLE KEY, foo DOUBLE) WITH (kafka_topic='input', value_format='KAFKA');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "input": [{"topic": "input", "key": 1.1, "value": 2.2}],
-      "output": [{"topic": "OUTPUT", "key": 1.1, "value": 2.2}]
+      "inputs": [{"topic": "input", "key": 1.1, "value": 2.2}],
+      "outputs": [{"topic": "OUTPUT", "key": 1.1, "value": 2.2}]
     },
     {
       "name": "MAP - C*",


### PR DESCRIPTION
### Description 

Some QTT test cases used `input` rather than `inputs` and `output` rather than `outputs`. Previously, QTT would have detected this mistake, but the check has been removed.

This change adds back in the check to ensure a test case provides at least one of:

- an expected exception
- input messages
- output messages

The change also corrects the bad tests and their historic plans


### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

