### PR TITLE
test: move QTT coercion into Kafka test serde

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
@@ -20,17 +20,17 @@ import static java.util.Objects.requireNonNull;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.test.TestFrameworkException;
 import io.confluent.ksql.test.serde.SerdeSupplier;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.connect.data.Schema.Type;
 
 public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
 
@@ -50,19 +50,6 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
     return new RowDeserializer();
   }
 
-  private SqlType getColumnType(final boolean isKey) {
-    final List<Column> columns = isKey ? schema.key() : schema.value();
-    if (columns.isEmpty()) {
-      throw new IllegalStateException("No columns in schema");
-    }
-
-    if (columns.size() != 1) {
-      throw new IllegalStateException("KAFKA format only supports single column schemas.");
-    }
-
-    return columns.get(0).type();
-  }
-
   private Serde<?> getSerde(final boolean isKey) {
     final List<Column> columns = isKey ? schema.key() : schema.value();
     if (columns.isEmpty()) {
@@ -79,17 +66,20 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
   }
 
   private static Serde<?> getSerde(final SqlType sqlType) {
-    final Type connectType = SchemaConverters.sqlToConnectConverter()
-        .toConnectSchema(sqlType)
-        .type();
-
-    switch (connectType) {
-      case INT32:
+    switch (sqlType.baseType()) {
+      case INTEGER:
         return Serdes.Integer();
-      case INT64:
-        return Serdes.Long();
-      case FLOAT64:
-        return Serdes.Double();
+      case BIGINT:
+        return Serdes.serdeFrom(
+            new TestNumberSerializer<>(Serdes.Long().serializer(), Long.class, Number::longValue),
+            new TestBigIntDeserializer(Serdes.Long().deserializer())
+        );
+      case DOUBLE:
+        return Serdes.serdeFrom(
+            new TestNumberSerializer<>(Serdes.Double().serializer(), Double.class,
+                Number::doubleValue),
+            new TestDoubleDeserializer(Serdes.Double().deserializer())
+        );
       case STRING:
         return Serdes.String();
       default:
@@ -134,6 +124,135 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
         throw new TestFrameworkException("Failed to deserialize " + type + ". "
             + e.getMessage(), e);
       }
+    }
+  }
+
+  /**
+   * Serializer that handles coercion to {@link Double}.
+   *
+   * <p>The QTT tests are written in JSON. When the input values are read from the JSON file
+   * numbers can be deserialized as an {@link Integer}, {@link Long}, or {@link BigDecimal}. The
+   * value needs converting to the correct type before serializing.
+   */
+  private static class TestNumberSerializer<T extends Number> implements Serializer<Object> {
+
+    private final Class<T> type;
+    private final Serializer<T> inner;
+    private final Function<Number, T> coercer;
+
+    TestNumberSerializer(
+        final Serializer<T> inner,
+        final Class<T> type,
+        final Function<Number, T> coercer
+    ) {
+      this.inner = requireNonNull(inner, "inner");
+      this.type = requireNonNull(type, "type");
+      this.coercer = requireNonNull(coercer, "coercer");
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+      inner.configure(configs, isKey);
+    }
+
+    @Override
+    public byte[] serialize(final String topicName, final Object value) {
+      final T coerced = coerce(value);
+      return inner.serialize(topicName, coerced);
+    }
+
+    @Override
+    public void close() {
+      inner.close();
+    }
+
+    private T coerce(final Object value) {
+      if (value == null) {
+        return null;
+      }
+
+      if (value instanceof Number) {
+        return coercer.apply((Number) value);
+      }
+
+      throw new TestFrameworkException("Can't serialize " + value + " as " + type.getSimpleName());
+    }
+  }
+
+  /**
+   * Deserializer that handles coercion from {@link Long} to {@link Integer}.
+   *
+   * <p>The QTT tests are written in JSON. When the expected values are read from the JSON file
+   * small numbers are deserialized as {@link Integer Integers}. This is not an issue. However, the
+   * deserializer needs to return the same if the actual value matches the expected value.
+   */
+  private static class TestBigIntDeserializer implements Deserializer<Object> {
+
+    private final Deserializer<Long> inner;
+
+    TestBigIntDeserializer(final Deserializer<Long> inner) {
+      this.inner = requireNonNull(inner, "inner");
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+      inner.configure(configs, isKey);
+    }
+
+    @Override
+    public Number deserialize(final String topicName, final byte[] bytes) {
+      final Long deserialized = inner.deserialize(topicName, bytes);
+      if (deserialized == null) {
+        return null;
+      }
+
+      if (Integer.MIN_VALUE < deserialized && deserialized < Integer.MAX_VALUE) {
+        return (int) (long) deserialized;
+      }
+
+      return deserialized;
+    }
+
+    @Override
+    public void close() {
+      inner.close();
+    }
+  }
+
+  /**
+   * Deserializer that handles coercion from {@link Double} to {@link BigDecimal}.
+   *
+   * <p>The QTT tests are written in JSON. When the expected values are read from the JSON file
+   * doubles are deserialized as {@link BigDecimal BigDecimals}. This is not an issue as BigDecimal
+   * is more accurate. However, the deserializer needs to return a `BigDecimal` so that the actual
+   * value matches the expected value.
+   */
+  private static class TestDoubleDeserializer implements Deserializer<Object> {
+
+    private final Deserializer<Double> inner;
+
+    TestDoubleDeserializer(final Deserializer<Double> inner) {
+      this.inner = requireNonNull(inner, "inner");
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+      inner.configure(configs, isKey);
+    }
+
+    @Override
+    public BigDecimal deserialize(final String topicName, final byte[] bytes) {
+      final Double deserialized = inner.deserialize(topicName, bytes);
+      if (deserialized == null) {
+        return null;
+      }
+
+      return BigDecimal.valueOf(deserialized);
+    }
+
+    @Override
+    public void close() {
+      inner.close();
     }
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -243,7 +243,7 @@ public class TestExecutor implements Closeable {
         ));
   }
 
-  private void validateTopicData(
+  private static void validateTopicData(
       final String topicName,
       final List<Record> expected,
       final Collection<ProducerRecord<?, ?>> actual,
@@ -254,14 +254,12 @@ public class TestExecutor implements Closeable {
           + "> records but it was <" + actual.size() + ">\n" + getActualsForErrorMessage(actual));
     }
 
-    final TopicInfo topicInfo = topicInfoCache.get(topicName);
-
     final Iterator<Record> expectedIt = expected.iterator();
     final Iterator<ProducerRecord<?, ?>> actualIt = actual.iterator();
 
     int i = 0;
     while (actualIt.hasNext() && expectedIt.hasNext()) {
-      final Record expectedRecord = topicInfo.coerceRecord(expectedIt.next(), i);
+      final Record expectedRecord = expectedIt.next();
       final ProducerRecord<?, ?> actualProducerRecord = actualIt.next();
 
       validateCreatedMessage(
@@ -325,21 +323,14 @@ public class TestExecutor implements Closeable {
       final TestCase testCase,
       final TopologyTestDriverContainer testDriver
   ) {
-    int inputRecordIndex = 0;
     for (final Record record : testCase.getInputRecords()) {
       if (testDriver.getSourceTopicNames().contains(record.getTopicName())) {
-
-        final TopicInfo topicInfo = topicInfoCache.get(record.getTopicName());
-
-        final Record coerced = topicInfo.coerceRecord(record, inputRecordIndex);
-
         processSingleRecord(
-            coerced.asProducerRecord(),
+            record.asProducerRecord(),
             testDriver,
             ImmutableSet.copyOf(kafka.getAllTopics())
         );
       }
-      ++inputRecordIndex;
     }
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -28,13 +28,9 @@ import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.DurationParser;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.SchemaConverters;
-import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.serde.kafka.KafkaFormat;
 import io.confluent.ksql.test.TestFrameworkException;
 import io.confluent.ksql.test.serde.SerdeSupplier;
 import io.confluent.ksql.test.utils.SerdeUtil;
@@ -236,93 +232,6 @@ public class TopicInfoCache {
       deserializer.configure(ImmutableMap.of(), false);
 
       return deserializer;
-    }
-
-    /**
-     * Coerce the key & value to the correct type.
-     *
-     * <p>The type of the key loaded from the JSON test case file may not be the exact match on
-     * type, e.g. JSON will load a small number as an integer, but the key type of the source might
-     * be a long.
-     *
-     * @param record the record to coerce
-     * @param msgIndex the index of the message, displayed in the error message
-     * @return a new Record with the correct key type.
-     */
-    public Record coerceRecord(
-        final Record record,
-        final int msgIndex
-    ) {
-      try {
-        final Object coercedKey = coerceKey(record.rawKey());
-        final Object coercedValue = coerceValue(record.value());
-        return record.withKeyValue(coercedKey, coercedValue);
-      } catch (final Exception e) {
-        throw new AssertionError(
-            "Topic '" + record.getTopicName() + "', message " + msgIndex
-                + ": Invalid test-case: could not coerce key in test case to required type. "
-                + e.getMessage(),
-            e);
-      }
-    }
-
-    private Object coerceKey(final Object key) {
-      if (schema.key().isEmpty()) {
-        // No key column
-        // - pass the key in as a string to allow tests to pass in data that should be ignored:
-        return key == null ? null : String.valueOf(key);
-      }
-
-      final SqlType keyType = schema
-          .key()
-          .get(0)
-          .type();
-
-      return DefaultSqlValueCoercer.INSTANCE
-          .coerce(key, keyType)
-          .orElseThrow(() -> new AssertionError("Invalid key for topic " + topicName + "."
-              + System.lineSeparator()
-              + "Expected KeyType: " + keyType
-              + System.lineSeparator()
-              + "Actual KeyType: " + SchemaConverters.javaToSqlConverter()
-              .toSqlType(key.getClass())
-              + ", key: " + key + "."
-              + System.lineSeparator()
-              + "This is likely caused by the key type in the test-case not matching the schema."
-          ))
-          .orElse(null);
-    }
-
-    private Object coerceValue(final Object value) {
-      // Only KAFKA format needs any value coercion at the moment:
-      if (!(valueFormat.getFormat() instanceof KafkaFormat)) {
-        return value;
-      }
-
-      if (schema.value().size() != 1) {
-        // Wrong column count:
-        // - pass the value as-is for negative testing:
-        return value == null ? null : String.valueOf(value);
-      }
-
-      final SqlType valueType = schema
-          .value()
-          .get(0)
-          .type();
-
-      return DefaultSqlValueCoercer.INSTANCE
-          .coerce(value, valueType)
-          .orElseThrow(() -> new AssertionError("Invalid value for topic " + topicName + "."
-              + System.lineSeparator()
-              + "Expected ValueType: " + valueType
-              + System.lineSeparator()
-              + "Actual ValueType: " + SchemaConverters.javaToSqlConverter()
-              .toSqlType(value.getClass())
-              + ", value: " + value + "."
-              + System.lineSeparator()
-              + "This is likely caused by the value type in the test-case not matching the schema."
-          ))
-          .orElse(null);
     }
   }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -207,17 +207,13 @@ public class RestTestExecutor implements Closeable {
           topicInfo.getKeySerializer(),
           topicInfo.getValueSerializer()
       )) {
-        for (int idx = 0; idx < records.size(); idx++) {
-          final Record record = records.get(idx);
-
-          final Record coerced = topicInfo.coerceRecord(record, idx);
-
+        for (final Record record : records) {
           producer.send(new ProducerRecord<>(
               topicName,
               null,
-              coerced.timestamp().orElse(0L),
-              coerced.key(),
-              coerced.value()
+              record.timestamp().orElse(0L),
+              record.key(),
+              record.value()
           ));
         }
       } catch (final Exception e) {

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplierTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplierTest.java
@@ -22,7 +22,9 @@ import static org.hamcrest.Matchers.is;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.math.BigDecimal;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.junit.Test;
@@ -32,13 +34,8 @@ public class KafkaSerdeSupplierTest {
   @Test
   public void shouldSerializeKeyAsStringIfNoKeyColumnsToAllowTestsToProveKeyIsIgnored() {
     // Given:
-    final KafkaSerdeSupplier supplier = new KafkaSerdeSupplier(
-        LogicalSchema.builder()
-            .valueColumn(ColumnName.of("Look no key col"), SqlTypes.STRING)
-            .build()
-    );
+    final Serializer<Object> serializer = getSerializer(SqlTypes.BIGINT);
 
-    final Serializer<Object> serializer = supplier.getSerializer(null);
     serializer.configure(ImmutableMap.of(), true);
 
     // When:
@@ -51,13 +48,8 @@ public class KafkaSerdeSupplierTest {
   @Test
   public void shouldDeserializeKeyAsStringIfNoKeyColumnsToAllowTestsToProveKeyIsIgnored() {
     // Given:
-    final KafkaSerdeSupplier supplier = new KafkaSerdeSupplier(
-        LogicalSchema.builder()
-            .valueColumn(ColumnName.of("Look no key col"), SqlTypes.STRING)
-            .build()
-    );
+    final Deserializer<?> deserializer = getDeserializer(SqlTypes.BIGINT);
 
-    final Deserializer<Object> deserializer = supplier.getDeserializer(null);
     deserializer.configure(ImmutableMap.of(), true);
 
     // When:
@@ -65,5 +57,91 @@ public class KafkaSerdeSupplierTest {
 
     // Then:
     assertThat(result, is("22"));
+  }
+
+  @Test
+  public void shouldSerializeIntAsLong() {
+    // Given:
+    final Serializer<Object> serializer = getSerializer(SqlTypes.BIGINT);
+
+    // When:
+    final byte[] result = serializer.serialize(null, 10);
+
+    assertThat(result, is(new byte[]{0, 0, 0, 0, 0, 0, 0, 10}));
+  }
+
+  @Test
+  public void shouldDeserializeSmallLongAsInt() {
+    // Given:
+    final Deserializer<?> deserializer = getDeserializer(SqlTypes.BIGINT);
+
+    // When:
+    final Object result = deserializer.deserialize(null, new byte[]{0, 0, 0, 0, 0, 0, 0, 11});
+
+    assertThat(result, is(11));
+  }
+
+  @Test
+  public void shouldDeserializeBigLongAsLong() {
+    // Given:
+    final Deserializer<?> deserializer = getDeserializer(SqlTypes.BIGINT);
+
+    // When:
+    final Object result = deserializer.deserialize(null, new byte[]{0, 0, 1, 0, 0, 0, 0, 11});
+
+    assertThat(result, is(1099511627787L));
+  }
+
+  @Test
+  public void shouldSerializeIntAsDouble() {
+    // Given:
+    final Serializer<Object> serializer = getSerializer(SqlTypes.DOUBLE);
+
+    // When:
+    final byte[] result = serializer.serialize(null, 234);
+
+    assertThat(result, is(new byte[]{64, 109, 64, 0, 0, 0, 0, 0}));
+  }
+
+  @Test
+  public void shouldSerializeLongAsDouble() {
+    // Given:
+    final Serializer<Object> serializer = getSerializer(SqlTypes.DOUBLE);
+
+    // When:
+    final byte[] result = serializer.serialize(null, 1099511627787L);
+
+    assertThat(result, is(new byte[]{66, 112, 0, 0, 0, 0, -80, 0}));
+  }
+
+  @Test
+  public void shouldDeserializeDoubleAsDecimal() {
+    // Given:
+    final Deserializer<?> deserializer = getDeserializer(SqlTypes.DOUBLE);
+
+    // When:
+    final Object result = deserializer.deserialize(null, new byte[]{66, 112, 0, 0, 0, 0, -80, 0});
+
+    assertThat(result, is(new BigDecimal("1099511627787")));
+  }
+
+  private static Serializer<Object> getSerializer(final SqlType colType) {
+    final Serializer<Object> serializer = getSerdeSupplier(colType).getSerializer(null);
+    serializer.configure(ImmutableMap.of(), false);
+    return serializer;
+  }
+
+  private static Deserializer<?> getDeserializer(final SqlType colType) {
+    final Deserializer<Object> deserializer = getSerdeSupplier(colType).getDeserializer(null);
+    deserializer.configure(ImmutableMap.of(), false);
+    return deserializer;
+  }
+
+  private static KafkaSerdeSupplier getSerdeSupplier(final SqlType colType) {
+    return new KafkaSerdeSupplier(
+        LogicalSchema.builder()
+            .valueColumn(ColumnName.of("Look no key col"), colType)
+            .build()
+    );
   }
 }


### PR DESCRIPTION
### Description 

Moves the coercion required by the Kafka Serde _into_ the Kafka Serde used by QTT.

Previously, this was handled by `TopicInfoCache`. However, it's only the `KAFKA` format that needs this, (as it has specific serde for different primitive types).  Moving it into `KafkaSerdeSupplier` simplifies the code path for other formats.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

