### PR TITLE
test: drop internal topics from QTT test cases

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -15,9 +15,6 @@
         {"topic": "test_topic", "timestamp": 12375, "key": 11, "value": {}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12345, "key": 11, "value": {"ID": 11, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12365, "key": 10, "value": {"ID": 10, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12375, "key": 11, "value": {"ID": 11, "KSQL_AGG_VARIABLE_0": 2}},
         {"topic": "OUTPUT", "key": 11, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 10, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 11, "value": {"COUNT": 2}}
@@ -96,16 +93,6 @@
         {"topic": "test_topic", "key": 4, "value": {"data": "d1"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 3}},
         {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": "d2", "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 2}},
@@ -132,16 +119,6 @@
         {"topic": "test_topic", "key": 4, "value": {"ADDRESS": {"STREET": "1st Steet", "Town": "Oxford"}}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "Oxford", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "Oxford"}}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "London", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "London"}}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "Oxford", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "Oxford"}}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "London", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "London"}}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "Oxford", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "Oxford"}}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "Oxford", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "Oxford"}, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "London", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "London"}, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "Oxford", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "Oxford"}, "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "London", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "London"}, "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "Oxford", "value": {"ROWTIME": 0, "ADDRESS": {"STREET": "1st Steet", "TOWN": "Oxford"}, "KSQL_AGG_VARIABLE_0": 3}},
         {"topic": "OUTPUT", "key": "Oxford", "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": "London", "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": "Oxford", "value": {"COUNT": 2}},
@@ -168,16 +145,6 @@
         {"topic": "test_topic", "key": 4, "value": {"data": "2-"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "22"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "333"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "003"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "22", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "333", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "003", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-", "KSQL_AGG_VARIABLE_0": 3}},
         {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 2}},
@@ -204,16 +171,6 @@
         {"topic": "test_topic", "key": 4, "value": {"data": "d1"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 3}},
         {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": "d2", "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 2}},
@@ -240,16 +197,6 @@
         {"topic": "test_topic", "key": 4, "value": {"data": "d1"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 0, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 0, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 3}},
         {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": "d2", "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": "d1", "value": {"COUNT": 2}},
@@ -276,16 +223,6 @@
         {"topic": "test_topic", "key": 4, "value": {"data": "2-"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "22"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "333"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "003"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "22", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "333", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "003", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-", "KSQL_AGG_VARIABLE_0": 3}},
         {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 2}},
@@ -312,17 +249,7 @@
         {"topic": "test_topic", "key": 4, "value": {"data": "2-"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "22"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "333"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": {"ROWTIME": 0, "DATA": "003"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "22", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "333", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "-2", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": {"ROWTIME": 0, "DATA": "003", "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ROWTIME": 0, "DATA": "2-", "KSQL_AGG_VARIABLE_0": 3}},
-        {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 1}},
+         {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 2, "value": {"COUNT": 2}},
         {"topic": "OUTPUT", "key": 3, "value": {"COUNT": 2}},
@@ -346,12 +273,6 @@
         {"topic": "test_topic", "value": {"data": 22}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 22, "value": {"ROWTIME": 0, "DATA": 22}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 333, "value": {"ROWTIME": 0, "DATA": 333}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 22, "value": {"ROWTIME": 0, "DATA": 22}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 22, "value": {"ROWTIME": 0, "DATA": 22, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 333, "value": {"ROWTIME": 0, "DATA": 333, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 22, "value": {"ROWTIME": 0, "DATA": 22, "KSQL_AGG_VARIABLE_0": 2}},
         {"topic": "OUTPUT", "key": 22, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 333, "value": {"COUNT": 1}},
         {"topic": "OUTPUT", "key": 22, "value": {"COUNT": 2}}
@@ -702,12 +623,6 @@
         {"topic": "test_topic", "key": 0, "value": {"V1": 10}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "0|+|10", "value": {"V0": 0, "V1": 10, "KSQL_INTERNAL_COL_2": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "1|+|20", "value": {"V0": 1, "V1": 20, "KSQL_INTERNAL_COL_2": 21}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "0|+|10", "value": {"V0": 0, "V1": 10, "KSQL_INTERNAL_COL_2": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "0|+|10", "value": {"V0": 0, "V1": 10, "KSQL_AGG_VARIABLE_0": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "1|+|20", "value": {"V0": 1, "V1": 20, "KSQL_AGG_VARIABLE_0": 21}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "0|+|10", "value": {"V0": 0, "V1": 10, "KSQL_AGG_VARIABLE_0": 20}},
         {"topic": "OUTPUT", "key": "0|+|10", "value": {"SUM": 10}},
         {"topic": "OUTPUT", "key": "1|+|20", "value": {"SUM": 21}},
         {"topic": "OUTPUT", "key": "0|+|10", "value": {"SUM": 20}}
@@ -730,12 +645,6 @@
         {"topic": "test_topic", "key": 0, "value": {"V1": 10}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 10, "value": {"V0": 0, "V1": 10, "KSQL_INTERNAL_COL_2": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 21, "value": {"V0": 1, "V1": 20, "KSQL_INTERNAL_COL_2": 21}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 10, "value": {"V0": 0, "V1": 10, "KSQL_INTERNAL_COL_2": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 10, "value": {"V0": 0, "V1": 10, "KSQL_AGG_VARIABLE_0": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 21, "value": {"V0": 1, "V1": 20, "KSQL_AGG_VARIABLE_0": 21}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 10, "value": {"V0": 0, "V1": 10, "KSQL_AGG_VARIABLE_0": 20}},
         {"topic": "OUTPUT", "key": 10, "value": {"SUM": 10}},
         {"topic": "OUTPUT", "key": 21, "value": {"SUM": 21}},
         {"topic": "OUTPUT", "key": 10, "value": {"SUM": 20}}
@@ -758,12 +667,6 @@
         {"topic": "test_topic", "key": 0, "value": {"V1": 10}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "0|+|10", "value": {"V0": 0, "V1": 10, "KSQL_INTERNAL_COL_2": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "1|+|20", "value": {"V0": 1, "V1": 20, "KSQL_INTERNAL_COL_2": 21}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "0|+|10", "value": {"V0": 0, "V1": 10, "KSQL_INTERNAL_COL_2": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "0|+|10", "value": {"V0": 0, "V1": 10, "KSQL_AGG_VARIABLE_0": 10}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "1|+|20", "value": {"V0": 1, "V1": 20, "KSQL_AGG_VARIABLE_0": 21}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "0|+|10", "value": {"V0": 0, "V1": 10, "KSQL_AGG_VARIABLE_0": 20}},
         {"topic": "OUTPUT", "key": "0|+|10", "value": {"SUM": 10}},
         {"topic": "OUTPUT", "key": "1|+|20", "value": null},
         {"topic": "OUTPUT", "key": "0|+|10", "value": {"SUM": 20}}
@@ -847,11 +750,6 @@
         {"topic": "test_topic", "key": "d1", "value": "-"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": "d1,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": "d2,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": "d1,0,2"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": "d2,0,2"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": "d1,0,3"},
         {"topic": "OUTPUT", "key": "d1", "value": "1"},
         {"topic": "OUTPUT", "key": "d2", "value": "1"},
         {"topic": "OUTPUT", "key": "d1", "value": "2"},
@@ -890,11 +788,6 @@
         {"topic": "test_topic", "key": "d1", "value": {}, "timestamp": 5}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"K": "d1", "ROWTIME": 1, "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 1},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"K": "d2", "ROWTIME": 2, "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 2},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"K": "d1", "ROWTIME": 3, "KSQL_AGG_VARIABLE_0": 2}, "timestamp": 3},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"K": "d2", "ROWTIME": 4, "KSQL_AGG_VARIABLE_0": 2}, "timestamp": 4},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"K": "d1", "ROWTIME": 5, "KSQL_AGG_VARIABLE_0": 3}, "timestamp": 5},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0":1}, "timestamp": 1},
         {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0":1}, "timestamp": 2},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0":2}, "timestamp": 3},
@@ -921,11 +814,6 @@
         {"topic": "test_topic", "key": "e", "value": {"ID": 1}, "timestamp": 5}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 1, "value": {"ID": 1, "ROWTIME": 1, "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 1},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ID": 2, "ROWTIME": 2, "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 2},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 1, "value": {"ID": 1, "ROWTIME": 3, "KSQL_AGG_VARIABLE_0": 2}, "timestamp": 3},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": {"ID": 2, "ROWTIME": 4, "KSQL_AGG_VARIABLE_0": 2}, "timestamp": 4},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 1, "value": {"ID": 1, "ROWTIME": 5, "KSQL_AGG_VARIABLE_0": 3}, "timestamp": 5},
         {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0":1}, "timestamp": 1},
         {"topic": "OUTPUT", "key": 2, "value": {"KSQL_COL_0":1}, "timestamp": 2},
         {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0":2}, "timestamp": 3},
@@ -952,11 +840,6 @@
         {"topic": "test_topic", "key": 3, "value": "3,a"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": "1,a,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": "2,b,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": "1,a,0,2"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": "2,b,0,2"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|3", "value": "3,a,0,1"},
         {"topic": "OUTPUT", "key": "a|+|1", "value": "1"},
         {"topic": "OUTPUT", "key": "b|+|2", "value": "1"},
         {"topic": "OUTPUT", "key": "a|+|1", "value": "2"},
@@ -1006,11 +889,6 @@
         {"topic": "test_topic", "key": 3, "value": {"F1": 3, "F2": "a"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": {"F1": 1, "F2": "a", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": {"F1": 2, "F2": "b", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": {"F1": 1, "F2": "a", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": {"F1": 2, "F2": "b", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|3", "value": {"F1": 3, "F2": "a", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
         {"topic": "OUTPUT", "key": "a|+|1", "value": {"KSQL_COL_0": 1}},
         {"topic": "OUTPUT", "key": "b|+|2", "value": {"KSQL_COL_0": 1}},
         {"topic": "OUTPUT", "key": "a|+|1", "value": {"KSQL_COL_0": 2}},
@@ -1085,13 +963,6 @@
         {"topic": "test_topic", "key": 1, "value": "1,a"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": "1,a,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": "2,b,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": "1,a,0,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|1", "value": "1,b,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": "2,b,0,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|1", "value": "1,b,0,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": "1,a,0,1"},
         {"topic": "OUTPUT", "key": "a|+|1", "value": "1"},
         {"topic": "OUTPUT", "key": "b|+|2", "value": "1"},
         {"topic": "OUTPUT", "key": "a|+|1", "value": "0"},
@@ -1120,13 +991,6 @@
         {"topic": "test_topic", "key": 1, "value": "1,a"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": "1,a,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": "2,b,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": "1,a,0,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|1", "value": "1,b,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": "2,b,0,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|1", "value": "1,b,0,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": "1,a,0,1"},
         {"topic": "OUTPUT", "key": "a|+|1", "value": "1,a,1"},
         {"topic": "OUTPUT", "key": "b|+|2", "value": "2,b,1"},
         {"topic": "OUTPUT", "key": "a|+|1", "value": "1,a,0"},
@@ -1156,13 +1020,6 @@
         {"topic": "test_topic", "key": 1, "value": {"F1": 1, "F2": "a"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": {"F1": 1, "F2": "a", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": {"F1": 2, "F2": "b", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": {"F1": 1, "F2": "a", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 0}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|1", "value": {"F1": 1, "F2": "b", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|2", "value": {"F1": 2, "F2": "b", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 0}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "b|+|1", "value": {"F1": 1, "F2": "b", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 0}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "a|+|1", "value": {"F1": 1, "F2": "a", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
         {"topic": "OUTPUT", "key": "a|+|1", "value": {"KSQL_COL_0": 1}},
         {"topic": "OUTPUT", "key": "b|+|2", "value": {"KSQL_COL_0": 1}},
         {"topic": "OUTPUT", "key": "a|+|1", "value": {"KSQL_COL_0": 0}},
@@ -1191,16 +1048,6 @@
         {"topic": "test_topic", "value": "d1"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": "d1,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": "d2,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": "d1,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": "d2,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": "d1,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": "d1,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": "d2,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": "d1,0,2"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": "d2,0,2"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": "d1,0,3"},
         {"topic": "OUTPUT", "key": "d1", "value": "1"},
         {"topic": "OUTPUT", "key": "d2", "value": "1"},
         {"topic": "OUTPUT", "key": "d1", "value": "2"},
@@ -1227,16 +1074,6 @@
         {"topic": "test_topic", "value": "0.1"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 0.1, "value": "0.1,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 0.2, "value": "0.2,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 0.1, "value": "0.1,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 0.2, "value": "0.2,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 0.1, "value": "0.1,0"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 0.1, "value": "0.1,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 0.2, "value": "0.2,0,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 0.1, "value": "0.1,0,2"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 0.2, "value": "0.2,0,2"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 0.1, "value": "0.1,0,3"},
         {"topic": "OUTPUT", "key": 0.1, "value": "1"},
         {"topic": "OUTPUT", "key": 0.2, "value": "1"},
         {"topic": "OUTPUT", "key": 0.1, "value": "2"},
@@ -1264,16 +1101,6 @@
         {"topic": "test_topic", "value": {"DATA": "d1"}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"DATA": "d1", "ROWTIME": 0}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"DATA": "d2", "ROWTIME": 0}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"DATA": "d1", "ROWTIME": 0}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d2", "value": {"DATA": "d2", "ROWTIME": 0}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": "d1", "value": {"DATA": "d1", "ROWTIME": 0}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"DATA": "d1", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"DATA": "d2", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"DATA": "d1", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"DATA": "d2", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"DATA": "d1", "ROWTIME": 0, "KSQL_AGG_VARIABLE_0": 3}},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0":1}},
         {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0":1}},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0":2}},
@@ -2007,9 +1834,6 @@
         {"topic": "test_topic", "value": {"DATA": "d1"}, "timestamp": 3}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 1, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 1},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"ROWTIME": 2, "DATA": "d2", "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 2},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"ROWTIME": 3, "DATA": "d1", "KSQL_AGG_VARIABLE_0": 2}, "timestamp": 3},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0": 1}, "timestamp": 1},
         {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0": 1}, "timestamp": 2},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0": 2}, "timestamp": 3}
@@ -2050,9 +1874,6 @@
         {"topic": "test_topic", "value": {"DATA": "d1"}, "timestamp": 3}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"DATA": "d1", "ROWTIME": 1, "KSQL_AGG_VARIABLE_0": 1, "KSQL_AGG_VARIABLE_1": 1}, "timestamp": 1},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"DATA": "d2", "ROWTIME": 2, "KSQL_AGG_VARIABLE_0": 1, "KSQL_AGG_VARIABLE_1": 1}, "timestamp": 2},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"DATA": "d1", "ROWTIME": 3, "KSQL_AGG_VARIABLE_0": 2, "KSQL_AGG_VARIABLE_1": 2}, "timestamp": 3},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0": 1, "KSQL_COL_1": 1, "COPY": "d1"}, "timestamp": 1},
         {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0": 1, "KSQL_COL_1": 1, "COPY": "d2"}, "timestamp": 2},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0": 2, "KSQL_COL_1": 2, "COPY": "d1"}, "timestamp": 3}
@@ -2070,9 +1891,6 @@
         {"topic": "test_topic", "value": {"DATA": "d1"}, "timestamp": 3}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"DATA": "d1", "KSQL_AGG_VARIABLE_0": 1, "KSQL_AGG_VARIABLE_1": 1}, "timestamp": 1},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d2", "value": {"DATA": "d2", "KSQL_AGG_VARIABLE_0": 1, "KSQL_AGG_VARIABLE_1": 1}, "timestamp": 2},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": "d1", "value": {"DATA": "d1", "KSQL_AGG_VARIABLE_0": 2, "KSQL_AGG_VARIABLE_1": 2}, "timestamp": 3},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0": 1, "KSQL_COL_1": 1}, "timestamp": 1},
         {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0": 1, "KSQL_COL_1": 1}, "timestamp": 2},
         {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0": 2, "KSQL_COL_1": 2}, "timestamp": 3}
@@ -2302,12 +2120,6 @@
         {"topic": "test_topic", "value": "2"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": "2,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 3, "value": "3,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition", "key": 2, "value": "2,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": "2,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 3, "value": "3,1"},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "key": 2, "value": "2,2"},
         {"topic": "OUTPUT", "key": 2, "value": "1"},
         {"topic": "OUTPUT", "key": 3, "value": "1"},
         {"topic": "OUTPUT", "key": 2, "value": "2"}
@@ -2335,9 +2147,6 @@
         {"topic": "test_topic", "timestamp": 12375, "key": "11", "value": {}}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12345, "key": "11", "value": {"Key": "11", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12365, "key": "10", "value": {"Key": "10", "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog", "timestamp": 12375, "key": "11", "value": {"Key": "11", "KSQL_AGG_VARIABLE_0": 2}},
         {"topic": "OUTPUT", "key": "11", "value": {"Value": 1}},
         {"topic": "OUTPUT", "key": "10", "value": {"Value": 1}},
         {"topic": "OUTPUT", "key": "11", "value": {"Value": 2}}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
@@ -167,10 +167,6 @@
         {"topic": "s2", "key": "s2-key", "value": {"K": "v1"}, "timestamp": 0}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_INSERTQUERY_0-Join-left-repartition", "key": "v1", "value": {"S1_K": "v1", "S1_ROWTIME": 0, "S1_ID": "s1-key"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_INSERTQUERY_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 0, "end": 1000, "type": "time"}, "key": "v1", "value": {"S1_K": "v1", "S1_ROWTIME": 0, "S1_ID": "s1-key"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_INSERTQUERY_0-Join-right-repartition", "key": "v1", "value": {"S2_K": "v1", "S2_ROWTIME": 0, "S2_ID": "s2-key"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_INSERTQUERY_0-KSTREAM-JOINOTHER-0000000017-store-changelog", "window": {"start": 0, "end": 1000, "type": "time"}, "key": "v1", "value": {"S2_K": "v1", "S2_ROWTIME": 0, "S2_ID": "s2-key"}},
         {"topic": "OUTPUT", "key": "v1", "value": {"DATA": "s1-keys2-key", "I": 1}}
       ]
     },

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -431,14 +431,6 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
         {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
         {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
         {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
@@ -472,14 +464,6 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
         {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
         {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
         {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
@@ -591,22 +575,6 @@
         {"topic": "left_topic", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 0, "T_K": null, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": null, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 10, "value": {"T_ROWTIME": 11000, "T_K": null, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 13000, "T_K": null, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": null, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": null, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 90, "value": {"T_ROWTIME": 17000, "T_K": null, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 30000, "T_K": null, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_K": null, "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": null, "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_K": null, "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_K": null, "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": null, "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": null, "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_K": null, "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_K": null, "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
         {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
         {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
         {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
@@ -640,22 +608,6 @@
         {"topic": "left_topic", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 0, "T_K": "", "T_ID": 0, "T_NAME": "zero", "T_VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 10000, "TT_K": "", "TT_ID": 0, "TT_F1": "blah", "TT_F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"T_ROWTIME": 11000, "T_K": "", "T_ID": 10, "T_NAME": "100", "T_VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 13000, "T_K": "", "T_ID": 0, "T_NAME": "foo", "T_VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 15000, "TT_K": "", "TT_ID": 0, "TT_F1": "a", "TT_F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"TT_ROWTIME": 16000, "TT_K": "", "TT_ID": 100, "TT_F1": "newblah", "TT_F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"T_ROWTIME": 17000, "T_K": "", "T_ID": 90, "T_NAME": "ninety", "T_VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 30000, "T_K": "", "T_ID": 0, "T_NAME": "bar", "T_VALUE": 99}, "timestamp": 30000},
         {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "", "F2": 0}, "timestamp": 0},
         {"topic": "OUTPUT", "key": 0, "value": {"NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
         {"topic": "OUTPUT", "key": 10, "value": {"NAME": "100", "VALUE": 5, "F1": "", "F2": 0}, "timestamp": 11000},
@@ -804,14 +756,6 @@
         {"topic": "left_topic", "key": 0, "value": {"NAME": "bar"}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 0, "end": 11000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 0, "TT_ID": 0, "TT_NAME": "zero"}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "window": {"start": 10000, "end": 21000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 10000, "T_ID": 0, "T_F1": "blah"}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 11000, "end": 22000, "type": "time"}, "key": 10, "value": {"TT_ROWTIME": 11000, "TT_ID": 10, "TT_NAME": "100"}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 13000, "end": 24000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 13000, "TT_ID": 0, "TT_NAME": "foo"}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "window": {"start": 15000, "end": 26000, "type": "time"}, "key": 0, "value": {"T_ROWTIME": 15000, "T_ID": 0, "T_F1": "a"}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "window": {"start": 16000, "end": 27000, "type": "time"}, "key": 100, "value": {"T_ROWTIME": 16000, "T_ID": 100, "T_F1": "newblah"}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 17000, "end": 28000, "type": "time"}, "key": 90, "value": {"TT_ROWTIME": 17000, "TT_ID": 90, "TT_NAME": "ninety"}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "window": {"start": 30000, "end": 41000, "type": "time"}, "key": 0, "value": {"TT_ROWTIME": 30000, "TT_ID": 0, "TT_NAME": "bar"}, "timestamp": 30000},
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "TT_NAME": "zero"}, "timestamp": 10000},
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "TT_NAME": "foo"}, "timestamp": 13000},
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "TT_NAME": "foo"}, "timestamp": 15000}
@@ -1508,7 +1452,6 @@
         {"topic": "right_topic", "key": 1, "value": {"x": 3}, "timestamp": 10}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 1, "value": {"TT_X": 3, "TT_ROWTIME": 10, "TT_ID": 1, "TT_KSQL_COL_0": 1}, "timestamp": 10},
         {"topic": "OUTPUT", "key": 1, "value": {"T_X": 2}, "timestamp": 10}
       ]
     },
@@ -1539,7 +1482,6 @@
         {"topic": "right_topic", "key": 1, "value": {"ROWKEY_3": 3}, "timestamp": 10}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 1, "value": {"TT_ROWKEY_3": 3, "TT_ROWTIME": 10, "TT_ROWKEY_1": 1, "TT_KSQL_COL_0": 1}, "timestamp": 10},
         {"topic": "OUTPUT", "key": 1, "value": {"ROWKEY_2": 2}, "timestamp": 10}
       ]
     },
@@ -1959,10 +1901,6 @@
         {"topic": "right_topic", "key": 2, "value": {"X": 4, "Y": {"Z": 10}}, "timestamp": 100}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-left-repartition", "key": 10, "value": {"S1_ROWTIME": 20, "S1_ID": 1, "S1_A": 1, "S1_B": {"C": 10}, "S1_C": 10}, "timestamp": 20},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-right-repartition", "key": 10, "value": {"S2_ROWTIME": 100, "S2_ID": 2, "S2_X": 4, "S2_Y": {"Z": 10}, "S2_Z": 10}, "timestamp": 100},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "key": 10, "value": {"S1_ROWTIME": 20, "S1_ID": 1, "S1_A": 1, "S1_B": {"C": 10}, "S1_C": 10}, "timestamp": 20, "window": {"start": 20, "end": 60020, "type": "time"}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KSTREAM-JOINOTHER-0000000017-store-changelog", "key": 10, "value": {"S2_ROWTIME": 100, "S2_ID": 2, "S2_X": 4, "S2_Y": {"Z": 10}, "S2_Z": 10}, "timestamp": 100, "window": {"start": 100, "end": 60100, "type": "time"}},
         {"topic": "OUTPUT", "key": 10, "value": {"S1_ROWTIME": 20, "S1_ID": 1, "S1_A": 1, "S1_B": {"C": 10}, "S2_ROWTIME": 100, "S2_ID": 2, "S2_X": 4, "S2_Y": {"Z": 10}}, "timestamp": 100}
       ],
       "post": {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -351,7 +351,6 @@
         {"topic": "left", "key": 0, "value": {"k": 1, "V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-repartition", "key": 1, "value": {"S1_K": 1, "S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0}, "timestamp": 12},
         {"topic": "OUTPUT", "key": 1, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
@@ -558,7 +557,6 @@
         {"topic": "left", "key": 0, "value": {"k": 1, "V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-repartition", "key": 1, "value": {"S1_K": 1, "S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0}, "timestamp": 12},
         {"topic": "OUTPUT", "key": 1, "value": {"S1_V0": 1, "T2_V0": 2, "T3_V0": 3}, "timestamp": 12}
       ],
       "post": {
@@ -663,11 +661,6 @@
         {"topic": "right", "key": 2, "value": {"k": 0, "V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-right-repartition", "key": 0, "value": {"S2_K": 0, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 2}, "timestamp": 11},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-right-repartition", "key": 0, "value": {"S2_K": 0, "S2_V0": 4, "S2_ROWTIME": 13, "S2_ID": 2}, "timestamp": 13},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-right-repartition", "key": 0, "value": {"S2_K": 0, "S2_V0": 6, "S2_ROWTIME": 100001, "S2_ID": 2}, "timestamp": 100001},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-left-repartition", "key": 0, "value": {"S1_K": 0, "S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 1}, "timestamp": 12},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-L_Join-left-repartition", "key": 0, "value": {"S1_K": 0, "S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 1}, "timestamp": 100000},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp": 12},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp": 13},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": 6, "T3_V0": 3}, "timestamp": 100001}
@@ -751,11 +744,6 @@
         {"topic": "right", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": null, "value": {"S1_V0": null, "S1_ROWTIME": null, "S1_ID": null, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 11},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 12},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 4, "S2_ROWTIME": 13, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 13},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": null, "S2_ROWTIME": null, "S2_ID": null, "KSQL_COL_0": null}, "timestamp": 100000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": 6, "S2_ROWTIME": 100001, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 100001},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 2, "T3_V0": 3}, "timestamp": 12},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_V0": 4, "T3_V0": 3}, "timestamp": 13},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_V0": null, "T3_V0": 3}, "timestamp": 100000},
@@ -784,11 +772,6 @@
         {"topic": "right", "key": 0, "value": {"V0": 6}, "timestamp": 100001}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": null, "value": {"S1_V0": null, "S1_ROWTIME": null, "S1_ID": null, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 11},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 2, "S2_ROWTIME": 11, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 12},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 1, "S1_ROWTIME": 12, "S1_ID": 0, "S2_V0": 4, "S2_ROWTIME": 13, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 13},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": null, "S2_ROWTIME": null, "S2_ID": null, "KSQL_COL_0": null}, "timestamp": 100000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition", "key": 0, "value": {"S1_V0": 5, "S1_ROWTIME": 100000, "S1_ID": 0, "S2_V0": 6, "S2_ROWTIME": 100001, "S2_ID": 0, "KSQL_COL_0": null}, "timestamp": 100001},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_ID": 0, "S2_V0": 2, "T3_ID": 0, "T3_V0": 3}, "timestamp": 12},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "S2_ID": 0, "S2_V0": 4, "T3_ID": 0, "T3_V0": 3}, "timestamp": 13},
         {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 5, "S2_ID": null, "S2_V0": null, "T3_ID": 0, "T3_V0": 3}, "timestamp": 100000},

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/table.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/table.json
@@ -27,7 +27,6 @@
         {"topic": "test_topic", "key": "1", "value": "2"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_T1_0-KsqlTopic-Reduce-changelog", "key": "1", "value": "2"},
         {"topic": "T1", "key": "1", "value": "2"}
       ]
     },
@@ -44,7 +43,6 @@
         {"topic": "test_topic", "key": "1", "value": "2"}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_T1_0-KsqlTopic-Reduce-changelog", "key": "1", "value": "2"},
         {"topic": "T1", "key": "1", "value": "2"}
       ]
     },


### PR DESCRIPTION
### Description 

The historical plans now capture all records send to internal topics, so there is no need for the QTT test cases to detail the internal messages. Removing them makes the tests easier to read.

### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

