### PR TITLE
fix: JSON format to set correct scale of decimals

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.serde.connect.ConnectSchemas;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -81,7 +82,7 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
       .put("BAZ", genericRow(3L, new BigDecimal("30.33"), Collections.singletonList("b"), Collections.emptyMap(), generateStruct(null), generateComplexStruct(2)))
       .put("BUZZ", genericRow(4L, new BigDecimal("40.44"), ImmutableList.of("c", "d"), Collections.emptyMap(), generateStruct(88), generateComplexStruct(3)))
       // Additional entries for repeated keys
-      .put("BAZ", genericRow(5L, new BigDecimal("12"), ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2"), generateStruct(0), generateComplexStruct(4)))
+      .put("BAZ", genericRow(5L, new BigDecimal("12.0"), ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2"), generateStruct(0), generateComplexStruct(4)))
       .put("BUZZ", genericRow(6L, new BigDecimal("10.1"), ImmutableList.of("f", "g"), Collections.emptyMap(), generateStruct(null), generateComplexStruct(5)))
       .build();
 
@@ -136,7 +137,7 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
   private static Struct generateComplexStruct(final int i) {
     final Struct complexStruct = new Struct(COMPLEX_FIELD_SCHEMA);
 
-    complexStruct.put("DECIMAL", new BigDecimal(i));
+    complexStruct.put("DECIMAL", new BigDecimal(i).setScale(1, RoundingMode.UNNECESSARY));
 
     final Struct struct = new Struct(COMPLEX_FIELD_SCHEMA.field("STRUCT").schema());
     struct.put("F1", "v" + i);

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_SR_should_not_trim_trailing_zeros/6.0.0_1593789506613/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_SR_should_not_trim_trailing_zeros/6.0.0_1593789506613/spec.json
@@ -31,7 +31,7 @@
       "topic" : "OUTPUT",
       "key" : null,
       "value" : {
-        "DEC" : 10.0
+        "DEC" : 10.0000
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1583419431528/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1583419431528/spec.json
@@ -55,31 +55,31 @@
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 10
+        "DEC" : 10.0000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 1
+        "DEC" : 1.0000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.1
+        "DEC" : 0.1000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.01
+        "DEC" : 0.0100
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.001
+        "DEC" : 0.0010
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1588893908853/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1588893908853/spec.json
@@ -55,31 +55,31 @@
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 10
+        "DEC" : 10.0000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 1
+        "DEC" : 1.0000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.1
+        "DEC" : 0.1000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.01
+        "DEC" : 0.0100
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.001
+        "DEC" : 0.0010
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1589910855902/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_scale_in_data_less_than_scale_in_type/6.0.0_1589910855902/spec.json
@@ -55,31 +55,31 @@
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 10
+        "DEC" : 10.0000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 1
+        "DEC" : 1.0000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.1
+        "DEC" : 0.1000
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.01
+        "DEC" : 0.0100
       }
     }, {
       "topic" : "OUTPUT",
       "key" : "",
       "value" : {
-        "DEC" : 0.001
+        "DEC" : 0.0010
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_should_not_trim_trailing_zeros/6.0.0_1593789506599/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_JSON_should_not_trim_trailing_zeros/6.0.0_1593789506599/spec.json
@@ -31,7 +31,7 @@
       "topic" : "OUTPUT",
       "key" : null,
       "value" : {
-        "DEC" : 10.0
+        "DEC" : 10.0000
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/explode_-_explode_different_types/5.5.0_1581572089881/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/explode_-_explode_different_types/5.5.0_1581572089881/spec.json
@@ -35,7 +35,7 @@
         "KSQL_COL_2" : 3.1,
         "KSQL_COL_3" : true,
         "KSQL_COL_4" : "foo",
-        "KSQL_COL_5" : 123.456
+        "KSQL_COL_5" : 123.4560000000
       }
     }, {
       "topic" : "OUTPUT",
@@ -46,7 +46,7 @@
         "KSQL_COL_2" : 4.1,
         "KSQL_COL_3" : false,
         "KSQL_COL_4" : "bar",
-        "KSQL_COL_5" : 456.123
+        "KSQL_COL_5" : 456.1230000000
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/explode_-_explode_different_types/6.0.0_1588893912305/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/explode_-_explode_different_types/6.0.0_1588893912305/spec.json
@@ -35,7 +35,7 @@
         "KSQL_COL_2" : 3.1,
         "KSQL_COL_3" : true,
         "KSQL_COL_4" : "foo",
-        "KSQL_COL_5" : 123.456
+        "KSQL_COL_5" : 123.4560000000
       }
     }, {
       "topic" : "OUTPUT",
@@ -46,7 +46,7 @@
         "KSQL_COL_2" : 4.1,
         "KSQL_COL_3" : false,
         "KSQL_COL_4" : "bar",
-        "KSQL_COL_5" : 456.123
+        "KSQL_COL_5" : 456.1230000000
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/explode_-_explode_different_types/6.0.0_1589910859868/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/explode_-_explode_different_types/6.0.0_1589910859868/spec.json
@@ -35,7 +35,7 @@
         "KSQL_COL_2" : 3.1,
         "KSQL_COL_3" : true,
         "KSQL_COL_4" : "foo",
-        "KSQL_COL_5" : 123.456
+        "KSQL_COL_5" : 123.4560000000
       }
     }, {
       "topic" : "OUTPUT",
@@ -46,7 +46,7 @@
         "KSQL_COL_2" : 4.1,
         "KSQL_COL_3" : false,
         "KSQL_COL_4" : "bar",
-        "KSQL_COL_5" : 456.123
+        "KSQL_COL_5" : 456.1230000000
       }
     } ],
     "topics" : [ {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_array_params/5.5.0_1581572104153/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_array_params/5.5.0_1581572104153/spec.json
@@ -63,7 +63,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_array_params/6.0.0_1588893946476/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_array_params/6.0.0_1588893946476/spec.json
@@ -63,7 +63,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_array_params/6.0.0_1589910892972/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_array_params/6.0.0_1589910892972/spec.json
@@ -63,7 +63,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_map_params/5.5.0_1581572104170/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_map_params/5.5.0_1581572104170/spec.json
@@ -77,7 +77,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_map_params/6.0.0_1588893946500/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_map_params/6.0.0_1588893946500/spec.json
@@ -77,7 +77,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_map_params/6.0.0_1589910892992/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_map_params/6.0.0_1589910892992/spec.json
@@ -77,7 +77,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_return_vals/5.5.0_1581572104193/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_return_vals/5.5.0_1581572104193/spec.json
@@ -38,7 +38,7 @@
         "KSQL_COL_2" : 3.1,
         "KSQL_COL_3" : true,
         "KSQL_COL_4" : "foo",
-        "KSQL_COL_5" : 123.456,
+        "KSQL_COL_5" : 123.4560000000,
         "KSQL_COL_6" : {
           "A" : "bar"
         }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_return_vals/6.0.0_1588893946522/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_return_vals/6.0.0_1588893946522/spec.json
@@ -38,7 +38,7 @@
         "KSQL_COL_2" : 3.1,
         "KSQL_COL_3" : true,
         "KSQL_COL_4" : "foo",
-        "KSQL_COL_5" : 123.456,
+        "KSQL_COL_5" : 123.4560000000,
         "KSQL_COL_6" : {
           "A" : "bar"
         }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_return_vals/6.0.0_1589910893013/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_return_vals/6.0.0_1589910893013/spec.json
@@ -38,7 +38,7 @@
         "KSQL_COL_2" : 3.1,
         "KSQL_COL_3" : true,
         "KSQL_COL_4" : "foo",
-        "KSQL_COL_5" : 123.456,
+        "KSQL_COL_5" : 123.4560000000,
         "KSQL_COL_6" : {
           "A" : "bar"
         }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_simple_params/5.5.0_1581572104135/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_simple_params/5.5.0_1581572104135/spec.json
@@ -63,7 +63,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_simple_params/6.0.0_1588893946443/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_simple_params/6.0.0_1588893946443/spec.json
@@ -63,7 +63,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_simple_params/6.0.0_1589910892938/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/table-functions_-_test_udtf_-_simple_params/6.0.0_1589910892938/spec.json
@@ -63,7 +63,7 @@
       "topic" : "OUTPUT",
       "key" : "0",
       "value" : {
-        "KSQL_COL_0" : "123.456"
+        "KSQL_COL_0" : "123.4560000000"
       }
     }, {
       "topic" : "OUTPUT",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -59,11 +59,11 @@
         {"topic": "test", "value": {"DEC": 0.0001}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "value": {"DEC": 10}},
-        {"topic": "OUTPUT", "value": {"DEC": 1}},
-        {"topic": "OUTPUT", "value": {"DEC": 0.1}},
-        {"topic": "OUTPUT", "value": {"DEC": 0.01}},
-        {"topic": "OUTPUT", "value": {"DEC": 0.001}},
+        {"topic": "OUTPUT", "value": {"DEC": 10.0000}},
+        {"topic": "OUTPUT", "value": {"DEC": 1.0000}},
+        {"topic": "OUTPUT", "value": {"DEC": 0.1000}},
+        {"topic": "OUTPUT", "value": {"DEC": 0.0100}},
+        {"topic": "OUTPUT", "value": {"DEC": 0.0010}},
         {"topic": "OUTPUT", "value": {"DEC": 0.0001}}
       ],
       "post": {
@@ -127,7 +127,7 @@
         {"topic": "test", "value": {"DEC": 1.0000}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "value": {"DEC": 10.0}},
+        {"topic": "OUTPUT", "value": {"DEC": 10.0000}},
         {"topic": "OUTPUT", "value": {"DEC": 1.0000}}
       ],
       "post": {
@@ -148,7 +148,7 @@
         {"topic": "test", "value": {"DEC": 1.0000}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "value": {"DEC": 10.0}},
+        {"topic": "OUTPUT", "value": {"DEC": 10.0000}},
         {"topic": "OUTPUT", "value": {"DEC": 1.0000}}
       ],
       "post": {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/explode.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/explode.json
@@ -76,8 +76,8 @@
         }
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": 1, "KSQL_COL_1": 2, "KSQL_COL_2": 3.1, "KSQL_COL_3": true, "KSQL_COL_4": "foo", "KSQL_COL_5": 123.456}},
-        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": 2, "KSQL_COL_1": 3, "KSQL_COL_2": 4.1, "KSQL_COL_3": false, "KSQL_COL_4": "bar", "KSQL_COL_5": 456.123}}
+        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": 1, "KSQL_COL_1": 2, "KSQL_COL_2": 3.1, "KSQL_COL_3": true, "KSQL_COL_4": "foo", "KSQL_COL_5": 123.4560000000}},
+        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": 2, "KSQL_COL_1": 3, "KSQL_COL_2": 4.1, "KSQL_COL_3": false, "KSQL_COL_4": "bar", "KSQL_COL_5": 456.1230000000}}
       ]
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/table-functions.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/table-functions.json
@@ -139,7 +139,7 @@
       ],
       "inputs": [
         {
-          "topic": "test_topic", "key": "0", "value": {"F0": 1, "F1": 2, "F2": 3.1, "F3": true, "F4": "foo", "F5": 123.456, "F6": {"A": "bar"}}
+          "topic": "test_topic", "key": "0", "value": {"F0": 1, "F1": 2, "F2": 3.1, "F3": true, "F4": "foo", "F5": 123.4560000000, "F6": {"A": "bar"}}
         }
       ],
       "outputs": [
@@ -148,7 +148,7 @@
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "3.1"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "true"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "foo"}},
-        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "123.456"}},
+        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "123.4560000000"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "Struct{A=bar}"}}
       ]
     },
@@ -187,7 +187,7 @@
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "3.1"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "true"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "foo"}},
-        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "123.456"}},
+        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "123.4560000000"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "Struct{A=bar}"}}
       ]
     },
@@ -208,7 +208,7 @@
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "3.1"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "true"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "foo"}},
-        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "123.456"}},
+        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "123.4560000000"}},
         {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": "Struct{A=bar}"}}
       ]
     },
@@ -224,7 +224,7 @@
         }
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": 1, "KSQL_COL_1": 2, "KSQL_COL_2": 3.1, "KSQL_COL_3": true, "KSQL_COL_4": "foo", "KSQL_COL_5": 123.456, "KSQL_COL_6": {"A": "bar"}}}
+        {"topic": "OUTPUT", "key": "0", "value": {"KSQL_COL_0": 1, "KSQL_COL_1": 2, "KSQL_COL_2": 3.1, "KSQL_COL_3": true, "KSQL_COL_4": "foo", "KSQL_COL_5": 123.4560000000, "KSQL_COL_6": {"A": "bar"}}}
       ],
       "post": {
         "sources": [


### PR DESCRIPTION
### Description 

It is the responsibility of the format to ensure the data returned matches the required schema. This includes the scale of decimals. The JSON format was not correctly setting the scale of decimals when deserializing. For example, give:

```sql
CREATE STREAM S (ID INT KEY, PRICE DECIMAL(10,2) WITH (kafka_topic='S', formats='JSON');
```

The above creates a stream with a single value column `PRICE` which should have a scale of `2`, i.e. two decimal places.

If the data in tbe Kafka record's value was to have too small a scale, e.g.

```json
{
   "price": 12
}
```

or

```json
{
   "price": 12.1
}
```

Then the deserializer was returning the decimal as provided, i.e. `12` or `12.1`. However, this is incorrect as the schema of the column states is has a scale of two. So all values for the column should have the scale set to two, i.e. the above examples should deserialize to `12.00` and `12.10`. With this change they now do.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

