### PR TITLE
chore: unwrap single keys on internal topics

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/serde/InternalFormats.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/serde/InternalFormats.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde;
+
+import io.confluent.ksql.execution.plan.Formats;
+
+/**
+ * Util class for creating internal formats.
+ */
+public final class InternalFormats {
+
+  private InternalFormats() {
+  }
+
+  /**
+   * Build formats for internal topics.
+   *
+   * <p>Internal topics don't normally need any serde options set, as they use the format
+   * defaults.  However, until ksqlDB supports wrapped single keys, any internal topic with a key
+   * format that supports both wrapping and unwrapping needs to have an explicit {@link
+   * SerdeOption#UNWRAP_SINGLE_KEYS} set to ensure backwards compatibility is easily achievable once
+   * wrapped keys are supported.
+   * 
+   * <p>Note: The unwrap feature should only be set when there is only a single key column. As
+   * ksql does not yet support multiple key columns, the only time there is no a single key column
+   * is when there is no key column, i.e. key-less streams. Internal topics, i.e. changelog and 
+   * repartition topics, are never key-less. Hence this method can safely set the unwrap feature
+   * without checking the schema.
+   *
+   * <p>The code that sets the option can be removed once wrapped keys are supported. Issue 6296
+   * tracks the removal.
+   *
+   * @param keyFormat key format.
+   * @param valueFormat value format.
+   * @return Formats instance.
+   * @see <a href=https://github.com/confluentinc/ksql/issues/6296>Issue 6296</a>
+   * @see SerdeOptionsFactory#buildInternal 
+   */
+  public static Formats of(final KeyFormat keyFormat, final ValueFormat valueFormat) {
+    return Formats.of(
+        keyFormat,
+        valueFormat,
+        SerdeOptionsFactory.buildInternal(keyFormat.getFormat())
+    );
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.structured;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
@@ -29,8 +28,8 @@ import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.InternalFormats;
 import io.confluent.ksql.serde.KeyFormat;
-import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
@@ -79,7 +78,7 @@ public class SchemaKGroupedStream {
       step = ExecutionStepFactory.streamWindowedAggregate(
           contextStacker,
           sourceStep,
-          Formats.of(keyFormat, valueFormat, SerdeOptions.of()),
+          InternalFormats.of(keyFormat, valueFormat),
           nonAggregateColumns,
           aggregations,
           windowExpression.get().getKsqlWindowExpression()
@@ -89,7 +88,7 @@ public class SchemaKGroupedStream {
       step = ExecutionStepFactory.streamAggregate(
           contextStacker,
           sourceStep,
-          Formats.of(keyFormat, valueFormat, SerdeOptions.of()),
+          InternalFormats.of(keyFormat, valueFormat),
           nonAggregateColumns,
           aggregations
       );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.function.TableAggregationFunction;
 import io.confluent.ksql.execution.function.UdafUtil;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.TableAggregate;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
@@ -30,8 +29,8 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.serde.InternalFormats;
 import io.confluent.ksql.serde.KeyFormat;
-import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.GrammaticalJoiner;
 import io.confluent.ksql.util.KsqlConfig;
@@ -99,7 +98,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
     final TableAggregate step = ExecutionStepFactory.tableAggregate(
         contextStacker,
         sourceTableStep,
-        Formats.of(keyFormat, valueFormat, SerdeOptions.of()),
+        InternalFormats.of(keyFormat, valueFormat),
         nonAggregateColumns,
         aggregations
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.serde.InternalFormats;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.serde.ValueFormat;
@@ -168,7 +169,7 @@ public class SchemaKStream<K> {
         contextStacker,
         JoinType.LEFT,
         keyColName,
-        Formats.of(keyFormat, valueFormat, SerdeOptions.of()),
+        InternalFormats.of(keyFormat, valueFormat),
         sourceStep,
         schemaKTable.getSourceTableStep()
     );
@@ -194,8 +195,8 @@ public class SchemaKStream<K> {
         contextStacker,
         JoinType.LEFT,
         keyColName,
-        Formats.of(keyFormat, leftFormat, SerdeOptions.of()),
-        Formats.of(keyFormat, rightFormat, SerdeOptions.of()),
+        InternalFormats.of(keyFormat, leftFormat),
+        InternalFormats.of(keyFormat, rightFormat),
         sourceStep,
         otherSchemaKStream.sourceStep,
         joinWindows
@@ -220,7 +221,7 @@ public class SchemaKStream<K> {
         contextStacker,
         JoinType.INNER,
         keyColName,
-        Formats.of(keyFormat, valueFormat, SerdeOptions.of()),
+        InternalFormats.of(keyFormat, valueFormat),
         sourceStep,
         schemaKTable.getSourceTableStep()
     );
@@ -246,8 +247,8 @@ public class SchemaKStream<K> {
         contextStacker,
         JoinType.INNER,
         keyColName,
-        Formats.of(keyFormat, leftFormat, SerdeOptions.of()),
-        Formats.of(keyFormat, rightFormat, SerdeOptions.of()),
+        InternalFormats.of(keyFormat, leftFormat),
+        InternalFormats.of(keyFormat, rightFormat),
         sourceStep,
         otherSchemaKStream.sourceStep,
         joinWindows
@@ -274,8 +275,8 @@ public class SchemaKStream<K> {
         contextStacker,
         JoinType.OUTER,
         keyColName,
-        Formats.of(keyFormat, leftFormat, SerdeOptions.of()),
-        Formats.of(keyFormat, rightFormat, SerdeOptions.of()),
+        InternalFormats.of(keyFormat, leftFormat),
+        InternalFormats.of(keyFormat, rightFormat),
         sourceStep,
         otherSchemaKStream.sourceStep,
         joinWindows
@@ -371,7 +372,7 @@ public class SchemaKStream<K> {
     final StreamGroupBy<K> source = ExecutionStepFactory.streamGroupBy(
         contextStacker,
         sourceStep,
-        Formats.of(rekeyedKeyFormat, valueFormat, SerdeOptions.of()),
+        InternalFormats.of(rekeyedKeyFormat, valueFormat),
         groupByExpressions
     );
 
@@ -397,7 +398,7 @@ public class SchemaKStream<K> {
         ExecutionStepFactory.streamGroupByKey(
             contextStacker,
             (ExecutionStep) sourceStep,
-            Formats.of(rekeyedKeyFormat, valueFormat, SerdeOptions.of())
+            InternalFormats.of(rekeyedKeyFormat, valueFormat)
         );
     return new SchemaKGroupedStream(
         step,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.serde.InternalFormats;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.RefinementInfo;
 import io.confluent.ksql.serde.SerdeOptions;
@@ -177,7 +178,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     final TableGroupBy<K> step = ExecutionStepFactory.tableGroupBy(
         contextStacker,
         sourceTableStep,
-        Formats.of(groupedKeyFormat, valueFormat, SerdeOptions.of()),
+        InternalFormats.of(groupedKeyFormat, valueFormat),
         groupByExpressions
     );
 
@@ -261,7 +262,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         contextStacker,
         sourceTableStep,
         refinementInfo,
-        Formats.of(keyFormat, valueFormat, SerdeOptions.of())
+        InternalFormats.of(keyFormat, valueFormat)
     );
 
     return new SchemaKTable<>(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsFactoryTest.java
@@ -343,4 +343,32 @@ public class SerdeOptionsFactoryTest {
     // Then:
     assertThat(result.findAny(SerdeOptions.KEY_WRAPPING_OPTIONS), is(Optional.empty()));
   }
+
+  @Test
+  public void shouldSetUnwrappedKeysIfInternalTopicHasKeyFormatSupportsBothWrappingAndUnwrapping() {
+    // When:
+    final SerdeOptions result = SerdeOptionsFactory.buildInternal(JSON);
+
+    // Then:
+    assertThat(result.findAny(SerdeOptions.KEY_WRAPPING_OPTIONS),
+        is(Optional.of(SerdeOption.UNWRAP_SINGLE_KEYS)));
+  }
+
+  @Test
+  public void shouldNotSetUnwrappedKeysIfInternalTopicHasKeyFormatsSupportsOnlyWrapping() {
+    // When:
+    final SerdeOptions result = SerdeOptionsFactory.buildInternal(PROTOBUF);
+
+    // Then:
+    assertThat(result.findAny(SerdeOptions.KEY_WRAPPING_OPTIONS), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldNotSetUnwrappedKeysIInternalTopicHasfKeyFormatsSupportsOnlyUnwrapping() {
+    // When:
+    final SerdeOptions result = SerdeOptionsFactory.buildInternal(KAFKA);
+
+    // Then:
+    assertThat(result.findAny(SerdeOptions.KEY_WRAPPING_OPTIONS), is(Optional.empty()));
+  }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/Formats.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/Formats.java
@@ -52,8 +52,9 @@ public final class Formats {
     return of(keyFormat.getFormatInfo(), valueFormat.getFormatInfo(), options);
   }
 
+  @SuppressWarnings("unused") // Invoked by reflection by Jackson
   @JsonCreator
-  public static Formats from(
+  static Formats from(
       @JsonProperty(value = "keyFormat", required = true) final FormatInfo keyFormat,
       @JsonProperty(value = "valueFormat", required = true) final FormatInfo valueFormat,
       @JsonProperty(value = "options") final Optional<Set<SerdeOption>> options


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/6209

Ensure internal changelog and repartition topics set `SerdeFeature.UNWRAP_SINGLES` if the key format supports both unwrapping and wrapping.  This is done to avoid ambiguity, which may cause compatibility issues once wrapped keys are supported.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

