### PR TITLE
test: update client integration test to use json keys

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.api.client.integration;
 import static io.confluent.ksql.api.client.util.ClientTestUtil.shouldReceiveRows;
 import static io.confluent.ksql.api.client.util.ClientTestUtil.subscribeAndWait;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_DEFAULT_KEY_FORMAT_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_KEY_FORMAT_ENABLED;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -68,6 +70,7 @@ import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.util.StructuredTypesDataProvider;
 import io.confluent.ksql.util.TestDataProvider;
@@ -126,7 +129,7 @@ public class ClientIntegrationTest {
           .keyColumn(ColumnName.of("STR"), SqlTypes.STRING)
           .valueColumn(ColumnName.of("LONG"), SqlTypes.BIGINT)
           .build(),
-      SerdeFeatures.of(),
+      SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES),
       SerdeFeatures.of()
   );
 
@@ -175,6 +178,8 @@ public class ClientIntegrationTest {
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
+      .withProperty(KSQL_KEY_FORMAT_ENABLED, true)
+      .withProperty(KSQL_DEFAULT_KEY_FORMAT_CONFIG, "JSON")
       .build();
 
   @ClassRule
@@ -896,7 +901,7 @@ public class ClientIntegrationTest {
       assertThat(description.fields().get(i).isKey(), is(isKey));
     }
     assertThat(description.topic(), is(TEST_TOPIC));
-    assertThat(description.keyFormat(), is("KAFKA"));
+    assertThat(description.keyFormat(), is("JSON"));
     assertThat(description.valueFormat(), is("JSON"));
     assertThat(description.readQueries(), hasSize(1));
     assertThat(description.readQueries().get(0).getQueryType(), is(QueryType.PERSISTENT));
@@ -920,7 +925,7 @@ public class ClientIntegrationTest {
             + "ARRAY_ARRAY ARRAY<ARRAY<STRING>>, ARRAY_STRUCT ARRAY<STRUCT<F1 STRING>>, "
             + "ARRAY_MAP ARRAY<MAP<STRING, INTEGER>>, MAP_ARRAY MAP<STRING, ARRAY<STRING>>, "
             + "MAP_MAP MAP<STRING, MAP<STRING, INTEGER>>, MAP_STRUCT MAP<STRING, STRUCT<F1 STRING>>>) "
-            + "WITH (KAFKA_TOPIC='STRUCTURED_TYPES_TOPIC', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');"));
+            + "WITH (KAFKA_TOPIC='STRUCTURED_TYPES_TOPIC', KEY_FORMAT='JSON', VALUE_FORMAT='JSON');"));
   }
 
   @Test

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslClientAuthFunctionalTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.cli;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -85,7 +86,7 @@ public class SslClientAuthFunctionalTest {
   public static void classSetUp() {
     final OrderDataProvider dataProvider = new OrderDataProvider();
     TEST_HARNESS.getKafkaCluster().createTopics(TOPIC_NAME);
-    TEST_HARNESS.produceRows(dataProvider.topicName(), dataProvider, JSON);
+    TEST_HARNESS.produceRows(dataProvider.topicName(), dataProvider, KAFKA, JSON);
   }
 
   @Before

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.cli;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -81,7 +82,7 @@ public class SslFunctionalTest {
   public static void classSetUp() {
     final OrderDataProvider dataProvider = new OrderDataProvider();
     TEST_HARNESS.getKafkaCluster().createTopics(TOPIC_NAME);
-    TEST_HARNESS.produceRows(dataProvider.topicName(), dataProvider, JSON);
+    TEST_HARNESS.produceRows(dataProvider.topicName(), dataProvider, KAFKA, JSON);
   }
 
   @Before

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX;
 import static java.lang.String.format;
@@ -86,6 +87,7 @@ public class EndToEndIntegrationTest {
   private static final String PAGE_VIEW_STREAM = "pageviews_original";
   private static final String USER_TABLE = "users_original";
 
+  private static final Format KEY_FORMAT = KAFKA;
   private static final Format VALUE_FORMAT = JSON;
   private static final UserDataProvider USER_DATA_PROVIDER = new UserDataProvider();
 
@@ -140,6 +142,7 @@ public class EndToEndIntegrationTest {
     TEST_HARNESS.produceRows(
         USERS_TOPIC,
         USER_DATA_PROVIDER,
+        KEY_FORMAT,
         VALUE_FORMAT,
         () -> System.currentTimeMillis() - 10000
     );
@@ -147,6 +150,7 @@ public class EndToEndIntegrationTest {
     TEST_HARNESS.produceRows(
         PAGE_VIEW_TOPIC,
         PAGE_VIEW_DATA_PROVIDER,
+        KEY_FORMAT,
         VALUE_FORMAT,
         System::currentTimeMillis
     );
@@ -221,7 +225,7 @@ public class EndToEndIntegrationTest {
         PAGE_VIEW_STREAM));
 
     TEST_HARNESS.produceRows(
-        PAGE_VIEW_TOPIC, PAGE_VIEW_DATA_PROVIDER, JSON, System::currentTimeMillis);
+        PAGE_VIEW_TOPIC, PAGE_VIEW_DATA_PROVIDER, KEY_FORMAT, VALUE_FORMAT, System::currentTimeMillis);
 
     TEST_HARNESS.waitForSubjectToBePresent(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -173,7 +173,9 @@ public class EndToEndIntegrationTest {
   public void shouldSelectAllFromUsers() throws Exception {
     final TransientQueryMetadata queryMetadata = executeStatement("SELECT * from %s EMIT CHANGES;", USER_TABLE);
 
-    final Set<?> expectedUsers = USER_DATA_PROVIDER.data().keySet();
+    final Set<String> expectedUsers = USER_DATA_PROVIDER.data().keySet().stream()
+        .map(s -> s.getString(USER_DATA_PROVIDER.key()))
+        .collect(Collectors.toSet());
 
     final List<GenericRow> rows = verifyAvailableRows(queryMetadata, expectedUsers.size());
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
@@ -34,13 +33,11 @@ import io.confluent.ksql.KsqlConfigTestUtil;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
-import io.confluent.ksql.schema.ksql.SchemaConverters;
-import io.confluent.ksql.schema.ksql.SimpleColumn;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.GenericKeySerDe;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.avro.AvroFormat;
-import io.confluent.ksql.serde.kafka.KafkaSerdeFactory;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
@@ -69,6 +66,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.data.Struct;
 import org.hamcrest.Matcher;
 import org.junit.rules.ExternalResource;
 
@@ -196,14 +194,16 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param valueFormat the format values should be produced as.
    * @return the map of produced rows
    */
-  public <K> Multimap<K, RecordMetadata> produceRows(
+  public Multimap<Struct, RecordMetadata> produceRows(
       final String topic,
-      final TestDataProvider<K> dataProvider,
+      final TestDataProvider dataProvider,
+      final Format keyFormat,
       final Format valueFormat
   ) {
     return produceRows(
         topic,
         dataProvider,
+        keyFormat,
         valueFormat,
         DEFAULT_TS_SUPPLIER
     );
@@ -218,16 +218,17 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param timestampSupplier supplier of timestamps.
    * @return the map of produced rows
    */
-  public <K> Multimap<K, RecordMetadata> produceRows(
+  public Multimap<Struct, RecordMetadata> produceRows(
       final String topic,
-      final TestDataProvider<K> dataProvider,
+      final TestDataProvider dataProvider,
+      final Format keyFormat,
       final Format valueFormat,
       final Supplier<Long> timestampSupplier
   ) {
     return produceRows(
         topic,
         dataProvider.data().entries(),
-        getKeySerializer(dataProvider.schema()),
+        getKeySerializer(keyFormat, dataProvider.schema()),
         getValueSerializer(valueFormat, dataProvider.schema()),
         timestampSupplier
     );
@@ -242,16 +243,17 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param valueFormat the format values should be produced as.
    * @return the map of produced rows
    */
-  public <K> Multimap<K, RecordMetadata> produceRows(
+  public Multimap<Struct, RecordMetadata> produceRows(
       final String topic,
-      final Collection<Entry<K, GenericRow>> rowsToPublish,
+      final Collection<Entry<Struct, GenericRow>> rowsToPublish,
       final PhysicalSchema schema,
+      final Format keyFormat,
       final Format valueFormat
   ) {
     return produceRows(
         topic,
         rowsToPublish,
-        getKeySerializer(schema),
+        getKeySerializer(keyFormat, schema),
         getValueSerializer(valueFormat, schema),
         DEFAULT_TS_SUPPLIER
     );
@@ -267,10 +269,10 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param timestampSupplier supplier of timestamps.
    * @return the map of produced rows, with an iteration order that matches produce order.
    */
-  public <K> Multimap<K, RecordMetadata> produceRows(
+  public Multimap<Struct, RecordMetadata> produceRows(
       final String topic,
-      final Collection<Entry<K, GenericRow>> recordsToPublish,
-      final Serializer<K> keySerializer,
+      final Collection<Entry<Struct, GenericRow>> recordsToPublish,
+      final Serializer<Struct> keySerializer,
       final Serializer<GenericRow> valueSerializer,
       final Supplier<Long> timestampSupplier
   ) {
@@ -325,13 +327,14 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param schema the schema of the value.
    * @return the list of consumed records.
    */
-  public <K> List<ConsumerRecord<K, GenericRow>> verifyAvailableRows(
+  public List<ConsumerRecord<Struct, GenericRow>> verifyAvailableRows(
       final String topic,
       final int expectedCount,
+      final Format keyFormat,
       final Format valueFormat,
       final PhysicalSchema schema
   ) {
-    return verifyAvailableRows(topic, hasSize(expectedCount), valueFormat, schema);
+    return verifyAvailableRows(topic, hasSize(expectedCount), keyFormat, valueFormat, schema);
   }
 
   /**
@@ -343,13 +346,14 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param schema the schema of the value.
    * @return the list of consumed records.
    */
-  public <K> List<ConsumerRecord<K, GenericRow>> verifyAvailableRows(
+  public List<ConsumerRecord<Struct, GenericRow>> verifyAvailableRows(
       final String topic,
-      final Matcher<? super List<ConsumerRecord<K, GenericRow>>> expected,
+      final Matcher<? super List<ConsumerRecord<Struct, GenericRow>>> expected,
+      final Format keyFormat,
       final Format valueFormat,
       final PhysicalSchema schema
   ) {
-    final Deserializer<K> keyDeserializer = getKeyDeserializer(schema);
+    final Deserializer<Struct> keyDeserializer = getKeyDeserializer(keyFormat, schema);
     return verifyAvailableRows(topic, expected, valueFormat, schema, keyDeserializer);
   }
 
@@ -360,7 +364,7 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param expected the expected rows.
    * @param valueFormat the format of the value.
    * @param schema the schema of the value.
-   * @param keyDeserializer the keyDeserilizer to use.
+   * @param keyDeserializer the keyDeserializer to use.
    * @param <K> the type of the key.
    * @return the list of consumed records.
    */
@@ -384,7 +388,7 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param expected the expected rows.
    * @param valueFormat the format of the value.
    * @param schema the schema of the value.
-   * @param keyDeserializer the key deserilizer to use.
+   * @param keyDeserializer the key deserializer to use.
    * @param timeout the max time to wait for the messages to be received.
    * @return the list of consumed records.
    */
@@ -416,13 +420,14 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param schema the schema of the value.
    * @return the list of consumed records.
    */
-  public <K> Map<K, GenericRow> verifyAvailableUniqueRows(
+  public Map<Struct, GenericRow> verifyAvailableUniqueRows(
       final String topic,
       final int expectedCount,
+      final Format keyFormat,
       final Format valueFormat,
       final PhysicalSchema schema
   ) {
-    return verifyAvailableNumUniqueRows(topic, is(expectedCount), valueFormat, schema);
+    return verifyAvailableNumUniqueRows(topic, is(expectedCount), keyFormat, valueFormat, schema);
   }
 
   /**
@@ -434,13 +439,14 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param schema the schema of the value.
    * @return the list of consumed records.
    */
-  public <K> Map<K, GenericRow> verifyAvailableNumUniqueRows(
+  public Map<Struct, GenericRow> verifyAvailableNumUniqueRows(
       final String topic,
       final Matcher<Integer> expectedCount,
+      final Format keyFormat,
       final Format valueFormat,
       final PhysicalSchema schema
   ) {
-    final Deserializer<K> keyDeserializer = getKeyDeserializer(schema);
+    final Deserializer<Struct> keyDeserializer = getKeyDeserializer(keyFormat, schema);
     final Deserializer<GenericRow> valueDeserializer = getValueDeserializer(valueFormat, schema);
 
     return verifyAvailableUniqueRows(
@@ -460,13 +466,14 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param schema the schema of the value.
    * @return the list of consumed records.
    */
-  public <K> Map<K, GenericRow> verifyAvailableUniqueRows(
+  public Map<Struct, GenericRow> verifyAvailableUniqueRows(
       final String topic,
-      final Matcher<Map<? extends K, ? extends GenericRow>> expected,
+      final Matcher<Map<? extends Struct, ? extends GenericRow>> expected,
+      final Format keyFormat,
       final Format valueFormat,
       final PhysicalSchema schema
   ) {
-    final Deserializer<K> keyDeserializer = getKeyDeserializer(schema);
+    final Deserializer<Struct> keyDeserializer = getKeyDeserializer(keyFormat, schema);
     final Deserializer<GenericRow> valueDeserializer = getValueDeserializer(valueFormat, schema);
 
     return verifyAvailableUniqueRows(
@@ -482,7 +489,7 @@ public final class IntegrationTestHarness extends ExternalResource {
    *
    * @param topic the name of the topic to check.
    * @param expected the expected records.
-   * @param keyDeserializer the keyDeserilizer to use.
+   * @param keyDeserializer the keyDeserializer to use.
    * @param valueDeserializer the valueDeserializer of use.
    * @return the list of consumed records.
    */
@@ -513,7 +520,7 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param expectedCount the expected number of records.
    * @param valueFormat the format of the value.
    * @param schema the schema of the value.
-   * @param keyDeserializer the keyDeserilizer to use.
+   * @param keyDeserializer the keyDeserializer to use.
    * @param <K> the type of the key.
    * @return the list of consumed records.
    */
@@ -535,7 +542,7 @@ public final class IntegrationTestHarness extends ExternalResource {
    * @param expectedCount the expected number of records.
    * @param valueFormat the format of the value.
    * @param schema the schema of the value.
-   * @param keyDeserializer the keyDeserilizer to use.
+   * @param keyDeserializer the keyDeserializer to use.
    * @param <K> the type of the key.
    * @return the list of consumed records.
    */
@@ -567,7 +574,7 @@ public final class IntegrationTestHarness extends ExternalResource {
    *
    * @param topicNames the names of the topics to await existence for.
    */
-  public void waitForTopicsToBePresent(final String... topicNames) throws Exception {
+  public void waitForTopicsToBePresent(final String... topicNames) {
     assertThatEventually(
         "topics not all present after 30 seconds. topics: " + Arrays.toString(topicNames),
         () -> {
@@ -589,7 +596,7 @@ public final class IntegrationTestHarness extends ExternalResource {
    *
    * @param subjectName the name of the subject to await existence for.
    */
-  public void waitForSubjectToBePresent(final String subjectName) throws Exception {
+  public void waitForSubjectToBePresent(final String subjectName) {
     assertThatEventually(
         "subject not present after 30 seconds. subject: " + subjectName,
         () -> {
@@ -610,7 +617,7 @@ public final class IntegrationTestHarness extends ExternalResource {
    *
    * @param subjectName the name of the subject to await absence for.
    */
-  public void waitForSubjectToBeAbsent(final String subjectName) throws Exception {
+  public void waitForSubjectToBeAbsent(final String subjectName) {
     assertThatEventually(
         "subject still present after 30 seconds. subject: " + subjectName,
         () -> {
@@ -645,25 +652,33 @@ public final class IntegrationTestHarness extends ExternalResource {
     kafkaCluster.stop();
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  private static <K> Serde<K> getKeySerde(final PhysicalSchema schema) {
-    final PersistenceSchema keySchema = schema.keySchema();
-
-    final SimpleColumn onlyColumn = Iterables.getOnlyElement(keySchema.columns());
-
-    final Class<?> javaType = SchemaConverters.sqlToJavaConverter()
-        .toJavaType(onlyColumn.type());
-
-    return (Serde) KafkaSerdeFactory
-        .getPrimitiveSerde(onlyColumn.type().baseType(), javaType);
+  private Serde<Struct> getKeySerde(
+      final Format format,
+      final PhysicalSchema schema,
+      final String loggerNamePrefix
+  ) {
+    return new GenericKeySerDe().create(
+        FormatInfo.of(format.name()),
+        schema.keySchema(),
+        new KsqlConfig(Collections.emptyMap()),
+        serviceContext.get().getSchemaRegistryClientFactory(),
+        loggerNamePrefix,
+        ProcessingLogContext.create()
+    );
   }
 
-  private static <K> Serializer<K> getKeySerializer(final PhysicalSchema schema) {
-    return IntegrationTestHarness.<K>getKeySerde(schema).serializer();
+  private Serializer<Struct> getKeySerializer(
+      final Format format,
+      final PhysicalSchema schema
+  ) {
+    return getKeySerde(format, schema, "producer").serializer();
   }
 
-  private static <K> Deserializer<K> getKeyDeserializer(final PhysicalSchema schema) {
-    return IntegrationTestHarness.<K>getKeySerde(schema).deserializer();
+  private Deserializer<Struct> getKeyDeserializer(
+      final Format format,
+      final PhysicalSchema schema
+  ) {
+    return getKeySerde(format, schema, "consumer").deserializer();
   }
 
   private Serde<GenericRow> getValueSerde(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.GenericRow.genericRow;
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -26,6 +27,8 @@ import io.confluent.ksql.KsqlConfigTestUtil;
 import io.confluent.ksql.ServiceInfo;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil.KeyBuilder;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
 import io.confluent.ksql.function.UserFunctionLoader;
@@ -47,7 +50,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.OrderDataProvider;
-import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,6 +57,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -121,20 +124,21 @@ public class JsonFormatTest {
   }
 
   private static void produceInitData() {
-    TEST_HARNESS.produceRows(inputTopic, ORDER_DATA_PROVIDER, JSON);
+    TEST_HARNESS.produceRows(inputTopic, ORDER_DATA_PROVIDER, KAFKA, JSON);
 
     final LogicalSchema messageSchema = LogicalSchema.builder()
         .keyColumn(SystemColumns.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(ColumnName.of("MESSAGE"), SqlTypes.STRING)
         .build();
 
+    final Struct messageKey = StructKeyUtil.keyBuilder(messageSchema).build("1");
     final GenericRow messageRow = genericRow(
         "{\"log\":{\"@timestamp\":\"2017-05-30T16:44:22.175Z\",\"@version\":\"1\","
         + "\"caasVersion\":\"0.0.2\",\"cloud\":\"aws\",\"logs\":[{\"entry\":\"first\"}],\"clusterId\":\"cp99\",\"clusterName\":\"kafka\",\"cpComponentId\":\"kafka\",\"host\":\"kafka-1-wwl0p\",\"k8sId\":\"k8s13\",\"k8sName\":\"perf\",\"level\":\"ERROR\",\"logger\":\"kafka.server.ReplicaFetcherThread\",\"message\":\"Found invalid messages during fetch for partition [foo512,172] offset 0 error Record is corrupt (stored crc = 1321230880, computed crc = 1139143803)\",\"networkId\":\"vpc-d8c7a9bf\",\"region\":\"us-west-2\",\"serverId\":\"1\",\"skuId\":\"sku5\",\"source\":\"kafka\",\"tenantId\":\"t47\",\"tenantName\":\"perf-test\",\"thread\":\"ReplicaFetcherThread-0-2\",\"zone\":\"us-west-2a\"},\"stream\":\"stdout\",\"time\":2017}"
     );
 
-    final Map<String, GenericRow> records = new HashMap<>();
-    records.put("1", messageRow);
+    final Map<Struct, GenericRow> records = new HashMap<>();
+    records.put(messageKey, messageRow);
 
     final PhysicalSchema schema = PhysicalSchema.from(
         messageSchema,
@@ -142,7 +146,7 @@ public class JsonFormatTest {
         SerdeFeatures.of()
     );
 
-    TEST_HARNESS.produceRows(messageLogTopic, records.entrySet(), schema, JSON);
+    TEST_HARNESS.produceRows(messageLogTopic, records.entrySet(), schema, KAFKA, JSON);
   }
 
   private void execInitCreateStreamQueries() {
@@ -170,38 +174,6 @@ public class JsonFormatTest {
     serviceContext.close();
   }
 
-  //@Test
-  public void testSelectDateTimeUDFs() {
-    final String streamName = "SelectDateTimeUDFsStream".toUpperCase();
-
-    final String selectColumns =
-        "(ORDERTIME+1500962514806) , TIMESTAMPTOSTRING(ORDERTIME+1500962514806, "
-        + "'yyyy-MM-dd HH:mm:ss.SSS'), "
-        + "STRINGTOTIMESTAMP"
-            + "(TIMESTAMPTOSTRING"
-            + "(ORDERTIME+1500962514806, 'yyyy-MM-dd HH:mm:ss.SSS'), 'yyyy-MM-dd HH:mm:ss.SSS')";
-    final String whereClause = "ORDERUNITS > 20 AND ITEMID LIKE '%_8'";
-
-    final String queryString = String.format(
-        "CREATE STREAM %s AS SELECT %s FROM %s WHERE %s;",
-        streamName,
-        selectColumns,
-        inputStream,
-        whereClause
-    );
-
-    executePersistentQuery(queryString);
-
-    final Map<String, GenericRow> expectedResults = new HashMap<>();
-    expectedResults.put("8", genericRow(1500962514814L,
-        "2017-07-24 23:01:54.814",
-        1500962514814L));
-
-    final Map<String, GenericRow> results = readNormalResults(streamName, expectedResults.size());
-
-    assertThat(results, equalTo(expectedResults));
-  }
-
   @Test
   public void testJsonStreamExtractor() {
     final String queryString = String.format("CREATE STREAM %s AS SELECT ROWKEY, EXTRACTJSONFIELD"
@@ -211,10 +183,11 @@ public class JsonFormatTest {
 
     executePersistentQuery(queryString);
 
-    final Map<String, GenericRow> expectedResults = new HashMap<>();
-    expectedResults.put("1", genericRow("aws"));
+    final Map<Struct, GenericRow> expectedResults = new HashMap<>();
+    final KeyBuilder keyBuilder = StructKeyUtil.keyBuilder(ColumnName.of("ROWKEY"), SqlTypes.STRING);
+    expectedResults.put(keyBuilder.build("1"), genericRow("aws"));
 
-    final Map<String, GenericRow> results = readNormalResults(streamName, expectedResults.size());
+    final Map<Struct, GenericRow> results = readNormalResults(streamName, expectedResults.size());
 
     assertThat(results, equalTo(expectedResults));
   }
@@ -228,10 +201,11 @@ public class JsonFormatTest {
 
     executePersistentQuery(queryString);
 
-    final Map<String, GenericRow> expectedResults = new HashMap<>();
-    expectedResults.put("1", genericRow("first"));
+    final Map<Struct, GenericRow> expectedResults = new HashMap<>();
+    final KeyBuilder keyBuilder = StructKeyUtil.keyBuilder(ColumnName.of("ROWKEY"), SqlTypes.STRING);
+    expectedResults.put(keyBuilder.build("1"), genericRow("first"));
 
-    final Map<String, GenericRow> results = readNormalResults(streamName, expectedResults.size());
+    final Map<Struct, GenericRow> results = readNormalResults(streamName, expectedResults.size());
 
     assertThat(results, equalTo(expectedResults));
   }
@@ -242,10 +216,10 @@ public class JsonFormatTest {
         .get(0);
 
     queryMetadata.start();
-    queryId = ((PersistentQueryMetadata)queryMetadata).getQueryId();
+    queryId = queryMetadata.getQueryId();
   }
 
-  private Map<String, GenericRow> readNormalResults(
+  private Map<Struct, GenericRow> readNormalResults(
       final String resultTopic,
       final int expectedNumMessages
   ) {
@@ -258,7 +232,7 @@ public class JsonFormatTest {
     );
 
     return TEST_HARNESS
-        .verifyAvailableUniqueRows(resultTopic, expectedNumMessages, JSON, resultSchema);
+        .verifyAvailableUniqueRows(resultTopic, expectedNumMessages, KAFKA, JSON, resultSchema);
   }
 
   private void terminateQuery() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
@@ -169,7 +170,7 @@ public class KafkaConsumerGroupClientTest {
 
   private void givenTopicExistsWithData() {
     TEST_HARNESS.ensureTopics(PARTITION_COUNT, topicName);
-    TEST_HARNESS.produceRows(topicName, new OrderDataProvider(), JSON, System::currentTimeMillis);
+    TEST_HARNESS.produceRows(topicName, new OrderDataProvider(), KAFKA, JSON, System::currentTimeMillis);
   }
 
   private KafkaConsumer<String, byte[]> createConsumer(final String group) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
@@ -100,7 +100,7 @@ public class ReplaceIntTest {
             "CREATE STREAM project WITH(kafka_topic='%s') AS SELECT k, col1 FROM source;",
             outputTopic));
 
-    TEST_HARNESS.produceRows(inputTopic, new Provider("1", "A", 1), FormatFactory.JSON);
+    TEST_HARNESS.produceRows(inputTopic, new Provider("1", "A", 1), FormatFactory.KAFKA, FormatFactory.JSON);
     assertForSource("PROJECT", outputTopic, ImmutableMap.of("1", GenericRow.genericRow("A")));
 
     // When:
@@ -108,7 +108,7 @@ public class ReplaceIntTest {
         String.format(
             "CREATE OR REPLACE STREAM project WITH(kafka_topic='%s') AS SELECT k, col1, col2 FROM source;",
             outputTopic));
-    TEST_HARNESS.produceRows(inputTopic, new Provider("2", "B", 2), FormatFactory.JSON);
+    TEST_HARNESS.produceRows(inputTopic, new Provider("2", "B", 2), FormatFactory.KAFKA, FormatFactory.JSON);
 
     // Then:
     final Map<String, GenericRow> expected = ImmutableMap.of(
@@ -127,15 +127,15 @@ public class ReplaceIntTest {
             "CREATE STREAM project WITH(kafka_topic='%s') AS SELECT k, col1 FROM source;",
             outputTopic));
 
-    TEST_HARNESS.produceRows(inputTopic, new Provider("1", "A", 1), FormatFactory.JSON);
+    TEST_HARNESS.produceRows(inputTopic, new Provider("1", "A", 1), FormatFactory.KAFKA, FormatFactory.JSON);
     assertForSource("PROJECT", outputTopic, ImmutableMap.of("1", GenericRow.genericRow("A")));
 
     // When:
     ksqlContext.sql(
         String.format(
             "CREATE OR REPLACE STREAM project WITH(kafka_topic='%s') AS SELECT k, col1 FROM source WHERE col1 <> 'A';", outputTopic));
-    TEST_HARNESS.produceRows(inputTopic, new Provider("2", "A", 2), FormatFactory.JSON); // this row should be filtered out
-    TEST_HARNESS.produceRows(inputTopic, new Provider("3", "C", 3), FormatFactory.JSON);
+    TEST_HARNESS.produceRows(inputTopic, new Provider("2", "A", 2), FormatFactory.KAFKA, FormatFactory.JSON); // this row should be filtered out
+    TEST_HARNESS.produceRows(inputTopic, new Provider("3", "C", 3), FormatFactory.KAFKA, FormatFactory.JSON);
 
     // Then:
     final Map<String, GenericRow> expected = ImmutableMap.of(
@@ -158,7 +158,7 @@ public class ReplaceIntTest {
     );
 
     assertThat(
-        TEST_HARNESS.verifyAvailableUniqueRows(topic, expected.size(), FormatFactory.JSON, resultSchema),
+        TEST_HARNESS.verifyAvailableUniqueRows(topic, expected.size(), FormatFactory.KAFKA, FormatFactory.JSON, resultSchema),
         is(expected)
     );
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil.KeyBuilder;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
@@ -37,6 +39,7 @@ import io.confluent.ksql.test.util.TopicTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.TestDataProvider;
 import java.util.Map;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -160,7 +163,7 @@ public class ReplaceIntTest {
     );
   }
 
-  private static class Provider extends TestDataProvider<String> {
+  private static class Provider extends TestDataProvider {
 
     private static final String SQL = "k VARCHAR KEY, col1 VARCHAR, col2 INT";
     private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
@@ -168,6 +171,7 @@ public class ReplaceIntTest {
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.INTEGER)
         .build();
+    private static final KeyBuilder KEY_BUILDER = StructKeyUtil.keyBuilder(LOGICAL_SCHEMA);
 
     public Provider(final String k, final String col1, final int col2) {
       super(
@@ -177,12 +181,12 @@ public class ReplaceIntTest {
       );
     }
 
-    private static Multimap<String, GenericRow> rows(
+    private static Multimap<Struct, GenericRow> rows(
         final String key,
         final String col1,
         final Integer col2
     ) {
-      return ImmutableListMultimap.of(key, GenericRow.genericRow(col1, col2));
+      return ImmutableListMultimap.of(KEY_BUILDER.build(key), GenericRow.genericRow(col1, col2));
     }
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceIntTest.java
@@ -101,7 +101,7 @@ public class ReplaceIntTest {
             outputTopic));
 
     TEST_HARNESS.produceRows(inputTopic, new Provider("1", "A", 1), FormatFactory.KAFKA, FormatFactory.JSON);
-    assertForSource("PROJECT", outputTopic, ImmutableMap.of("1", GenericRow.genericRow("A")));
+    assertForSource("PROJECT", outputTopic, ImmutableMap.of(Provider.KEY_BUILDER.build("1"), GenericRow.genericRow("A")));
 
     // When:
     ksqlContext.sql(
@@ -111,9 +111,9 @@ public class ReplaceIntTest {
     TEST_HARNESS.produceRows(inputTopic, new Provider("2", "B", 2), FormatFactory.KAFKA, FormatFactory.JSON);
 
     // Then:
-    final Map<String, GenericRow> expected = ImmutableMap.of(
-        "1", GenericRow.genericRow("A", null),  // this row is leftover from the original query
-        "2", GenericRow.genericRow("B", 2)      // this row is an artifact from the new query
+    final Map<Struct, GenericRow> expected = ImmutableMap.of(
+        Provider.KEY_BUILDER.build("1"), GenericRow.genericRow("A", null),  // this row is leftover from the original query
+        Provider.KEY_BUILDER.build("2"), GenericRow.genericRow("B", 2)      // this row is an artifact from the new query
     );
     assertForSource("PROJECT", outputTopic, expected);
   }
@@ -128,7 +128,7 @@ public class ReplaceIntTest {
             outputTopic));
 
     TEST_HARNESS.produceRows(inputTopic, new Provider("1", "A", 1), FormatFactory.KAFKA, FormatFactory.JSON);
-    assertForSource("PROJECT", outputTopic, ImmutableMap.of("1", GenericRow.genericRow("A")));
+    assertForSource("PROJECT", outputTopic, ImmutableMap.of(Provider.KEY_BUILDER.build("1"), GenericRow.genericRow("A")));
 
     // When:
     ksqlContext.sql(
@@ -138,9 +138,9 @@ public class ReplaceIntTest {
     TEST_HARNESS.produceRows(inputTopic, new Provider("3", "C", 3), FormatFactory.KAFKA, FormatFactory.JSON);
 
     // Then:
-    final Map<String, GenericRow> expected = ImmutableMap.of(
-        "1", GenericRow.genericRow("A"),  // this row is leftover from the original query
-        "3", GenericRow.genericRow("C")   // this row is an artifact from the new query
+    final Map<Struct, GenericRow> expected = ImmutableMap.of(
+        Provider.KEY_BUILDER.build("1"), GenericRow.genericRow("A"),  // this row is leftover from the original query
+        Provider.KEY_BUILDER.build("3"), GenericRow.genericRow("C")   // this row is an artifact from the new query
     );
     assertForSource("PROJECT", outputTopic, expected);
   }
@@ -148,7 +148,7 @@ public class ReplaceIntTest {
   private void assertForSource(
       final String sourceName,
       final String topic,
-      final Map<String, GenericRow> expected
+      final Map<Struct, GenericRow> expected
   ) {
     DataSource source = ksqlContext.getMetaStore().getSource(SourceName.of(sourceName));
     PhysicalSchema resultSchema = PhysicalSchema.from(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER1;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER2;
@@ -350,7 +351,7 @@ public class SecureIntegrationTest {
 
     final OrderDataProvider orderDataProvider = new OrderDataProvider();
 
-    TEST_HARNESS.produceRows(INPUT_TOPIC, orderDataProvider, JSON);
+    TEST_HARNESS.produceRows(INPUT_TOPIC, orderDataProvider, KAFKA, JSON);
   }
 
   private void awaitAsyncInputTopicCreation() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.integration;
 import static io.confluent.ksql.GenericRow.genericRow;
 import static io.confluent.ksql.serde.FormatFactory.AVRO;
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -43,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -75,8 +77,8 @@ public class StreamsSelectAndProjectIntTest {
   private String avroTopicName;
   private String intermediateStream;
   private String resultStream;
-  private Multimap<String, RecordMetadata> producedAvroRecords;
-  private Multimap<String, RecordMetadata> producedJsonRecords;
+  private Multimap<Struct, RecordMetadata> producedAvroRecords;
+  private Multimap<Struct, RecordMetadata> producedJsonRecords;
 
   @Before
   public void before() {
@@ -86,8 +88,8 @@ public class StreamsSelectAndProjectIntTest {
     avroTopicName = TopicTestUtil.uniqueTopicName("avro");
 
     TEST_HARNESS.ensureTopics(jsonTopicName, avroTopicName);
-    producedJsonRecords = TEST_HARNESS.produceRows(jsonTopicName, DATA_PROVIDER, JSON);
-    producedAvroRecords = TEST_HARNESS.produceRows(avroTopicName, DATA_PROVIDER, AVRO);
+    producedJsonRecords = TEST_HARNESS.produceRows(jsonTopicName, DATA_PROVIDER, KAFKA, JSON);
+    producedAvroRecords = TEST_HARNESS.produceRows(avroTopicName, DATA_PROVIDER, KAFKA, AVRO);
 
     createOrdersStream();
   }
@@ -196,8 +198,8 @@ public class StreamsSelectAndProjectIntTest {
 
   private void testTimestampColumnSelection(
       final String inputStreamName,
-      final Format dataSourceSerDe,
-      final Multimap<String, RecordMetadata> recordMetadataMap
+      final Format valueFormat,
+      final Multimap<Struct, RecordMetadata> recordMetadataMap
   ) {
     final String query1String =
         String.format("CREATE STREAM %s WITH (timestamp='RTIME') AS SELECT ORDERTIME, "
@@ -213,7 +215,7 @@ public class StreamsSelectAndProjectIntTest {
     ksqlContext.sql(query1String);
 
     final Map<Long, GenericRow> expectedResults = new HashMap<>();
-    final RecordMetadata order_6 = Iterables.getLast(recordMetadataMap.get("ORDER_6"));
+    final RecordMetadata order_6 = Iterables.getLast(recordMetadataMap.get(DATA_PROVIDER.keyFrom("ORDER_6")));
     expectedResults.put(8L,
         genericRow(
             null,
@@ -230,31 +232,33 @@ public class StreamsSelectAndProjectIntTest {
     TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         expectedResults.size(),
-        dataSourceSerDe,
+        KAFKA,
+        valueFormat,
         getResultSchema());
   }
 
   private void testSelectProjectKeyTimestamp(
       final String inputStreamName,
       final Format valueFormat,
-      final Multimap<String, RecordMetadata> recordMetadataMap
+      final Multimap<Struct, RecordMetadata> recordMetadataMap
   ) {
     ksqlContext.sql(String.format("CREATE STREAM %s AS SELECT ORDERID, ORDERTIME, ROWTIME AS RTIME, ITEMID "
         + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID = "
         + "'ITEM_8';", resultStream, inputStreamName));
 
-    final List<ConsumerRecord<Long, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
+    final List<ConsumerRecord<Struct, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         1,
+        KAFKA,
         valueFormat,
         getResultSchema()
     );
 
-    assertThat(results.get(0).key(), is("ORDER_6"));
+    assertThat(results.get(0).key(), is(DATA_PROVIDER.keyFrom("ORDER_6")));
     assertThat(results.get(0).value(),
         is(genericRow(
             8L,
-            Iterables.getLast(recordMetadataMap.get("ORDER_6")).timestamp(),
+            Iterables.getLast(recordMetadataMap.get(DATA_PROVIDER.keyFrom("ORDER_6"))).timestamp(),
             "ITEM_8")
         )
     );
@@ -262,15 +266,16 @@ public class StreamsSelectAndProjectIntTest {
 
   private void testSelectProject(
       final String inputStreamName,
-      final Format dataSourceSerDe
+      final Format valueFormat
   ) {
     ksqlContext.sql(String.format("CREATE STREAM %s AS SELECT ORDERID, ORDERTIME, ITEMID, ORDERUNITS, "
                                   + "PRICEARRAY FROM %s;", resultStream, inputStreamName));
 
-    final List<ConsumerRecord<String, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
+    final List<ConsumerRecord<Struct, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         DATA_PROVIDER.data().size(),
-        dataSourceSerDe,
+        KAFKA,
+        valueFormat,
         getResultSchema());
 
     final GenericRow value = results.get(0).value();
@@ -288,9 +293,10 @@ public class StreamsSelectAndProjectIntTest {
                                   + "ORDERUNITS, "
         + "PRICEARRAY FROM %s;", resultStream, AVRO_STREAM_NAME));
 
-    final List<ConsumerRecord<String, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
+    final List<ConsumerRecord<Struct, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         DATA_PROVIDER.data().size(),
+        KAFKA,
         JSON,
         getResultSchema());
 
@@ -309,6 +315,7 @@ public class StreamsSelectAndProjectIntTest {
     TEST_HARNESS.verifyAvailableUniqueRows(
         resultStream.toUpperCase(),
         is(DATA_PROVIDER.finalData()),
+        KAFKA,
         valueFormat,
         DATA_PROVIDER.schema()
     );
@@ -316,7 +323,7 @@ public class StreamsSelectAndProjectIntTest {
 
   private void testSelectWithFilter(
       final String inputStreamName,
-      final Format dataSourceSerDe
+      final Format valueFormat
   ) {
     ksqlContext.sql("CREATE STREAM " + resultStream + " AS "
         + "SELECT * FROM " + inputStreamName + " WHERE ORDERUNITS > 40;");
@@ -324,7 +331,8 @@ public class StreamsSelectAndProjectIntTest {
     TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         4,
-        dataSourceSerDe,
+        KAFKA,
+        valueFormat,
         DATA_PROVIDER.schema());
   }
 
@@ -335,9 +343,10 @@ public class StreamsSelectAndProjectIntTest {
     ksqlContext.sql("INSERT INTO " + resultStream +
         " SELECT ORDERID, ORDERTIME, ITEMID, ORDERUNITS, PRICEARRAY FROM " + JSON_STREAM_NAME + ";");
 
-    final List<ConsumerRecord<String, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
+    final List<ConsumerRecord<Struct, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         DATA_PROVIDER.data().size(),
+        KAFKA,
         JSON,
         getResultSchema());
 
@@ -353,9 +362,10 @@ public class StreamsSelectAndProjectIntTest {
     ksqlContext.sql("INSERT INTO " + resultStream + " "
         + "SELECT ORDERID, ORDERTIME, ITEMID, ORDERUNITS, PRICEARRAY FROM " + AVRO_STREAM_NAME + ";");
 
-    final List<ConsumerRecord<String, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
+    final List<ConsumerRecord<Struct, GenericRow>> results = TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         DATA_PROVIDER.data().size(),
+        KAFKA,
         AVRO,
         getResultSchema());
 
@@ -373,6 +383,7 @@ public class StreamsSelectAndProjectIntTest {
     TEST_HARNESS.verifyAvailableUniqueRows(
         resultStream.toUpperCase(),
         is(DATA_PROVIDER.finalData()),
+        KAFKA,
         JSON,
         DATA_PROVIDER.schema()
     );
@@ -388,6 +399,7 @@ public class StreamsSelectAndProjectIntTest {
     TEST_HARNESS.verifyAvailableUniqueRows(
         resultStream.toUpperCase(),
         is(DATA_PROVIDER.finalData()),
+        KAFKA,
         AVRO,
         DATA_PROVIDER.schema()
     );
@@ -403,6 +415,7 @@ public class StreamsSelectAndProjectIntTest {
     TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         4,
+        KAFKA,
         JSON,
         DATA_PROVIDER.schema());
   }
@@ -417,6 +430,7 @@ public class StreamsSelectAndProjectIntTest {
     TEST_HARNESS.verifyAvailableRows(
         resultStream.toUpperCase(),
         4,
+        KAFKA,
         AVRO,
         DATA_PROVIDER.schema());
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.GenericRow.genericRow;
 import static io.confluent.ksql.serde.FormatFactory.AVRO;
 import static io.confluent.ksql.serde.FormatFactory.DELIMITED;
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -45,8 +46,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -69,8 +72,8 @@ public class UdfIntTest {
   private static final String DELIMITED_TOPIC_NAME = "delimitedTopic";
   private static final String DELIMITED_STREAM_NAME = "items_delimited";
 
-  private static Multimap<String, RecordMetadata> jsonRecordMetadataMap;
-  private static Multimap<String, RecordMetadata> avroRecordMetadataMap;
+  private static Multimap<Struct, RecordMetadata> jsonRecordMetadataMap;
+  private static Multimap<Struct, RecordMetadata> avroRecordMetadataMap;
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
@@ -102,26 +105,26 @@ public class UdfIntTest {
     final OrderDataProvider orderDataProvider = new OrderDataProvider();
     final ItemDataProvider itemDataProvider = new ItemDataProvider();
 
-    jsonRecordMetadataMap = TEST_HARNESS.produceRows(JSON_TOPIC_NAME, orderDataProvider, JSON);
+    jsonRecordMetadataMap = TEST_HARNESS.produceRows(JSON_TOPIC_NAME, orderDataProvider, KAFKA, JSON);
 
-    avroRecordMetadataMap = TEST_HARNESS.produceRows(AVRO_TOPIC_NAME, orderDataProvider, AVRO);
+    avroRecordMetadataMap = TEST_HARNESS.produceRows(AVRO_TOPIC_NAME, orderDataProvider, KAFKA, AVRO);
 
-    TEST_HARNESS.produceRows(DELIMITED_TOPIC_NAME, itemDataProvider, DELIMITED);
+    TEST_HARNESS.produceRows(DELIMITED_TOPIC_NAME, itemDataProvider, KAFKA, DELIMITED);
   }
 
   public UdfIntTest(final Format format) {
     switch (format.name()) {
       case AvroFormat.NAME:
         this.testData =
-            new TestData(format, AVRO_TOPIC_NAME, AVRO_STREAM_NAME, avroRecordMetadataMap);
+            new TestData(format, AVRO_TOPIC_NAME, AVRO_STREAM_NAME, avroRecordMetadataMap, OrderDataProvider::buildKey);
         break;
       case JsonFormat.NAME:
         this.testData =
-            new TestData(format, JSON_TOPIC_NAME, JSON_STREAM_NAME, jsonRecordMetadataMap);
+            new TestData(format, JSON_TOPIC_NAME, JSON_STREAM_NAME, jsonRecordMetadataMap, OrderDataProvider::buildKey);
         break;
       default:
         this.testData =
-            new TestData(format, DELIMITED_TOPIC_NAME, DELIMITED_STREAM_NAME, ImmutableListMultimap.of());
+            new TestData(format, DELIMITED_TOPIC_NAME, DELIMITED_STREAM_NAME, ImmutableListMultimap.of(), ItemDataProvider::buildKey);
         break;
     }
   }
@@ -156,9 +159,9 @@ public class UdfIntTest {
     ksqlContext.sql(queryString);
 
     // Then:
-    final Map<String, GenericRow> results = consumeOutputMessages();
+    final Map<Struct, GenericRow> results = consumeOutputMessages();
 
-    assertThat(results, is(ImmutableMap.of("ORDER_6",
+    assertThat(results, is(ImmutableMap.of(testData.keySupplier.apply("ORDER_6"),
         genericRow("ITEM_8", 800.0, 1110.0, 12.0, true))));
   }
 
@@ -183,9 +186,9 @@ public class UdfIntTest {
     ksqlContext.sql(queryString);
 
     // Then:
-    final Map<String, GenericRow> results = consumeOutputMessages();
+    final Map<Struct, GenericRow> results = consumeOutputMessages();
 
-    assertThat(results, is(ImmutableMap.of("ORDER_6",
+    assertThat(results, is(ImmutableMap.of(testData.keySupplier.apply("ORDER_6"),
         genericRow(80, "true", 8.0, "80.0"))));
   }
 
@@ -208,11 +211,11 @@ public class UdfIntTest {
     ksqlContext.sql(queryString);
 
     // Then:
-    final Map<String, GenericRow> results = consumeOutputMessages();
+    final Map<Struct, GenericRow> results = consumeOutputMessages();
 
     final long ts = testData.getLast("ORDER_6").timestamp();
 
-    assertThat(results, equalTo(ImmutableMap.of("ORDER_6",
+    assertThat(results, equalTo(ImmutableMap.of(testData.keySupplier.apply("ORDER_6"),
         genericRow(ts, ts + 10000, ts + 100, "ITEM_8"))));
   }
 
@@ -230,9 +233,9 @@ public class UdfIntTest {
     ksqlContext.sql(queryString);
 
     // Then:
-    final Map<String, GenericRow> results = consumeOutputMessages();
+    final Map<Struct, GenericRow> results = consumeOutputMessages();
 
-    assertThat(results, equalTo(Collections.singletonMap("ITEM_1",
+    assertThat(results, equalTo(Collections.singletonMap(testData.keySupplier.apply("ITEM_1"),
         genericRow("home cinema"))));
   }
 
@@ -257,7 +260,7 @@ public class UdfIntTest {
     }
   }
 
-  private <K> Map<K, GenericRow> consumeOutputMessages() {
+  private Map<Struct, GenericRow> consumeOutputMessages() {
 
     final DataSource source = ksqlContext
         .getMetaStore()
@@ -272,6 +275,7 @@ public class UdfIntTest {
     return TEST_HARNESS.verifyAvailableUniqueRows(
         resultStreamName,
         1,
+        KAFKA,
         testData.format,
         resultSchema);
   }
@@ -281,21 +285,24 @@ public class UdfIntTest {
     private final Format format;
     private final String sourceStreamName;
     private final String sourceTopicName;
-    private final Multimap<String, RecordMetadata> recordMetadata;
+    private final Multimap<Struct, RecordMetadata> recordMetadata;
+    private final Function<String, Struct> keySupplier;
 
     private TestData(
         final Format format,
         final String sourceTopicName,
         final String sourceStreamName,
-        final Multimap<String, RecordMetadata> recordMetadata) {
+        final Multimap<Struct, RecordMetadata> recordMetadata,
+        final Function<String, Struct> keySupplier) {
       this.format = format;
       this.sourceStreamName = sourceStreamName;
       this.sourceTopicName = sourceTopicName;
       this.recordMetadata = recordMetadata;
+      this.keySupplier = keySupplier;
     }
 
     RecordMetadata getLast(final String key) {
-      return Iterables.getLast(recordMetadata.get(key));
+      return Iterables.getLast(recordMetadata.get(keySupplier.apply(key)));
     }
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.GenericRow.genericRow;
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.test.util.ConsumerTestUtil.hasUniqueRecords;
 import static io.confluent.ksql.test.util.MapMatchers.mapHasItems;
@@ -115,8 +116,8 @@ public class WindowingIntTest {
     TEST_HARNESS.ensureTopics(sourceTopicName, ORDERS_STREAM.toUpperCase());
 
     final OrderDataProvider dataProvider = new OrderDataProvider();
-    TEST_HARNESS.produceRows(sourceTopicName, dataProvider, JSON, () -> batch0SentMs);
-    TEST_HARNESS.produceRows(sourceTopicName, dataProvider, JSON, () -> batch0SentMs + batch1Delay);
+    TEST_HARNESS.produceRows(sourceTopicName, dataProvider, KAFKA, JSON, () -> batch0SentMs);
+    TEST_HARNESS.produceRows(sourceTopicName, dataProvider, KAFKA, JSON, () -> batch0SentMs + batch1Delay);
 
     createOrdersStream();
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.materialization.ks;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.confluent.ksql.test.util.AssertEventually.RetryOnException;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -97,6 +98,7 @@ public class KsMaterializationFunctionalTest {
   private static final String PAGE_VIEWS_TOPIC = "page_views_topic";
   private static final String PAGE_VIEWS_STREAM = "page_views_stream";
 
+  private static final Format KEY_FORMAT = KAFKA;
   private static final Format VALUE_FORMAT = JSON;
   private static final UserDataProvider USER_DATA_PROVIDER = new UserDataProvider();
   private static final PageViewDataProvider PAGE_VIEW_DATA_PROVIDER = new PageViewDataProvider();
@@ -147,6 +149,7 @@ public class KsMaterializationFunctionalTest {
     TEST_HARNESS.produceRows(
         USERS_TOPIC,
         USER_DATA_PROVIDER,
+        KEY_FORMAT,
         VALUE_FORMAT
     );
 
@@ -154,6 +157,7 @@ public class KsMaterializationFunctionalTest {
       TEST_HARNESS.produceRows(
           PAGE_VIEWS_TOPIC,
           PAGE_VIEW_DATA_PROVIDER,
+          KEY_FORMAT,
           VALUE_FORMAT,
           windowTime::toEpochMilli
       );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -20,13 +20,16 @@ import static io.confluent.ksql.GenericRow.genericRow;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil.KeyBuilder;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeFeatures;
+import org.apache.kafka.connect.data.Struct;
 
-public class ItemDataProvider extends TestDataProvider<String> {
+public class ItemDataProvider extends TestDataProvider {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("ID"), SqlTypes.STRING)
@@ -36,19 +39,25 @@ public class ItemDataProvider extends TestDataProvider<String> {
   private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
       .from(LOGICAL_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of());
 
-  private static final Multimap<String, GenericRow> ROWS = ImmutableListMultimap
-      .<String, GenericRow>builder()
-      .put("ITEM_1", genericRow("home cinema"))
-      .put("ITEM_2", genericRow("clock radio"))
-      .put("ITEM_3", genericRow("road bike"))
-      .put("ITEM_4", genericRow("mountain bike"))
-      .put("ITEM_5", genericRow("snowboard"))
-      .put("ITEM_6", genericRow("iphone 10"))
-      .put("ITEM_7", genericRow("gopro"))
-      .put("ITEM_8", genericRow("cat"))
+  private static final KeyBuilder KEY_BUILDER = StructKeyUtil.keyBuilder(LOGICAL_SCHEMA);
+
+  private static final Multimap<Struct, GenericRow> ROWS = ImmutableListMultimap
+      .<Struct, GenericRow>builder()
+      .put(buildKey("ITEM_1"), genericRow("home cinema"))
+      .put(buildKey("ITEM_2"), genericRow("clock radio"))
+      .put(buildKey("ITEM_3"), genericRow("road bike"))
+      .put(buildKey("ITEM_4"), genericRow("mountain bike"))
+      .put(buildKey("ITEM_5"), genericRow("snowboard"))
+      .put(buildKey("ITEM_6"), genericRow("iphone 10"))
+      .put(buildKey("ITEM_7"), genericRow("gopro"))
+      .put(buildKey("ITEM_8"), genericRow("cat"))
       .build();
 
   public ItemDataProvider() {
     super("ITEM", PHYSICAL_SCHEMA, ROWS);
+  }
+
+  private static Struct buildKey(final String key) {
+    return KEY_BUILDER.build(key);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -57,7 +57,7 @@ public class ItemDataProvider extends TestDataProvider {
     super("ITEM", PHYSICAL_SCHEMA, ROWS);
   }
 
-  private static Struct buildKey(final String key) {
+  public static Struct buildKey(final String key) {
     return KEY_BUILDER.build(key);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -22,14 +22,17 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil.KeyBuilder;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeFeatures;
 import java.util.Map;
+import org.apache.kafka.connect.data.Struct;
 
-public class OrderDataProvider extends TestDataProvider<String> {
+public class OrderDataProvider extends TestDataProvider {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("ORDERID"), SqlTypes.STRING)
@@ -44,16 +47,18 @@ public class OrderDataProvider extends TestDataProvider<String> {
   private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
       .from(LOGICAL_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of());
 
+  private static final KeyBuilder KEY_BUILDER = StructKeyUtil.keyBuilder(LOGICAL_SCHEMA);
+
   private static final Map<String, Double> MAP_FIELD = ImmutableMap.of(
       "key1", 1.0,
       "key2", 2.0,
       "key3", 3.0
   );
 
-  private static final Multimap<String, GenericRow> ROWS = ImmutableListMultimap
-      .<String, GenericRow>builder()
+  private static final Multimap<Struct, GenericRow> ROWS = ImmutableListMultimap
+      .<Struct, GenericRow>builder()
       .put(
-          "ORDER_1",
+          buildKey("ORDER_1"),
           genericRow(
               1L,
               "ITEM_1",
@@ -63,7 +68,7 @@ public class OrderDataProvider extends TestDataProvider<String> {
               MAP_FIELD
           ))
       .put(
-          "ORDER_2",
+          buildKey("ORDER_2"),
           genericRow(
               2L,
               "ITEM_2",
@@ -73,7 +78,7 @@ public class OrderDataProvider extends TestDataProvider<String> {
               MAP_FIELD
           ))
       .put(
-          "ORDER_3",
+          buildKey("ORDER_3"),
           genericRow(
               3L,
               "ITEM_3",
@@ -83,7 +88,7 @@ public class OrderDataProvider extends TestDataProvider<String> {
               MAP_FIELD
           ))
       .put(
-          "ORDER_4",
+          buildKey("ORDER_4"),
           genericRow(
               4L,
               "ITEM_4",
@@ -93,7 +98,7 @@ public class OrderDataProvider extends TestDataProvider<String> {
               MAP_FIELD
           ))
       .put(
-          "ORDER_5",
+          buildKey("ORDER_5"),
           genericRow(
               5L,
               "ITEM_5",
@@ -103,7 +108,7 @@ public class OrderDataProvider extends TestDataProvider<String> {
               MAP_FIELD
           ))
       .put(
-          "ORDER_6",
+          buildKey("ORDER_6"),
           genericRow(
               6L,
               "ITEM_6",
@@ -113,7 +118,7 @@ public class OrderDataProvider extends TestDataProvider<String> {
               MAP_FIELD
           ))
       .put(
-          "ORDER_6",
+          buildKey("ORDER_6"),
           genericRow(
               7L,
               "ITEM_7",
@@ -123,7 +128,7 @@ public class OrderDataProvider extends TestDataProvider<String> {
               MAP_FIELD
           ))
       .put(
-          "ORDER_6",
+          buildKey("ORDER_6"),
           genericRow(
               8L,
               "ITEM_8",
@@ -136,5 +141,9 @@ public class OrderDataProvider extends TestDataProvider<String> {
 
   public OrderDataProvider() {
     super("ORDER", PHYSICAL_SCHEMA, ROWS);
+  }
+
+  private static Struct buildKey(final String key) {
+    return KEY_BUILDER.build(key);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -143,7 +143,11 @@ public class OrderDataProvider extends TestDataProvider {
     super("ORDER", PHYSICAL_SCHEMA, ROWS);
   }
 
-  private static Struct buildKey(final String key) {
+  public Struct keyFrom(final String key) {
+    return buildKey(key);
+  }
+
+  public static Struct buildKey(final String key) {
     return KEY_BUILDER.build(key);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -19,13 +19,16 @@ import static io.confluent.ksql.GenericRow.genericRow;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil.KeyBuilder;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeFeatures;
+import org.apache.kafka.connect.data.Struct;
 
-public class PageViewDataProvider extends TestDataProvider<String> {
+public class PageViewDataProvider extends TestDataProvider {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("PAGEID"), SqlTypes.STRING)
@@ -36,19 +39,25 @@ public class PageViewDataProvider extends TestDataProvider<String> {
   private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
       .from(LOGICAL_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of());
 
-  private static final Multimap<String, GenericRow> ROWS = ImmutableListMultimap
-      .<String, GenericRow>builder()
-      .put("PAGE_1", genericRow("USER_1", 1L))
-      .put("PAGE_2", genericRow("USER_2", 2L))
-      .put("PAGE_3", genericRow("USER_4", 3L))
-      .put("PAGE_4", genericRow("USER_3", 4L))
-      .put("PAGE_5", genericRow("USER_0", 5L))
+  private static final KeyBuilder KEY_BUILDER = StructKeyUtil.keyBuilder(LOGICAL_SCHEMA);
+
+  private static final Multimap<Struct, GenericRow> ROWS = ImmutableListMultimap
+      .<Struct, GenericRow>builder()
+      .put(buildKey("PAGE_1"), genericRow("USER_1", 1L))
+      .put(buildKey("PAGE_2"), genericRow("USER_2", 2L))
+      .put(buildKey("PAGE_3"), genericRow("USER_4", 3L))
+      .put(buildKey("PAGE_4"), genericRow("USER_3", 4L))
+      .put(buildKey("PAGE_5"), genericRow("USER_0", 5L))
       // Duplicate page views from different users.
-      .put("PAGE_5", genericRow("USER_2", 6L))
-      .put("PAGE_5", genericRow("USER_3", 7L))
+      .put(buildKey("PAGE_5"), genericRow("USER_2", 6L))
+      .put(buildKey("PAGE_5"), genericRow("USER_3", 7L))
       .build();
 
   public PageViewDataProvider() {
     super("PAGEVIEW", PHYSICAL_SCHEMA, ROWS);
+  }
+
+  private static Struct buildKey(final String key) {
+    return KEY_BUILDER.build(key);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil.KeyBuilder;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -39,7 +41,7 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
-public class StructuredTypesDataProvider extends TestDataProvider<String> {
+public class StructuredTypesDataProvider extends TestDataProvider {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("STR"), SqlTypes.STRING)
@@ -71,23 +73,29 @@ public class StructuredTypesDataProvider extends TestDataProvider<String> {
   private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
       .from(LOGICAL_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of());
 
+  private static final KeyBuilder KEY_BUILDER = StructKeyUtil.keyBuilder(LOGICAL_SCHEMA);
+
   private static final ConnectSchema VALUE_CONNECT_SCHEMA = ConnectSchemas.columnsToConnectSchema(LOGICAL_SCHEMA.value());
   private static final Schema STRUCT_FIELD_SCHEMA = VALUE_CONNECT_SCHEMA.field("STRUCT").schema();
   private static final Schema COMPLEX_FIELD_SCHEMA = VALUE_CONNECT_SCHEMA.field("COMPLEX").schema();
 
-  private static final Multimap<String, GenericRow> ROWS = ImmutableListMultimap
-      .<String, GenericRow>builder()
-      .put("FOO", genericRow(1L, new BigDecimal("1.11"), Collections.singletonList("a"), Collections.singletonMap("k1", "v1"), generateStruct(2), generateComplexStruct(0)))
-      .put("BAR", genericRow(2L, new BigDecimal("2.22"), Collections.emptyList(), Collections.emptyMap(), generateStruct(3), generateComplexStruct(1)))
-      .put("BAZ", genericRow(3L, new BigDecimal("30.33"), Collections.singletonList("b"), Collections.emptyMap(), generateStruct(null), generateComplexStruct(2)))
-      .put("BUZZ", genericRow(4L, new BigDecimal("40.44"), ImmutableList.of("c", "d"), Collections.emptyMap(), generateStruct(88), generateComplexStruct(3)))
+  private static final Multimap<Struct, GenericRow> ROWS = ImmutableListMultimap
+      .<Struct, GenericRow>builder()
+      .put(buildKey("FOO"), genericRow(1L, new BigDecimal("1.11"), Collections.singletonList("a"), Collections.singletonMap("k1", "v1"), generateStruct(2), generateComplexStruct(0)))
+      .put(buildKey("BAR"), genericRow(2L, new BigDecimal("2.22"), Collections.emptyList(), Collections.emptyMap(), generateStruct(3), generateComplexStruct(1)))
+      .put(buildKey("BAZ"), genericRow(3L, new BigDecimal("30.33"), Collections.singletonList("b"), Collections.emptyMap(), generateStruct(null), generateComplexStruct(2)))
+      .put(buildKey("BUZZ"), genericRow(4L, new BigDecimal("40.44"), ImmutableList.of("c", "d"), Collections.emptyMap(), generateStruct(88), generateComplexStruct(3)))
       // Additional entries for repeated keys
-      .put("BAZ", genericRow(5L, new BigDecimal("12.0"), ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2"), generateStruct(0), generateComplexStruct(4)))
-      .put("BUZZ", genericRow(6L, new BigDecimal("10.1"), ImmutableList.of("f", "g"), Collections.emptyMap(), generateStruct(null), generateComplexStruct(5)))
+      .put(buildKey("BAZ"), genericRow(5L, new BigDecimal("12.0"), ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2"), generateStruct(0), generateComplexStruct(4)))
+      .put(buildKey("BUZZ"), genericRow(6L, new BigDecimal("10.1"), ImmutableList.of("f", "g"), Collections.emptyMap(), generateStruct(null), generateComplexStruct(5)))
       .build();
 
   public StructuredTypesDataProvider() {
     super("STRUCTURED_TYPES", PHYSICAL_SCHEMA, ROWS);
+  }
+
+  private static Struct buildKey(final String key) {
+    return KEY_BUILDER.build(key);
   }
 
   @SuppressWarnings("unchecked")

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.connect.ConnectSchemas;
 import java.math.BigDecimal;
@@ -71,7 +72,7 @@ public class StructuredTypesDataProvider extends TestDataProvider {
       .build();
 
   private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
-      .from(LOGICAL_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of());
+      .from(LOGICAL_SCHEMA, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), SerdeFeatures.of());
 
   private static final KeyBuilder KEY_BUILDER = StructKeyUtil.keyBuilder(LOGICAL_SCHEMA);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
@@ -24,19 +24,20 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.KeyValue;
 
-public class TestDataProvider<K> {
+public class TestDataProvider {
 
   private final String topicName;
   private final PhysicalSchema schema;
-  private final Multimap<K, GenericRow> data;
+  private final Multimap<Struct, GenericRow> data;
   private final String kstreamName;
 
   public TestDataProvider(
       final String namePrefix,
       final PhysicalSchema schema,
-      final Multimap<K, GenericRow> data
+      final Multimap<Struct, GenericRow> data
   ) {
     this.topicName = Objects.requireNonNull(namePrefix, "namePrefix") + "_TOPIC";
     this.kstreamName = namePrefix + "_KSTREAM";
@@ -62,11 +63,11 @@ public class TestDataProvider<K> {
     return schema;
   }
 
-  public Multimap<K, GenericRow> data() {
+  public Multimap<Struct, GenericRow> data() {
     return data;
   }
 
-  public Map<K, GenericRow> finalData() {
+  public Map<Struct, GenericRow> finalData() {
     return data.entries().stream()
         .collect(Collectors.toMap(
             Entry::getKey,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -57,7 +57,7 @@ public class UserDataProvider extends TestDataProvider {
   }
 
   public String getStringKey(final int position) {
-    return Iterables.get(data().keySet(), position).getString("USERID");
+    return Iterables.get(data().keySet(), position).getString(key());
   }
 
   private static Struct buildKey(final String key) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -19,13 +19,16 @@ import static io.confluent.ksql.GenericRow.genericRow;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Multimap;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil.KeyBuilder;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeFeatures;
+import org.apache.kafka.connect.data.Struct;
 
-public class UserDataProvider extends TestDataProvider<String> {
+public class UserDataProvider extends TestDataProvider {
 
   private static final LogicalSchema LOGICAL_SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
@@ -37,16 +40,22 @@ public class UserDataProvider extends TestDataProvider<String> {
   private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema
       .from(LOGICAL_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of());
 
-  private static final Multimap<String, GenericRow> ROWS = ImmutableListMultimap
-      .<String, GenericRow>builder()
-      .put("USER_0", genericRow(0L, "FEMALE", "REGION_0"))
-      .put("USER_1", genericRow(1L, "MALE", "REGION_1"))
-      .put("USER_2", genericRow(2L, "FEMALE", "REGION_1"))
-      .put("USER_3", genericRow(3L, "MALE", "REGION_0"))
-      .put("USER_4", genericRow(4L, "MALE", "REGION_4"))
+  private static final KeyBuilder KEY_BUILDER = StructKeyUtil.keyBuilder(LOGICAL_SCHEMA);
+
+  private static final Multimap<Struct, GenericRow> ROWS = ImmutableListMultimap
+      .<Struct, GenericRow>builder()
+      .put(buildKey("USER_0"), genericRow(0L, "FEMALE", "REGION_0"))
+      .put(buildKey("USER_1"), genericRow(1L, "MALE", "REGION_1"))
+      .put(buildKey("USER_2"), genericRow(2L, "FEMALE", "REGION_1"))
+      .put(buildKey("USER_3"), genericRow(3L, "MALE", "REGION_0"))
+      .put(buildKey("USER_4"), genericRow(4L, "MALE", "REGION_4"))
       .build();
 
   public UserDataProvider() {
     super("USER", PHYSICAL_SCHEMA, ROWS);
+  }
+
+  private static Struct buildKey(final String key) {
+    return KEY_BUILDER.build(key);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 import static io.confluent.ksql.GenericRow.genericRow;
 
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.util.StructKeyUtil;
@@ -53,6 +54,10 @@ public class UserDataProvider extends TestDataProvider {
 
   public UserDataProvider() {
     super("USER", PHYSICAL_SCHEMA, ROWS);
+  }
+
+  public String getStringKey(final int position) {
+    return Iterables.get(data().keySet(), position).getString("USERID");
   }
 
   private static Struct buildKey(final String key) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -116,7 +116,7 @@ public class ApiIntegrationTest {
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(TEST_TOPIC);
 
-    TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, FormatFactory.JSON);
+    TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, FormatFactory.KAFKA, FormatFactory.JSON);
 
     RestIntegrationTestUtil.createStream(REST_APP, TEST_DATA_PROVIDER);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.integration;
 
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -88,7 +89,7 @@ public class ClusterTerminationTest {
     TEST_HARNESS.getKafkaCluster().waitForTopicsToBePresent(SINK_TOPIC);
 
     // Produce to stream so that schema is registered by AvroConverter
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, JSON, System::currentTimeMillis);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, KAFKA, JSON, System::currentTimeMillis);
 
     TEST_HARNESS.waitForSubjectToBePresent(SINK_TOPIC + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HeartbeatAgentFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HeartbeatAgentFunctionalTest.java
@@ -86,7 +86,7 @@ public class HeartbeatAgentFunctionalTest {
   @BeforeClass
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.KAFKA, FormatFactory.JSON);
     RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
@@ -114,7 +114,7 @@ public class LagReportingAgentFunctionalTest {
   public static void setUpClass() {
     TEST_HARNESS.deleteInternalTopics("KSQL");
     TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.KAFKA, FormatFactory.JSON);
     RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -87,6 +87,7 @@ public class PullQueryFunctionalTest {
   private static final String USER_WITH_ACCESS_PWD = "changeme";
 
   private static final UserDataProvider USER_PROVIDER = new UserDataProvider();
+  private static final Format KEY_FORMAT = FormatFactory.KAFKA;
   private static final Format VALUE_FORMAT = FormatFactory.JSON;
   private static final int HEADER = 1;
 
@@ -156,6 +157,7 @@ public class PullQueryFunctionalTest {
     TEST_HARNESS.produceRows(
         USER_TOPIC,
         USER_PROVIDER,
+        KEY_FORMAT,
         VALUE_FORMAT,
         timestampSupplier::getAndIncrement
     );
@@ -184,7 +186,7 @@ public class PullQueryFunctionalTest {
   @Test
   public void shouldGetSingleKeyFromBothNodes() {
     // Given:
-    final String key = Iterables.get(USER_PROVIDER.data().keySet(), 0);
+    final String key = USER_PROVIDER.getStringKey(0);
 
     makeAdminRequest(
         "CREATE TABLE " + output + " AS"
@@ -211,7 +213,7 @@ public class PullQueryFunctionalTest {
   @Test
   public void shouldGetSingleWindowedKeyFromBothNodes() {
     // Given:
-    final String key = Iterables.get(USER_PROVIDER.data().keySet(), 0);
+    final String key = USER_PROVIDER.getStringKey(0);
 
     makeAdminRequest(
         "CREATE TABLE " + output + " AS"
@@ -257,6 +259,7 @@ public class PullQueryFunctionalTest {
     TEST_HARNESS.verifyAvailableUniqueRows(
         output.toUpperCase(),
         USER_PROVIDER.data().size(),
+        KEY_FORMAT,
         VALUE_FORMAT,
         AGGREGATE_SCHEMA
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
@@ -98,7 +97,7 @@ public class PullQueryRoutingFunctionalTest {
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
   private static final TemporaryFolder TMP = new TemporaryFolder();
   private static final int BASE_TIME = 1_000_000;
-  private final static String KEY = Iterables.get(USER_PROVIDER.data().keySet(), 0);
+  private final static String KEY = USER_PROVIDER.getStringKey(0);
   private final AtomicLong timestampSupplier = new AtomicLong(BASE_TIME);
   private String output;
   private String queryId;
@@ -213,6 +212,7 @@ public class PullQueryRoutingFunctionalTest {
     TEST_HARNESS.produceRows(
         topic,
         USER_PROVIDER,
+        FormatFactory.KAFKA,
         FormatFactory.JSON,
         timestampSupplier::getAndIncrement
     );
@@ -372,6 +372,7 @@ public class PullQueryRoutingFunctionalTest {
     TEST_HARNESS.produceRows(
         topic,
         USER_PROVIDER,
+        FormatFactory.KAFKA,
         FormatFactory.JSON,
         timestampSupplier::getAndIncrement
     );
@@ -495,6 +496,7 @@ public class PullQueryRoutingFunctionalTest {
     TEST_HARNESS.verifyAvailableUniqueRows(
         output.toUpperCase(),
         USER_PROVIDER.data().size(),
+        FormatFactory.KAFKA,
         FormatFactory.JSON,
         AGGREGATE_SCHEMA
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQuerySingleNodeFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQuerySingleNodeFunctionalTest.java
@@ -30,7 +30,6 @@ import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
@@ -93,8 +92,8 @@ public class PullQuerySingleNodeFunctionalTest {
   private static final UserDataProvider USER_PROVIDER = new UserDataProvider();
   private static final int HEADER = 1;
   private static final int BASE_TIME = 1_000_000;
-  private final static String KEY = Iterables.get(USER_PROVIDER.data().keySet(), 0);
-  private final static String KEY_3 = Iterables.get(USER_PROVIDER.data().keySet(), 3);
+  private final static String KEY = USER_PROVIDER.getStringKey(0);
+  private final static String KEY_3 = USER_PROVIDER.getStringKey(3);
   private static final Map<String, ?> LAG_FILTER_3 =
       ImmutableMap.of(KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG, "3");
 
@@ -180,6 +179,7 @@ public class PullQuerySingleNodeFunctionalTest {
     TEST_HARNESS.produceRows(
         topic,
         USER_PROVIDER,
+        FormatFactory.KAFKA,
         FormatFactory.JSON,
         timestampSupplier::getAndIncrement
     );
@@ -309,6 +309,7 @@ public class PullQuerySingleNodeFunctionalTest {
     testHarness.verifyAvailableUniqueRows(
         output.toUpperCase(),
         USER_PROVIDER.data().size(),
+        FormatFactory.KAFKA,
         FormatFactory.JSON,
         AGGREGATE_SCHEMA
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -172,7 +172,7 @@ public class RestApiTest {
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
 
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.KAFKA, FormatFactory.JSON);
 
     RestIntegrationTestUtil.createStream(REST_APP, PAGE_VIEWS_PROVIDER);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -272,13 +272,13 @@ public final class RestIntegrationTestUtil {
   }
 
   public static void createStream(final TestKsqlRestApp restApp,
-      final TestDataProvider<?> dataProvider) {
+      final TestDataProvider dataProvider) {
     createStream(restApp, dataProvider, Optional.empty());
   }
 
   public static void createStream(
       final TestKsqlRestApp restApp,
-      final TestDataProvider<?> dataProvider,
+      final TestDataProvider dataProvider,
       final Optional<BasicCredentials> userCreds
   ) {
     makeKsqlRequest(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeFunctionalTest.java
@@ -74,7 +74,7 @@ public class ShowQueriesMultiNodeFunctionalTest {
   @BeforeClass
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.KAFKA, FormatFactory.JSON);
     RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ShowQueriesMultiNodeWithTlsFunctionalTest.java
@@ -73,7 +73,7 @@ public class ShowQueriesMultiNodeWithTlsFunctionalTest {
   @BeforeClass
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.KAFKA, FormatFactory.JSON);
     RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
@@ -138,7 +138,7 @@ public class SystemAuthenticationFunctionalTest {
   private static void commonClassSetup(final IntegrationTestHarness TEST_HARNESS,
       final TestKsqlRestApp REST_APP_0) {
     TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
-    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.JSON);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.KAFKA, FormatFactory.JSON);
     RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER, Optional.of(USER1));
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server;
 
 import static io.confluent.ksql.serde.FormatFactory.AVRO;
 import static io.confluent.ksql.serde.FormatFactory.JSON;
+import static io.confluent.ksql.serde.FormatFactory.KAFKA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
@@ -89,8 +90,8 @@ public class StandaloneExecutorFunctionalTest {
   @BeforeClass
   public static void classSetUp() {
     final OrderDataProvider provider = new OrderDataProvider();
-    TEST_HARNESS.produceRows(AVRO_TOPIC, provider, AVRO);
-    TEST_HARNESS.produceRows(JSON_TOPIC, provider, JSON);
+    TEST_HARNESS.produceRows(AVRO_TOPIC, provider, KAFKA, AVRO);
+    TEST_HARNESS.produceRows(JSON_TOPIC, provider, KAFKA, JSON);
     DATA_SIZE = provider.data().size();
     UNIQUE_DATA_SIZE = provider.finalData().size();
     DATA_SCHEMA = provider.schema();
@@ -169,11 +170,11 @@ public class StandaloneExecutorFunctionalTest {
 
     // Then:
     // CSAS and INSERT INTO both input into S1:
-    TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE * 2, JSON, dataSchema);
+    TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE * 2, KAFKA, JSON, dataSchema);
     // CTAS only into T1:
-    TEST_HARNESS.verifyAvailableUniqueRows(t1, UNIQUE_DATA_SIZE, JSON, dataSchema);
+    TEST_HARNESS.verifyAvailableUniqueRows(t1, UNIQUE_DATA_SIZE, KAFKA, JSON, dataSchema);
     // S2 should be empty as 'auto.offset.reset' unset:
-    TEST_HARNESS.verifyAvailableUniqueRows(s2, 0, JSON, dataSchema);
+    TEST_HARNESS.verifyAvailableUniqueRows(s2, 0, KAFKA, JSON, dataSchema);
   }
 
   @Test
@@ -212,11 +213,11 @@ public class StandaloneExecutorFunctionalTest {
 
     // Then:
     // CSAS and INSERT INTO both input into S1:
-    TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE * 2, AVRO, dataSchema);
+    TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE * 2, KAFKA, AVRO, dataSchema);
     // CTAS only into T1:
-    TEST_HARNESS.verifyAvailableUniqueRows(t1, UNIQUE_DATA_SIZE, AVRO, dataSchema);
+    TEST_HARNESS.verifyAvailableUniqueRows(t1, UNIQUE_DATA_SIZE, KAFKA, AVRO, dataSchema);
     // S2 should be empty as 'auto.offset.reset' unset:
-    TEST_HARNESS.verifyAvailableUniqueRows(s2, 0, AVRO, dataSchema);
+    TEST_HARNESS.verifyAvailableUniqueRows(s2, 0, KAFKA, AVRO, dataSchema);
   }
 
   @Test
@@ -233,7 +234,7 @@ public class StandaloneExecutorFunctionalTest {
     standalone.startAsync();
 
     // Then:
-    TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE, AVRO, DATA_SCHEMA);
+    TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE, KAFKA, AVRO, DATA_SCHEMA);
   }
 
   @Test
@@ -300,7 +301,7 @@ public class StandaloneExecutorFunctionalTest {
     standalone.startAsync();
 
     // Then:
-    TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE, JSON, DATA_SCHEMA);
+    TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE, KAFKA, JSON, DATA_SCHEMA);
   }
 
   private static void givenIncompatibleSchemaExists(final String topicName) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KeySerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KeySerdeFactory.java
@@ -38,7 +38,7 @@ public interface KeySerdeFactory {
    * @param schemaRegistryClientFactory supplier of SR client.
    * @param loggerNamePrefix processing logger name prefix
    * @param processingLogContext processing logger context.
-   * @return the value serde.
+   * @return the key serde.
    */
   Serde<Struct> create(
       FormatInfo format,
@@ -59,7 +59,7 @@ public interface KeySerdeFactory {
    * @param schemaRegistryClientFactory supplier of SR client.
    * @param loggerNamePrefix processing logger name prefix
    * @param processingLogContext processing logger context.
-   * @return the value serde.
+   * @return the key serde.
    */
   Serde<Windowed<Struct>> create(
       FormatInfo format,


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/6217

This PR updates integration tests to work with non-KAFKA keys and updates ClientIntegrationTest to use JSON keys, which validates that the new API endpoints behave as expected with non-KAFKA keys.

Three commits:
- remove hard-coding of Kafka serdes from IntegrationTestHarness, and update TestDataProviders accordingly
- update integration tests in light of changes above
- update ClientIntegrationTest to use JSON keys

### Testing done 

Test-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

