### PR TITLE
refactor: move transactional command topic inside CommandStore

### DIFF
--- a/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.benchmark;
 
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.avro.random.generator.Generator;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -183,6 +184,7 @@ public class SerdeBenchmark {
       return new RowGenerator(generator, keyField, Optional.empty());
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     private static Generator getGenerator(final String schemaName) throws IOException {
       final Path schemaPath = SCHEMA_DIR.resolve(schemaName + SCHEMA_FILE_SUFFIX);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -663,6 +663,11 @@ public final class KsqlRestApplication implements Executable {
 
     final String commandTopicName = ReservedInternalTopics.commandTopic(ksqlConfig);
 
+    final Errors errorHandler = new Errors(restConfig.getConfiguredInstance(
+        KsqlRestConfig.KSQL_SERVER_ERROR_MESSAGES,
+        ErrorMessages.class
+    ));
+
     final CommandStore commandStore = CommandStore.Factory.create(
         ksqlConfig,
         commandTopicName,
@@ -670,7 +675,8 @@ public final class KsqlRestApplication implements Executable {
         ksqlConfig.addConfluentMetricsContextConfigsKafka(
             restConfig.getCommandConsumerProperties()),
         ksqlConfig.addConfluentMetricsContextConfigsKafka(
-            restConfig.getCommandProducerProperties())
+            restConfig.getCommandProducerProperties()),
+        errorHandler
     );
 
     final InteractiveStatementExecutor statementExecutor =
@@ -696,11 +702,6 @@ public final class KsqlRestApplication implements Executable {
 
     final Optional<KsqlAuthorizationValidator> authorizationValidator =
         KsqlAuthorizationValidatorFactory.create(ksqlConfig, serviceContext);
-
-    final Errors errorHandler = new Errors(restConfig.getConfiguredInstance(
-        KsqlRestConfig.KSQL_SERVER_ERROR_MESSAGES,
-        ErrorMessages.class
-    ));
 
     final Optional<LagReportingAgent> lagReportingAgent =
         initializeLagReportingAgent(restConfig, ksqlEngine, serviceContext);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandQueue.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandQueue.java
@@ -20,7 +20,6 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
-import org.apache.kafka.clients.producer.Producer;
 
 /**
  * Represents a queue of {@link Command}s that must be distributed to all
@@ -37,15 +36,10 @@ public interface CommandQueue extends Closeable {
    *
    * @param commandId              The id of the command to be distributed
    * @param command                The command to be distributed
-   * @param transactionalProducer  The transactional producer used to for enqueue the command
    * @return an asynchronous tracker that can be used to determine the current
    *         state of the command
    */
-  QueuedCommandStatus enqueueCommand(
-      CommandId commandId,
-      Command command,
-      Producer<CommandId, Command> transactionalProducer
-  );
+  QueuedCommandStatus enqueueCommand(CommandId commandId, Command command);
   
   /**
    * Polls the Queue for any commands that have been enqueued since the last
@@ -79,13 +73,6 @@ public interface CommandQueue extends Closeable {
    */
   void ensureConsumedPast(long seqNum, Duration timeout)
       throws InterruptedException, TimeoutException;
-
-  /**
-   * Creates a transactional producer for producing to the command topic.
-   *
-   * @return a TransactionalProducer
-   */
-  Producer<CommandId, Command> createTransactionalProducer();
 
   /**
    * Blocks until the command topic consumer has processed all records up to

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.computation;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.server.CommandTopic;
 import io.confluent.ksql.rest.server.CommandTopicBackup;
@@ -41,16 +42,12 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,12 +69,9 @@ public class CommandStore implements CommandQueue, Closeable {
   private final String commandTopicName;
   private final Duration commandQueueCatchupTimeout;
   private final Map<String, Object> kafkaConsumerProperties;
-  private final Map<String, Object> kafkaProducerProperties;
-  private final Serializer<CommandId> commandIdSerializer;
-  private final Serializer<Command> commandSerializer;
   private final Deserializer<CommandId> commandIdDeserializer;
   private final CommandTopicBackup commandTopicBackup;
-  
+  private final TransactionManager<CommandId, Command> transactionManager;
 
   public static final class Factory {
 
@@ -89,7 +83,8 @@ public class CommandStore implements CommandQueue, Closeable {
         final String commandTopicName,
         final Duration commandQueueCatchupTimeout,
         final Map<String, Object> kafkaConsumerProperties,
-        final Map<String, Object> kafkaProducerProperties
+        final Map<String, Object> kafkaProducerProperties,
+        final Errors errorMessageHandler
     ) {
       kafkaConsumerProperties.put(
           ConsumerConfig.ISOLATION_LEVEL_CONFIG,
@@ -98,14 +93,6 @@ public class CommandStore implements CommandQueue, Closeable {
       kafkaConsumerProperties.put(
           ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
           "none"
-      );
-      kafkaProducerProperties.put(
-          ProducerConfig.TRANSACTIONAL_ID_CONFIG,
-          ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
-      );
-      kafkaProducerProperties.put(
-          ProducerConfig.ACKS_CONFIG,
-          "all"
       );
 
       CommandTopicBackup commandTopicBackup = new CommandTopicBackupNoOp();
@@ -116,6 +103,14 @@ public class CommandStore implements CommandQueue, Closeable {
         );
       }
 
+      final TransactionManager<CommandId, Command> transactionManager = new TransactionManager<>(
+          ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+          kafkaProducerProperties,
+          InternalTopicSerdes.serializer(),
+          InternalTopicSerdes.serializer(),
+          errorMessageHandler
+      );
+
       return new CommandStore(
           commandTopicName,
           new CommandTopic(
@@ -125,12 +120,10 @@ public class CommandStore implements CommandQueue, Closeable {
           ),
           new SequenceNumberFutureStore(),
           kafkaConsumerProperties,
-          kafkaProducerProperties,
           commandQueueCatchupTimeout,
-          InternalTopicSerdes.serializer(),
-          InternalTopicSerdes.serializer(),
           InternalTopicSerdes.deserializer(CommandId.class),
-          commandTopicBackup
+          commandTopicBackup,
+          transactionManager
       );
     }
   }
@@ -140,12 +133,10 @@ public class CommandStore implements CommandQueue, Closeable {
       final CommandTopic commandTopic,
       final SequenceNumberFutureStore sequenceNumberFutureStore,
       final Map<String, Object> kafkaConsumerProperties,
-      final Map<String, Object> kafkaProducerProperties,
       final Duration commandQueueCatchupTimeout,
-      final Serializer<CommandId> commandIdSerializer,
-      final Serializer<Command> commandSerializer,
       final Deserializer<CommandId> commandIdDeserializer,
-      final CommandTopicBackup commandTopicBackup
+      final CommandTopicBackup commandTopicBackup,
+      final TransactionManager<CommandId, Command> transactionManager
   ) {
     this.commandTopic = Objects.requireNonNull(commandTopic, "commandTopic");
     this.commandStatusMap = Maps.newConcurrentMap();
@@ -155,17 +146,13 @@ public class CommandStore implements CommandQueue, Closeable {
         Objects.requireNonNull(commandQueueCatchupTimeout, "commandQueueCatchupTimeout");
     this.kafkaConsumerProperties =
         Objects.requireNonNull(kafkaConsumerProperties, "kafkaConsumerProperties");
-    this.kafkaProducerProperties =
-        Objects.requireNonNull(kafkaProducerProperties, "kafkaProducerProperties");
     this.commandTopicName = Objects.requireNonNull(commandTopicName, "commandTopicName");
-    this.commandIdSerializer =
-        Objects.requireNonNull(commandIdSerializer, "commandIdSerializer");
-    this.commandSerializer =
-        Objects.requireNonNull(commandSerializer, "commandSerializer");
     this.commandIdDeserializer =
         Objects.requireNonNull(commandIdDeserializer, "commandIdDeserializer");
     this.commandTopicBackup =
         Objects.requireNonNull(commandTopicBackup, "commandTopicBackup");
+    this.transactionManager =
+        Objects.requireNonNull(transactionManager, "transactionManager");
   }
 
   @Override
@@ -190,11 +177,7 @@ public class CommandStore implements CommandQueue, Closeable {
   }
 
   @Override
-  public QueuedCommandStatus enqueueCommand(
-      final CommandId commandId,
-      final Command command,
-      final Producer<CommandId, Command> transactionalProducer
-  ) {
+  public QueuedCommandStatus enqueueCommand(final CommandId commandId, final Command command) {
     final CommandStatusFuture statusFuture = commandStatusMap.compute(
         commandId,
         (k, v) -> {
@@ -210,14 +193,23 @@ public class CommandStore implements CommandQueue, Closeable {
           );
         }
     );
+
     try {
       final ProducerRecord<CommandId, Command> producerRecord = new ProducerRecord<>(
           commandTopicName,
           COMMAND_TOPIC_PARTITION,
           commandId,
           command);
-      final RecordMetadata recordMetadata =
-          transactionalProducer.send(producerRecord).get();
+
+      final RecordMetadata recordMetadata = transactionManager.executeTransaction(
+          producer -> {
+            try {
+              return producer.send(producerRecord).get();
+            } catch (final Exception e) {
+              throw new KsqlException(e);
+            }
+          });
+
       return new QueuedCommandStatus(recordMetadata.offset(), statusFuture);
     } catch (final Exception e) {
       commandStatusMap.remove(commandId);
@@ -292,15 +284,6 @@ public class CommandStore implements CommandQueue, Closeable {
               timeout.toMillis()
           ));
     }
-  }
-
-  @Override
-  public Producer<CommandId, Command> createTransactionalProducer() {
-    return new KafkaProducer<>(
-        kafkaProducerProperties,
-        commandIdSerializer,
-        commandSerializer
-    );
   }
 
   @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/TransactionManager.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/TransactionManager.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.computation;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.Errors;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * This class is used for executing transactions when producing records to Kafka. TransactionManager
+ * creates a new instance of {@link KafkaProducer} for each transaction.
+ * </p>
+ * The TransactionManager is built for a key/value serializer only.
+ *
+ * @param <K> The key serializer to use when creating instances of KafkaProducer
+ * @param <V> The value serializer to use when creating instances of KafkaProducer
+ */
+public final class TransactionManager<K, V> {
+  private static final String ACKS_WAIT_FOR_ALL_REPLICAS = "all";
+
+  private final Map<String, Object> producerProperties;
+  private final Serializer<K> keySerializer;
+  private final Serializer<V> valueSerializer;
+  private final Errors errorMessageHandler;
+  private final KafkaProducerSupplier<K, V> kafkaProducerSupplier;
+
+  interface KafkaProducerSupplier<K, V> {
+    KafkaProducer<K, V> newProducer(
+        Map<String, Object> properties,
+        Serializer<K> keySerializer,
+        Serializer<V> valueSerializer
+    );
+  }
+
+  public TransactionManager(
+      final String transactionalId,
+      final Map<String, Object> producerProperties,
+      final Serializer<K> keySerializer,
+      final Serializer<V> valueSerializer,
+      final Errors errorMessageHandler
+  ) {
+    this(
+        transactionalId,
+        producerProperties,
+        keySerializer,
+        valueSerializer,
+        errorMessageHandler,
+        KafkaProducer::new
+    );
+  }
+
+  @VisibleForTesting
+  TransactionManager(
+      final String transactionalId,
+      final Map<String, Object> producerProperties,
+      final Serializer<K> keySerializer,
+      final Serializer<V> valueSerializer,
+      final Errors errorMessageHandler,
+      final KafkaProducerSupplier<K, V> kafkaProducerSupplier
+  ) {
+    this.producerProperties = copyAndSetTransactionConfigs(
+        transactionalId,
+        requireNonNull(producerProperties, "producerProperties")
+    );
+
+    this.keySerializer = requireNonNull(keySerializer, "keySerializer");
+    this.valueSerializer = requireNonNull(valueSerializer, "valueSerializer");
+    this.errorMessageHandler = requireNonNull(errorMessageHandler, "errorMessageHandler");
+    this.kafkaProducerSupplier = requireNonNull(kafkaProducerSupplier, "kafkaProducerSupplier");
+  }
+
+  private Map<String, Object> copyAndSetTransactionConfigs(
+      final String transactionalId,
+      final Map<String, Object> producerProperties
+  ) {
+    final ImmutableMap.Builder<String, Object> mapBuilder = new ImmutableMap.Builder<>();
+
+    mapBuilder.putAll(producerProperties);
+    mapBuilder.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+    mapBuilder.put(ProducerConfig.ACKS_CONFIG, ACKS_WAIT_FOR_ALL_REPLICAS);
+
+    return mapBuilder.build();
+  }
+
+  /**
+   * Executes the {@code transactionBlock} as a single transaction.
+   *
+   * @param transactionBlock The block of code to execute in a single transaction.*
+   */
+  public <T> T executeTransaction(final Function<Producer<K, V>, T> transactionBlock) {
+    try (Producer<K, V> producer = createTransactionalProducer()) {
+      producer.beginTransaction();
+
+      try {
+        final T result = transactionBlock.apply(producer);
+        producer.commitTransaction();
+        return result;
+      } catch (final ProducerFencedException
+          | OutOfOrderSequenceException
+          | AuthorizationException e
+      ) {
+        // We can't recover from these exceptions, so our only option is close producer and exit.
+        // This catch doesn't abort() since doing that would throw another exception.
+        throw e;
+      } catch (final Exception e) {
+        producer.abortTransaction();
+        throw e;
+      }
+    }
+  }
+
+  private Producer<K, V> createTransactionalProducer() {
+    final Producer<K, V> producer = kafkaProducerSupplier
+        .newProducer(producerProperties, keySerializer, valueSerializer);
+
+    try {
+      producer.initTransactions();
+    } catch (final TimeoutException e) {
+      throw new RuntimeException(errorMessageHandler.transactionInitTimeoutErrorMessage(e), e);
+    }
+
+    return producer;
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/TransactionManagerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/TransactionManagerTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.computation;
+
+import io.confluent.ksql.rest.Errors;
+import io.confluent.ksql.rest.entity.CommandId;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TransactionManagerTest {
+  private static final String TRANSACTION_ID = "transactionId";
+
+  @Mock
+  private KafkaProducer<CommandId, Command> transactionalProducer;
+  @Mock
+  private Serializer<CommandId> keySerializer;
+  @Mock
+  private Serializer<Command> valueSerializer;
+  @Mock
+  private RecordMetadata recordMetadata;
+  @Mock
+  private Function<Producer<CommandId, Command>, RecordMetadata> transactionBlock;
+
+  private TransactionManager<CommandId, Command> transactionManager;
+
+  @Before
+  public void setup() {
+    when(transactionBlock.apply(any())).thenReturn(recordMetadata);
+
+    transactionManager = new TransactionManager<>(
+        TRANSACTION_ID,
+        Collections.emptyMap(),
+        keySerializer,
+        valueSerializer,
+        mock(Errors.class),
+        (a, b, c) -> transactionalProducer
+    );
+  }
+
+  @Test
+  public void shouldExecuteTransaction() {
+    // When:
+    final Object result = transactionManager.executeTransaction(transactionBlock);
+
+    // Then:
+    assertThat(result, is(recordMetadata));
+
+    final InOrder inOrder = Mockito.inOrder(transactionalProducer, transactionBlock);
+    inOrder.verify(transactionalProducer).initTransactions();
+    inOrder.verify(transactionalProducer).beginTransaction();
+    inOrder.verify(transactionBlock).apply(transactionalProducer);
+    inOrder.verify(transactionalProducer).commitTransaction();
+  }
+
+  @Test
+  public void shouldThrowExecuteTransactionWhenKafkaProducerCannotBeCreated() {
+    // Given:
+    transactionManager = new TransactionManager<>(
+        TRANSACTION_ID,
+        Collections.emptyMap(),
+        keySerializer,
+        valueSerializer,
+        mock(Errors.class),
+        (a, b, c) -> { throw new RuntimeException("kafka-error"); }
+    );
+
+    // When:
+    final Exception e = assertThrows(
+        RuntimeException.class,
+        () -> transactionManager.executeTransaction(transactionBlock)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("kafka-error"));
+    verifyZeroInteractions(transactionalProducer);
+    verifyZeroInteractions(transactionBlock);
+  }
+
+  @Test
+  public void shouldThrowExecuteTransactionWhenInitTransactionFails() {
+    // Given:
+    doThrow(new RuntimeException("init-error"))
+        .when(transactionalProducer).initTransactions();
+
+    // When:
+    final Exception e = assertThrows(
+        RuntimeException.class,
+        () -> transactionManager.executeTransaction(transactionBlock)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("init-error"));
+    verifyZeroInteractions(transactionBlock);
+    verify(transactionalProducer).initTransactions();
+    verifyNoMoreInteractions(transactionalProducer);
+  }
+
+  @Test
+  public void shouldThrowExecuteTransactionWhenBeginTransactionFails() {
+    // Given:
+    doThrow(new RuntimeException("begin-error"))
+        .when(transactionalProducer).beginTransaction();
+
+    // When:
+    final Exception e = assertThrows(
+        RuntimeException.class,
+        () -> transactionManager.executeTransaction(transactionBlock)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("begin-error"));
+    verifyZeroInteractions(transactionBlock);
+    verify(transactionalProducer).initTransactions();
+    verify(transactionalProducer).beginTransaction();
+    verify(transactionalProducer).close();
+    verifyNoMoreInteractions(transactionalProducer);
+  }
+
+  @Test
+  public void shouldThrowAndAbortExecuteTransactionWhenTransactionBlockFails() {
+    // Given:
+    doThrow(new RuntimeException("block-error"))
+        .when(transactionBlock).apply(transactionalProducer);
+
+    // When:
+    final Exception e = assertThrows(
+        RuntimeException.class,
+        () -> transactionManager.executeTransaction(transactionBlock)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("block-error"));
+    verify(transactionalProducer).initTransactions();
+    verify(transactionalProducer).beginTransaction();
+    verify(transactionBlock).apply(transactionalProducer);
+    verify(transactionalProducer).abortTransaction();
+    verify(transactionalProducer).close();
+    verifyNoMoreInteractions(transactionalProducer);
+  }
+
+  @Test
+  public void shouldThrowAndAbortExecuteTransactionWhenCommitTransactionFails() {
+    // Given:
+    doThrow(new RuntimeException("commit-error"))
+        .when(transactionalProducer).commitTransaction();
+
+    // When:
+    final Exception e = assertThrows(
+        RuntimeException.class,
+        () -> transactionManager.executeTransaction(transactionBlock)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("commit-error"));
+    verify(transactionalProducer).initTransactions();
+    verify(transactionalProducer).beginTransaction();
+    verify(transactionBlock).apply(transactionalProducer);
+    verify(transactionalProducer).commitTransaction();
+    verify(transactionalProducer).abortTransaction();
+    verify(transactionalProducer).close();
+    verifyNoMoreInteractions(transactionalProducer);
+  }
+
+  @Test
+  public void shouldThrowAndNotAbortExecuteTransactionOnNonAbortedExceptions() {
+    // Given:
+    doThrow(ProducerFencedException.class)
+        .when(transactionalProducer).commitTransaction();
+
+    // When:
+    final Exception e = assertThrows(
+        ProducerFencedException.class,
+        () -> transactionManager.executeTransaction(transactionBlock)
+    );
+
+    // Then:
+    assertThat(e, instanceOf(ProducerFencedException.class));
+    verify(transactionalProducer).initTransactions();
+    verify(transactionalProducer).beginTransaction();
+    verify(transactionBlock).apply(transactionalProducer);
+    verify(transactionalProducer).commitTransaction();
+    verify(transactionalProducer).close();
+    verifyNoMoreInteractions(transactionalProducer);
+  }
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/DefaultErrorMessages.java
@@ -44,7 +44,7 @@ public class DefaultErrorMessages implements ErrorMessages {
 
   @Override
   public String transactionInitTimeoutErrorMessage(final Exception e) {
-    return "Timeout while initializing transaction to the KSQL command topic."
+    return "Timeout while initializing a transaction."
         + System.lineSeparator()
         + "If you're running a single Kafka broker, " 
         + "ensure that the following configs are set to 1 on the broker:"


### PR DESCRIPTION
### Description 
Note: This refactor helps continue working on the KSQL restore metadata command.

The refactor moves the transactional operations when writing commands to the command topic inside the `CommandStore`. This guarantees the `enqueueCommand` is always done in a transactional operation, and not depending on the caller to create the transactional context.

The main class to review is the `TransactionManager`, which is in charge of executing code that uses the `KafkaProducer` using a single transaction. i.e.
```
TransactionManager transactionManager = ...;
ProducerRecord record = ...;

transactionManager.executeTransaction(producer -> {
   return producer.send(record).get();
});
```
`TransactionManager` initializes and begins each transaction before calling the transaction block. It commits the transaction afterewards, or aborts it in case the transaction block throws an exception.

I made `TransactionManager` generic so it can be used in future code (i.e. passing multiple values in insert/value statement).

The rest of the code does:
- `CommandStore` calls the `TransactionManager` to execute the command topic producer in a single transaction.
- `DistributingExecutor` just calls `enqueueCommand` expecting the transaction happens internally.
- Tests

### Testing done 
Added unit tests
Verified manually in the CLI by executing some CREATE/DROP commands.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

