### PR TITLE
chore: add ksqldb staging repo to release maven settings (MINOR)

### DIFF
--- a/maven-settings-template.xml
+++ b/maven-settings-template.xml
@@ -16,12 +16,19 @@
           <name>Confluent</name>
           <url>PACKAGES_MAVEN_URL</url>
         </repository>
+
+        <!-- needed for HTML API doc generation post-release only --> 
+        <repository>
+          <id>ksqldb-staging</id>
+          <name>ksqlDB staging</name>
+          <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
+        </repository>
       </repositories>
 
       <pluginRepositories>
 
         <pluginRepository>
-          <id>confluent-artifactory-central</id>
+          <id>confluent-other</id>
           <name>Confluent Plugin Repository</name>
           <url>PACKAGES_MAVEN_URL</url>
           <layout>default</layout>


### PR DESCRIPTION
### Description 

This is needed in order to generate HTML API docs from javadocs on Java client interfaces from release tags, rather than release branches. The former is preferred so that the version displayed on the HTML docs will be the release version (e.g., 0.12.0) rather than the master version (e.g., 6.1.0-SNAPSHOT). See https://github.com/confluentinc/ksql/pull/6323 for an example of the difference.

### Testing done 

Non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

