### PR TITLE
docs: cherry-pick: link to ksqlDB 0.12.0 blog post (DOCS-5495)

### DIFF
--- a/docs/operate-and-deploy/changelog.md
+++ b/docs/operate-and-deploy/changelog.md
@@ -9,11 +9,13 @@ keywords: ksqldb, changelog
 Version 0.12.0
 --------------
 
+- [ksqlDB 0.12.0 Introduces Real-Time Query Upgrades and Automatic Query Restarts](https://www.confluent.io/blog/ksqldb-0-12-0-features-updates/)
 - [ksqlDB v0.12.0 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0120-2020-08-26)
 
 Version 0.11.0
 --------------
 
+- [Announcing ksqlDB 0.11.0](https://www.confluent.io/blog/ksqldb-0-11-0-features-and-improvements)
 - [ksqlDB v0.11.0 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0110-2020-08-03)
 
 Version 0.10.1


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/6318.

* docs: link to ksqlDB 0.12.0 blog post (DOCS-5489)

* docs: add missing link to 0.11.0 blog post