### PR TITLE
chore: ensure CLI works with other key formats

### DIFF
--- a/docs/developer-guide/create-a-stream.md
+++ b/docs/developer-guide/create-a-stream.md
@@ -70,10 +70,10 @@ SHOW STREAMS;
 Your output should resemble:
 
 ```
- Stream Name | Kafka Topic | Format
----------------------------------------
- PAGEVIEWS   | pageviews   | DELIMITED
----------------------------------------
+ Stream Name | Kafka Topic | Key Format | Value Format | Windowed
+-----------------------------------------------------------------
+ PAGEVIEWS   | pageviews   | KAFKA      | DELIMITED    | false   
+-----------------------------------------------------------------
 ```
 
 Get the schema for the stream:

--- a/docs/developer-guide/create-a-table.md
+++ b/docs/developer-guide/create-a-table.md
@@ -76,10 +76,10 @@ SHOW TABLES;
 Your output should resemble:
 
 ```
- Table Name | Kafka Topic | Format | Windowed
-----------------------------------------------
- USERS      | users       | JSON   | false
-----------------------------------------------
+ Table Name | Kafka Topic | Key Format | Value Format | Windowed
+----------------------------------------------------------------
+ USERS      | users       | KAFKA      | JSON          | false
+----------------------------------------------------------------
 ```
 
 Get the schema for the table:
@@ -216,11 +216,11 @@ SHOW TABLES;
 Your output should resemble:
 
 ```
- Table Name   | Kafka Topic  | Format | Windowed
--------------------------------------------------
- USERS        | users        | JSON   | false
- USERS_FEMALE | USERS_FEMALE | JSON   | false
--------------------------------------------------
+ Table Name   | Kafka Topic  | Key Format | Value Format | Windowed
+-------------------------------------------------------------------
+ USERS        | users        | KAFKA      | JSON         | false
+ USERS_FEMALE | USERS_FEMALE | KAFKA      | JSON         | false
+-------------------------------------------------------------------
 ```
 
 Print some rows in the table:

--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -613,7 +613,13 @@ List ksqlDB streams:
 ```java
 List<StreamInfo> streams = client.listStreams().get();
 for (StreamInfo stream : streams) {
-  System.out.println(stream.getName() + " " + stream.getTopic() + " " + stream.getFormat());
+  System.out.println(
+     stream.getName() 
+     + " " + stream.getTopic() 
+     + " " + stream.getKeyFormat()
+     + " " + stream.getValueFormat()
+     + " " + stream.isWindowed()
+  );
 }
 ``` 
 
@@ -621,7 +627,13 @@ List ksqlDB tables:
 ```java
 List<TableInfo> tables = client.listTables().get();
 for (TableInfo table : tables) {
-  System.out.println(table.getName() + " " + table.getTopic() + " " + table.getFormat() + " " + table.isWindowed());
+  System.out.println(
+       table.getName() 
+       + " " + table.getTopic() 
+       + " " + table.getKeyFormat()
+       + " " + table.getValueFormat()
+       + " " + table.isWindowed()
+    );
 }
 ```
 
@@ -629,7 +641,11 @@ List Kafka topics:
 ```java
 List<TopicInfo> topics = client.listTopics().get();
 for (TopicInfo topic : topics) {
-  System.out.println(topic.getName() + " " + topic.getPartitions() + " " + topic.getReplicasPerPartition());
+  System.out.println(
+       topic.getName() 
+       + " " + topic.getPartitions() 
+       + " " + topic.getReplicasPerPartition()
+  );
 }
 ```
 

--- a/docs/developer-guide/ksqldb-reference/describe.md
+++ b/docs/developer-guide/ksqldb-reference/describe.md
@@ -73,7 +73,7 @@ Your output should resemble:
 ```
 Type                 : TABLE
 Timestamp field      : Not set - using <ROWTIME>
-Key format           : STRING
+Key format           : KAFKA
 Value format         : JSON
 Kafka output topic   : IP_SUM (partitions: 4, replication: 1)
 

--- a/docs/developer-guide/test-and-debug/processing-log.md
+++ b/docs/developer-guide/test-and-debug/processing-log.md
@@ -276,10 +276,10 @@ When you start ksqlDB, you should see the stream in your list of streams:
 ```
 ksql> list streams;
 
- Stream Name        | Kafka Topic            | Format
-------------------------------------------------------
- PROCESSING_LOG     | processing_log         | JSON
-------------------------------------------------------
+ Stream Name    | Kafka Topic      | Key Format | Value Format | Windowed
+-------------------------------------------------------------------------
+ PROCESSING_LOG | processing_log   | KAFKA      | JSON         |
+-------------------------------------------------------------------------
 
 ksql> describe PROCESSING_LOG;
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/StreamInfo.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/StreamInfo.java
@@ -31,8 +31,17 @@ public interface StreamInfo {
   String getTopic();
 
   /**
-   * @return the format of the data in this stream
+   * @return the key format of the data in this stream
    */
-  String getFormat();
+  String getKeyFormat();
 
+  /**
+   * @return the value format of the data in this stream
+   */
+  String getValueFormat();
+
+  /**
+   * @return whether the key is windowed.
+   */
+  boolean isWindowed();
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/StreamInfo.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/StreamInfo.java
@@ -31,6 +31,14 @@ public interface StreamInfo {
   String getTopic();
 
   /**
+   * @deprecated since 0.14, use {@link #getValueFormat()}
+   */
+  @Deprecated
+  default String getFormat() {
+    return getValueFormat();
+  }
+
+  /**
    * @return the key format of the data in this stream
    */
   String getKeyFormat();

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/TableInfo.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/TableInfo.java
@@ -31,13 +31,17 @@ public interface TableInfo {
   String getTopic();
 
   /**
-   * @return the format of the data in this table
+   * @return the key format of the data in this table
    */
-  String getFormat();
+  String getKeyFormat();
+
+  /**
+   * @return the value format of the data in this table
+   */
+  String getValueFormat();
 
   /**
    * @return whether this ksqlDB table is windowed
    */
   boolean isWindowed();
-
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/TableInfo.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/TableInfo.java
@@ -31,6 +31,14 @@ public interface TableInfo {
   String getTopic();
 
   /**
+   * @deprecated since 0.14, use {@link #getValueFormat()}
+   */
+  @Deprecated
+  default String getFormat() {
+    return getValueFormat();
+  }
+
+  /**
    * @return the key format of the data in this table
    */
   String getKeyFormat();

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -170,7 +170,10 @@ final class AdminResponseHandlers {
           .map(o -> new StreamInfoImpl(
               o.getString("name"),
               o.getString("topic"),
-              o.getString("format")))
+              o.getString("keyFormat", "KAFKA"),
+              o.getString("valueFormat", o.getString("format", "UNKNOWN")),
+              o.getBoolean("isWindowed", false)
+          ))
           .collect(Collectors.toList())
       );
     } catch (Exception e) {
@@ -194,7 +197,8 @@ final class AdminResponseHandlers {
           .map(o -> new TableInfoImpl(
               o.getString("name"),
               o.getString("topic"),
-              o.getString("format"),
+              o.getString("keyFormat", "KAFKA"),
+              o.getString("valueFormat", o.getString("format", "UNKNOWN")),
               o.getBoolean("isWindowed")))
           .collect(Collectors.toList())
       );

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/StreamInfoImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/StreamInfoImpl.java
@@ -22,12 +22,22 @@ public class StreamInfoImpl implements StreamInfo {
 
   private final String name;
   private final String topicName;
-  private final String format;
+  private final String keyFormat;
+  private final String valueFormat;
+  private final boolean windowed;
 
-  StreamInfoImpl(final String name, final String topicName, final String format) {
+  StreamInfoImpl(
+      final String name,
+      final String topicName,
+      final String keyFormat,
+      final String valueFormat,
+      final boolean windowed
+  ) {
     this.name = Objects.requireNonNull(name);
     this.topicName = Objects.requireNonNull(topicName);
-    this.format = Objects.requireNonNull(format);
+    this.keyFormat = Objects.requireNonNull(keyFormat);
+    this.valueFormat = Objects.requireNonNull(valueFormat);
+    this.windowed = windowed;
   }
 
   @Override
@@ -41,8 +51,18 @@ public class StreamInfoImpl implements StreamInfo {
   }
 
   @Override
-  public String getFormat() {
-    return format;
+  public String getKeyFormat() {
+    return keyFormat;
+  }
+
+  @Override
+  public String getValueFormat() {
+    return valueFormat;
+  }
+
+  @Override
+  public boolean isWindowed() {
+    return windowed;
   }
 
   @Override
@@ -54,14 +74,16 @@ public class StreamInfoImpl implements StreamInfo {
       return false;
     }
     final StreamInfoImpl that = (StreamInfoImpl) o;
-    return name.equals(that.name)
+    return windowed == that.windowed
+        && name.equals(that.name)
         && topicName.equals(that.topicName)
-        && format.equals(that.format);
+        && keyFormat.equals(that.keyFormat)
+        && valueFormat.equals(that.valueFormat);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, topicName, format);
+    return Objects.hash(name, topicName, keyFormat, valueFormat, windowed);
   }
 
   @Override
@@ -69,7 +91,9 @@ public class StreamInfoImpl implements StreamInfo {
     return "StreamInfo{"
         + "name='" + name + '\''
         + ", topicName='" + topicName + '\''
-        + ", format='" + format + '\''
+        + ", keyFormat='" + keyFormat + '\''
+        + ", valueFormat='" + valueFormat + '\''
+        + ", windowed='" + windowed + '\''
         + '}';
   }
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/TableInfoImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/TableInfoImpl.java
@@ -22,19 +22,22 @@ public class TableInfoImpl implements TableInfo {
 
   private final String name;
   private final String topicName;
-  private final String format;
-  private final boolean isWindowed;
+  private final String keyFormat;
+  private final String valueFormat;
+  private final boolean windowed;
 
   TableInfoImpl(
       final String name,
       final String topicName,
-      final String format,
-      final boolean isWindowed
+      final String keyFormat,
+      final String valueFormat,
+      final boolean windowed
   ) {
     this.name = Objects.requireNonNull(name);
     this.topicName = Objects.requireNonNull(topicName);
-    this.format = Objects.requireNonNull(format);
-    this.isWindowed = isWindowed;
+    this.valueFormat = Objects.requireNonNull(valueFormat);
+    this.keyFormat = Objects.requireNonNull(keyFormat);
+    this.windowed = windowed;
   }
 
   @Override
@@ -48,13 +51,18 @@ public class TableInfoImpl implements TableInfo {
   }
 
   @Override
-  public String getFormat() {
-    return format;
+  public String getKeyFormat() {
+    return keyFormat;
+  }
+
+  @Override
+  public String getValueFormat() {
+    return valueFormat;
   }
 
   @Override
   public boolean isWindowed() {
-    return isWindowed;
+    return windowed;
   }
 
   @Override
@@ -66,15 +74,16 @@ public class TableInfoImpl implements TableInfo {
       return false;
     }
     final TableInfoImpl tableInfo = (TableInfoImpl) o;
-    return isWindowed == tableInfo.isWindowed
+    return windowed == tableInfo.windowed
         && name.equals(tableInfo.name)
         && topicName.equals(tableInfo.topicName)
-        && format.equals(tableInfo.format);
+        && keyFormat.equals(tableInfo.keyFormat)
+        && valueFormat.equals(tableInfo.valueFormat);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, topicName, format, isWindowed);
+    return Objects.hash(name, topicName, keyFormat, valueFormat, windowed);
   }
 
   @Override
@@ -82,8 +91,9 @@ public class TableInfoImpl implements TableInfo {
     return "TableInfo{"
         + "name='" + name + '\''
         + ", topicName='" + topicName + '\''
-        + ", format='" + format + '\''
-        + ", isWindowed=" + isWindowed
+        + ", keyFormat='" + keyFormat + '\''
+        + ", valueFormat='" + valueFormat + '\''
+        + ", windowed=" + windowed
         + '}';
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/StreamInfoImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/StreamInfoImplTest.java
@@ -18,25 +18,31 @@ package io.confluent.ksql.api.client.impl;
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 
+@SuppressWarnings("UnstableApiUsage")
 public class StreamInfoImplTest {
 
   @Test
   public void shouldImplementHashCodeAndEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new StreamInfoImpl("name", "topic", "JSON"),
-            new StreamInfoImpl("name", "topic", "JSON")
+            new StreamInfoImpl("name", "topic", "KAFKA", "JSON", false),
+            new StreamInfoImpl("name", "topic", "KAFKA", "JSON", false)
         )
         .addEqualityGroup(
-            new StreamInfoImpl("other_name", "topic", "JSON")
+            new StreamInfoImpl("other_name", "topic", "KAFKA", "JSON", false)
         )
         .addEqualityGroup(
-            new StreamInfoImpl("name", "other_topic", "JSON")
+            new StreamInfoImpl("name", "other_topic", "KAFKA", "JSON", false)
         )
         .addEqualityGroup(
-            new StreamInfoImpl("name", "topic", "AVRO")
+            new StreamInfoImpl("name", "topic", "AVRO", "JSON", false)
+        )
+        .addEqualityGroup(
+            new StreamInfoImpl("name", "topic", "KAFKA", "AVRO", false)
+        )
+        .addEqualityGroup(
+            new StreamInfoImpl("name", "topic", "KAFKA", "JSON", true)
         )
         .testEquals();
   }
-
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/TableInfoImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/TableInfoImplTest.java
@@ -18,28 +18,31 @@ package io.confluent.ksql.api.client.impl;
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 
+@SuppressWarnings("UnstableApiUsage")
 public class TableInfoImplTest {
 
   @Test
   public void shouldImplementHashCodeAndEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new TableInfoImpl("name", "topic", "JSON", true),
-            new TableInfoImpl("name", "topic", "JSON", true)
+            new TableInfoImpl("name", "topic", "KAFKA", "JSON", true),
+            new TableInfoImpl("name", "topic", "KAFKA", "JSON", true)
         )
         .addEqualityGroup(
-            new TableInfoImpl("other_name", "topic", "JSON", true)
+            new TableInfoImpl("other_name", "topic", "KAFKA", "JSON", true)
         )
         .addEqualityGroup(
-            new TableInfoImpl("name", "other_topic", "JSON", true)
+            new TableInfoImpl("name", "other_topic", "KAFKA", "JSON", true)
         )
         .addEqualityGroup(
-            new TableInfoImpl("name", "topic", "AVRO", true)
+            new TableInfoImpl("name", "other_topic", "AVRO", "JSON", true)
         )
         .addEqualityGroup(
-            new TableInfoImpl("name", "topic", "JSON", false)
+            new TableInfoImpl("name", "topic", "KAFKA", "AVRO", true)
+        )
+        .addEqualityGroup(
+            new TableInfoImpl("name", "topic", "KAFKA", "JSON", false)
         )
         .testEquals();
   }
-
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -841,7 +841,9 @@ public class ClientIntegrationTest {
     final List<TableInfo> tables = client.listTables().get();
 
     // Then
-    assertThat("" + tables, tables, contains(tableInfo(AGG_TABLE, AGG_TABLE, "JSON", false)));
+    assertThat("" + tables, tables, contains(
+        tableInfo(AGG_TABLE, AGG_TABLE, KEY_FORMAT.name(), VALUE_FORMAT.name(), false)
+    ));
   }
 
   @SuppressWarnings("unchecked")
@@ -1163,11 +1165,21 @@ public class ClientIntegrationTest {
   private static Matcher<? super StreamInfo> streamForProvider(
       final TestDataProvider testDataProvider
   ) {
-    return streamInfo(testDataProvider.kstreamName(), testDataProvider.topicName(), "JSON");
+    return streamInfo(
+        testDataProvider.kstreamName(),
+        testDataProvider.topicName(),
+        KEY_FORMAT.name(),
+        VALUE_FORMAT.name(),
+        false
+    );
   }
 
   private static Matcher<? super StreamInfo> streamInfo(
-      final String streamName, final String topicName, final String format
+      final String streamName,
+      final String topicName,
+      final String keyFormat,
+      final String valueFormat,
+      final boolean isWindowed
   ) {
     return new TypeSafeDiagnosingMatcher<StreamInfo>() {
       @Override
@@ -1180,7 +1192,13 @@ public class ClientIntegrationTest {
         if (!topicName.equals(actual.getTopic())) {
           return false;
         }
-        if (!format.equals(actual.getFormat())) {
+        if (!keyFormat.equals(actual.getValueFormat())) {
+          return false;
+        }
+        if (!valueFormat.equals(actual.getValueFormat())) {
+          return false;
+        }
+        if (isWindowed != actual.isWindowed()) {
           return false;
         }
         return true;
@@ -1189,13 +1207,18 @@ public class ClientIntegrationTest {
       @Override
       public void describeTo(final Description description) {
         description.appendText(String.format(
-            "streamName: %s. topicName: %s. format: %s", streamName, topicName, format));
+            "tableName: %s. topicName: %s. keyFormat: %s. valueFormat: %s. isWindowed: %s",
+            streamName, topicName, keyFormat, valueFormat, isWindowed));
       }
     };
   }
 
   private static Matcher<? super TableInfo> tableInfo(
-      final String tableName, final String topicName, final String format, final boolean isWindowed
+      final String tableName,
+      final String topicName,
+      final String keyFormat,
+      final String valueFormat,
+      final boolean isWindowed
   ) {
     return new TypeSafeDiagnosingMatcher<TableInfo>() {
       @Override
@@ -1208,7 +1231,10 @@ public class ClientIntegrationTest {
         if (!topicName.equals(actual.getTopic())) {
           return false;
         }
-        if (!format.equals(actual.getFormat())) {
+        if (!keyFormat.equals(actual.getKeyFormat())) {
+          return false;
+        }
+        if (!valueFormat.equals(actual.getValueFormat())) {
           return false;
         }
         if (isWindowed != actual.isWindowed()) {
@@ -1220,8 +1246,8 @@ public class ClientIntegrationTest {
       @Override
       public void describeTo(final Description description) {
         description.appendText(String.format(
-            "tableName: %s. topicName: %s. format: %s. isWindowed: %s",
-            tableName, topicName, format, isWindowed));
+            "tableName: %s. topicName: %s. keyFormat: %s. valueFormat: %s. isWindowed: %s",
+            tableName, topicName, keyFormat, valueFormat, isWindowed));
       }
     };
   }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
@@ -122,12 +122,12 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
   private static class KsqlExpander extends DefaultExpander {
 
     private static final String EXPANDED_CS =
-        "CREATE STREAM s (field1 type1, field2 type2) "
-            + "WITH (KAFKA_TOPIC='topic-name', VALUE_FORMAT='json');";
+        "CREATE STREAM s (field1 type1 KEY, field2 type2) "
+            + "WITH (KAFKA_TOPIC='topic-name', FORMAT='json');";
 
     private static final String EXPANDED_CT =
-        "CREATE TABLE t (field1 type1, field2 type2) "
-            + "WITH (KAFKA_TOPIC='topic-name', VALUE_FORMAT='json');";
+        "CREATE TABLE t (field1 type1 PRIMARY KEY, field2 type2) "
+            + "WITH (KAFKA_TOPIC='topic-name', FORMAT='json');";
 
     private static final Map<String, String> shortcuts = ImmutableMap.of(
         "cs", EXPANDED_CS,

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/StreamsListTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/StreamsListTableBuilder.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 public class StreamsListTableBuilder implements TableBuilder<StreamsList> {
 
   private static final List<String> HEADERS =
-      ImmutableList.of("Stream Name", "Kafka Topic", "Format");
+      ImmutableList.of("Stream Name", "Kafka Topic", "Key Format", "Value Format", "Windowed");
 
   @Override
   public Table buildTable(final StreamsList entity) {
@@ -35,7 +35,13 @@ public class StreamsListTableBuilder implements TableBuilder<StreamsList> {
         .getStreams()
         .stream()
         .sorted(Comparator.comparing(SourceInfo::getName))
-        .map(s -> ImmutableList.of(s.getName(), s.getTopic(), s.getFormat()));
+        .map(s -> ImmutableList.of(
+            s.getName(),
+            s.getTopic(),
+            s.getKeyFormat(),
+            s.getValueFormat(),
+            Boolean.toString(s.isWindowed())
+        ));
 
     return new Builder()
         .withColumnHeaders(HEADERS)

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/TablesListTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/TablesListTableBuilder.java
@@ -27,15 +27,20 @@ import java.util.stream.Stream;
 public class TablesListTableBuilder implements TableBuilder<TablesList> {
 
   private static final List<String> HEADERS =
-      ImmutableList.of("Table Name", "Kafka Topic", "Format", "Windowed");
+      ImmutableList.of("Table Name", "Kafka Topic", "Key Format", "Value Format", "Windowed");
 
   @Override
   public Table buildTable(final TablesList entity) {
     final Stream<List<String>> rows = entity.getTables()
         .stream()
         .sorted(Comparator.comparing(SourceInfo::getName))
-        .map(t -> ImmutableList.of(t.getName(), t.getTopic(), t.getFormat(),
-            Boolean.toString(t.getIsWindowed())));
+        .map(t -> ImmutableList.of(
+            t.getName(),
+            t.getTopic(),
+            t.getKeyFormat(),
+            t.getValueFormat(),
+            Boolean.toString(t.isWindowed())
+        ));
 
     return new Builder()
         .withColumnHeaders(HEADERS)

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -389,7 +389,7 @@ public class CliTest {
 
     assertRunListCommand(
         "streams",
-        isRow(ORDER_DATA_PROVIDER.kstreamName(), ORDER_DATA_PROVIDER.topicName(), "JSON")
+        isRow(ORDER_DATA_PROVIDER.kstreamName(), ORDER_DATA_PROVIDER.topicName(), "KAFKA", "JSON", "false")
     );
 
     assertRunListCommand("tables", is(EMPTY_RESULT));

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -832,50 +832,13 @@ public class ConsoleTest {
   }
 
   @Test
-  public void testPrintStreamsList() {
+  public void shouldPrintStreamsList() {
     // Given:
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
-        new StreamsList("e",
-            ImmutableList.of(new SourceInfo.Stream("TestStream", "TestTopic", "AVRO")))
-    ));
-
-    // When:
-    console.printKsqlEntityList(entityList);
-
-    // Then:
-    final String output = terminal.getOutputString();
-    if (console.getOutputFormat() == OutputFormat.JSON) {
-      assertThat(output, is("[ {" + NEWLINE
-          + "  \"@type\" : \"streams\"," + NEWLINE
-          + "  \"statementText\" : \"e\"," + NEWLINE
-          + "  \"streams\" : [ {" + NEWLINE
-          + "    \"type\" : \"STREAM\"," + NEWLINE
-          + "    \"name\" : \"TestStream\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"AVRO\"" + NEWLINE
-          + "  } ]," + NEWLINE
-          + "  \"warnings\" : [ ]" + NEWLINE
-          + "} ]" + NEWLINE));
-    } else {
-      assertThat(output, is("" + NEWLINE
-          + " Stream Name | Kafka Topic | Format " + NEWLINE
-          + "------------------------------------" + NEWLINE
-          + " TestStream  | TestTopic   | AVRO   " + NEWLINE
-          + "------------------------------------" + NEWLINE));
-    }
-  }
-
-  @Test
-  public void testSortedPrintStreamsList() {
-    // Given:
-    final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
-            new StreamsList("e",
-                    ImmutableList.of(
-                            new SourceInfo.Stream("B", "TestTopic", "AVRO"),
-                            new SourceInfo.Stream("A", "TestTopic", "AVRO"),
-                            new SourceInfo.Stream("Z", "TestTopic", "AVRO"),
-                            new SourceInfo.Stream("C", "TestTopic", "AVRO")
-                    ))
+        new StreamsList("e", ImmutableList.of(
+            new SourceInfo.Stream("B", "t2", "KAFKA", "AVRO", false),
+            new SourceInfo.Stream("A", "t1", "JSON", "JSON", true)
+        ))
     ));
 
     // When:
@@ -890,85 +853,38 @@ public class ConsoleTest {
           + "  \"streams\" : [ {" + NEWLINE
           + "    \"type\" : \"STREAM\"," + NEWLINE
           + "    \"name\" : \"B\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"AVRO\"" + NEWLINE
+          + "    \"topic\" : \"t2\"," + NEWLINE
+          + "    \"keyFormat\" : \"KAFKA\"," + NEWLINE
+          + "    \"valueFormat\" : \"AVRO\"," + NEWLINE
+          + "    \"isWindowed\" : false" + NEWLINE
           + "  }, {" + NEWLINE
           + "    \"type\" : \"STREAM\"," + NEWLINE
           + "    \"name\" : \"A\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"AVRO\"" + NEWLINE
-          + "  }, {" + NEWLINE
-          + "    \"type\" : \"STREAM\"," + NEWLINE
-          + "    \"name\" : \"Z\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"AVRO\"" + NEWLINE
-          + "  }, {" + NEWLINE
-          + "    \"type\" : \"STREAM\"," + NEWLINE
-          + "    \"name\" : \"C\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"AVRO\"" + NEWLINE
+          + "    \"topic\" : \"t1\"," + NEWLINE
+          + "    \"keyFormat\" : \"JSON\"," + NEWLINE
+          + "    \"valueFormat\" : \"JSON\"," + NEWLINE
+          + "    \"isWindowed\" : true" + NEWLINE
           + "  } ]," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE
           + "} ]" + NEWLINE));
     } else {
       assertThat(output, is("" + NEWLINE
-          + " Stream Name | Kafka Topic | Format " + NEWLINE
-          + "------------------------------------" + NEWLINE
-          + " A           | TestTopic   | AVRO   " + NEWLINE
-          + " B           | TestTopic   | AVRO   " + NEWLINE
-          + " C           | TestTopic   | AVRO   " + NEWLINE
-          + " Z           | TestTopic   | AVRO   " + NEWLINE
-          + "------------------------------------" + NEWLINE));
+          + " Stream Name | Kafka Topic | Key Format | Value Format | Windowed " + NEWLINE
+          + "------------------------------------------------------------------" + NEWLINE
+          + " A           | t1          | JSON       | JSON         | true     " + NEWLINE
+          + " B           | t2          | KAFKA      | AVRO         | false    " + NEWLINE
+          + "------------------------------------------------------------------" + NEWLINE));
     }
   }
 
   @Test
-  public void testPrintTablesList() {
+  public void shouldPrintTablesList() {
     // Given:
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
-        new TablesList("e",
-            ImmutableList.of(new SourceInfo.Table("TestTable", "TestTopic", "JSON", false)))
-    ));
-
-    // When:
-    console.printKsqlEntityList(entityList);
-
-    // Then:
-    final String output = terminal.getOutputString();
-    if (console.getOutputFormat() == OutputFormat.JSON) {
-      assertThat(output, is("[ {" + NEWLINE
-          + "  \"@type\" : \"tables\"," + NEWLINE
-          + "  \"statementText\" : \"e\"," + NEWLINE
-          + "  \"tables\" : [ {" + NEWLINE
-          + "    \"type\" : \"TABLE\"," + NEWLINE
-          + "    \"name\" : \"TestTable\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"JSON\"," + NEWLINE
-          + "    \"isWindowed\" : false" + NEWLINE
-          + "  } ]," + NEWLINE
-          + "  \"warnings\" : [ ]" + NEWLINE
-          + "} ]" + NEWLINE));
-    } else {
-      assertThat(output, is("" + NEWLINE
-          + " Table Name | Kafka Topic | Format | Windowed " + NEWLINE
-          + "----------------------------------------------" + NEWLINE
-          + " TestTable  | TestTopic   | JSON   | false    " + NEWLINE
-          + "----------------------------------------------" + NEWLINE));
-    }
-  }
-
-  @Test
-  public void testSortedPrintTablesList() {
-    // Given:
-    final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
-            new TablesList("e",
-                    ImmutableList.of(
-                            new SourceInfo.Table("B", "TestTopic", "JSON", false),
-                            new SourceInfo.Table("A", "TestTopic", "JSON", false),
-                            new SourceInfo.Table("Z", "TestTopic", "JSON", false),
-                            new SourceInfo.Table("C", "TestTopic", "JSON", false)
-                    )
-            )
+        new TablesList("e", ImmutableList.of(
+            new SourceInfo.Table("B", "t2", "JSON", "JSON", true),
+            new SourceInfo.Table("A", "t1", "KAFKA", "AVRO", false)
+        ))
     ));
 
     // When:
@@ -983,39 +899,27 @@ public class ConsoleTest {
           + "  \"tables\" : [ {" + NEWLINE
           + "    \"type\" : \"TABLE\"," + NEWLINE
           + "    \"name\" : \"B\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"JSON\"," + NEWLINE
-          + "    \"isWindowed\" : false" + NEWLINE
+          + "    \"topic\" : \"t2\"," + NEWLINE
+          + "    \"keyFormat\" : \"JSON\"," + NEWLINE
+          + "    \"valueFormat\" : \"JSON\"," + NEWLINE
+          + "    \"isWindowed\" : true" + NEWLINE
           + "  }, {" + NEWLINE
           + "    \"type\" : \"TABLE\"," + NEWLINE
           + "    \"name\" : \"A\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"JSON\"," + NEWLINE
-          + "    \"isWindowed\" : false" + NEWLINE
-          + "  }, {" + NEWLINE
-          + "    \"type\" : \"TABLE\"," + NEWLINE
-          + "    \"name\" : \"Z\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"JSON\"," + NEWLINE
-          + "    \"isWindowed\" : false" + NEWLINE
-          + "  }, {" + NEWLINE
-          + "    \"type\" : \"TABLE\"," + NEWLINE
-          + "    \"name\" : \"C\"," + NEWLINE
-          + "    \"topic\" : \"TestTopic\"," + NEWLINE
-          + "    \"format\" : \"JSON\"," + NEWLINE
+          + "    \"topic\" : \"t1\"," + NEWLINE
+          + "    \"keyFormat\" : \"KAFKA\"," + NEWLINE
+          + "    \"valueFormat\" : \"AVRO\"," + NEWLINE
           + "    \"isWindowed\" : false" + NEWLINE
           + "  } ]," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE
           + "} ]" + NEWLINE));
     } else {
       assertThat(output, is("" + NEWLINE
-          + " Table Name | Kafka Topic | Format | Windowed " + NEWLINE
-          + "----------------------------------------------" + NEWLINE
-          + " A          | TestTopic   | JSON   | false    " + NEWLINE
-          + " B          | TestTopic   | JSON   | false    " + NEWLINE
-          + " C          | TestTopic   | JSON   | false    " + NEWLINE
-          + " Z          | TestTopic   | JSON   | false    " + NEWLINE
-          + "----------------------------------------------" + NEWLINE));
+          + " Table Name | Kafka Topic | Key Format | Value Format | Windowed " + NEWLINE
+          + "-----------------------------------------------------------------" + NEWLINE
+          + " A          | t1          | KAFKA      | AVRO         | false    " + NEWLINE
+          + " B          | t2          | JSON       | JSON         | true     " + NEWLINE
+          + "-----------------------------------------------------------------" + NEWLINE));
     }
   }
 
@@ -1175,7 +1079,7 @@ public class ConsoleTest {
                 "stats",
                 "errors",
                 true,
-                "kafka",
+                "json",
                 "avro",
                 "kadka-topic",
                 2, 1,
@@ -1262,7 +1166,7 @@ public class ConsoleTest {
           + "    \"statistics\" : \"stats\"," + NEWLINE
           + "    \"errorStats\" : \"errors\"," + NEWLINE
           + "    \"extended\" : true," + NEWLINE
-          + "    \"keyFormat\" : \"kafka\"," + NEWLINE
+          + "    \"keyFormat\" : \"json\"," + NEWLINE
           + "    \"valueFormat\" : \"avro\"," + NEWLINE
           + "    \"topic\" : \"kadka-topic\"," + NEWLINE
           + "    \"partitions\" : 2," + NEWLINE
@@ -1309,7 +1213,7 @@ public class ConsoleTest {
           + "Name                 : TestSource" + NEWLINE
           + "Type                 : TABLE" + NEWLINE
           + "Timestamp field      : 2000-01-01" + NEWLINE
-          + "Key format           : kafka" + NEWLINE
+          + "Key format           : json" + NEWLINE
           + "Value format         : avro" + NEWLINE
           + "Kafka topic          : kadka-topic (partitions: 2, replication: 1)" + NEWLINE
           + "Statement            : sql statement text" + NEWLINE

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -342,7 +342,9 @@ public final class ListSourceExecutor {
     return new Stream(
         dataSource.getName().text(),
         dataSource.getKsqlTopic().getKafkaTopicName(),
-        dataSource.getKsqlTopic().getValueFormat().getFormat()
+        dataSource.getKsqlTopic().getKeyFormat().getFormat(),
+        dataSource.getKsqlTopic().getValueFormat().getFormat(),
+        dataSource.getKsqlTopic().getKeyFormat().isWindowed()
     );
   }
 
@@ -350,6 +352,7 @@ public final class ListSourceExecutor {
     return new Table(
         dataSource.getName().text(),
         dataSource.getKsqlTopic().getKafkaTopicName(),
+        dataSource.getKsqlTopic().getKeyFormat().getFormat(),
         dataSource.getKsqlTopic().getValueFormat().getFormat(),
         dataSource.getKsqlTopic().getKeyFormat().isWindowed()
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -282,7 +282,7 @@ public class KsqlRestApplicationTest {
     final StreamsList streamsList =
         new StreamsList(
             LIST_STREAMS_SQL,
-            Collections.singletonList(new SourceInfo.Stream(LOG_STREAM_NAME, "", "")));
+            Collections.singletonList(new SourceInfo.Stream(LOG_STREAM_NAME, "", "", "", false)));
     when(response.getEntity()).thenReturn(new KsqlEntityList(Collections.singletonList(streamsList)));
     
     when(ksqlResource.handleKsqlStatements(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -113,12 +113,16 @@ public class ListSourceExecutorTest {
         new SourceInfo.Stream(
             stream1.getName().toString(FormatOptions.noEscape()),
             stream1.getKafkaTopicName(),
-            stream1.getKsqlTopic().getValueFormat().getFormat()
+            stream1.getKsqlTopic().getKeyFormat().getFormat(),
+            stream1.getKsqlTopic().getValueFormat().getFormat(),
+            stream1.getKsqlTopic().getKeyFormat().isWindowed()
         ),
         new SourceInfo.Stream(
             stream2.getName().toString(FormatOptions.noEscape()),
             stream2.getKafkaTopicName(),
-            stream2.getKsqlTopic().getValueFormat().getFormat()
+            stream2.getKsqlTopic().getKeyFormat().getFormat(),
+            stream2.getKsqlTopic().getValueFormat().getFormat(),
+            stream1.getKsqlTopic().getKeyFormat().isWindowed()
         )
     ));
   }
@@ -179,12 +183,14 @@ public class ListSourceExecutorTest {
         new SourceInfo.Table(
             table1.getName().toString(FormatOptions.noEscape()),
             table1.getKsqlTopic().getKafkaTopicName(),
+            table2.getKsqlTopic().getKeyFormat().getFormat(),
             table1.getKsqlTopic().getValueFormat().getFormat(),
             table1.getKsqlTopic().getKeyFormat().isWindowed()
         ),
         new SourceInfo.Table(
             table2.getName().toString(FormatOptions.noEscape()),
             table2.getKsqlTopic().getKafkaTopicName(),
+            table2.getKsqlTopic().getKeyFormat().getFormat(),
             table2.getKsqlTopic().getValueFormat().getFormat(),
             table2.getKsqlTopic().getKeyFormat().isWindowed()
         )

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2012,6 +2012,7 @@ public class KsqlResourceTest {
     return new SourceInfo.Table(
         table.getName().toString(FormatOptions.noEscape()),
         table.getKsqlTopic().getKafkaTopicName(),
+        table.getKsqlTopic().getKeyFormat().getFormat(),
         table.getKsqlTopic().getValueFormat().getFormat(),
         table.getKsqlTopic().getKeyFormat().isWindowed()
     );
@@ -2024,7 +2025,9 @@ public class KsqlResourceTest {
     return new SourceInfo.Stream(
         stream.getName().toString(FormatOptions.noEscape()),
         stream.getKsqlTopic().getKafkaTopicName(),
-        stream.getKsqlTopic().getValueFormat().getFormat()
+        stream.getKsqlTopic().getKeyFormat().getFormat(),
+        stream.getKsqlTopic().getValueFormat().getFormat(),
+        stream.getKsqlTopic().getKeyFormat().isWindowed()
     );
   }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceInfo.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceInfo.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.rest.entity;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,73 +25,99 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.confluent.ksql.rest.entity.SourceInfo.Stream;
 import io.confluent.ksql.rest.entity.SourceInfo.Table;
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "STREAM", value = Stream.class),
     @JsonSubTypes.Type(name = "TABLE", value = Table.class),
-    })
-public class SourceInfo {
+})
+public abstract class SourceInfo {
+
   private final String name;
   private final String topic;
-  private final String format;
+  private final String keyFormat;
+  private final String valueFormat;
+  private final boolean windowed;
 
-  public SourceInfo(final String name, final String topic, final String format) {
-    this.name = name;
-    this.topic = topic;
-    this.format = format;
+  SourceInfo(
+      final String name,
+      final String topic,
+      final String keyFormat,
+      final String valueFormat,
+      final boolean windowed
+  ) {
+    this.name = requireNonNull(name, "name");
+    this.topic = requireNonNull(topic, "topic");
+    this.keyFormat = requireNonNull(keyFormat, "keyFormat");
+    this.valueFormat = requireNonNull(valueFormat, "valueFormat");
+    this.windowed = windowed;
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Stream extends SourceInfo {
+
+    @Deprecated // Since 0.13 "format" is not being sent. Remove in future release.
     @JsonCreator
     public Stream(
         @JsonProperty("name") final String name,
         @JsonProperty("topic") final String topic,
-        @JsonProperty("format") final String format
+        @JsonProperty("keyFormat") final Optional<String> keyFormat,
+        @JsonProperty("valueFormat") final Optional<String> valueFormat,
+        @JsonProperty("isWindowed") final Optional<Boolean> windowed,
+        @JsonProperty("format") final Optional<String> legacyValueFormat
     ) {
-      super(name, topic, format);
+      this(
+          name,
+          topic,
+          keyFormat.orElse("KAFKA"),
+          valueFormat.orElse(legacyValueFormat.orElse("UNKNOWN")),
+          windowed.orElse(false)
+      );
+    }
+
+    public Stream(
+        final String name,
+        final String topic,
+        final String keyFormat,
+        final String valueFormat,
+        final boolean windowed
+    ) {
+      super(name, topic, keyFormat, valueFormat, windowed);
     }
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Table extends SourceInfo {
-    private final boolean isWindowed;
 
+    @Deprecated // Since 0.13 "format" is not being sent. Remove in future release.
     @JsonCreator
     public Table(
         @JsonProperty("name") final String name,
         @JsonProperty("topic") final String topic,
-        @JsonProperty("format") final String format,
-        @JsonProperty("isWindowed") final Boolean isWindowed
+        @JsonProperty("keyFormat") final Optional<String> keyFormat,
+        @JsonProperty("valueFormat") final Optional<String> valueFormat,
+        @JsonProperty("isWindowed") final Optional<Boolean> windowed,
+        @JsonProperty("format") final Optional<String> legacyValueFormat
     ) {
-      super(name, topic, format);
-      this.isWindowed = isWindowed;
+      this(
+          name,
+          topic,
+          keyFormat.orElse("KAFKA"),
+          valueFormat.orElse(legacyValueFormat.orElse("UNKNOWN")),
+          windowed.orElse(false)
+      );
     }
 
-    public boolean getIsWindowed() {
-      return isWindowed;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      if (!super.equals(o)) {
-        return false;
-      }
-      final Table table = (Table) o;
-      return isWindowed == table.isWindowed;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(super.hashCode(), isWindowed);
+    public Table(
+        final String name,
+        final String topic,
+        final String keyFormat,
+        final String valueFormat,
+        final boolean windowed
+    ) {
+      super(name, topic, keyFormat, valueFormat, windowed);
     }
   }
 
@@ -101,8 +129,17 @@ public class SourceInfo {
     return topic;
   }
 
-  public String getFormat() {
-    return format;
+  public String getKeyFormat() {
+    return keyFormat;
+  }
+
+  public String getValueFormat() {
+    return valueFormat;
+  }
+
+  @JsonProperty("isWindowed")
+  public boolean isWindowed() {
+    return windowed;
   }
 
   @Override
@@ -114,13 +151,15 @@ public class SourceInfo {
       return false;
     }
     final SourceInfo that = (SourceInfo) o;
-    return Objects.equals(name, that.name)
-           && Objects.equals(topic, that.topic)
-           && Objects.equals(format, that.format);
+    return windowed == that.windowed
+        && Objects.equals(name, that.name)
+        && Objects.equals(topic, that.topic)
+        && Objects.equals(keyFormat, that.keyFormat)
+        && Objects.equals(valueFormat, that.valueFormat);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, topic, format);
+    return Objects.hash(name, topic, keyFormat, valueFormat, windowed);
   }
 }

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SourceInfoTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SourceInfoTest.java
@@ -1,0 +1,49 @@
+package io.confluent.ksql.rest.entity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.ksql.rest.ApiJsonMapper;
+import io.confluent.ksql.rest.entity.SourceInfo.Stream;
+import io.confluent.ksql.rest.entity.SourceInfo.Table;
+import org.junit.Test;
+
+public class SourceInfoTest {
+
+  private static final ObjectMapper MAPPER = ApiJsonMapper.INSTANCE.get();
+
+  @Test
+  public void shouldDeserializeLegacyStream() throws Exception {
+    // Given:
+    final String legacyJson = "{"
+        + "\"type\":\"STREAM\","
+        + "\"name\":\"vic\","
+        + "\"topic\":\"bob\","
+        + "\"format\":\"john\""
+        + "}";
+
+    // When:
+    final SourceInfo result = MAPPER.readValue(legacyJson, SourceInfo.class);
+
+    // Then:
+    assertThat(result, is(new Stream("vic", "bob", "KAFKA", "john", false)));
+  }
+
+  @Test
+  public void shouldDeserializeLegacyTable() throws Exception {
+    // Given:
+    final String legacyJson = "{"
+        + "\"type\":\"TABLE\","
+        + "\"name\":\"vic\","
+        + "\"topic\":\"bob\","
+        + "\"format\":\"john\""
+        + "}";
+
+    // When:
+    final SourceInfo result = MAPPER.readValue(legacyJson, SourceInfo.class);
+
+    // Then:
+    assertThat(result, is(new Table("vic", "bob", "KAFKA", "john", false)));
+  }
+}


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/6218

Updates a few places in the rest api, cli and the new Java client to specify the key format as well as the value format.

Unfortunately, the value format was called `format`.  This change introduces a `keyFormat` and `valueFormat` to hold the two formats, but both the CLI and new Java client are backwards compatible with the old JSON schema.

Also in this commit, streams also indicate if there key is windowed.  This means the key is serialized using the windowed serializer. It is possible to have a stream over a topic with a windowed key. Now the CLI and Java client expose this info.

Main change was to `show tables` and `show streams` response.  Previously, these returned

```
ksql> show streams;

 Stream Name | Kafka Topic | Format
---------------------------------------
 PAGEVIEWS   | pageviews   | DELIMITED
---------------------------------------

ksql> show tables;

 Table Name | Kafka Topic | Format | Windowed
----------------------------------------------
 USERS      | users       | JSON   | false
----------------------------------------------
```

And now return:

```
ksql> show streams;

 Stream Name | Kafka Topic | Key Format | Value Format | Windowed
-----------------------------------------------------------------
 PAGEVIEWS   | pageviews   | KAFKA      | DELIMITED    | false
-----------------------------------------------------------------

ksql> show tables;

 Table Name | Kafka Topic | Key Format | Value Format | Windowed
----------------------------------------------------------------
 USERS      | users       | KAFKA      | JSON          | false
----------------------------------------------------------------
```

### Testing done 

Usual + manually created streams and tables with non-KAFKA keys and ensured it all worked.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

