### PR TITLE
chore: fail joins where the key format differs

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -73,7 +73,7 @@ public class JoinNode extends PlanNode {
   }
 
   private static final ImmutableList<KeyProperty> KEY_PROPERTIES = ImmutableList.of(
-      new KeyProperty("format", kf -> kf.getFormatInfo().getFormat()),
+      new KeyProperty("formats", kf -> kf.getFormatInfo().getFormat()),
       new KeyProperty("properties", kf -> kf.getFormatInfo().getProperties()),
       new KeyProperty("features", KeyFormat::getFeatures),
       new KeyProperty("widowing", kf -> kf.getWindowInfo()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -49,6 +49,7 @@ import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
+import io.confluent.ksql.testing.EffectivelyImmutable;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import java.util.Arrays;
@@ -653,10 +654,12 @@ public class JoinNode extends PlanNode {
     }
   }
 
+  @Immutable
   private static class KeyProperty {
 
-    final String name;
-    final Function<KeyFormat, ?> getter;
+    private final String name;
+    @EffectivelyImmutable
+    private final Function<KeyFormat, ?> getter;
 
     KeyProperty(final String name, final Function<KeyFormat, ?> getter) {
       this.name = requireNonNull(name, "name");

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -786,7 +786,7 @@ public class JoinNodeTest {
 
     // Then:
     assertThat(e.getMessage(),
-        containsString("Incompatible key format. `left` has AVRO while `right` has JSON"));
+        containsString("Incompatible key formats. `left` has AVRO while `right` has JSON"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -55,10 +55,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlStructuredDataOutputNodeTest {
 
-  private static final String QUERY_ID_VALUE = "output-test";
-
-  private static final String SINK_KAFKA_TOPIC_NAME = "output_kafka";
-
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field1"), SqlTypes.STRING)
@@ -105,7 +101,6 @@ public class KsqlStructuredDataOutputNodeTest {
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
-    when(ksqlTopic.getKafkaTopicName()).thenReturn(SINK_KAFKA_TOPIC_NAME);
     when(ksqlTopic.getKeyFormat()).thenReturn(PROTOBUF_KEY_FORMAT);
     when(ksqlTopic.getValueFormat()).thenReturn(JSON_FORMAT);
 

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1988,6 +1988,21 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 1, "value": {"R_A": 1, "L_B": 1, "R_B": -1, "L_C": 2, "R_C": -2}, "timestamp":  11}
       ]
+    },
+    {
+      "name": "key format mismatch",
+      "statements": [
+        "CREATE STREAM L (A INT KEY, B INT, C INT) WITH (kafka_topic='LEFT', key_format='KAFKA', value_format='JSON');",
+        "CREATE TABLE R (A INT PRIMARY KEY, B INT, C INT) WITH (kafka_topic='RIGHT', format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM L INNER JOIN R ON L.A = R.A;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Incompatible key formats. `L` has KAFKA while `R` has JSON"
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/6213

Add code to throw a useful error message if a join has incompatible key formats. QTT test added too.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

