### PR TITLE
chore: wire up key_format in C*AS statements

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -49,7 +49,6 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatFactory;
-import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormatUtils;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -312,7 +311,7 @@ final class EngineExecutor {
     if (statement.getStatement() instanceof CreateSource) {
       final CreateSource createSource = (CreateSource) statement.getStatement();
       throwOnUnsupportedKeyFormat(
-          SourcePropertiesUtil.getKeyFormat(createSource.getProperties()));
+          SourcePropertiesUtil.getKeyFormat(createSource.getProperties()).getFormat());
     }
 
     if (statement.getStatement() instanceof CreateAsSelect) {
@@ -322,9 +321,9 @@ final class EngineExecutor {
     }
   }
 
-  private void throwOnUnsupportedKeyFormat(final FormatInfo formatInfo) {
+  private void throwOnUnsupportedKeyFormat(final String keyFormat) {
     final KsqlConfig ksqlConfig = config.getConfig(true);
-    final Format format = FormatFactory.of(formatInfo);
+    final Format format = FormatFactory.fromName(keyFormat);
     if (!KeyFormatUtils.isSupportedKeyFormat(ksqlConfig, format)) {
       throw new KsqlException("The key format '" + format.name() + "' is not currently supported.");
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -200,49 +200,6 @@ public class AnalyzerFunctionalTest {
   }
 
   @Test
-  public void shouldFailIfExplicitNamespaceIsProvidedForNonAvroTopic() {
-    final String simpleQuery = "CREATE STREAM FOO WITH (VALUE_FORMAT='JSON', VALUE_AVRO_SCHEMA_FULL_NAME='com.custom.schema', KAFKA_TOPIC='TEST_TOPIC1') AS SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
-    final List<Statement> statements = parse(simpleQuery, jsonMetaStore);
-    final CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) statements.get(0);
-    final Query query = createStreamAsSelect.getQuery();
-
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "");
-
-    // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "JSON does not support the following configs: [fullSchemaName]"));
-  }
-
-  @Test
-  public void shouldFailIfExplicitNamespaceIsProvidedButEmpty() {
-    final CreateStreamAsSelect createStreamAsSelect = parseSingle(
-        "CREATE STREAM FOO "
-            + "WITH (VALUE_FORMAT='AVRO', VALUE_AVRO_SCHEMA_FULL_NAME='', KAFKA_TOPIC='TEST_TOPIC1') "
-            + "AS SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;");
-
-    final Query query = createStreamAsSelect.getQuery();
-
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "");
-
-    // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> analyzer.analyze(query, Optional.of(createStreamAsSelect.getSink()))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "fullSchemaName cannot be empty. Format configuration: {fullSchemaName=}"
-    ));
-  }
-
-  @Test
   public void shouldCaptureProjectionColumnRefs() {
     // Given:
     query = parseSingle("Select COL0, COL0 + COL1, SUBSTRING(COL2, 1) from TEST1;");

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -687,6 +687,26 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Schema is not compatible with Avro: Illegal initial character: 1AvroDoesNotLikeFieldsThatStartWithNumbers"
       }
+    },
+    {
+      "name": "empty full schema name",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, foo STRING) WITH (kafka_topic='input_topic', value_format='AVRO', VALUE_AVRO_SCHEMA_FULL_NAME=' ');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "fullSchemaName cannot be empty. Format configuration: {fullSchemaName=}"
+      }
+    },
+    {
+      "name": "full schema name used with non-Avro format",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, foo STRING) WITH (kafka_topic='input_topic', value_format='JSON', VALUE_AVRO_SCHEMA_FULL_NAME='com.custom.schema');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "JSON does not support the following configs: [fullSchemaName]"
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
@@ -293,6 +293,94 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "The key format 'AVRO' is not currently supported"
       }
+    },
+    {
+      "name": "override key format - create stream as select",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='JSON');",
+        "CREATE STREAM OUTPUT WITH (key_format='JSON') AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "inputs": [
+        {"topic": "input_topic", "key": "hello", "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "hello", "value": {"FOO": 10}}
+      ],
+      "post": {
+        "sources": [
+          {"name" : "INPUT", "type" : "stream", "keyFormat" : {"format": "KAFKA"}, "valueFormat" : "JSON"},
+          {"name" : "OUTPUT", "type" : "stream", "keyFormat" : {"format": "JSON"}, "valueFormat" : "JSON"}
+        ]
+      }
+    },
+    {
+      "name": "override key format - create table as select",
+      "statements": [
+        "CREATE TABLE INPUT (K STRING PRIMARY KEY, foo INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='JSON');",
+        "CREATE TABLE OUTPUT WITH (key_format='JSON') AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "inputs": [
+        {"topic": "input_topic", "key": "hello", "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "hello", "value": {"FOO": 10}}
+      ],
+      "post": {
+        "sources": [
+          {"name" : "INPUT", "type" : "table", "keyFormat" : {"format": "KAFKA"}, "valueFormat" : "JSON"},
+          {"name" : "OUTPUT", "type" : "table", "keyFormat" : {"format": "JSON"}, "valueFormat" : "JSON"}
+        ]
+      }
+    },
+    {
+      "name": "override formats - create stream as select",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='AVRO');",
+        "CREATE STREAM OUTPUT WITH (format='JSON') AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "inputs": [
+        {"topic": "input_topic", "key": "hello", "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "hello", "value": {"FOO": 10}}
+      ],
+      "post": {
+        "sources": [
+          {"name" : "INPUT", "type" : "stream", "keyFormat" : {"format": "KAFKA"}, "valueFormat" : "AVRO"},
+          {"name" : "OUTPUT", "type" : "stream", "keyFormat" : {"format": "JSON"}, "valueFormat" : "JSON"}
+        ]
+      }
+    },
+    {
+      "name": "override formats - create table as select",
+      "statements": [
+        "CREATE TABLE INPUT (K STRING PRIMARY KEY, foo INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='AVRO');",
+        "CREATE TABLE OUTPUT WITH (format='JSON') AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "inputs": [
+        {"topic": "input_topic", "key": "hello", "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "hello", "value": {"FOO": 10}}
+      ],
+      "post": {
+        "sources": [
+          {"name" : "INPUT", "type" : "table", "keyFormat" : {"format": "KAFKA"}, "valueFormat" : "AVRO"},
+          {"name" : "OUTPUT", "type" : "table", "keyFormat" : {"format": "JSON"}, "valueFormat" : "JSON"}
+        ]
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/formats.json
@@ -381,6 +381,20 @@
           {"name" : "OUTPUT", "type" : "table", "keyFormat" : {"format": "JSON"}, "valueFormat" : "JSON"}
         ]
       }
+    },
+    {
+      "name": "override key format - with unsupported type",
+      "statements": [
+        "CREATE STREAM INPUT (K BOOLEAN KEY, foo INT) WITH (kafka_topic='input_topic', format='JSON');",
+        "CREATE STREAM OUTPUT WITH (key_format='KAFKA') AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'BOOLEAN'"
+      }
     }
   ]
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.ColumnReferenceParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateAsConfigs;
-import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.avro.AvroFormat;
@@ -100,17 +99,22 @@ public final class CreateSourceAsProperties {
     return SerdeFeatures.from(builder.build());
   }
 
-  public Optional<FormatInfo> getKeyFormat() {
+  public Optional<String> getKeyFormat() {
     final String keyFormat = getFormatName()
         .orElse(props.getString(CommonCreateConfigs.KEY_FORMAT_PROPERTY));
-    return Optional.ofNullable(keyFormat).map(format -> FormatInfo.of(format, ImmutableMap.of()));
+    return Optional.ofNullable(keyFormat);
   }
 
-  public Optional<FormatInfo> getValueFormat() {
+  public Optional<String> getValueFormat() {
     final String valueFormat = getFormatName()
         .orElse(props.getString(CommonCreateConfigs.VALUE_FORMAT_PROPERTY));
-    return Optional.ofNullable(valueFormat)
-        .map(format -> FormatInfo.of(format, getValueFormatProperties()));
+    return Optional.ofNullable(valueFormat);
+  }
+
+  @SuppressWarnings("MethodMayBeStatic")
+  public Map<String, String> getKeyFormatProperties() {
+    // Current none.... coming soon.
+    return ImmutableMap.of();
   }
 
   public Map<String, String> getValueFormatProperties() {

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Test;
 
+@SuppressWarnings("UnstableApiUsage")
 public class CreateSourceAsPropertiesTest {
 
   @Test
@@ -250,8 +251,8 @@ public class CreateSourceAsPropertiesTest {
             VALUE_FORMAT_PROPERTY, new StringLiteral("AVRO")));
 
     // When / Then:
-    assertThat(props.getKeyFormat().get().getFormat(), is("KAFKA"));
-    assertThat(props.getValueFormat().get().getFormat(), is("AVRO"));
+    assertThat(props.getKeyFormat(), is(Optional.of("KAFKA")));
+    assertThat(props.getValueFormat(), is(Optional.of("AVRO")));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Wire up `KEY_FORMAT` and `FORMAT` explicitly provided in C*AS statements.

See https://github.com/confluentinc/ksql/pull/6292#pullrequestreview-497613436

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

