### PR TITLE
fix: backup files are re-created on every restart

### DIFF
--- a/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.benchmark;
 
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.avro.random.generator.Generator;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -183,6 +184,7 @@ public class SerdeBenchmark {
       return new RowGenerator(generator, keyField, Optional.empty());
     }
 
+    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     private static Generator getGenerator(final String schemaName) throws IOException {
       final Path schemaPath = SCHEMA_DIR.resolve(schemaName + SCHEMA_FILE_SUFFIX);
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/json/PlanJsonMapper.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/json/PlanJsonMapper.java
@@ -32,23 +32,19 @@ public enum PlanJsonMapper {
 
   INSTANCE;
 
-  private final ObjectMapper mapper = newInstance();
-
-  public static ObjectMapper newInstance() {
-    return new ObjectMapper()
-        .registerModules(
-            new Jdk8Module(),
-            new JavaTimeModule(),
-            new KsqlParserSerializationModule(),
-            new KsqlTypesSerializationModule(),
-            new KsqlTypesDeserializationModule()
-        )
-        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-        .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-        .enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES)
-        .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
-        .setSerializationInclusion(Include.NON_EMPTY);
-  }
+  private final ObjectMapper mapper = new ObjectMapper()
+      .registerModules(
+          new Jdk8Module(),
+          new JavaTimeModule(),
+          new KsqlParserSerializationModule(),
+          new KsqlTypesSerializationModule(),
+          new KsqlTypesDeserializationModule()
+      )
+      .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+      .enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES)
+      .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+      .setSerializationInclusion(Include.NON_EMPTY);
 
   public ObjectMapper get() {
     return mapper;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/json/PlanJsonMapper.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/json/PlanJsonMapper.java
@@ -32,19 +32,23 @@ public enum PlanJsonMapper {
 
   INSTANCE;
 
-  private final ObjectMapper mapper = new ObjectMapper()
-      .registerModules(
-          new Jdk8Module(),
-          new JavaTimeModule(),
-          new KsqlParserSerializationModule(),
-          new KsqlTypesSerializationModule(),
-          new KsqlTypesDeserializationModule()
-      )
-      .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-      .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-      .enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES)
-      .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
-      .setSerializationInclusion(Include.NON_EMPTY);
+  private final ObjectMapper mapper = newInstance();
+
+  public static ObjectMapper newInstance() {
+    return new ObjectMapper()
+        .registerModules(
+            new Jdk8Module(),
+            new JavaTimeModule(),
+            new KsqlParserSerializationModule(),
+            new KsqlTypesSerializationModule(),
+            new KsqlTypesDeserializationModule()
+        )
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+        .enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES)
+        .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+        .setSerializationInclusion(Include.NON_EMPTY);
+  }
 
   public ObjectMapper get() {
     return mapper;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
@@ -15,152 +15,70 @@
 
 package io.confluent.ksql.rest.server;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.confluent.ksql.execution.json.PlanJsonMapper;
-import io.confluent.ksql.rest.entity.CommandId;
-import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
-import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 /**
  * A file that is used by the backup service to replay command_topic commands.
  */
 public final class BackupReplayFile implements Closeable {
-  enum Versions {
-    NO_VERSION, V1
-  }
+  private static final String KEY_VALUE_SEPARATOR_STR = ":";
+  private static final String NEW_LINE_SEPARATOR_STR = "\n";
 
-  // Current version of the Backup file
-  private static final String BACKUP_VERSION_HEADER = "BACKUP_VERSION";
-  private static final Versions DEFAULT_BACKUP_VERSION = Versions.V1;
-
-  // Include.ALWAYS is necessary to serialize nulls and empty values. This is required to allow
-  // the CommandTopicBackupImpl to compare against all properties from a record read from
-  // the command topic, which come with nulls and empty values.
-  private static final ObjectMapper MAPPER = PlanJsonMapper.INSTANCE.get()
-      .setSerializationInclusion(JsonInclude.Include.ALWAYS);
-
-  private static final String KEY_VALUE_SEPARATOR = ":";
+  private static final byte[] KEY_VALUE_SEPARATOR_BYTES =
+      KEY_VALUE_SEPARATOR_STR.getBytes(StandardCharsets.UTF_8);
+  private static final byte[] NEW_LINE_SEPARATOR_BYTES =
+      NEW_LINE_SEPARATOR_STR.getBytes(StandardCharsets.UTF_8);
 
   private final File file;
-  private final BufferedWriter writer;
-  private final Versions version;
+  private final FileOutputStream writer;
 
-  public static BackupReplayFile newFile(final Path path) {
-    final String versionHeader =
-        String.format("%s=%s%n", BACKUP_VERSION_HEADER, DEFAULT_BACKUP_VERSION);
-
-    try {
-      // Fails if the file already exists
-      Files.createFile(path, PosixFilePermissions.asFileAttribute(
-          PosixFilePermissions.fromString("rw-------")
-      ));
-
-      Files.write(path, versionHeader.getBytes(StandardCharsets.UTF_8));
-    } catch (final IOException e) {
-      throw new KsqlException(
-          String.format("Failed to create replay file: %s", path), e);
-    }
-
-    return new BackupReplayFile(path.toFile(), DEFAULT_BACKUP_VERSION);
-  }
-
-  public static BackupReplayFile openFile(final File file) {
-    return new BackupReplayFile(file, readVersion(file));
-  }
-
-  private static Versions readVersion(final File file) {
-    final Optional<String> firstLine;
-
-    try {
-      firstLine = Files.lines(file.toPath(), StandardCharsets.UTF_8).limit(1).findAny();
-    } catch (final IOException e) {
-      throw new KsqlException(
-          String.format("Failed to read replay file: %s", file.getAbsolutePath()), e);
-    }
-
-    if (firstLine.isPresent() && isVersionLine(firstLine.get())) {
-      final String backupVersion = firstLine.get().substring(BACKUP_VERSION_HEADER.length() + 1);
-      return Versions.valueOf(backupVersion);
-    }
-
-    return Versions.NO_VERSION;
-  }
-
-  private static boolean isVersionLine(final String line) {
-    return line.startsWith(BACKUP_VERSION_HEADER);
-  }
-
-  private BackupReplayFile(final File file, final Versions version) {
-    this.version = Objects.requireNonNull(version, "version");;
+  public BackupReplayFile(final File file) {
     this.file = Objects.requireNonNull(file, "file");
     this.writer = createWriter(file);
   }
 
-  private static BufferedWriter createWriter(final File file) {
+  private static FileOutputStream createWriter(final File file) {
     try {
-      return new BufferedWriter(new OutputStreamWriter(
-          new FileOutputStream(file, true),
-          StandardCharsets.UTF_8)
-      );
+      return new FileOutputStream(file, true);
     } catch (final FileNotFoundException e) {
       throw new KsqlException(
-          String.format("Failed to create replay file: %s", file.getAbsolutePath()), e);
+          String.format("Failed to create/open replay file: %s", file.getAbsolutePath()), e);
     }
-  }
-
-  public Versions getVersion() {
-    return version;
   }
 
   public String getPath() {
     return file.getAbsolutePath();
   }
 
-  public void write(final CommandId commandId, final Command command) throws IOException {
-    writer.write(MAPPER.writeValueAsString(commandId));
-    writer.write(KEY_VALUE_SEPARATOR);
-    writer.write(MAPPER.writeValueAsString(command));
-    writer.write("\n");
+  public void write(final ConsumerRecord<byte[], byte[]> record) throws IOException {
+    writer.write(record.key());
+    writer.write(KEY_VALUE_SEPARATOR_BYTES);
+    writer.write(record.value());
+    writer.write(NEW_LINE_SEPARATOR_BYTES);
     writer.flush();
   }
 
-  public void write(final List<Pair<CommandId, Command>> records) throws IOException {
-    for (final Pair<CommandId, Command> record : records) {
-      write(record.left, record.right);
-    }
-  }
-
-  public List<Pair<CommandId, Command>> readRecords() throws IOException {
-    final List<Pair<CommandId, Command>> commands = new ArrayList<>();
+  public List<Pair<byte[], byte[]>> readRecords() throws IOException {
+    final List<Pair<byte[], byte[]>> commands = new ArrayList<>();
     for (final String line : Files.readAllLines(file.toPath(), StandardCharsets.UTF_8)) {
-      // Ignore version header
-      if (isVersionLine(line)) {
-        continue;
-      }
-
-      final String commandId = line.substring(0, line.indexOf(KEY_VALUE_SEPARATOR));
-      final String command = line.substring(line.indexOf(KEY_VALUE_SEPARATOR) + 1);
+      final String commandId = line.substring(0, line.indexOf(KEY_VALUE_SEPARATOR_STR));
+      final String command = line.substring(line.indexOf(KEY_VALUE_SEPARATOR_STR) + 1);
 
       commands.add(new Pair<>(
-          MAPPER.readValue(commandId.getBytes(StandardCharsets.UTF_8), CommandId.class),
-          MAPPER.readValue(command.getBytes(StandardCharsets.UTF_8), Command.class)
+          commandId.getBytes(StandardCharsets.UTF_8),
+          command.getBytes(StandardCharsets.UTF_8)
       ));
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.rest.server;
 
 import com.google.common.collect.Lists;
 import io.confluent.ksql.rest.server.computation.QueuedCommand;
-import io.confluent.ksql.util.KsqlServerException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -87,10 +86,10 @@ public class CommandTopic {
       for (ConsumerRecord<byte[], byte[]> record : iterable) {
         try {
           backupRecord(record);
-        } catch (final KsqlServerException e) {
+        } catch (final Exception e) {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
-              + "restored or all backup files are deleted.");
+              + "restored or all backup files are deleted.", e);
           return records;
         }
         records.add(record);
@@ -114,10 +113,10 @@ public class CommandTopic {
       for (final ConsumerRecord<byte[], byte[]> record : records) {
         try {
           backupRecord(record);
-        } catch (final KsqlServerException e) {
+        } catch (final Exception e) {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
-              + "restored or all backup files are deleted.");
+              + "restored or all backup files are deleted.", e);
           return restoreCommands;
         }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -21,13 +21,16 @@ import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -57,7 +60,7 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
   private final Ticker ticker;
 
   private BackupReplayFile replayFile;
-  private List<Pair<CommandId, Command>> latestReplay;
+  private List<Pair<byte[], byte[]>> latestReplay;
   private int latestReplayIdx;
   private boolean corruptionDetected;
 
@@ -118,25 +121,11 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
     return latestReplayIdx < latestReplay.size();
   }
 
-  private boolean isRecordInLatestReplay(final ConsumerRecord<CommandId, Command> record) {
-    final Pair<CommandId, Command> latestReplayRecord = latestReplay.get(latestReplayIdx);
+  private boolean isRecordInLatestReplay(final ConsumerRecord<byte[], byte[]> record) {
+    final Pair<byte[], byte[]> latestReplayRecord = latestReplay.get(latestReplayIdx);
 
-    final boolean equalRecord;
-    switch (replayFile.getVersion()) {
-      // Compare only the command statement for non-versioned files. The command properties in the
-      // the backup may have missing nulls and empty values, which cause records to be different.
-      // Nulls and empty values are always written in backups V1 and newer.
-      case NO_VERSION:
-        equalRecord = record.key().equals(latestReplayRecord.getLeft())
-            && record.value().getStatement().equalsIgnoreCase(
-                latestReplayRecord.getRight().getStatement());
-        break;
-      default:
-        equalRecord = record.key().equals(latestReplayRecord.getLeft())
-            && record.value().equals(latestReplayRecord.getRight());
-    }
-
-    if (equalRecord) {
+    if (Arrays.equals(record.key(), latestReplayRecord.getLeft())
+        && Arrays.equals(record.value(), latestReplayRecord.getRight())) {
       latestReplayIdx++;
       return true;
     }
@@ -144,32 +133,34 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
     return false;
   }
 
-  @Override
-  public void writeRecord(final ConsumerRecord<byte[], byte[]> record) {
-    final ConsumerRecord<CommandId, Command> deserializedRecord;
+  private void throwIfInvalidRecord(final ConsumerRecord<byte[], byte[]> record) {
     try {
-      deserializedRecord = new ConsumerRecord<>(
-          record.topic(),
-          record.partition(),
-          record.offset(),
-          InternalTopicSerdes.deserializer(CommandId.class)
-              .deserialize(record.topic(), record.key()),
-          InternalTopicSerdes.deserializer(Command.class)
-              .deserialize(record.topic(), record.value())
-      );
-    } catch (Exception e) {
-      LOG.error("Failed to deserialize command topic record when backing it up: {}:{}",
-          record.key(), record.value());
-      return;
+      InternalTopicSerdes.deserializer(CommandId.class).deserialize(record.topic(), record.key());
+    } catch (final Exception e) {
+      throw new KsqlException(String.format(
+          "Cannot deserialize record key: %s",
+          new String(record.key(), StandardCharsets.UTF_8)
+      ));
     }
-    writeCommandToBackup(deserializedRecord);
+
+    try {
+      InternalTopicSerdes.deserializer(Command.class).deserialize(record.topic(), record.value());
+    } catch (final Exception e) {
+      throw new KsqlException(String.format(
+          "Cannot deserialize record value: %s",
+          new String(record.value(), StandardCharsets.UTF_8)
+      ));
+    }
   }
 
-  void writeCommandToBackup(final ConsumerRecord<CommandId, Command> record) {
+  @Override
+  public void writeRecord(final ConsumerRecord<byte[], byte[]> record) {
     if (corruptionDetected) {
       throw new KsqlServerException(
           "Failed to write record due to out of sync command topic and backup file: " + record);
     }
+
+    throwIfInvalidRecord(record);
 
     if (isRestoring()) {
       if (isRecordInLatestReplay(record)) {
@@ -186,7 +177,7 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
     }
 
     try {
-      replayFile.write(record.key(), record.value());
+      replayFile.write(record);
     } catch (final IOException e) {
       LOG.warn("Failed to write to file {}. The command topic backup is not complete. "
               + "Make sure the file exists and has permissions to write. KSQL must be restarted "
@@ -211,10 +202,10 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
   }
 
   private BackupReplayFile newReplayFile() {
-    return BackupReplayFile.newFile(Paths.get(
+    return new BackupReplayFile(Paths.get(
         backupLocation.getAbsolutePath(),
         String.format("%s%s_%s", PREFIX, topicName, ticker.read())
-    ));
+    ).toFile());
   }
 
   private Optional<BackupReplayFile> latestReplayFile() {
@@ -245,7 +236,7 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
     }
 
     return (latestBakFile != null)
-        ? Optional.of(BackupReplayFile.openFile(latestBakFile))
+        ? Optional.of(new BackupReplayFile(latestBakFile))
         : Optional.empty();
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -138,8 +138,8 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
       InternalTopicSerdes.deserializer(CommandId.class).deserialize(record.topic(), record.key());
     } catch (final Exception e) {
       throw new KsqlException(String.format(
-          "Cannot deserialize record key: %s",
-          new String(record.key(), StandardCharsets.UTF_8)
+          "Failed to backup record because it cannot deserialize key: %s",
+          new String(record.key(), StandardCharsets.UTF_8), e
       ));
     }
 
@@ -147,8 +147,8 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
       InternalTopicSerdes.deserializer(Command.class).deserialize(record.topic(), record.value());
     } catch (final Exception e) {
       throw new KsqlException(String.format(
-          "Cannot deserialize record value: %s",
-          new String(record.value(), StandardCharsets.UTF_8)
+          "Failed to backup record because it cannot deserialize value: %s",
+          new String(record.value(), StandardCharsets.UTF_8), e
       ));
     }
   }
@@ -215,7 +215,7 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
 
     File latestBakFile = null;
     if (files != null) {
-      long latestTs = -1;
+      long latestTs = 0;
       for (int i = 0; i < files.length; i++) {
         final File bakFile = files[i];
         final String bakTimestamp = bakFile.getName().substring(prefixFilename.length());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
@@ -144,8 +144,8 @@ public class BackupReplayFileTest {
   private ConsumerRecord<byte[], byte[]> newStreamRecord(final String key, final String value) {
     final ConsumerRecord<byte[], byte[]> consumerRecord = mock(ConsumerRecord.class);
 
-    when(consumerRecord.key()).thenReturn(key.getBytes());
-    when(consumerRecord.value()).thenReturn(value.getBytes());
+    when(consumerRecord.key()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
+    when(consumerRecord.value()).thenReturn(value.getBytes(StandardCharsets.UTF_8));
 
     return consumerRecord;
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
@@ -49,7 +49,16 @@ public class BackupReplayFileTest {
   @Before
   public void setup() throws IOException {
     internalReplayFile = backupLocation.newFile(REPLAY_FILE_NAME);
-    replayFile = new BackupReplayFile(internalReplayFile);
+    replayFile = BackupReplayFile.openFile(internalReplayFile);
+  }
+
+  @Test
+  public void shouldGetVersion() {
+    // When
+    final BackupReplayFile.Versions version = replayFile.getVersion();
+
+    // Then
+    assertThat(version, is(BackupReplayFile.Versions.NO_VERSION));
   }
 
   @Test
@@ -75,7 +84,8 @@ public class BackupReplayFileTest {
     assertThat(commands.size(), is(1));
     assertThat(commands.get(0), is(
         "\"stream/stream1/create\"" + KEY_VALUE_SEPARATOR
-            + "{\"statement\":\"CREATE STREAM stream1 (id INT) WITH (kafka_topic='stream1')\"}"
+            + "{\"statement\":\"CREATE STREAM stream1 (id INT) WITH (kafka_topic='stream1')\""
+            + ",\"streamsProperties\":{},\"originalProperties\":{},\"plan\":null,\"version\":null}"
     ));
   }
 
@@ -93,11 +103,13 @@ public class BackupReplayFileTest {
     assertThat(commands.size(), is(2));
     assertThat(commands.get(0), is(
         "\"stream/stream1/create\"" + KEY_VALUE_SEPARATOR
-            + "{\"statement\":\"CREATE STREAM stream1 (id INT) WITH (kafka_topic='stream1')\"}"
+            + "{\"statement\":\"CREATE STREAM stream1 (id INT) WITH (kafka_topic='stream1')\","
+            + "\"streamsProperties\":{},\"originalProperties\":{},\"plan\":null,\"version\":null}"
     ));
     assertThat(commands.get(1), is(
         "\"stream/stream2/create\"" + KEY_VALUE_SEPARATOR
-            + "{\"statement\":\"CREATE STREAM stream2 (id INT) WITH (kafka_topic='stream2')\"}"
+            + "{\"statement\":\"CREATE STREAM stream2 (id INT) WITH (kafka_topic='stream2')\","
+            + "\"streamsProperties\":{},\"originalProperties\":{},\"plan\":null,\"version\":null}"
     ));
   }
 
@@ -120,7 +132,8 @@ public class BackupReplayFileTest {
     assertThat(commands.get(0), is(
         "\"stream/stream1/create\"" + KEY_VALUE_SEPARATOR
             + "{\"statement\":"
-            + "\"CREATE STREAM stream1 (id INT, f\\n1 INT) WITH (kafka_topic='topic1)\"}"
+            + "\"CREATE STREAM stream1 (id INT, f\\n1 INT) WITH (kafka_topic='topic1)\""
+            + ",\"streamsProperties\":{},\"originalProperties\":{},\"plan\":null,\"version\":null}"
     ));
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -19,11 +19,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Ticker;
-import io.confluent.ksql.rest.entity.CommandId;
-import io.confluent.ksql.rest.server.computation.Command;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
@@ -33,7 +33,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
-import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Before;
 import org.junit.Rule;
@@ -47,9 +46,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class CommandTopicBackupImplTest {
   private static final String COMMAND_TOPIC_NAME = "command_topic";
 
-  private Pair<CommandId, Command> command1 = newStreamRecord("stream1");
-  private Pair<CommandId, Command> command2 = newStreamRecord("stream2");
-  private Pair<CommandId, Command> command3 = newStreamRecord("stream3");
+  private ConsumerRecord<byte[], byte[]> command1 = newStreamRecord("stream1");
+  private ConsumerRecord<byte[], byte[]> command2 = newStreamRecord("stream2");
+  private ConsumerRecord<byte[], byte[]> command3 = newStreamRecord("stream3");
 
   @Mock
   private Ticker ticker;
@@ -65,15 +64,27 @@ public class CommandTopicBackupImplTest {
         backupLocation.getRoot().getAbsolutePath(), COMMAND_TOPIC_NAME, ticker);
   }
 
-  private Pair<CommandId, Command> newStreamRecord(final String streamName) {
-    final CommandId commandId = new CommandId(
-        CommandId.Type.STREAM, streamName, CommandId.Action.CREATE);
-    final Command command = new Command(
-        String.format("CREATE STREAM %s (id INT) WITH (kafka_topic='%s", streamName, streamName),
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()
-    );
+  private ConsumerRecord<byte[], byte[]> newStreamRecord(final String streamName) {
+    return newStreamRecord(buildKey(streamName), buildValue(streamName));
+  }
 
-    return new Pair<>(commandId, command);
+  @SuppressWarnings("unchecked")
+  private ConsumerRecord<byte[], byte[]> newStreamRecord(final String key, final String value) {
+    final ConsumerRecord<byte[], byte[]> consumerRecord = mock(ConsumerRecord.class);
+
+    when(consumerRecord.key()).thenReturn(key.getBytes());
+    when(consumerRecord.value()).thenReturn(value.getBytes());
+
+    return consumerRecord;
+  }
+
+  private String buildKey(final String streamName) {
+    return String.format("\"stream/%s/create\"", streamName);
+  }
+
+  private String buildValue(final String streamName) {
+    return String.format("{\"statement\":\"CREATE STREAM %s (id INT) WITH (kafka_topic='%s')\"}",
+        streamName, streamName);
   }
 
   @Test
@@ -147,41 +158,70 @@ public class CommandTopicBackupImplTest {
   }
 
   @Test
+  public void shouldThrowWhenRecordIsNotValidCommandId() {
+    // Given
+    commandTopicBackup.initialize();
+
+    // When
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> commandTopicBackup.writeRecord(new ConsumerRecord<>(
+        "topic1", 0, 0, "stream/a/create/invalid".getBytes(), command1.value())));
+
+    // Then
+    assertThat(e.getMessage(), containsString(
+        "Cannot deserialize record key: stream/a/create/invalid"));
+  }
+
+  @Test
+  public void shouldThrowWhenRecordIsNotValidCommand() {
+    // Given
+    commandTopicBackup.initialize();
+
+    // When
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> commandTopicBackup.writeRecord(new ConsumerRecord<>(
+            "topic1", 0, 0, command1.key(), "my command".getBytes())));
+
+    // Then
+    assertThat(e.getMessage(), containsString(
+        "Cannot deserialize record value: my command"));
+  }
+
+  @Test
   public void shouldWriteCommandToBackupToReplayFile() throws IOException {
     // Given
     commandTopicBackup.initialize();
 
     // When
-    final ConsumerRecord<CommandId, Command> record = newConsumerRecord(command1);
-    commandTopicBackup.writeCommandToBackup(record);
+    commandTopicBackup.writeRecord(command1);
 
     // Then
-    final List<Pair<CommandId, Command>> commands =
-        commandTopicBackup.getReplayFile().readRecords();
+    final List<Pair<byte[], byte[]>> commands = commandTopicBackup.getReplayFile().readRecords();
     assertThat(commands.size(), is(1));
-    assertThat(commands.get(0).left, is(command1.left));
-    assertThat(commands.get(0).right, is(command1.right));
+    assertThat(commands.get(0).left, is(command1.key()));
+    assertThat(commands.get(0).right, is(command1.value()));
   }
 
   @Test
   public void shouldIgnoreRecordPreviouslyReplayed() throws IOException {
     // Given
-    final ConsumerRecord<CommandId, Command> record = newConsumerRecord(command1);
     commandTopicBackup.initialize();
-    commandTopicBackup.writeCommandToBackup(record);
+    commandTopicBackup.writeRecord(command1);
     final BackupReplayFile previousReplayFile = commandTopicBackup.getReplayFile();
 
     // When
     // A 2nd initialize call will open the latest backup and read the previous replayed commands
     commandTopicBackup.initialize();
-    commandTopicBackup.writeCommandToBackup(record);
+    commandTopicBackup.writeRecord(command1);
     final BackupReplayFile currentReplayFile = commandTopicBackup.getReplayFile();
 
     // Then
-    final List<Pair<CommandId, Command>> commands = currentReplayFile.readRecords();
+    final List<Pair<byte[], byte[]>> commands = currentReplayFile.readRecords();
     assertThat(commands.size(), is(1));
-    assertThat(commands.get(0).left, is(command1.left));
-    assertThat(commands.get(0).right, is(command1.right));
+    assertThat(commands.get(0).left, is(command1.key()));
+    assertThat(commands.get(0).right, is(command1.value()));
     assertThat(currentReplayFile.getPath(), is(previousReplayFile.getPath()));
   }
 
@@ -190,18 +230,16 @@ public class CommandTopicBackupImplTest {
     // Given
     commandTopicBackup = new CommandTopicBackupImpl(
         backupLocation.getRoot().getAbsolutePath(), COMMAND_TOPIC_NAME, ticker);
-    final ConsumerRecord<CommandId, Command> record1 = newConsumerRecord(command1);
     commandTopicBackup.initialize();
-    commandTopicBackup.writeCommandToBackup(record1);
+    commandTopicBackup.writeRecord(command1);
     final BackupReplayFile previousReplayFile = commandTopicBackup.getReplayFile();
 
     // When
     // A 2nd initialize call will open the latest backup and read the previous replayed commands
     commandTopicBackup.initialize();
-    final ConsumerRecord<CommandId, Command> record2 = newConsumerRecord(command2);
     // The write command will conflicts with what's already in the backup file
     try {
-      commandTopicBackup.writeCommandToBackup(record2);
+      commandTopicBackup.writeRecord(command2);
       assertThat(true, is(false));
     } catch (final KsqlServerException e) {
       // This is expected so we do nothing
@@ -212,7 +250,7 @@ public class CommandTopicBackupImplTest {
     assertThat(currentReplayFile.getPath(), is(previousReplayFile.getPath()));
     assertThat(commandTopicBackup.commandTopicCorruption(), is(true));
     try {
-      commandTopicBackup.writeCommandToBackup(record2);
+      commandTopicBackup.writeRecord(command2);
       assertThat(true, is(false));
     } catch (final KsqlServerException e) {
       // This is expected so we do nothing
@@ -222,22 +260,19 @@ public class CommandTopicBackupImplTest {
   @Test
   public void shouldWritePreviousReplayedRecordsAlreadyChecked() throws IOException {
     // Given
-    final ConsumerRecord<CommandId, Command> record1 = newConsumerRecord(command1);
-    final ConsumerRecord<CommandId, Command> record2 = newConsumerRecord(command2);
     commandTopicBackup.initialize();
-    commandTopicBackup.writeCommandToBackup(record1);
-    commandTopicBackup.writeCommandToBackup(record2);
+    commandTopicBackup.writeRecord(command1);
+    commandTopicBackup.writeRecord(command2);
     final BackupReplayFile previousReplayFile = commandTopicBackup.getReplayFile();
 
     // When
     // A 2nd initialize call will open the latest backup and read the previous replayed commands
     commandTopicBackup.initialize();
     // command1 is ignored because it was previously replayed
-    commandTopicBackup.writeCommandToBackup(record1);
+    commandTopicBackup.writeRecord(command1);
     // The write command will conflicts with what's already in the backup file
-    final ConsumerRecord<CommandId, Command> record3 = newConsumerRecord(command3);
     try {
-      commandTopicBackup.writeCommandToBackup(record3);
+      commandTopicBackup.writeRecord(command3);
       assertThat(true, is(false));
     } catch (final KsqlServerException e) {
       // This is expected so we do nothing
@@ -245,20 +280,20 @@ public class CommandTopicBackupImplTest {
     final BackupReplayFile currentReplayFile = commandTopicBackup.getReplayFile();
 
     // Then
-    List<Pair<CommandId, Command>> commands = previousReplayFile.readRecords();
+    List<Pair<byte[], byte[]>> commands = previousReplayFile.readRecords();
     assertThat(commands.size(), is(2));
-    assertThat(commands.get(0).left, is(command1.left));
-    assertThat(commands.get(0).right, is(command1.right));
-    assertThat(commands.get(1).left, is(command2.left));
-    assertThat(commands.get(1).right, is(command2.right));
+    assertThat(commands.get(0).left, is(command1.key()));
+    assertThat(commands.get(0).right, is(command1.value()));
+    assertThat(commands.get(1).left, is(command2.key()));
+    assertThat(commands.get(1).right, is(command2.value()));
 
     // the backup file should be the same and the contents shouldn't have been modified
     commands = currentReplayFile.readRecords();
     assertThat(commands.size(), is(2));
-    assertThat(commands.get(0).left, is(command1.left));
-    assertThat(commands.get(0).right, is(command1.right));
-    assertThat(commands.get(1).left, is(command2.left));
-    assertThat(commands.get(1).right, is(command2.right));
+    assertThat(commands.get(0).left, is(command1.key()));
+    assertThat(commands.get(0).right, is(command1.value()));
+    assertThat(commands.get(1).left, is(command2.key()));
+    assertThat(commands.get(1).right, is(command2.value()));
     assertThat(currentReplayFile.getPath(), is(previousReplayFile.getPath()));
     assertThat(commandTopicBackup.commandTopicCorruption(), is(true));
   }
@@ -334,11 +369,5 @@ public class CommandTopicBackupImplTest {
     assertThat(replayFile.getPath(), is(String.format(
         "%s/backup_command_topic_111", backupLocation.getRoot().getAbsolutePath()
     )));
-  }
-
-  private ConsumerRecord<CommandId, Command> newConsumerRecord(
-      final Pair<CommandId, Command> record
-  ) {
-    return new ConsumerRecord<>("topic", 0, 0, record.left, record.right);
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -72,8 +73,8 @@ public class CommandTopicBackupImplTest {
   private ConsumerRecord<byte[], byte[]> newStreamRecord(final String key, final String value) {
     final ConsumerRecord<byte[], byte[]> consumerRecord = mock(ConsumerRecord.class);
 
-    when(consumerRecord.key()).thenReturn(key.getBytes());
-    when(consumerRecord.value()).thenReturn(value.getBytes());
+    when(consumerRecord.key()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
+    when(consumerRecord.value()).thenReturn(value.getBytes(StandardCharsets.UTF_8));
 
     return consumerRecord;
   }
@@ -166,11 +167,12 @@ public class CommandTopicBackupImplTest {
     final Exception e = assertThrows(
         KsqlException.class,
         () -> commandTopicBackup.writeRecord(new ConsumerRecord<>(
-        "topic1", 0, 0, "stream/a/create/invalid".getBytes(), command1.value())));
+        "topic1", 0, 0,
+            "stream/a/create/invalid".getBytes(StandardCharsets.UTF_8), command1.value())));
 
     // Then
     assertThat(e.getMessage(), containsString(
-        "Cannot deserialize record key: stream/a/create/invalid"));
+        "Failed to backup record because it cannot deserialize key: stream/a/create/invalid"));
   }
 
   @Test
@@ -182,11 +184,12 @@ public class CommandTopicBackupImplTest {
     final Exception e = assertThrows(
         KsqlException.class,
         () -> commandTopicBackup.writeRecord(new ConsumerRecord<>(
-            "topic1", 0, 0, command1.key(), "my command".getBytes())));
+            "topic1", 0, 0, command1.key(),
+            "my command".getBytes(StandardCharsets.UTF_8))));
 
     // Then
     assertThat(e.getMessage(), containsString(
-        "Cannot deserialize record value: my command"));
+        "Failed to backup record because it cannot deserialize value: my command"));
   }
 
   @Test


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
This PR fixes an issue with backups re-created over and over again on every server restart. 

The cause was that sometimes the command topic comes with command properties (originalProperties) with nulls and empty values. When the backup serializes those properties to write them as JSON in the file, the nulls and empty are missing. Later, when restarting the server, the command properties read from command topic are not equals from the ones found in the backup file; so a new backup file is created.

The fix makes sure to include nulls and empty properties in the backup file. It also adds a header to include the version of the backup file. When the backup file do not contain a version header (during an upgrade to 0.13), then the comparison will only use the commandId and the command statement (without the properties), so it the server start does not fail with degradation state.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
Modified test cases
Verified manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

