### PR TITLE
feat: `NONE` format for key-less streams

### DIFF
--- a/docs/developer-guide/serialization.md
+++ b/docs/developer-guide/serialization.md
@@ -11,10 +11,8 @@ at runtime. ksqlDB offers several mechanisms for controlling serialization
 and deserialization.
 
 The primary mechanism is by choosing the serialization format when you
-create a stream or table and specify the `VALUE_FORMAT` in the `WITH`
+create a stream or table and specify `FORMAT`, `KEY_FORMAT` or `VALUE_FORMAT` in the `WITH`
 clause.
-
-While ksqlDB supports different value formats, it requires keys to be `KAFKA` format.
 
 ```sql
 -- create table with JSON value format:
@@ -22,6 +20,7 @@ CREATE TABLE ORDERS (
     F0 INT PRIMARY KEY, 
     F1 STRING
   ) WITH (
+    KEY_FORMAT='KAFKA',
     VALUE_FORMAT='JSON', 
     ...
   );
@@ -39,8 +38,8 @@ ksqlDB supports these serialization formats:
 -   [`KAFKA`](#kafka) supports primitives serialized using the standard Kafka serializers. 
 -   [`PROTOBUF`](#protobuf) supports Protocol Buffers.
 
-All formats are supported as value formats. Only a subset of formats are
-currently supported as key formats. See individual formats for details.
+
+Not all formats can be used as both key and value formats. See individual formats for details.
 
 ### NONE
 
@@ -57,14 +56,14 @@ The `NONE` format is a special marker format that is used to indicate ksqlDB sho
 deserialize that part of the  {{ site.ak }} record.
 
 It's main use is as the `KEY_FORMAT` of key-less streams, especially where a default key format 
-has been set, via `ksql.persistence.default.format.key`, that supports Schema inference. If the
+has been set, via [`ksql.persistence.default.format.key`][1] that supports Schema inference. If the
 key format was not overridden, the server would attempt to load the key schema from the {{ site.sr }}.
 If the schema existed, the key columns would be inferred from the schema, which may not be the intent.
-If the schema did no exist, the statment would be rejected.  In such situations, the key format can
+If the schema did not exist, the statement would be rejected.  In such situations, the key format can
 be set to `NONE`: 
 
 ```sql
-CREATE STREAM KEY_LESS_STREAM (
+CREATE STREAM KEYLESS_STREAM (
     VAL STRING
   ) WITH (
     KEY_FORMAT='NONE',
@@ -73,16 +72,19 @@ CREATE STREAM KEY_LESS_STREAM (
   );
 ```
 
-Any statement using format `NONE` that defines columns will result in an error.
+Any statement that sets the key format to `NONE` and has key columns defined, will result in an error.
 
 If a `CREATE TABLE AS` or `CREATE STREAM AS` statement has a source with a key format of `NONE`, but
-the newly created table or stream has key column, then you may either explicitly define the key 
-format to use in the `WITH` clause, or the default key format, as set in `ksql.persistence.default.format.key`
+the newly created table or stream has key columns, then you may either explicitly define the key 
+format to use in the `WITH` clause, or the default key format, as set in [`ksql.persistence.default.format.key`][1]
 will be used.
+
+Conversely, a `CREATE STREAM AS` statement that removes the key columns, i.e. via `PARTITION BY null`
+will automatically set the key format to `NONE`.
 
 ```sql
 -- keyless stream with NONE key format:
-CREATE STREAM KEY_LESS_STREAM (
+CREATE STREAM KEYLESS_STREAM (
     VAL STRING
   ) WITH (
     KEY_FORMAT='NONE',
@@ -92,12 +94,12 @@ CREATE STREAM KEY_LESS_STREAM (
 
 -- Table created from stream with explicit key format declared in WITH clause:
 CREATE TABLE T WITH (KEY_FORMAT='KAFKA') AS 
-  SELECT VAL, COUNT() FROM KEY_LESS_STREAM
+  SELECT VAL, COUNT() FROM KEYLESS_STREAM
   GROUP BY VAL;
 
 -- or, using the default key format set in the ksql.persistence.default.format.key config:
 CREATE TABLE T AS 
-  SELECT VAL, COUNT() FROM KEY_LESS_STREAM
+  SELECT VAL, COUNT() FROM KEYLESS_STREAM
   GROUP BY VAL;
 ```
 
@@ -616,3 +618,5 @@ CREATE STREAM BAD_SINK WITH(WRAP_SINGLE_VALUE=true) AS SELECT ID, COST FROM S EM
 ## Suggested Reading
 
 - Blog post: [I’ve Got the Key, I’ve Got the Secret. Here’s How Keys Work in ksqlDB 0.10](https://www.confluent.io/blog/ksqldb-0-10-updates-key-columns/)
+
+[1]: ../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencedefaultformatkey

--- a/docs/developer-guide/serialization.md
+++ b/docs/developer-guide/serialization.md
@@ -32,7 +32,7 @@ Serialization Formats
 
 ksqlDB supports these serialization formats:
 
--   [`NONE`](#none) used to indicate the data should not be derialized.
+-   [`NONE`](#none) used to indicate the data should not be deserialized.
 -   [`DELIMITED`](#delimited) supports comma separated values.
 -   [`JSON`](#json) and [`JSON_SR`](#json) support JSON values, with and within schema registry integration 
 -   [`AVRO`](#avro) supports AVRO serialized values. 

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -296,6 +296,12 @@ If not set and no explicit key format is provided in the statement, via either t
 
 For supported formats, see [Serialization Formats](../../../developer-guide/serialization.md#serialization-formats).
 
+[CREATE STREAM AS SELECT](../../../developer-guide/ksqldb-reference/create-stream-as-select.md) and
+[CREATE TABLE AS SELECT](../../../developer-guide/ksqldb-reference/create-table-as-select.md) 
+statements that create streams or tables with key columns, where the source stream or table 
+has a [NONE](../../../developer-guide/serialization.md#none) key format, will also use the default
+key format set in this configuration if no explicit key format is declared in the `WITH` clause.
+
 ### ksql.persistence.default.format.value
 
 Sets the default value for the `VALUE_FORMAT` property if one is

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/serde/InternalFormats.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/serde/InternalFormats.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.serde;
 
 import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.serde.json.JsonFormat;
+import io.confluent.ksql.serde.none.NoneFormat;
 
 /**
  * Util class for creating internal formats.
@@ -50,10 +52,15 @@ public final class InternalFormats {
    * @see SerdeFeaturesFactory#buildInternal
    */
   public static Formats of(final KeyFormat keyFormat, final ValueFormat valueFormat) {
+    // Do not use NONE format for internal topics:
+    final FormatInfo formatInfo = keyFormat.getFormatInfo().getFormat().equals(NoneFormat.NAME)
+        ? FormatInfo.of(JsonFormat.NAME)
+        : keyFormat.getFormatInfo();
+
     return Formats.of(
-        keyFormat.getFormatInfo(),
+        formatInfo,
         valueFormat.getFormatInfo(),
-        SerdeFeaturesFactory.buildInternal(FormatFactory.of(keyFormat.getFormatInfo())),
+        SerdeFeaturesFactory.buildInternal(FormatFactory.of(formatInfo)),
         SerdeFeatures.of()
     );
   }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/none/NoneSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/none/NoneSerdeSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.ksql.test.serde.none;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.serde.voids.KsqlVoidSerde;
+import io.confluent.ksql.test.serde.SerdeSupplier;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class NoneSerdeSupplier implements SerdeSupplier<Void> {
+
+  @Override
+  public Serializer<Void> getSerializer(final SchemaRegistryClient schemaRegistryClient) {
+    return new KsqlVoidSerde<Void>().serializer();
+  }
+
+  @Override
+  public Deserializer<Void> getDeserializer(final SchemaRegistryClient schemaRegistryClient) {
+    return new KsqlVoidSerde<Void>().deserializer();
+  }
+} 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
@@ -35,11 +35,13 @@ import io.confluent.ksql.serde.delimited.DelimitedFormat;
 import io.confluent.ksql.serde.json.JsonFormat;
 import io.confluent.ksql.serde.json.JsonSchemaFormat;
 import io.confluent.ksql.serde.kafka.KafkaFormat;
+import io.confluent.ksql.serde.none.NoneFormat;
 import io.confluent.ksql.serde.protobuf.ProtobufFormat;
 import io.confluent.ksql.test.serde.SerdeSupplier;
 import io.confluent.ksql.test.serde.avro.ValueSpecAvroSerdeSupplier;
 import io.confluent.ksql.test.serde.json.ValueSpecJsonSerdeSupplier;
 import io.confluent.ksql.test.serde.kafka.KafkaSerdeSupplier;
+import io.confluent.ksql.test.serde.none.NoneSerdeSupplier;
 import io.confluent.ksql.test.serde.protobuf.ValueSpecProtobufSerdeSupplier;
 import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
@@ -72,6 +74,7 @@ public final class SerdeUtil {
       case JsonSchemaFormat.NAME: return new ValueSpecJsonSerdeSupplier(true);
       case DelimitedFormat.NAME:  return new StringSerdeSupplier();
       case KafkaFormat.NAME:      return new KafkaSerdeSupplier(schema);
+      case NoneFormat.NAME:       return new NoneSerdeSupplier();
       default:
         throw new InvalidFieldException("format", "unsupported value: " + format);
     }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_as_key_format_of_keyless_stream/6.1.0_1601581259035/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_as_key_format_of_keyless_stream/6.1.0_1601581259035/plan.json
@@ -1,0 +1,140 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (FOO INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='NONE', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`FOO` INTEGER",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "NONE"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`FOO` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "NONE"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "NONE"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`FOO` INTEGER"
+          },
+          "selectExpressions" : [ "FOO AS FOO" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "NONE"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_as_key_format_of_keyless_stream/6.1.0_1601581259035/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_as_key_format_of_keyless_stream/6.1.0_1601581259035/spec.json
@@ -1,0 +1,104 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1601581259035,
+  "path" : "query-validation-tests/none.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`FOO` INTEGER"
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`FOO` INTEGER"
+    }
+  },
+  "testCase" : {
+    "name" : "as key format of keyless stream",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "foo" : 10
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : "data that should be ignored",
+      "value" : {
+        "foo" : 11
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : null
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "FOO" : 10
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "FOO" : 11
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : null
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', key_format='NONE', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` INTEGER",
+        "keyFormat" : {
+          "format" : "NONE"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` INTEGER",
+        "keyFormat" : {
+          "format" : "NONE"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "NONE"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "NONE"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_as_key_format_of_keyless_stream/6.1.0_1601581259035/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_as_key_format_of_keyless_stream/6.1.0_1601581259035/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_from_keyless_stream/6.1.0_1601581259075/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_from_keyless_stream/6.1.0_1601581259075/plan.json
@@ -1,0 +1,140 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (FOO INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`FOO` INTEGER",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (KEY_FORMAT='NONE') AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`FOO` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "NONE"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`FOO` INTEGER"
+          },
+          "selectExpressions" : [ "FOO AS FOO" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "NONE"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_from_keyless_stream/6.1.0_1601581259075/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_from_keyless_stream/6.1.0_1601581259075/spec.json
@@ -1,0 +1,92 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1601581259075,
+  "path" : "query-validation-tests/none.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`FOO` INTEGER"
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`FOO` INTEGER"
+    }
+  },
+  "testCase" : {
+    "name" : "in CSAS from keyless stream",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : "ignored",
+      "value" : {
+        "FOO" : 10
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : null
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "FOO" : 10
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : null
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='JSON');", "CREATE STREAM OUTPUT WITH(key_format='NONE') AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` INTEGER",
+        "keyFormat" : {
+          "format" : "NONE"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "NONE"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_from_keyless_stream/6.1.0_1601581259075/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_from_keyless_stream/6.1.0_1601581259075/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_partitioning_by_null/6.1.0_1601581259089/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_partitioning_by_null/6.1.0_1601581259089/plan.json
@@ -1,0 +1,147 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID INTEGER KEY, FOO INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` INTEGER KEY, `FOO` INTEGER",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (KEY_FORMAT='NONE') AS SELECT *\nFROM INPUT INPUT\nPARTITION BY null\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`FOO` INTEGER, `ID` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "NONE"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSelectKeyV2",
+            "properties" : {
+              "queryContext" : "PartitionBy"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "input_topic",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "sourceSchema" : "`ID` INTEGER KEY, `FOO` INTEGER"
+            },
+            "keyExpression" : "null"
+          },
+          "selectExpressions" : [ "FOO AS FOO", "ID AS ID" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "NONE"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_partitioning_by_null/6.1.0_1601581259089/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_partitioning_by_null/6.1.0_1601581259089/spec.json
@@ -1,0 +1,93 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1601581259089,
+  "path" : "query-validation-tests/none.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` INTEGER KEY, `FOO` INTEGER"
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`FOO` INTEGER, `ID` INTEGER"
+    }
+  },
+  "testCase" : {
+    "name" : "in CSAS partitioning by null",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 9,
+      "value" : {
+        "FOO" : 10
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : null
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "FOO" : 10,
+        "ID" : 9
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : null
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID INT KEY, foo INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='JSON');", "CREATE STREAM OUTPUT WITH(key_format='NONE') AS SELECT * FROM INPUT PARTITION BY null;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` INTEGER KEY, `FOO` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` INTEGER, `ID` INTEGER",
+        "keyFormat" : {
+          "format" : "NONE"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "NONE"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_partitioning_by_null/6.1.0_1601581259089/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/none_-_in_CSAS_partitioning_by_null/6.1.0_1601581259089/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> PartitionBy-SelectKey
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: PartitionBy-SelectKey (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- PartitionBy-SelectKey
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/none.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/none.json
@@ -1,0 +1,181 @@
+{
+  "comments": [
+    "NONE format testing."
+  ],
+  "tests": [
+    {
+      "name": "as key format of keyless stream",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', key_format='NONE', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": null, "value": {"foo": 10}},
+        {"topic": "input_topic", "key": "data that should be ignored", "value": {"foo": 11}},
+        {"topic": "input_topic", "key": null, "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 11}},
+        {"topic": "OUTPUT", "key": null, "value": null}
+      ]
+    },
+    {
+      "name": "as key format of keyed stream",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (kafka_topic='input_topic', key_format='NONE', value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'NONE' format can only be used when no columns are defined. Got: [`K` STRING KEY]"
+      }
+    },
+    {
+      "name": "as key format of table",
+      "statements": [
+        "CREATE TABLE INPUT (K STRING PRIMARY KEY, foo INT) WITH (kafka_topic='input_topic', key_format='NONE', value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'NONE' format can only be used when no columns are defined. Got: [`K` STRING KEY]"
+      }
+    },
+    {
+      "name": "as value format with value columns",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', value_format='NONE');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'NONE' format can only be used when no columns are defined. Got: [`FOO` INTEGER]"
+      }
+    },
+    {
+      "name": "in CSAS from keyless stream",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='JSON');",
+        "CREATE STREAM OUTPUT WITH(key_format='NONE') AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "ignored", "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": null}
+      ]
+    },
+    {
+      "name": "in CSAS partitioning by null",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, foo INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='JSON');",
+        "CREATE STREAM OUTPUT WITH(key_format='NONE') AS SELECT * FROM INPUT PARTITION BY null;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 9, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10, "ID": 9}},
+        {"topic": "OUTPUT", "key": null, "value": null}
+      ]
+    },
+    {
+      "name": "explicitly set in CSAS with key",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='JSON');",
+        "CREATE STREAM OUTPUT WITH (key_format='NONE') AS SELECT * FROM INPUT PARTITION BY BAR;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'NONE' format can only be used when no columns are defined. Got: [`BAR` INTEGER KEY]"
+      }
+    },
+    {
+      "name": "explicitly set in CTAS",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key_format='KAFKA', value_format='JSON');",
+        "CREATE TABLE OUTPUT WITH (key_format='NONE') AS SELECT BAR AS K, COUNT() FROM INPUT GROUP BY BAR;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'NONE' format can only be used when no columns are defined. Got: [`K` INTEGER KEY]"
+      }
+    },
+    {
+      "name": "inherited in CSAS - PARTITION BY",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key_format='NONE', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY BAR;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true,
+        "ksql.persistence.default.format.key": "JSON"
+      },
+      "inputs": [
+        {"topic": "input_topic", "key": null, "value": {"foo": 10}},
+        {"topic": "input_topic", "key": "data that should be ignored", "value": {"foo": 11}},
+        {"topic": "input_topic", "key": null, "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 11}},
+        {"topic": "OUTPUT", "key": null, "value": null}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyFormat": {"format": "JSON"}}
+        ]
+      }
+    },
+    {
+      "name": "inherited in CSAS - JOIN with repartition",
+      "enabled": false,
+      "comment": "Will be enabled as part of https://github.com/confluentinc/ksql/issues/6213",
+      "statements": [
+        "CREATE TABLE T (ID INT PRIMARY KEY, VAL STRING) WITH (kafka_topic='t', value_format='JSON');",
+        "CREATE STREAM S (ID INT) WITH (kafka_topic='s', key_format='NONE', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT S.ID, VAL FROM S JOIN T ON S.ID = T.ID;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true,
+        "ksql.persistence.default.format.key": "JSON"
+      },
+      "inputs": [
+        {"topic": "t", "key": 10, "value": {"VAL": "hello"}},
+        {"topic": "s", "key": null, "value": {"id": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 10, "value": {"VAL": "hello"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyFormat": {"format": "JSON"}}
+        ]
+      }
+    },
+    {
+      "name": "inherited in CTAS - GROUP BY",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', key_format='NONE', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT FOO, COUNT() AS COUNT FROM INPUT GROUP BY FOO;"
+      ],
+      "properties": {
+        "ksql.key.format.enabled": true,
+        "ksql.persistence.default.format.key": "JSON"
+      },
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 22}},
+        {"topic": "input_topic", "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 22, "value": {"COUNT": 1}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyFormat": {"format": "JSON"}}
+        ]
+      }
+    }
+  ]
+}

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
@@ -51,7 +51,9 @@ public interface Format {
   /**
    * @return The set of features the format supports.
    */
-  Set<SerdeFeature> supportedFeatures();
+  default Set<SerdeFeature> supportedFeatures() {
+    return ImmutableSet.of();
+  }
 
   /**
    * @param feature the feature to test

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/FormatFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/FormatFactory.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.serde.delimited.DelimitedFormat;
 import io.confluent.ksql.serde.json.JsonFormat;
 import io.confluent.ksql.serde.json.JsonSchemaFormat;
 import io.confluent.ksql.serde.kafka.KafkaFormat;
+import io.confluent.ksql.serde.none.NoneFormat;
 import io.confluent.ksql.serde.protobuf.ProtobufFormat;
 import io.confluent.ksql.util.KsqlException;
 
@@ -34,6 +35,7 @@ public final class FormatFactory {
   public static final Format PROTOBUF   = new ProtobufFormat();
   public static final Format KAFKA      = new KafkaFormat();
   public static final Format DELIMITED  = new DelimitedFormat();
+  public static final Format NONE       = new NoneFormat();
 
   private FormatFactory() {
   }
@@ -57,6 +59,7 @@ public final class FormatFactory {
       case ProtobufFormat.NAME:   return PROTOBUF;
       case KafkaFormat.NAME:      return KAFKA;
       case DelimitedFormat.NAME:  return DELIMITED;
+      case NoneFormat.NAME:       return NONE;
       default:
         throw new KsqlException("Unknown format: " + name);
     }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KeyFormatUtils.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KeyFormatUtils.java
@@ -22,7 +22,7 @@ import java.util.List;
 public final class KeyFormatUtils {
 
   private static final List<Format> SUPPORTED_KEY_FORMATS =
-      ImmutableList.of(FormatFactory.KAFKA, FormatFactory.DELIMITED);
+      ImmutableList.of(FormatFactory.NONE, FormatFactory.KAFKA, FormatFactory.DELIMITED);
   private static final List<Format> KEY_FORMATS_UNDER_DEVELOPMENT =
       ImmutableList.of(FormatFactory.JSON);
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/none/NoneFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/none/NoneFormat.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.none;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatProperties;
+import io.confluent.ksql.serde.SerdeUtils;
+import io.confluent.ksql.serde.voids.KsqlVoidSerde;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.kafka.common.serialization.Serde;
+
+/**
+ * Format used to indicate no data.
+ */
+public class NoneFormat implements Format {
+
+  public static final String NAME = "NONE";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public Serde<List<?>> getSerde(
+      final PersistenceSchema schema,
+      final Map<String, String> formatProperties,
+      final KsqlConfig ksqlConfig,
+      final Supplier<SchemaRegistryClient> srClientFactory
+  ) {
+    FormatProperties.validateProperties(name(), formatProperties, getSupportedProperties());
+    SerdeUtils.throwOnUnsupportedFeatures(schema.features(), supportedFeatures());
+
+    if (!schema.columns().isEmpty()) {
+      throw new KsqlException("The '" + NAME
+          + "' format can only be used when no columns are defined. Got: " + schema.columns());
+    }
+
+    return new KsqlVoidSerde<>();
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/none/NoneFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/none/NoneFormatTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.none;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.ksql.SimpleColumn;
+import io.confluent.ksql.serde.SerdeFeature;
+import io.confluent.ksql.serde.SerdeFeatures;
+import io.confluent.ksql.serde.voids.KsqlVoidSerde;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.kafka.common.serialization.Serde;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NoneFormatTest {
+
+  @Mock
+  private PersistenceSchema schema;
+  @Mock
+  private KsqlConfig ksqlConfig;
+  @Mock
+  private Supplier<SchemaRegistryClient> srClientFactory;
+  @Mock
+  private SimpleColumn column;
+  private Map<String, String> formatProps = new HashMap<>();
+  private NoneFormat format;
+
+  @Before
+  public void setUp() {
+    format = new NoneFormat();
+
+    when(schema.columns()).thenReturn(ImmutableList.of());
+    when(schema.features()).thenReturn(SerdeFeatures.of());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnUnsupportedFeatures() {
+    // Given:
+    when(schema.features()).thenReturn(SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+
+    // When:
+    format.getSerde(schema, formatProps, ksqlConfig, srClientFactory);
+  }
+
+  @Test(expected = KsqlException.class)
+  public void shouldThrowOnUnsupportedProps() {
+    // Given:
+    formatProps = ImmutableMap.of("some", "prop");
+
+    // When:
+    format.getSerde(schema, formatProps, ksqlConfig, srClientFactory);
+  }
+
+  @Test
+  public void shouldThrowOnColumns() {
+    // Given:
+    when(schema.columns()).thenReturn(ImmutableList.of(column));
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> format.getSerde(schema, formatProps, ksqlConfig, srClientFactory)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        is("The 'NONE' format can only be used when no columns are defined. Got: [column]"));
+  }
+
+  @Test
+  public void shouldReturnVoidSerde() {
+    // When:
+    final Serde<List<?>> serde = format.getSerde(schema, formatProps, ksqlConfig, srClientFactory);
+
+    // Then:
+    assertThat(serde, instanceOf(KsqlVoidSerde.class));
+  }
+}


### PR DESCRIPTION
### Description 

fixes: #6221

Introduce a `NONE` format, used to indicate the key data, in key-less streams, should not be deserialized.

There's a piece of follow up work to make joins involving key-less streams with `NONE` key format work.  This will be done under https://github.com/confluentinc/ksql/issues/6213.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

