### PR TITLE
chore: wire in auto-register for key schemas

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -27,6 +27,7 @@ public final class KsqlConstants {
   public static final String STREAMS_CHANGELOG_TOPIC_SUFFIX = "-changelog";
   public static final String STREAMS_REPARTITION_TOPIC_SUFFIX = "-repartition";
 
+  public static final String SCHEMA_REGISTRY_KEY_SUFFIX = "-key";
   public static final String SCHEMA_REGISTRY_VALUE_SUFFIX = "-value";
 
   public static final long defaultSinkWindowChangeLogAdditionalRetention = 1000000;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.ksql.SimpleColumn;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
@@ -43,6 +44,7 @@ import io.confluent.ksql.util.KsqlSchemaRegistryNotConfiguredException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 public class SchemaRegisterInjector implements Injector {
@@ -76,27 +78,42 @@ public class SchemaRegisterInjector implements Injector {
     // since this injector is chained after the TopicCreateInjector,
     // we can assume that the kafka topic is always present in the
     // statement properties
+    final CreateSource statement = cs.getStatement();
+    final LogicalSchema schema = statement.getElements().toLogicalSchema();
 
-    final LogicalSchema schema = cs.getStatement().getElements().toLogicalSchema();
+    final FormatInfo keyFormat = SourcePropertiesUtil.getKeyFormat(statement.getProperties());
+    final SerdeFeatures keyFeatures = SerdeFeaturesFactory.buildKeyFeatures(
+        schema,
+        FormatFactory.of(keyFormat)
+    );
+    registerSchema(
+        schema.key(),
+        statement.getProperties().getKafkaTopic(),
+        keyFormat,
+        keyFeatures,
+        cs.getSessionConfig().getConfig(false),
+        cs.getStatementText(),
+        false,
+        KsqlConstants.SCHEMA_REGISTRY_KEY_SUFFIX
+    );
 
-    final FormatInfo valueFormat = SourcePropertiesUtil
-        .getValueFormat(cs.getStatement().getProperties());
-
+    final FormatInfo valueFormat = SourcePropertiesUtil.getValueFormat(statement.getProperties());
     final SerdeFeatures valFeatures = SerdeFeaturesFactory.buildValueFeatures(
         schema,
         FormatFactory.of(valueFormat),
-        cs.getStatement().getProperties().getValueSerdeFeatures(),
+        statement.getProperties().getValueSerdeFeatures(),
         cs.getSessionConfig().getConfig(false)
     );
 
     registerSchema(
-        schema,
-        cs.getStatement().getProperties().getKafkaTopic(),
+        schema.withoutPseudoAndKeyColsInValue().value(),
+        statement.getProperties().getKafkaTopic(),
         valueFormat,
         valFeatures,
         cs.getSessionConfig().getConfig(false),
         cs.getStatementText(),
-        false
+        false,
+        KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
     );
   }
 
@@ -115,24 +132,36 @@ public class SchemaRegisterInjector implements Injector {
         ));
 
     registerSchema(
-        queryMetadata.getLogicalSchema(),
+        queryMetadata.getLogicalSchema().key(),
+        queryMetadata.getResultTopic().getKafkaTopicName(),
+        queryMetadata.getResultTopic().getKeyFormat().getFormatInfo(),
+        queryMetadata.getPhysicalSchema().keySchema().features(),
+        cas.getSessionConfig().getConfig(false),
+        cas.getStatementText(),
+        true,
+        KsqlConstants.SCHEMA_REGISTRY_KEY_SUFFIX
+    );
+    registerSchema(
+        queryMetadata.getLogicalSchema().withoutPseudoAndKeyColsInValue().value(),
         queryMetadata.getResultTopic().getKafkaTopicName(),
         queryMetadata.getResultTopic().getValueFormat().getFormatInfo(),
         queryMetadata.getPhysicalSchema().valueSchema().features(),
         cas.getSessionConfig().getConfig(false),
         cas.getStatementText(),
-        true
+        true,
+        KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
     );
   }
 
   private void registerSchema(
-      final LogicalSchema schema,
+      final List<? extends SimpleColumn> schema,
       final String topic,
       final FormatInfo formatInfo,
-      final SerdeFeatures valFeatures,
+      final SerdeFeatures serdeFeatures,
       final KsqlConfig config,
       final String statementText,
-      final boolean registerIfSchemaExists
+      final boolean registerIfSchemaExists,
+      final String subjectSuffix
   ) {
     final Format format = FormatFactory.of(formatInfo);
     if (!format.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)) {
@@ -149,16 +178,13 @@ public class SchemaRegisterInjector implements Injector {
 
     try {
       final SchemaRegistryClient srClient = serviceContext.getSchemaRegistryClient();
-      final String subject = topic + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
+      final String subject = topic + subjectSuffix;
 
       if (registerIfSchemaExists || !srClient.getAllSubjects().contains(subject)) {
         final SchemaTranslator translator = format.getSchemaTranslator(formatInfo.getProperties());
 
         final ParsedSchema parsedSchema = translator.toParsedSchema(
-            PersistenceSchema.from(
-                schema.withoutPseudoAndKeyColsInValue().value(),
-                valFeatures
-            )
+            PersistenceSchema.from(schema, serdeFeatures)
         );
 
         srClient.register(subject, parsedSchema);

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -157,7 +157,7 @@ public final class TestCaseBuilderUtil {
 
       final Optional<ParsedSchema> keySchema =
           keyFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
-              ? buildValueSchema(sql, logicalSchema.key(), keyFormatInfo, keyFormat, keySerdeFeats)
+              ? buildSchema(sql, logicalSchema.key(), keyFormatInfo, keyFormat, keySerdeFeats)
               : Optional.empty();
 
       final FormatInfo valFormatInfo = SourcePropertiesUtil.getValueFormat(props);
@@ -167,7 +167,7 @@ public final class TestCaseBuilderUtil {
 
       final Optional<ParsedSchema> valueSchema =
           valFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
-              ? buildValueSchema(
+              ? buildSchema(
                   sql, logicalSchema.value(), valFormatInfo, valFormat, valSerdeFeats)
               : Optional.empty();
 
@@ -212,22 +212,22 @@ public final class TestCaseBuilderUtil {
     }
   }
 
-  private static Optional<ParsedSchema> buildValueSchema(
+  private static Optional<ParsedSchema> buildSchema(
       final String sql,
       final List<Column> schema,
-      final FormatInfo valueFormatInfo,
-      final Format valueFormat,
-      final SerdeFeatures valFeatures
+      final FormatInfo formatInfo,
+      final Format format,
+      final SerdeFeatures serdeFeatures
   ) {
     if (schema.isEmpty()) {
       return Optional.empty();
     }
 
     try {
-      final SchemaTranslator translator = valueFormat
-          .getSchemaTranslator(valueFormatInfo.getProperties());
+      final SchemaTranslator translator = format
+          .getSchemaTranslator(formatInfo.getProperties());
 
-      return Optional.of(translator.toParsedSchema(PersistenceSchema.from(schema, valFeatures)
+      return Optional.of(translator.toParsedSchema(PersistenceSchema.from(schema, serdeFeatures)
       ));
     } catch (final Exception e) {
       // Statement won't parse: this will be detected/handled later.
@@ -238,14 +238,11 @@ public final class TestCaseBuilderUtil {
     }
   }
 
-  private static SerdeFeatures buildKeyFeatures(
-      final Format valueFormat,
-      final LogicalSchema logicalSchema
-  ) {
+  private static SerdeFeatures buildKeyFeatures(final Format format, final LogicalSchema schema) {
     try {
       return SerdeFeaturesFactory.buildKeyFeatures(
-          logicalSchema,
-          valueFormat
+          schema,
+          format
       );
     } catch (final Exception e) {
       // Catch block allows negative tests to fail in the correct place, i.e. later.

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.properties.with.SourcePropertiesUtil;
 import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.RegisterType;
+import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.serde.Format;
@@ -130,7 +131,7 @@ public final class TestCaseBuilderUtil {
 
     // Get topics from inputs and outputs fields:
     Streams.concat(inputs.stream(), outputs.stream())
-        .map(record -> new Topic(record.getTopicName(), Optional.empty()))
+        .map(record -> new Topic(record.getTopicName(), Optional.empty(), Optional.empty()))
         .forEach(topic -> allTopics.putIfAbsent(topic.getName(), topic));
 
     return allTopics.values();
@@ -147,12 +148,27 @@ public final class TestCaseBuilderUtil {
       final CreateSource statement = (CreateSource) stmt.getStatement();
       final CreateSourceProperties props = statement.getProperties();
 
-      final FormatInfo valueFormatInfo = SourcePropertiesUtil.getValueFormat(props);
-      final Format valueFormat = FormatFactory.fromName(valueFormatInfo.getFormat());
+      final LogicalSchema logicalSchema = statement.getElements().toLogicalSchema();
+
+      final FormatInfo keyFormatInfo = SourcePropertiesUtil.getKeyFormat(props);
+      final Format keyFormat = FormatFactory.fromName(keyFormatInfo.getFormat());
+      final SerdeFeatures keySerdeFeats = buildKeyFeatures(
+          keyFormat, logicalSchema);
+
+      final Optional<ParsedSchema> keySchema =
+          keyFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
+              ? buildValueSchema(sql, logicalSchema.key(), keyFormatInfo, keyFormat, keySerdeFeats)
+              : Optional.empty();
+
+      final FormatInfo valFormatInfo = SourcePropertiesUtil.getValueFormat(props);
+      final Format valFormat = FormatFactory.fromName(valFormatInfo.getFormat());
+      final SerdeFeatures valSerdeFeats = buildValueFeatures(
+          ksqlConfig, props, valFormat, logicalSchema);
 
       final Optional<ParsedSchema> valueSchema =
-          valueFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
-              ? buildValueSchema(sql, ksqlConfig, statement, props, valueFormatInfo, valueFormat)
+          valFormat.supportsFeature(SerdeFeature.SCHEMA_INFERENCE)
+              ? buildValueSchema(
+                  sql, logicalSchema.value(), valFormatInfo, valFormat, valSerdeFeats)
               : Optional.empty();
 
       final int partitions = props.getPartitions()
@@ -161,7 +177,7 @@ public final class TestCaseBuilderUtil {
       final short rf = props.getReplicas()
           .orElse(Topic.DEFAULT_RF);
 
-      return new Topic(props.getKafkaTopic(), partitions, rf, valueSchema);
+      return new Topic(props.getKafkaTopic(), partitions, rf, keySchema, valueSchema);
     };
 
     try {
@@ -198,26 +214,20 @@ public final class TestCaseBuilderUtil {
 
   private static Optional<ParsedSchema> buildValueSchema(
       final String sql,
-      final KsqlConfig ksqlConfig,
-      final CreateSource statement,
-      final CreateSourceProperties props,
+      final List<Column> schema,
       final FormatInfo valueFormatInfo,
-      final Format valueFormat
+      final Format valueFormat,
+      final SerdeFeatures valFeatures
   ) {
-    final LogicalSchema logicalSchema = statement.getElements().toLogicalSchema();
-    if (logicalSchema.value().isEmpty()) {
+    if (schema.isEmpty()) {
       return Optional.empty();
     }
-
-    final SerdeFeatures valFeatures =
-        buildValueFeatures(ksqlConfig, props, valueFormat, logicalSchema);
 
     try {
       final SchemaTranslator translator = valueFormat
           .getSchemaTranslator(valueFormatInfo.getProperties());
 
-      return Optional.of(translator.toParsedSchema(
-          PersistenceSchema.from(logicalSchema.value(), valFeatures)
+      return Optional.of(translator.toParsedSchema(PersistenceSchema.from(schema, valFeatures)
       ));
     } catch (final Exception e) {
       // Statement won't parse: this will be detected/handled later.
@@ -225,6 +235,21 @@ public final class TestCaseBuilderUtil {
           .println("Error getting schema translator statement (which may be expected): " + sql);
       e.printStackTrace(System.out);
       return Optional.empty();
+    }
+  }
+
+  private static SerdeFeatures buildKeyFeatures(
+      final Format valueFormat,
+      final LogicalSchema logicalSchema
+  ) {
+    try {
+      return SerdeFeaturesFactory.buildKeyFeatures(
+          logicalSchema,
+          valueFormat
+      );
+    } catch (final Exception e) {
+      // Catch block allows negative tests to fail in the correct place, i.e. later.
+      return SerdeFeatures.of();
     }
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
@@ -29,23 +29,27 @@ public class Topic {
   private final String name;
   private final int numPartitions;
   private final short replicas;
-  private final Optional<ParsedSchema> schema;
+  private final Optional<ParsedSchema> keySchema;
+  private final Optional<ParsedSchema> valueSchema;
 
   public Topic(
       final String name,
-      final Optional<ParsedSchema> schema
+      final Optional<ParsedSchema> keySchema,
+      final Optional<ParsedSchema> valueSchema
   ) {
-    this(name, DEFAULT_PARTITIONS, DEFAULT_RF, schema);
+    this(name, DEFAULT_PARTITIONS, DEFAULT_RF, keySchema, valueSchema);
   }
 
   public Topic(
       final String name,
       final int numPartitions,
       final int replicas,
-      final Optional<ParsedSchema> schema
+      final Optional<ParsedSchema> keySchema,
+      final Optional<ParsedSchema> valueSchema
   ) {
     this.name = requireNonNull(name, "name");
-    this.schema = requireNonNull(schema, "schema");
+    this.keySchema = requireNonNull(keySchema, "keySchema");
+    this.valueSchema = requireNonNull(valueSchema, "valueSchema");
     this.numPartitions = numPartitions;
     this.replicas = (short) replicas;
   }
@@ -54,8 +58,12 @@ public class Topic {
     return name;
   }
 
-  public Optional<ParsedSchema> getSchema() {
-    return schema;
+  public Optional<ParsedSchema> getKeySchema() {
+    return keySchema;
+  }
+
+  public Optional<ParsedSchema> getValueSchema() {
+    return valueSchema;
   }
 
   public int getNumPartitions() {
@@ -79,11 +87,12 @@ public class Topic {
     return numPartitions == topic.numPartitions
         && replicas == topic.replicas
         && Objects.equals(name, topic.name)
-        && Objects.equals(schema, topic.schema);
+        && Objects.equals(keySchema, topic.keySchema)
+        && Objects.equals(valueSchema, topic.valueSchema);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, numPartitions, replicas, schema);
+    return Objects.hash(name, numPartitions, replicas, keySchema, valueSchema);
   }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
@@ -49,7 +49,7 @@ public class SchemaTranslationTest {
   private static final String DDL_STATEMENT = "CREATE STREAM " + TOPIC_NAME
       + " (ROWKEY STRING KEY) WITH (KAFKA_TOPIC='" + TOPIC_NAME + "', VALUE_FORMAT='AVRO');";
 
-  private static final Topic OUTPUT_TOPIC = new Topic(OUTPUT_TOPIC_NAME, Optional.empty());
+  private static final Topic OUTPUT_TOPIC = new Topic(OUTPUT_TOPIC_NAME, Optional.empty(), Optional.empty());
 
   private final TestCase testCase;
 
@@ -167,7 +167,7 @@ public class SchemaTranslationTest {
       final String testName = buildTestName(originalFileName, name, "");
 
       try {
-        final Topic srcTopic = new Topic(TOPIC_NAME, Optional.of(schema));
+        final Topic srcTopic = new Topic(TOPIC_NAME, Optional.empty(), Optional.of(schema));
 
         final List<Record> inputRecords = generateInputRecords(schema.rawSchema());
         final List<Record> outputRecords = getOutputRecords(inputRecords);

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -186,7 +186,7 @@ public class RestTestExecutor implements Closeable {
           createJob
       );
 
-      topic.getSchema().ifPresent(schema -> {
+      topic.getValueSchema().ifPresent(schema -> {
         try {
           serviceContext.getSchemaRegistryClient()
               .register(topic.getName() + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, schema);

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
@@ -34,6 +34,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class StubKafkaServiceTest {
 
   @Mock
+  private ParsedSchema avroKeySchema;
+  @Mock
   private ParsedSchema avroSchema;
   @Mock
   private ProducerRecord<String, String> producerRecord;
@@ -47,7 +49,7 @@ public class StubKafkaServiceTest {
 
     kafka = StubKafkaService.create();
 
-    topic = new Topic(producerRecord.topic(), Optional.of(avroSchema));
+    topic = new Topic(producerRecord.topic(), Optional.of(avroKeySchema), Optional.of(avroSchema));
   }
 
   @Test
@@ -67,7 +69,8 @@ public class StubKafkaServiceTest {
         topic.getName(),
         topic.getNumPartitions() + 1,
         topic.getReplicas() + 1,
-        topic.getSchema()
+        topic.getKeySchema(),
+        topic.getValueSchema()
     );
 
     // When:

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
@@ -70,7 +70,7 @@ public class TestExecutorUtilTest {
     ksqlConfig = new KsqlConfig(TestExecutor.baseConfig());
     stubKafkaService = StubKafkaService.create();
 
-    stubKafkaService.ensureTopic(new Topic("test_topic", Optional.empty()));
+    stubKafkaService.ensureTopic(new Topic("test_topic", Optional.empty(), Optional.empty()));
   }
 
   @After


### PR DESCRIPTION
### Description 
Partial work for #6222 - this PR supports _writing_ to schema registry (and ensuring compatibility) for formats that support schema inference. This PR also includes most of the piping we need to test it in QTT, but I haven't actually written any of those tests until we have `AVRO` key formats wired up.

### Testing done 
Unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

