### PR TITLE
chore: fix build by pinning AK to 6.1.0-23-ccs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
         <scala.version>2.13.2</scala.version>
         <apache.io.version>2.6</apache.io.version>
+        <kafka.version>6.1.0-23-ccs</kafka.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 

The following AK commit: https://github.com/apache/kafka/pull/9156 seems to have broken the `KsMaterializationFunctionalTest#shouldIgnoreHavingClause` test. I'm not entirely sure why, but while we're looking into that I'm pinning AK to the earlier microversion to unblock our master

### Testing done 

Ran the test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

