### PR TITLE
fix: recovery hangs when using TERMINATE ALL

### DIFF
--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -399,7 +399,7 @@ public final class SqlFormatter {
     @Override
     protected Void visitTerminateQuery(final TerminateQuery node, final Integer context) {
       builder.append("TERMINATE ");
-      builder.append(node.getQueryId().map(QueryId::toString).orElse("ALL"));
+      builder.append(node.getQueryId().map(QueryId::toString).orElse(TerminateQuery.ALL_QUERIES));
       return null;
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TerminateQuery.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TerminateQuery.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 @Immutable
 public final class TerminateQuery extends Statement {
 
+  public static final String ALL_QUERIES = "ALL";
   private final Optional<QueryId> queryId;
 
   public static TerminateQuery all(final Optional<NodeLocation> location) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
@@ -110,7 +110,7 @@ public class CommandIdAssigner {
   private static CommandId getTerminateCommandId(final TerminateQuery terminateQuery) {
     return new CommandId(
         CommandId.Type.TERMINATE,
-        terminateQuery.getQueryId().map(QueryId::toString).orElse("ALL"),
+        terminateQuery.getQueryId().map(QueryId::toString).orElse(TerminateQuery.ALL_QUERIES),
         CommandId.Action.EXECUTE
     );
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -649,6 +649,19 @@ public class RecoveryTest {
   }
 
   @Test
+  public void shouldRecoverTerminateAll() {
+    server1.submitCommands(
+        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
+        "CREATE STREAM B AS SELECT * FROM A;",
+        "INSERT INTO B SELECT * FROM A;",
+        "TERMINATE ALL;",
+        "DROP STREAM B;",
+        "CREATE STREAM B AS SELECT * FROM A;"
+    );
+    shouldRecover(commands);
+  }
+
+  @Test
   public void shouldRecoverDrop() {
     server1.submitCommands(
         "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",


### PR DESCRIPTION
### Description 

fixes #6390

this PR now properly handles `TERMINATE ALL`. I checked to see if I could do this without "hacking" the fact that the `QueryId` is `ALL` but it would require parsing the statement, which would require quite a few changes (like passing the engine into the compactor, which doesn't sound right). Anything else (changing the `CommandId`) is not backwards compatible.

### Testing done 

Unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

