### PR TITLE
chore: wire up QTT for AVRO format

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
@@ -99,9 +99,7 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
       final T schema;
       try {
-        final String subject = isKey
-                ? topic + KsqlConstants.SCHEMA_REGISTRY_KEY_SUFFIX
-                : topic + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
+        final String subject = KsqlConstants.getSRSubject(topic, isKey);
         final int id = srClient.getLatestSchemaMetadata(subject).getId();
         schema = (T) srClient.getSchemaBySubjectAndId(subject, id);
       } catch (Exception e) {

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
@@ -57,13 +57,19 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
   }
 
   @Override
-  public Serializer<Object> getSerializer(final SchemaRegistryClient schemaRegistryClient) {
-    return new SpecSerializer(schemaRegistryClient);
+  public Serializer<Object> getSerializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
+    return new SpecSerializer(schemaRegistryClient, isKey);
   }
 
   @Override
-  public Deserializer<Object> getDeserializer(final SchemaRegistryClient schemaRegistryClient) {
-    return new SpecDeserializer(schemaRegistryClient);
+  public Deserializer<Object> getDeserializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
+    return new SpecDeserializer(schemaRegistryClient, isKey);
   }
 
   protected abstract Schema fromParsedSchema(T schema);
@@ -72,14 +78,16 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
     private final SchemaRegistryClient srClient;
     private final Converter converter;
+    private final boolean isKey;
 
-    SpecSerializer(final SchemaRegistryClient srClient) {
+    SpecSerializer(final SchemaRegistryClient srClient, final boolean isKey) {
       this.srClient = Objects.requireNonNull(srClient, "srClient");
       this.converter = converterFactory.apply(srClient);
       converter.configure(
           ImmutableMap.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"),
-          false
+          isKey
       );
+      this.isKey = isKey;
     }
 
     @SuppressWarnings("unchecked")
@@ -91,7 +99,9 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
       final T schema;
       try {
-        final String subject = topic + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
+        final String subject = isKey
+                ? topic + KsqlConstants.SCHEMA_REGISTRY_KEY_SUFFIX
+                : topic + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
         final int id = srClient.getLatestSchemaMetadata(subject).getId();
         schema = (T) srClient.getSchemaBySubjectAndId(subject, id);
       } catch (Exception e) {
@@ -192,11 +202,11 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
     private final Converter converter;
 
-    SpecDeserializer(final SchemaRegistryClient srClient) {
+    SpecDeserializer(final SchemaRegistryClient srClient, final boolean isKey) {
       this.converter = converterFactory.apply(srClient);
       converter.configure(
           ImmutableMap.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"),
-          false
+          isKey
       );
     }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/SerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/SerdeSupplier.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.serialization.Serializer;
 
 public interface SerdeSupplier<T> {
 
-  Serializer<T> getSerializer(SchemaRegistryClient schemaRegistryClient, final boolean isKey);
+  Serializer<T> getSerializer(SchemaRegistryClient schemaRegistryClient, boolean isKey);
 
-  Deserializer<T> getDeserializer(SchemaRegistryClient schemaRegistryClient, final boolean isKey);
+  Deserializer<T> getDeserializer(SchemaRegistryClient schemaRegistryClient, boolean isKey);
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/SerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/SerdeSupplier.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.serialization.Serializer;
 
 public interface SerdeSupplier<T> {
 
-  Serializer<T> getSerializer(SchemaRegistryClient schemaRegistryClient);
+  Serializer<T> getSerializer(SchemaRegistryClient schemaRegistryClient, final boolean isKey);
 
-  Deserializer<T> getDeserializer(SchemaRegistryClient schemaRegistryClient);
+  Deserializer<T> getDeserializer(SchemaRegistryClient schemaRegistryClient, final boolean isKey);
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
@@ -49,12 +49,12 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
   }
 
   @Override
-  public Serializer<Object> getSerializer(final SchemaRegistryClient schemaRegistryClient) {
+  public Serializer<Object> getSerializer(final SchemaRegistryClient schemaRegistryClient, final boolean isKey) {
     return new ValueSpecJsonSerializer();
   }
 
   @Override
-  public Deserializer<Object> getDeserializer(final SchemaRegistryClient schemaRegistryClient) {
+  public Deserializer<Object> getDeserializer(final SchemaRegistryClient schemaRegistryClient, final boolean isKey) {
     return new ValueSpecJsonDeserializer();
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
@@ -49,12 +49,18 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
   }
 
   @Override
-  public Serializer<Object> getSerializer(final SchemaRegistryClient schemaRegistryClient, final boolean isKey) {
+  public Serializer<Object> getSerializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
     return new ValueSpecJsonSerializer();
   }
 
   @Override
-  public Deserializer<Object> getDeserializer(final SchemaRegistryClient schemaRegistryClient, final boolean isKey) {
+  public Deserializer<Object> getDeserializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
     return new ValueSpecJsonDeserializer();
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
@@ -41,12 +41,18 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
   }
 
   @Override
-  public Serializer<Object> getSerializer(final SchemaRegistryClient schemaRegistryClient) {
+  public Serializer<Object> getSerializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
     return new RowSerializer();
   }
 
   @Override
-  public Deserializer<Object> getDeserializer(final SchemaRegistryClient schemaRegistryClient) {
+  public Deserializer<Object> getDeserializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
     return new RowDeserializer();
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/none/NoneSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/none/NoneSerdeSupplier.java
@@ -25,12 +25,18 @@ import org.apache.kafka.common.serialization.Serializer;
 public class NoneSerdeSupplier implements SerdeSupplier<Void> {
 
   @Override
-  public Serializer<Void> getSerializer(final SchemaRegistryClient schemaRegistryClient) {
+  public Serializer<Void> getSerializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
     return new KsqlVoidSerde<Void>().serializer();
   }
 
   @Override
-  public Deserializer<Void> getDeserializer(final SchemaRegistryClient schemaRegistryClient) {
+  public Deserializer<Void> getDeserializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
     return new KsqlVoidSerde<Void>().deserializer();
   }
 } 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/string/StringSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/string/StringSerdeSupplier.java
@@ -25,12 +25,18 @@ import org.apache.kafka.common.serialization.Serializer;
 public class StringSerdeSupplier implements SerdeSupplier<String> {
 
   @Override
-  public Serializer<String> getSerializer(final SchemaRegistryClient schemaRegistryClient) {
+  public Serializer<String> getSerializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
     return Serdes.String().serializer();
   }
 
   @Override
-  public Deserializer<String> getDeserializer(final SchemaRegistryClient schemaRegistryClient) {
+  public Deserializer<String> getDeserializer(
+      final SchemaRegistryClient schemaRegistryClient,
+      final boolean isKey
+  ) {
     return Serdes.String().deserializer();
   }
 } 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -279,14 +279,14 @@ public final class TestExecutorUtil {
 
       topic.getKeySchema().ifPresent(schema -> {
         try {
-          srClient.register(topic.getName() + KsqlConstants.SCHEMA_REGISTRY_KEY_SUFFIX, schema);
+          srClient.register(KsqlConstants.getSRSubject(topic.getName(), true), schema);
         } catch (final Exception e) {
           throw new RuntimeException(e);
         }
       });
       topic.getValueSchema().ifPresent(schema -> {
         try {
-          srClient.register(topic.getName() + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, schema);
+          srClient.register(KsqlConstants.getSRSubject(topic.getName(), false), schema);
         } catch (final Exception e) {
           throw new RuntimeException(e);
         }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -277,6 +277,13 @@ public final class TestExecutorUtil {
           topic.getNumPartitions(),
           topic.getReplicas());
 
+      topic.getKeySchema().ifPresent(schema -> {
+        try {
+          srClient.register(topic.getName() + KsqlConstants.SCHEMA_REGISTRY_KEY_SUFFIX, schema);
+        } catch (final Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
       topic.getValueSchema().ifPresent(schema -> {
         try {
           srClient.register(topic.getName() + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, schema);

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -356,7 +356,7 @@ public class TopicInfoCache {
       final SerdeSupplier<?> keySerdeSupplier = SerdeUtil
           .getKeySerdeSupplier(keyFormat, schema);
 
-      final Serializer<?> serializer = keySerdeSupplier.getSerializer(srClient);
+      final Serializer<?> serializer = keySerdeSupplier.getSerializer(srClient, true);
 
       serializer.configure(ImmutableMap.of(
           AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "something"
@@ -370,7 +370,7 @@ public class TopicInfoCache {
       final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil
           .getSerdeSupplier(FormatFactory.of(valueFormat.getFormatInfo()), schema);
 
-      final Serializer<?> serializer = valueSerdeSupplier.getSerializer(srClient);
+      final Serializer<?> serializer = valueSerdeSupplier.getSerializer(srClient, false);
 
       serializer.configure(ImmutableMap.of(
           AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "something"
@@ -383,7 +383,7 @@ public class TopicInfoCache {
       final SerdeSupplier<?> keySerdeSupplier = SerdeUtil
           .getKeySerdeSupplier(keyFormat, schema);
 
-      final Deserializer<?> deserializer = keySerdeSupplier.getDeserializer(srClient);
+      final Deserializer<?> deserializer = keySerdeSupplier.getDeserializer(srClient, true);
 
       deserializer.configure(ImmutableMap.of(), true);
 
@@ -403,7 +403,7 @@ public class TopicInfoCache {
       final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil
           .getSerdeSupplier(FormatFactory.of(valueFormat.getFormatInfo()), schema);
 
-      final Deserializer<?> deserializer = valueSerdeSupplier.getDeserializer(srClient);
+      final Deserializer<?> deserializer = valueSerdeSupplier.getDeserializer(srClient, false);
 
       deserializer.configure(ImmutableMap.of(), false);
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
@@ -127,8 +127,10 @@ public final class SerdeUtil {
     if (windowType == WindowType.SESSION) {
       return new SerdeSupplier<Windowed<T>>() {
         @Override
-        public Serializer<Windowed<T>> getSerializer(final SchemaRegistryClient srClient) {
-          final Serializer<T> serializer = inner.getSerializer(srClient);
+        public Serializer<Windowed<T>> getSerializer(
+            final SchemaRegistryClient srClient, final boolean isKey
+        ) {
+          final Serializer<T> serializer = inner.getSerializer(srClient, isKey);
           serializer.configure(ImmutableMap.of(
               AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "something"
           ), true);
@@ -136,8 +138,11 @@ public final class SerdeUtil {
         }
 
         @Override
-        public Deserializer<Windowed<T>> getDeserializer(final SchemaRegistryClient srClient) {
-          final Deserializer<T> deserializer = inner.getDeserializer(srClient);
+        public Deserializer<Windowed<T>> getDeserializer(
+            final SchemaRegistryClient srClient,
+            final boolean isKey
+        ) {
+          final Deserializer<T> deserializer = inner.getDeserializer(srClient, isKey);
           deserializer.configure(ImmutableMap.of(), true);
           return new SessionWindowedDeserializer<>(deserializer);
         }
@@ -146,8 +151,11 @@ public final class SerdeUtil {
 
     return new SerdeSupplier<Windowed<T>>() {
       @Override
-      public Serializer<Windowed<T>> getSerializer(final SchemaRegistryClient srClient) {
-        final Serializer<T> serializer = inner.getSerializer(srClient);
+      public Serializer<Windowed<T>> getSerializer(
+          final SchemaRegistryClient srClient,
+          final boolean isKey
+      ) {
+        final Serializer<T> serializer = inner.getSerializer(srClient, isKey);
         serializer.configure(ImmutableMap.of(
             AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "something"
         ), true);
@@ -156,8 +164,11 @@ public final class SerdeUtil {
 
       @SuppressWarnings("OptionalGetWithoutIsPresent")
       @Override
-      public Deserializer<Windowed<T>> getDeserializer(final SchemaRegistryClient srClient) {
-        final Deserializer<T> deserializer = inner.getDeserializer(srClient);
+      public Deserializer<Windowed<T>> getDeserializer(
+          final SchemaRegistryClient srClient,
+          final boolean isKey
+      ) {
+        final Deserializer<T> deserializer = inner.getDeserializer(srClient, isKey);
         deserializer.configure(ImmutableMap.of(), true);
         return new TimeWindowedDeserializer<>(
             deserializer,

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -186,6 +186,14 @@ public class RestTestExecutor implements Closeable {
           createJob
       );
 
+      topic.getKeySchema().ifPresent(schema -> {
+        try {
+          serviceContext.getSchemaRegistryClient()
+              .register(topic.getName() + KsqlConstants.SCHEMA_REGISTRY_KEY_SUFFIX, schema);
+        } catch (final Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
       topic.getValueSchema().ifPresent(schema -> {
         try {
           serviceContext.getSchemaRegistryClient()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -189,7 +189,7 @@ public class RestTestExecutor implements Closeable {
       topic.getKeySchema().ifPresent(schema -> {
         try {
           serviceContext.getSchemaRegistryClient()
-              .register(topic.getName() + KsqlConstants.SCHEMA_REGISTRY_KEY_SUFFIX, schema);
+              .register(KsqlConstants.getSRSubject(topic.getName(), true), schema);
         } catch (final Exception e) {
           throw new RuntimeException(e);
         }
@@ -197,7 +197,7 @@ public class RestTestExecutor implements Closeable {
       topic.getValueSchema().ifPresent(schema -> {
         try {
           serviceContext.getSchemaRegistryClient()
-              .register(topic.getName() + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX, schema);
+              .register(KsqlConstants.getSRSubject(topic.getName(), false), schema);
         } catch (final Exception e) {
           throw new RuntimeException(e);
         }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplierTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplierTest.java
@@ -49,7 +49,7 @@ public class ValueSpecJsonSerdeSupplierTest {
   @Test
   public void shouldSerializeDecimalsWithOutStrippingTrailingZeros_Plain() {
     // Given:
-    final Serializer<Object> serializer = plainSerde.getSerializer(srClient);
+    final Serializer<Object> serializer = plainSerde.getSerializer(srClient, false);
 
     // When:
     final byte[] bytes = serializer.serialize("t", new BigDecimal("10.0"));
@@ -61,7 +61,7 @@ public class ValueSpecJsonSerdeSupplierTest {
   @Test
   public void shouldDeserializeDecimalsWithoutStrippingTrailingZeros_Plain() {
     // Given:
-    final Deserializer<Object> deserializer = plainSerde.getDeserializer(srClient);
+    final Deserializer<Object> deserializer = plainSerde.getDeserializer(srClient, false);
 
     final byte[] bytes = "10.0".getBytes(UTF_8);
 
@@ -75,7 +75,7 @@ public class ValueSpecJsonSerdeSupplierTest {
   @Test
   public void shouldSerializeDecimalsWithOutStrippingTrailingZeros_Sr() throws Exception {
     // Given:
-    final Serializer<Object> serializer = srSerde.getSerializer(srClient);
+    final Serializer<Object> serializer = srSerde.getSerializer(srClient, false);
 
     // When:
     final byte[] bytes = serializer.serialize("t", new BigDecimal("10.0"));
@@ -87,7 +87,7 @@ public class ValueSpecJsonSerdeSupplierTest {
   @Test
   public void shouldDeserializeDecimalsWithoutStrippingTrailingZeros_Sr() {
     // Given:
-    final Deserializer<Object> deserializer = srSerde.getDeserializer(srClient);
+    final Deserializer<Object> deserializer = srSerde.getDeserializer(srClient, false);
 
     final byte[] jsonBytes = "10.0".getBytes(UTF_8);
     final byte[] bytes = new byte[jsonBytes.length + JsonSerdeUtils.SIZE_OF_SR_PREFIX];

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplierTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplierTest.java
@@ -126,13 +126,13 @@ public class KafkaSerdeSupplierTest {
   }
 
   private static Serializer<Object> getSerializer(final SqlType colType) {
-    final Serializer<Object> serializer = getSerdeSupplier(colType).getSerializer(null);
+    final Serializer<Object> serializer = getSerdeSupplier(colType).getSerializer(null, false);
     serializer.configure(ImmutableMap.of(), false);
     return serializer;
   }
 
   private static Deserializer<?> getDeserializer(final SqlType colType) {
-    final Deserializer<Object> deserializer = getSerdeSupplier(colType).getDeserializer(null);
+    final Deserializer<Object> deserializer = getSerdeSupplier(colType).getDeserializer(null, false);
     deserializer.configure(ImmutableMap.of(), false);
     return deserializer;
   }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -540,7 +540,7 @@ public class TestExecutorTest {
   ) {
     final byte[] serializedKey = keySerializer.serialize("", key);
     final byte[] serializeValue = new ValueSpecJsonSerdeSupplier(false)
-        .getSerializer(null)
+        .getSerializer(null, false)
         .serialize("", value);
 
     return new ProducerRecord<byte[], byte[]>(

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -641,6 +641,62 @@
       }
     },
     {
+      "name": "BOOLEAN - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K BOOLEAN KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "boolean"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": true, "value": {"FOO": 10}},
+        {"topic": "input_topic", "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": true, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "value": null}
+      ]
+    },
+    {
+      "name": "INT - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K INT KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "int"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 10, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": 12, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 10, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": 12, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
       "name": "map with non-string keys fails - C*",
       "statements": [
         "CREATE STREAM INPUT (foo MAP<INT, DOUBLE>) WITH (kafka_topic='input_topic', value_format='AVRO');"

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
@@ -138,7 +138,7 @@ public interface Format {
       Map<String, String> formatProperties,
       KsqlConfig ksqlConfig,
       Supplier<SchemaRegistryClient> srClientFactory,
-      final boolean isKey
+      boolean isKey
   );
 
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
@@ -130,13 +130,15 @@ public interface Format {
    * @param formatProperties any format specific properties
    * @param ksqlConfig the session config
    * @param srClientFactory supplier of the SR client
+   * @param isKey whether or not we're retreiving a key serde
    * @return a serde pair capable of (de)serializing the data in this format.
    */
   Serde<List<?>> getSerde(
       PersistenceSchema schema,
       Map<String, String> formatProperties,
       KsqlConfig ksqlConfig,
-      Supplier<SchemaRegistryClient> srClientFactory
+      Supplier<SchemaRegistryClient> srClientFactory,
+      final boolean isKey
   );
 
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericKeySerDe.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericKeySerDe.java
@@ -123,7 +123,7 @@ public final class GenericKeySerDe implements KeySerdeFactory {
     }
 
     final Serde<List<?>> formatSerde = innerFactory
-        .createFormatSerde("Key", format, schema, ksqlConfig, schemaRegistryClientFactory);
+        .createFormatSerde("Key", format, schema, ksqlConfig, schemaRegistryClientFactory, true);
 
     final Serde<Struct> structSerde = toStructSerde(formatSerde, schema);
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericRowSerDe.java
@@ -97,7 +97,7 @@ public final class GenericRowSerDe implements ValueSerdeFactory {
       final Optional<TrackedCallback> tracker
   ) {
     final Serde<List<?>> formatSerde =
-        innerFactory.createFormatSerde("Value", format, schema, ksqlConfig, srClientFactory);
+        innerFactory.createFormatSerde("Value", format, schema, ksqlConfig, srClientFactory, false);
 
     final Serde<GenericRow> genericRowSerde = toGenericRowSerde(formatSerde, schema);
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/GenericSerdeFactory.java
@@ -56,13 +56,19 @@ final class GenericSerdeFactory {
       final FormatInfo formatInfo,
       final PersistenceSchema schema,
       final KsqlConfig ksqlConfig,
-      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
+      final boolean isKey
   ) {
     final Format format = formatFactory.apply(formatInfo);
 
     try {
       return format
-          .getSerde(schema, formatInfo.getProperties(), ksqlConfig, schemaRegistryClientFactory);
+          .getSerde(schema,
+              formatInfo.getProperties(),
+              ksqlConfig,
+              schemaRegistryClientFactory,
+              isKey
+          );
     } catch (final Exception e) {
       throw new SchemaNotSupportedException(target + " format does not support schema."
           + System.lineSeparator()

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KeyFormatUtils.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KeyFormatUtils.java
@@ -24,7 +24,7 @@ public final class KeyFormatUtils {
   private static final List<Format> SUPPORTED_KEY_FORMATS =
       ImmutableList.of(FormatFactory.NONE, FormatFactory.KAFKA, FormatFactory.DELIMITED);
   private static final List<Format> KEY_FORMATS_UNDER_DEVELOPMENT =
-      ImmutableList.of(FormatFactory.JSON);
+      ImmutableList.of(FormatFactory.JSON, FormatFactory.AVRO);
 
   /**
    * Until the primitive key work is complete, not all formats are supported as key formats.

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroFormat.java
@@ -72,7 +72,8 @@ public final class AvroFormat extends ConnectFormat {
       final Map<String, String> formatProps,
       final KsqlConfig config,
       final Supplier<SchemaRegistryClient> srFactory,
-      final Class<T> targetType
+      final Class<T> targetType,
+      final boolean isKey
   ) {
     // Ensure schema is compatible by converting to Avro schema:
     getConnectSchemaTranslator(formatProps).fromConnectSchema(connectSchema);
@@ -80,6 +81,6 @@ public final class AvroFormat extends ConnectFormat {
     final String schemaFullName = new AvroProperties(formatProps).getFullSchemaName();
 
     return new KsqlAvroSerdeFactory(schemaFullName)
-        .createSerde(connectSchema, config, srFactory, targetType);
+        .createSerde(connectSchema, config, srFactory, targetType, isKey);
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroSerdeFactory.java
@@ -51,7 +51,8 @@ class KsqlAvroSerdeFactory {
       final ConnectSchema schema,
       final KsqlConfig ksqlConfig,
       final Supplier<SchemaRegistryClient> srFactory,
-      final Class<T> targetType
+      final Class<T> targetType,
+      final boolean isKey
   ) {
     AvroUtil.throwOnInvalidSchema(schema);
 
@@ -59,14 +60,16 @@ class KsqlAvroSerdeFactory {
         schema,
         ksqlConfig,
         srFactory,
-        targetType
+        targetType,
+        isKey
     );
 
     final Supplier<Deserializer<T>> deserializerSupplier = createConnectDeserializer(
         schema,
         ksqlConfig,
         srFactory,
-        targetType
+        targetType,
+        isKey
     );
 
     // Sanity check:
@@ -83,13 +86,14 @@ class KsqlAvroSerdeFactory {
       final ConnectSchema schema,
       final KsqlConfig ksqlConfig,
       final Supplier<SchemaRegistryClient> srFactory,
-      final Class<T> targetType
+      final Class<T> targetType,
+      final boolean isKey
   ) {
     return () -> {
       final AvroDataTranslator translator = createAvroTranslator(schema);
 
       final AvroConverter avroConverter =
-          getAvroConverter(srFactory.get(), ksqlConfig);
+          getAvroConverter(srFactory.get(), ksqlConfig, isKey);
 
       return new KsqlConnectSerializer<>(
           translator.getAvroCompatibleSchema(),
@@ -104,13 +108,14 @@ class KsqlAvroSerdeFactory {
       final ConnectSchema schema,
       final KsqlConfig ksqlConfig,
       final Supplier<SchemaRegistryClient> srFactory,
-      final Class<T> targetType
+      final Class<T> targetType,
+      final boolean isKey
   ) {
     return () -> {
       final AvroDataTranslator translator = createAvroTranslator(schema);
 
       final AvroConverter avroConverter =
-          getAvroConverter(srFactory.get(), ksqlConfig);
+          getAvroConverter(srFactory.get(), ksqlConfig, isKey);
 
       return new KsqlConnectDeserializer<>(avroConverter, translator, targetType);
     };
@@ -122,7 +127,8 @@ class KsqlAvroSerdeFactory {
 
   private static AvroConverter getAvroConverter(
       final SchemaRegistryClient schemaRegistryClient,
-      final KsqlConfig ksqlConfig
+      final KsqlConfig ksqlConfig,
+      final boolean isKey
   ) {
     final AvroConverter avroConverter = new AvroConverter(schemaRegistryClient);
 
@@ -134,7 +140,7 @@ class KsqlAvroSerdeFactory {
 
     avroConfig.put(AvroDataConfig.CONNECT_META_DATA_CONFIG, false);
 
-    avroConverter.configure(avroConfig, false);
+    avroConverter.configure(avroConfig, isKey);
     return avroConverter;
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/DelimitedFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/DelimitedFormat.java
@@ -63,8 +63,8 @@ public final class DelimitedFormat implements Format {
       final PersistenceSchema schema,
       final Map<String, String> formatProperties,
       final KsqlConfig ksqlConfig,
-      final Supplier<SchemaRegistryClient> srClientFactory
-  ) {
+      final Supplier<SchemaRegistryClient> srClientFactory,
+      final boolean isKey) {
     FormatProperties.validateProperties(name(), formatProperties, getSupportedProperties());
     SerdeUtils.throwOnUnsupportedFeatures(schema.features(), supportedFeatures());
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonFormat.java
@@ -59,7 +59,8 @@ public class JsonFormat extends ConnectFormat {
       final Map<String, String> formatProps,
       final KsqlConfig config,
       final Supplier<SchemaRegistryClient> srFactory,
-      final Class<T> targetType
+      final Class<T> targetType,
+      final boolean isKey
   ) {
     return new KsqlJsonSerdeFactory(false)
         .createSerde(connectSchema, config, srFactory, targetType);

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaFormat.java
@@ -62,7 +62,8 @@ public class JsonSchemaFormat extends ConnectFormat {
       final Map<String, String> formatProps,
       final KsqlConfig config,
       final Supplier<SchemaRegistryClient> srFactory,
-      final Class<T> targetType
+      final Class<T> targetType,
+      final boolean isKey
   ) {
     return new KsqlJsonSerdeFactory(true)
         .createSerde(connectSchema, config, srFactory, targetType);

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaFormat.java
@@ -52,8 +52,8 @@ public class KafkaFormat implements Format {
       final PersistenceSchema schema,
       final Map<String, String> formatProperties,
       final KsqlConfig ksqlConfig,
-      final Supplier<SchemaRegistryClient> srClientFactory
-  ) {
+      final Supplier<SchemaRegistryClient> srClientFactory,
+      final boolean isKey) {
     FormatProperties.validateProperties(name(), formatProperties, getSupportedProperties());
     SerdeUtils.throwOnUnsupportedFeatures(schema.features(), supportedFeatures());
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/none/NoneFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/none/NoneFormat.java
@@ -45,8 +45,8 @@ public class NoneFormat implements Format {
       final PersistenceSchema schema,
       final Map<String, String> formatProperties,
       final KsqlConfig ksqlConfig,
-      final Supplier<SchemaRegistryClient> srClientFactory
-  ) {
+      final Supplier<SchemaRegistryClient> srClientFactory,
+      final boolean isKey) {
     FormatProperties.validateProperties(name(), formatProperties, getSupportedProperties());
     SerdeUtils.throwOnUnsupportedFeatures(schema.features(), supportedFeatures());
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
@@ -61,7 +61,8 @@ public class ProtobufFormat extends ConnectFormat {
       final Map<String, String> formatProps,
       final KsqlConfig config,
       final Supplier<SchemaRegistryClient> srFactory,
-      final Class<T> targetType
+      final Class<T> targetType,
+      final boolean isKey
   ) {
     return ProtobufSerdeFactory.createSerde(connectSchema, config, srFactory, targetType);
   }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
@@ -97,7 +97,7 @@ public class GenericKeySerDeTest {
   public void setUp() {
     factory = new GenericKeySerDe(innerFactory);
 
-    when(innerFactory.createFormatSerde(any(), any(), any(), any(), any())).thenReturn(innerSerde);
+    when(innerFactory.createFormatSerde(any(), any(), any(), any(), any(), any())).thenReturn(innerSerde);
     when(innerFactory.wrapInLoggingSerde(any(), any(), any())).thenReturn(loggingSerde);
     when(innerFactory.wrapInTrackingSerde(any(), any())).thenReturn(trackingSerde);
 
@@ -112,7 +112,7 @@ public class GenericKeySerDeTest {
         Optional.empty());
 
     // Then:
-    verify(innerFactory).createFormatSerde("Key", format, schema, config, srClientFactory);
+    verify(innerFactory).createFormatSerde("Key", format, schema, config, srClientFactory, true);
   }
 
   @Test
@@ -123,7 +123,7 @@ public class GenericKeySerDeTest {
             Optional.empty());
 
     // Then:
-    verify(innerFactory).createFormatSerde("Key", format, schema, config, srClientFactory);
+    verify(innerFactory).createFormatSerde("Key", format, schema, config, srClientFactory, true);
   }
 
   @Test

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -97,7 +98,7 @@ public class GenericKeySerDeTest {
   public void setUp() {
     factory = new GenericKeySerDe(innerFactory);
 
-    when(innerFactory.createFormatSerde(any(), any(), any(), any(), any(), any())).thenReturn(innerSerde);
+    when(innerFactory.createFormatSerde(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(innerSerde);
     when(innerFactory.wrapInLoggingSerde(any(), any(), any())).thenReturn(loggingSerde);
     when(innerFactory.wrapInTrackingSerde(any(), any())).thenReturn(trackingSerde);
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
@@ -99,7 +99,7 @@ public class GenericRowSerDeTest {
     serializer = new GenericRowSerializer(innerSerializer, 2);
     deserializer = new GenericRowDeserializer(innerDeserializer, 2);
 
-    when(innerFactory.createFormatSerde(any(), any(), any(), any(), any())).thenReturn(innerSerde);
+    when(innerFactory.createFormatSerde(any(), any(), any(), any(), any(), any())).thenReturn(innerSerde);
     when(innerFactory.wrapInLoggingSerde(any(), any(), any())).thenReturn(loggingSerde);
     when(innerFactory.wrapInTrackingSerde(any(), any())).thenReturn(trackingSerde);
     when(innerSerde.serializer()).thenReturn(innerSerializer);
@@ -114,7 +114,7 @@ public class GenericRowSerDeTest {
         Optional.empty());
 
     // Then:
-    verify(innerFactory).createFormatSerde("Value", format, schema, config, srClientFactory);
+    verify(innerFactory).createFormatSerde("Value", format, schema, config, srClientFactory, false);
   }
 
   @Test

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericRowSerDeTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -99,7 +100,7 @@ public class GenericRowSerDeTest {
     serializer = new GenericRowSerializer(innerSerializer, 2);
     deserializer = new GenericRowDeserializer(innerDeserializer, 2);
 
-    when(innerFactory.createFormatSerde(any(), any(), any(), any(), any(), any())).thenReturn(innerSerde);
+    when(innerFactory.createFormatSerde(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(innerSerde);
     when(innerFactory.wrapInLoggingSerde(any(), any(), any())).thenReturn(loggingSerde);
     when(innerFactory.wrapInTrackingSerde(any(), any())).thenReturn(trackingSerde);
     when(innerSerde.serializer()).thenReturn(innerSerializer);

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericSerdeFactoryTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericSerdeFactoryTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -139,7 +140,7 @@ public class GenericSerdeFactoryTest {
   @Test
   public void shouldThrowIfGetSerdeThrows() {
     // Given:
-    when(format.getSerde(any(), any(), any(), any(), false)).thenThrow(new RuntimeException("boom"));
+    when(format.getSerde(any(), any(), any(), any(), eq(false))).thenThrow(new RuntimeException("boom"));
 
     // When:
     final Exception actual = assertThrows(

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericSerdeFactoryTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericSerdeFactoryTest.java
@@ -103,7 +103,7 @@ public class GenericSerdeFactoryTest {
   @Test
   public void shouldInvokeFormatFactoryWithCorrectParams() {
     // When:
-    serdeFactory.createFormatSerde("target", formatInfo, schema, config, srClientFactory);
+    serdeFactory.createFormatSerde("target", formatInfo, schema, config, srClientFactory, false);
 
     // Then:
     verify(formatFactory).apply(formatInfo);
@@ -120,7 +120,7 @@ public class GenericSerdeFactoryTest {
     final Exception actual = assertThrows(
         RuntimeException.class,
         () -> serdeFactory
-            .createFormatSerde("target", formatInfo, schema, config, srClientFactory)
+            .createFormatSerde("target", formatInfo, schema, config, srClientFactory, false)
     );
 
     // Then:
@@ -130,22 +130,22 @@ public class GenericSerdeFactoryTest {
   @Test
   public void shouldInvokeFormatWithCorrectParams() {
     // When:
-    serdeFactory.createFormatSerde("target", formatInfo, schema, config, srClientFactory);
+    serdeFactory.createFormatSerde("target", formatInfo, schema, config, srClientFactory, false);
 
     // Then:
-    verify(format).getSerde(schema, formatProperties, config, srClientFactory);
+    verify(format).getSerde(schema, formatProperties, config, srClientFactory, false);
   }
 
   @Test
   public void shouldThrowIfGetSerdeThrows() {
     // Given:
-    when(format.getSerde(any(), any(), any(), any())).thenThrow(new RuntimeException("boom"));
+    when(format.getSerde(any(), any(), any(), any(), false)).thenThrow(new RuntimeException("boom"));
 
     // When:
     final Exception actual = assertThrows(
         SchemaNotSupportedException.class,
         () -> serdeFactory
-            .createFormatSerde("Target-A", formatInfo, schema, config, srClientFactory)
+            .createFormatSerde("Target-A", formatInfo, schema, config, srClientFactory, false)
     );
 
     // Then:

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroFormatTest.java
@@ -52,7 +52,7 @@ public class AvroFormatTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> format.getSerde(schema, formatProps, config, srFactory)
+        () -> format.getSerde(schema, formatProps, config, srFactory, false)
     );
 
     // Then:

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
@@ -1526,8 +1526,8 @@ public class KsqlAvroDeserializerTest {
         schema,
         KSQL_CONFIG,
         () -> schemaRegistryClient,
-        targetType
-    ).deserializer();
+        targetType,
+        false).deserializer();
 
     deserializer.configure(Collections.emptyMap(), false);
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -654,8 +654,8 @@ public class KsqlAvroSerializerTest {
                 schema,
                 ksqlConfig,
                 () -> schemaRegistryClient,
-                Map.class
-            )
+                Map.class,
+                false)
     );
 
     // Then:
@@ -681,8 +681,8 @@ public class KsqlAvroSerializerTest {
                 schema,
                 ksqlConfig,
                 () -> schemaRegistryClient,
-                Struct.class
-            )
+                Struct.class,
+                false)
     );
 
     // Then:
@@ -1022,8 +1022,8 @@ public class KsqlAvroSerializerTest {
                 (ConnectSchema) ksqlRecordSchema,
                 ksqlConfig,
                 () -> schemaRegistryClient,
-                Struct.class
-            ).serializer();
+                Struct.class,
+                false).serializer();
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, ksqlRecord);
@@ -1145,8 +1145,8 @@ public class KsqlAvroSerializerTest {
             (ConnectSchema) schema,
             ksqlConfig,
             () -> schemaRegistryClient,
-            targetType
-        ).serializer();
+            targetType,
+            false).serializer();
   }
 
   private org.apache.avro.Schema avroSchemaStoredInSchemaRegistry() {

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectFormatTest.java
@@ -102,11 +102,11 @@ public class ConnectFormatTest {
     when(persistenceSchema.columns()).thenReturn(ImmutableList.of(singleColumn));
 
     // When:
-    format.getSerde(persistenceSchema, formatProps, config, srFactory);
+    format.getSerde(persistenceSchema, formatProps, config, srFactory, false);
 
     // Then:
     verify(format)
-        .getConnectSerde(SINGLE_FIELD_SCHEMA, formatProps, config, srFactory, Struct.class);
+        .getConnectSerde(SINGLE_FIELD_SCHEMA, formatProps, config, srFactory, Struct.class, false);
   }
 
   @Test
@@ -121,11 +121,11 @@ public class ConnectFormatTest {
 
     // When:
     final Serde<List<?>> result = format
-        .getSerde(persistenceSchema, formatProps, config, srFactory);
+        .getSerde(persistenceSchema, formatProps, config, srFactory, false);
 
     // Then:
     verify(format)
-        .getConnectSerde(fieldSchema, formatProps, config, srFactory, Integer.class);
+        .getConnectSerde(fieldSchema, formatProps, config, srFactory, Integer.class, false);
 
     assertThat(result.serializer(), instanceOf(UnwrappedSerializer.class));
     assertThat(result.deserializer(), instanceOf(UnwrappedDeserializer.class));
@@ -147,7 +147,7 @@ public class ConnectFormatTest {
         .build();
 
     final Serializer<List<?>> serializer = format
-        .getSerde(persistenceSchema, formatProps, config, srFactory)
+        .getSerde(persistenceSchema, formatProps, config, srFactory, false)
         .serializer();
 
     final List<?> values = ImmutableList.of(new Struct(connectSchema));
@@ -200,7 +200,8 @@ public class ConnectFormatTest {
         final Map<String, String> formatProps,
         final KsqlConfig config,
         final Supplier<SchemaRegistryClient> srFactory,
-        final Class<T> targetType
+        final Class<T> targetType,
+        final boolean isKey
     ) {
       return serde;
     }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/none/NoneFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/none/NoneFormatTest.java
@@ -70,7 +70,7 @@ public class NoneFormatTest {
     when(schema.features()).thenReturn(SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // When:
-    format.getSerde(schema, formatProps, ksqlConfig, srClientFactory);
+    format.getSerde(schema, formatProps, ksqlConfig, srClientFactory, false);
   }
 
   @Test(expected = KsqlException.class)
@@ -79,7 +79,7 @@ public class NoneFormatTest {
     formatProps = ImmutableMap.of("some", "prop");
 
     // When:
-    format.getSerde(schema, formatProps, ksqlConfig, srClientFactory);
+    format.getSerde(schema, formatProps, ksqlConfig, srClientFactory, false);
   }
 
   @Test
@@ -90,7 +90,7 @@ public class NoneFormatTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> format.getSerde(schema, formatProps, ksqlConfig, srClientFactory)
+        () -> format.getSerde(schema, formatProps, ksqlConfig, srClientFactory, false)
     );
 
     // Then:
@@ -101,7 +101,7 @@ public class NoneFormatTest {
   @Test
   public void shouldReturnVoidSerde() {
     // When:
-    final Serde<List<?>> serde = format.getSerde(schema, formatProps, ksqlConfig, srClientFactory);
+    final Serde<List<?>> serde = format.getSerde(schema, formatProps, ksqlConfig, srClientFactory, false);
 
     // Then:
     assertThat(serde, instanceOf(KsqlVoidSerde.class));


### PR DESCRIPTION
### Description 

🥳 this is most of the plumbing necessary to test avro keys in QTT (I added some samples in `avro.json`). It fixes up a lot of the real plumbing that wasn't properly piped to have the key schema passed to the underlying connect converters.

The best news? Looks like we have primitive avro keys working OOTB!

### Testing done 

Updated tests where appropriate, and added `avro.json` to test it end-to-end.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

