### PR TITLE
chore: revert "fix build by pinning AK to 6.1.0-23-ccs"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,6 @@
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
         <scala.version>2.13.2</scala.version>
         <apache.io.version>2.6</apache.io.version>
-        <kafka.version>6.1.0-23-ccs</kafka.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Reverts confluentinc/ksql#6396 because it breaks the main confluent packaging build. 