### PR TITLE
docs: fix merge conflict from the other side (DOCS-5620)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/select-pull-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-pull-query.md
@@ -36,7 +36,7 @@ Execute a pull query by sending an HTTP request to the ksqlDB REST API, and
 the API responds with a single response.  
 
 The WHERE clause must contain a single primary-key to retrieve and may
-optionally include bounds on WINDOWSTART if the materialized table is windowed.
+optionally include bounds on `WINDOWSTART` and `WINDOWEND` if the materialized table is windowed.
 For more information, see 
 [Time and Windows in ksqlDB](../../concepts/time-and-windows-in-ksqldb-queries.md).
 

--- a/docs/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-push-query.md
@@ -198,3 +198,21 @@ SELECT orderzip_code, TOPK(order_total, 5) FROM orders
   GROUP BY order_zipcode
   EMIT CHANGES;
 ```
+
+#### EMIT
+
+The EMIT clause lets you control the output refinement of your push query. The output refinement is
+how you would like to *emit* your results. 
+
+ksqlDB supports the following output refinement types.
+
+#### CHANGES
+
+This is the standard output refinement for push queries, for when we would like to see all changes 
+happening.
+
+#### FINAL
+
+This is for when we want to emit only the final result of a windowed aggregation, and suppress the 
+intermediate results until the window closes. Note that this output refinement is supported only 
+for windowed aggregations.


### PR DESCRIPTION
Trying to fix pint merge conflict by making 6.0.x the same as master. I'll need to undo this once pint merge is clear.