### PR TITLE
chore: qtt coverage for avro primitive keys

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/WindowData.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/WindowData.java
@@ -19,6 +19,7 @@ package io.confluent.ksql.test.model;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 
@@ -52,5 +53,24 @@ public final class WindowData {
 
   public long size() {
     return end - start;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final WindowData that = (WindowData) o;
+    return start == that.start
+        && end == that.end
+        && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(start, end, type);
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Record.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Record.java
@@ -34,10 +34,12 @@ public class Record {
   private final Optional<Long> timestamp;
   private final WindowData window;
   private final Optional<JsonNode> jsonValue;
+  private final Optional<JsonNode> jsonKey;
 
   public Record(
       final String topicName,
       final Object key,
+      final JsonNode jsonKey,
       final Object value,
       final JsonNode jsonValue,
       final Optional<Long> timestamp,
@@ -45,6 +47,7 @@ public class Record {
   ) {
     this.topicName = requireNonNull(topicName, "topicName");
     this.key = key;
+    this.jsonKey = Optional.ofNullable(jsonKey);
     this.value = value;
     this.jsonValue = Optional.ofNullable(jsonValue);
     this.timestamp = requireNonNull(timestamp, "timestamp");
@@ -94,6 +97,10 @@ public class Record {
     return window;
   }
 
+  public Optional<JsonNode> getJsonKey() {
+    return jsonKey;
+  }
+
   public Optional<JsonNode> getJsonValue() {
     return jsonValue;
   }
@@ -102,6 +109,7 @@ public class Record {
     return new Record(
         topicName,
         key,
+        jsonKey.orElse(null),
         value,
         jsonValue.orElse(null),
         timestamp,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -65,7 +65,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -78,7 +77,6 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
@@ -588,8 +586,8 @@ public class TestExecutor implements Closeable {
 
     if (expectedRecord.getWindow() != null) {
       final Windowed<?> windowed = (Windowed<?>) actualKey;
-      if (!new WindowData(windowed).equals(expectedRecord.getWindow()) ||
-          !ExpectedRecordComparator.matches(((Windowed<?>) actualKey).key(), expectedKey)) {
+      if (!new WindowData(windowed).equals(expectedRecord.getWindow())
+          || !ExpectedRecordComparator.matches(((Windowed<?>) actualKey).key(), expectedKey)) {
         throw error;
       }
     } else {

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
@@ -8,6 +8,7 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableList;
 import io.confluent.avro.random.generator.Generator;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
@@ -83,6 +84,7 @@ public class SchemaTranslationTest {
       final Record record = new Record(
           TOPIC_NAME,
           "test-key",
+          JsonNodeFactory.instance.textNode("test-key"),
           avroToValueSpec(avro, avroSchema, true),
           spec,
           Optional.of(0L),
@@ -100,6 +102,7 @@ public class SchemaTranslationTest {
             r -> new Record(
                 OUTPUT_TOPIC_NAME,
                 "test-key",
+                JsonNodeFactory.instance.textNode("test-key"),
                 r.value(),
                 r.getJsonValue().orElse(null),
                 Optional.of(0L),

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/RecordNodeTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/RecordNodeTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import io.confluent.ksql.test.tools.Record;
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -16,7 +17,7 @@ public class RecordNodeTest {
     // Given:
     final RecordNode node = new RecordNode(
       "topic",
-        Optional.empty(),
+        NullNode.getInstance(),
         new DecimalNode(new BigDecimal("10.000")),
         Optional.empty(),
         Optional.empty()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
@@ -124,7 +124,7 @@ public class KsqlTestingToolTest {
 
     // Then:
     assertThat(errContent.toString(UTF_8),
-        containsString("Test failed: Topic 'S1', message 0: Expected <1001, \"101\"> with timestamp=0 but was <101, \"101\"> with timestamp=0\n"));
+        containsString("Test failed: Topic 'S1', message 0: Expected <\"1001\", \"101\"> with timestamp=0 but was <101, \"101\"> with timestamp=0\n"));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.confluent.ksql.test.model.WindowData;
 import java.util.Optional;
 import org.apache.kafka.streams.kstream.Windowed;

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.confluent.ksql.test.model.WindowData;
 import java.util.Optional;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -36,6 +37,7 @@ public class RecordTest {
     final Record record = new Record(
         TOPIC_NAME,
         10,
+        null,
         "bar",
         null,
         Optional.of(1000L),
@@ -55,6 +57,7 @@ public class RecordTest {
     final Record record = new Record(
         TOPIC_NAME,
         "foo",
+        null,
         "bar",
         null,
         Optional.of(1000L),
@@ -78,6 +81,7 @@ public class RecordTest {
     final Record record = new Record(
         TOPIC_NAME,
         "foo",
+        null,
         "bar",
         null,
         Optional.of(1000L),

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -342,8 +342,8 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec0 = producerRecord(sinkTopic, 123456719L, "k1", "v1");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", "v1", null, Optional.of(1L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k1", "v1", null, Optional.of(1L), null);
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", null, "v1", null, Optional.of(1L), null);
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k1", null, "v1", null, Optional.of(1L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
     // When:
@@ -366,7 +366,7 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, "k2", "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", "v1", null, Optional.of(1L), null);
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", null, "v1", null, Optional.of(1L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0));
 
     // When:
@@ -390,9 +390,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, "k2", "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", null, "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", "different",
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", null, "different",
         TextNode.valueOf("different"), Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
@@ -414,9 +414,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, "k2", "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", null, "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", "v2", TextNode.valueOf("v2"),
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", null, "v2", TextNode.valueOf("v2"),
         Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
@@ -433,9 +433,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, 1, "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, 1, "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, 1, null, "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, 1, "v2", TextNode.valueOf("v2"),
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, 1, null, "v2", TextNode.valueOf("v2"),
         Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -390,9 +391,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, "k2", "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", null, "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", JsonNodeFactory.instance.textNode("k1"), "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", null, "different",
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", JsonNodeFactory.instance.textNode("k2"), "different",
         TextNode.valueOf("different"), Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
@@ -404,7 +405,7 @@ public class TestExecutorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Expected <k2, \"different\"> with timestamp=123456789 but was <k2, \"v2\"> with timestamp=123456789"));
+        "Expected <\"k2\", \"different\"> with timestamp=123456789 but was <k2, \"v2\"> with timestamp=123456789"));
   }
 
   @Test
@@ -414,9 +415,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, "k2", "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", null, "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", JsonNodeFactory.instance.textNode("k1"), "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", null, "v2", TextNode.valueOf("v2"),
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", JsonNodeFactory.instance.textNode("k2"), "v2", TextNode.valueOf("v2"),
         Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
@@ -433,9 +434,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, 1, "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, 1, null, "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, 1, JsonNodeFactory.instance.numberNode(1), "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, 1, null, "v2", TextNode.valueOf("v2"),
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, 1, JsonNodeFactory.instance.numberNode(1), "v2", TextNode.valueOf("v2"),
         Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -391,9 +391,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, "k2", "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", JsonNodeFactory.instance.textNode("k1"), "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", TextNode.valueOf("k1"), "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", JsonNodeFactory.instance.textNode("k2"), "different",
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", TextNode.valueOf("k2"), "different",
         TextNode.valueOf("different"), Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
@@ -415,9 +415,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, "k2", "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", JsonNodeFactory.instance.textNode("k1"), "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, "k1", TextNode.valueOf("k1"), "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", JsonNodeFactory.instance.textNode("k2"), "v2", TextNode.valueOf("v2"),
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, "k2", TextNode.valueOf("k2"), "v2", TextNode.valueOf("v2"),
         Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 
@@ -434,9 +434,9 @@ public class TestExecutorTest {
     final ProducerRecord<byte[], byte[]> rec1 = producerRecord(sinkTopic, 123456789L, 1, "v2");
     when(kafkaService.readRecords(SINK_TOPIC_NAME)).thenReturn(ImmutableList.of(rec0, rec1));
 
-    final Record expected_0 = new Record(SINK_TOPIC_NAME, 1, JsonNodeFactory.instance.numberNode(1), "v1", TextNode.valueOf("v1"),
+    final Record expected_0 = new Record(SINK_TOPIC_NAME, 1, IntNode.valueOf(1), "v1", TextNode.valueOf("v1"),
         Optional.of(123456719L), null);
-    final Record expected_1 = new Record(SINK_TOPIC_NAME, 1, JsonNodeFactory.instance.numberNode(1), "v2", TextNode.valueOf("v2"),
+    final Record expected_1 = new Record(SINK_TOPIC_NAME, 1, IntNode.valueOf(1), "v2", TextNode.valueOf("v2"),
         Optional.of(123456789L), null);
     when(testCase.getOutputRecords()).thenReturn(ImmutableList.of(expected_0, expected_1));
 

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -668,12 +668,373 @@
       ]
     },
     {
+      "name": "BOOLEAN - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "boolean"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": true, "value": {"FOO": 10}},
+        {"topic": "input_topic", "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": true, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "value": null}
+      ]
+    },
+    {
       "name": "INT - key - no inference",
       "properties": {
         "ksql.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "int"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 10, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": 12, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 10, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": 12, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "INT - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "int"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 10, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": 12, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 10, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": 12, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "BIGINT - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K BIGINT KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "long"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 998877665544332211, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 998877665544332211, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "BIGINT - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "long"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 998877665544332211, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 998877665544332211, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "DOUBLE - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K DOUBLE KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "double"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 654.321, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 654.321, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "DOUBLE - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "double"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 654.321, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 654.321, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "STRING - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K VARCHAR KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "string"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "foo", "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "foo", "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "STRING - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "string"},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "foo", "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "foo", "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "DECIMAL - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K DECIMAL(4,2) KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 4,
+            "scale": 2
+          },
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 65.21, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 65.21, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "DECIMAL - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 4,
+            "scale": 2
+          },
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 65.21, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 65.21, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "ARRAY - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K ARRAY<VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {
+            "type": "array",
+            "items": "string"
+          },
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Unsupported key schema: [`K` ARRAY<STRING> KEY]"
+      }
+    },
+    {
+      "name": "ARRAY - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {
+            "type": "array",
+            "items": "string"
+          },
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Unsupported key schema: [`ROWVAL` ARRAY<STRING> KEY]"
+      }
+    },
+    {
+      "name": "INT - key - key and value inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT WITH (kafka_topic='input_topic', format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
       "topics": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -649,15 +649,6 @@
         "CREATE STREAM INPUT (K BOOLEAN KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "topics": [
-        {
-          "name": "input_topic",
-          "keySchema": {"type": "boolean"},
-          "keyFormat": "AVRO",
-          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
-          "valueFormat": "AVRO"
-        }
-      ],
       "inputs": [
         {"topic": "input_topic", "key": true, "value": {"FOO": 10}},
         {"topic": "input_topic", "value": null}
@@ -702,15 +693,6 @@
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
-      ],
-      "topics": [
-        {
-          "name": "input_topic",
-          "keySchema": {"type": "int"},
-          "keyFormat": "AVRO",
-          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
-          "valueFormat": "AVRO"
-        }
       ],
       "inputs": [
         {"topic": "input_topic", "key": 10, "value": {"FOO": 10}},
@@ -761,15 +743,6 @@
         "CREATE STREAM INPUT (K BIGINT KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "topics": [
-        {
-          "name": "input_topic",
-          "keySchema": {"type": "long"},
-          "keyFormat": "AVRO",
-          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
-          "valueFormat": "AVRO"
-        }
-      ],
       "inputs": [
         {"topic": "input_topic", "key": 998877665544332211, "value": {"FOO": 10}},
         {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
@@ -814,15 +787,6 @@
       "statements": [
         "CREATE STREAM INPUT (K DOUBLE KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
-      ],
-      "topics": [
-        {
-          "name": "input_topic",
-          "keySchema": {"type": "double"},
-          "keyFormat": "AVRO",
-          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
-          "valueFormat": "AVRO"
-        }
       ],
       "inputs": [
         {"topic": "input_topic", "key": 654.321, "value": {"FOO": 10}},
@@ -869,15 +833,6 @@
         "CREATE STREAM INPUT (K VARCHAR KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "topics": [
-        {
-          "name": "input_topic",
-          "keySchema": {"type": "string"},
-          "keyFormat": "AVRO",
-          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
-          "valueFormat": "AVRO"
-        }
-      ],
       "inputs": [
         {"topic": "input_topic", "key": "foo", "value": {"FOO": 10}},
         {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
@@ -922,20 +877,6 @@
       "statements": [
         "CREATE STREAM INPUT (K DECIMAL(4,2) KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
-      ],
-      "topics": [
-        {
-          "name": "input_topic",
-          "keySchema": {
-            "type": "bytes",
-            "logicalType": "decimal",
-            "precision": 4,
-            "scale": 2
-          },
-          "keyFormat": "AVRO",
-          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
-          "valueFormat": "AVRO"
-        }
       ],
       "inputs": [
         {"topic": "input_topic", "key": 65.21, "value": {"FOO": 10}},
@@ -985,18 +926,6 @@
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');"
-      ],
-      "topics": [
-        {
-          "name": "input_topic",
-          "keySchema": {
-            "type": "array",
-            "items": "string"
-          },
-          "keyFormat": "AVRO",
-          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
-          "valueFormat": "AVRO"
-        }
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",


### PR DESCRIPTION
### Description 

Adds coverage for AVRO in QTT tests. In order to support decimal (and in future when we want to compare structs) I needed to change the test framework to compare the `JsonNode` instead of the java-ified value, piggy-backing on the existing value comparison framework.

### Testing done 

Ran the QTT tests :) 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

