### PR TITLE
fix: Properly clean up state when executing a command fails

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandQueue.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandQueue.java
@@ -88,6 +88,12 @@ public interface CommandQueue extends Closeable {
   Producer<CommandId, Command> createTransactionalProducer();
 
   /**
+   * If a command created with enqueueCommand has had errors and the transaction has failed or been
+   * aborted, this should be called to ensure state is cleaned up.
+   */
+  void abortCommand(CommandId commandId);
+
+  /**
    * Blocks until the command topic consumer has processed all records up to
    * the current offset when this method is called.
    *

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -304,6 +304,21 @@ public class CommandStore implements CommandQueue, Closeable {
   }
 
   @Override
+  public void abortCommand(final CommandId commandId) {
+    commandStatusMap.compute(
+        commandId,
+        (k, v) -> {
+          if (v == null) {
+            throw new IllegalStateException(
+                String.format("Trying to abort an unknown commandId (%s)", commandId)
+            );
+          }
+          return null;
+        }
+    );
+  }
+
+  @Override
   public void waitForCommandConsumer() {
     try {
       final long endOffset = getCommandTopicOffset();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -308,10 +308,8 @@ public class CommandStore implements CommandQueue, Closeable {
     commandStatusMap.compute(
         commandId,
         (k, v) -> {
-          if (v == null) {
-            throw new IllegalStateException(
-                String.format("Trying to abort an unknown commandId (%s)", commandId)
-            );
+          if (v != null) {
+            LOG.info("Aborting existing command {}", commandId);
           }
           return null;
         }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
@@ -368,6 +368,25 @@ public class CommandStoreTest {
     verify(commandTopic).start();
   }
 
+  @Test
+  public void shouldThrowErrorOnAbortUnknown() {
+    // When/Then:
+    assertThrows(
+        IllegalStateException.class,
+        () -> commandStore.abortCommand(commandId)
+    );
+  }
+
+  @Test
+  public void shouldSuccessfullyAbortAndRetry() {
+    // Given:
+    commandStore.enqueueCommand(commandId, command, transactionalProducer);
+
+    // When/Then:
+    commandStore.abortCommand(commandId);
+    commandStore.enqueueCommand(commandId, command, transactionalProducer);
+  }
+
   private static ConsumerRecords<byte[], byte[]> buildRecords(final Object... args) {
     assertThat(args.length % 2, equalTo(0));
     final List<ConsumerRecord<byte[], byte[]>> records = new ArrayList<>();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
@@ -369,15 +369,6 @@ public class CommandStoreTest {
   }
 
   @Test
-  public void shouldThrowErrorOnAbortUnknown() {
-    // When/Then:
-    assertThrows(
-        IllegalStateException.class,
-        () -> commandStore.abortCommand(commandId)
-    );
-  }
-
-  @Test
   public void shouldSuccessfullyAbortAndRetry() {
     // Given:
     commandStore.enqueueCommand(commandId, command, transactionalProducer);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -73,6 +73,8 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.junit.Before;
 import org.junit.Test;
@@ -400,5 +402,37 @@ public class DistributingExecutorTest {
     assertThat(e.getMessage(), containsString(
         "Cannot insert into read-only topic: "
             + "default_ksql_processing_log"));
+  }
+
+  @Test
+  public void shouldAbortOnError_ProducerFencedException() {
+    // When:
+    doThrow(new ProducerFencedException("Error!")).when(transactionalProducer).commitTransaction();
+    final Exception e = assertThrows(
+        KsqlServerException.class,
+        () -> distributor.execute(CONFIGURED_STATEMENT, executionContext, securityContext)
+    );
+
+    assertThat(e.getMessage(), containsString("Could not write the statement "
+        + "'statement' into the command topic."));
+
+    // Then:
+    verify(queue).abortCommand(IDGEN.getCommandId(CONFIGURED_STATEMENT.getStatement()));
+  }
+
+  @Test
+  public void shouldAbortOnError_Exception() {
+    // When:
+    doThrow(new RuntimeException("Error!")).when(transactionalProducer).commitTransaction();
+    final Exception e = assertThrows(
+        KsqlServerException.class,
+        () -> distributor.execute(CONFIGURED_STATEMENT, executionContext, securityContext)
+    );
+
+    assertThat(e.getMessage(), containsString("Could not write the statement "
+        + "'statement' into the command topic."));
+
+    // Then:
+    verify(queue).abortCommand(IDGEN.getCommandId(CONFIGURED_STATEMENT.getStatement()));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -174,6 +174,10 @@ public class RecoveryTest {
     }
 
     @Override
+    public void abortCommand(CommandId commandId) {
+    }
+
+    @Override
     public boolean corruptionDetected() {
       return false;
     }


### PR DESCRIPTION
### Description 
Attempts to cleanup and state associated with a command id when a transaction for that command fails to commit properly.

Fixes #6340 

### Testing done 
Ran unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

