### PR TITLE
fix: support unwrapped struct value inference

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
+import io.confluent.ksql.serde.SerdeFeaturesFactory;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.util.ErrorMessageUtil;
@@ -123,7 +124,7 @@ public class DefaultSchemaInjector implements Injector {
         props.getKafkaTopic(),
         props.getKeySchemaId(),
         keyFormat,
-        SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES),
+        SerdeFeaturesFactory.buildInternal(FormatFactory.of(keyFormat)),
         statement.getStatementText(),
         true
     ));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.schema.ksql.inference.TopicSchemaSupplier.SchemaResult;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
+import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.util.ErrorMessageUtil;
@@ -122,6 +123,7 @@ public class DefaultSchemaInjector implements Injector {
         props.getKafkaTopic(),
         props.getKeySchemaId(),
         keyFormat,
+        SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES),
         statement.getStatementText(),
         true
     ));
@@ -141,6 +143,7 @@ public class DefaultSchemaInjector implements Injector {
         props.getKafkaTopic(),
         props.getValueSchemaId(),
         valueFormat,
+        props.getValueSerdeFeatures(),
         statement.getStatementText(),
         false
     ));
@@ -150,12 +153,13 @@ public class DefaultSchemaInjector implements Injector {
       final String topicName,
       final Optional<Integer> schemaId,
       final FormatInfo expectedFormat,
+      final SerdeFeatures serdeFeatures,
       final String statementText,
       final boolean isKey
   ) {
     final SchemaResult result = isKey
-        ? schemaSupplier.getKeySchema(topicName, schemaId, expectedFormat)
-        : schemaSupplier.getValueSchema(topicName, schemaId, expectedFormat);
+        ? schemaSupplier.getKeySchema(topicName, schemaId, expectedFormat, serdeFeatures)
+        : schemaSupplier.getValueSchema(topicName, schemaId, expectedFormat, serdeFeatures);
 
     if (result.failureReason.isPresent()) {
       final Exception cause = result.failureReason.get();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SchemaTranslator;
-import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
@@ -135,8 +134,8 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
     try {
       columns = translator.toColumns(
           parsedSchema,
-          isKey,
-          serdeFeatures.enabled(SerdeFeature.UNWRAP_SINGLES)
+          serdeFeatures,
+          isKey
       );
     } catch (final Exception e) {
       return notCompatible(topic, parsedSchema.canonicalString(), e, isKey);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/TopicSchemaSupplier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/TopicSchemaSupplier.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.schema.ksql.inference;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.schema.ksql.SimpleColumn;
 import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.SerdeFeatures;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -34,13 +35,15 @@ public interface TopicSchemaSupplier {
    * @param topicName the name of the topic.
    * @param schemaId  optional schema id to retrieve.
    * @param expectedFormat the expected format of the schema.
+   * @param serdeFeatures serde features associated with the request.
    * @return the schema and id or an error message should the schema not be present or compatible.
    * @throws RuntimeException on communication issues with remote services.
    */
   SchemaResult getKeySchema(
       String topicName,
       Optional<Integer> schemaId,
-      FormatInfo expectedFormat
+      FormatInfo expectedFormat,
+      SerdeFeatures serdeFeatures
   );
 
   /**
@@ -50,13 +53,15 @@ public interface TopicSchemaSupplier {
    * @param topicName the name of the topic.
    * @param schemaId  optional schema id to retrieve.
    * @param expectedFormat the expected format of the schema.
+   * @param serdeFeatures serde features associated with the request.
    * @return the schema and id or an error message should the schema not be present or compatible.
    * @throws RuntimeException on communication issues with remote services.
    */
   SchemaResult getValueSchema(
       String topicName,
       Optional<Integer> schemaId,
-      FormatInfo expectedFormat
+      FormatInfo expectedFormat,
+      SerdeFeatures serdeFeatures
   );
 
   final class SchemaAndId {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplierTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplierTest.java
@@ -39,6 +39,8 @@ import io.confluent.ksql.schema.ksql.inference.TopicSchemaSupplier.SchemaResult;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SchemaTranslator;
+import io.confluent.ksql.serde.SerdeFeature;
+import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
 import java.util.Map;
@@ -92,7 +94,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     when(parsedSchema.canonicalString()).thenReturn(AVRO_SCHEMA);
 
     when(format.getSchemaTranslator(any())).thenReturn(schemaTranslator);
-    when(schemaTranslator.toColumns(eq(parsedSchema), anyBoolean())).thenReturn(ImmutableList.of(column1));
+    when(schemaTranslator.toColumns(eq(parsedSchema), anyBoolean(), anyBoolean()))
+        .thenReturn(ImmutableList.of(column1));
     when(schemaTranslator.name()).thenReturn("AVRO");
 
     when(expectedFormat.getProperties()).thenReturn(formatProperties);
@@ -105,7 +108,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
 
     // When:
     final SchemaResult result = supplier
-        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -128,8 +131,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     when(parsedSchema.schemaType()).thenReturn(ProtobufSchema.TYPE);
 
     // When:
-    final SchemaResult result = supplier
-        .getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+    final SchemaResult result = supplier.getKeySchema(
+        TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -154,7 +157,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
 
     // When:
     final SchemaResult result = supplier
-        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -171,8 +174,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(notFoundException());
 
     // When:
-    final SchemaResult result = supplier
-        .getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+    final SchemaResult result = supplier.getKeySchema(
+        TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -189,8 +192,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(notFoundException());
 
     // When:
-    final SchemaResult result = supplier.getValueSchema(TOPIC_NAME, Optional.of(42),
-        expectedFormat);
+    final SchemaResult result = supplier.getValueSchema(
+        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -207,8 +210,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(notFoundException());
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(TOPIC_NAME, Optional.of(42),
-        expectedFormat);
+    final SchemaResult result = supplier.getKeySchema(
+        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -225,8 +228,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(unauthorizedException());
 
     // When:
-    final SchemaResult result = supplier.getValueSchema(TOPIC_NAME, Optional.of(42),
-        expectedFormat);
+    final SchemaResult result = supplier.getValueSchema(
+        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -243,8 +246,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(unauthorizedException());
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(TOPIC_NAME, Optional.of(42),
-        expectedFormat);
+    final SchemaResult result = supplier.getKeySchema(
+        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -261,8 +264,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(forbiddenException());
 
     // When:
-    final SchemaResult result = supplier.getValueSchema(TOPIC_NAME, Optional.of(42),
-        expectedFormat);
+    final SchemaResult result = supplier.getValueSchema(
+        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -279,8 +282,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(forbiddenException());
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(TOPIC_NAME, Optional.of(42),
-        expectedFormat);
+    final SchemaResult result = supplier.getKeySchema(
+        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -299,7 +302,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat)
+        () -> supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of())
     );
 
     // Then:
@@ -316,7 +319,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat)
+        () -> supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
     );
 
     // Then:
@@ -333,7 +336,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat)
+        () -> supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of())
     );
 
     // Then:
@@ -350,7 +353,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat)
+        () -> supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
     );
 
     // Then:
@@ -367,7 +370,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat)
+        () -> supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of())
     );
 
     // Then:
@@ -384,7 +387,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat)
+        () -> supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
     );
 
     // Then:
@@ -401,7 +404,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat)
+        () -> supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of())
     );
 
     // Then:
@@ -418,7 +421,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat)
+        () -> supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
     );
 
     // Then:
@@ -429,12 +432,12 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldReturnErrorFromGetValueSchemaIfCanNotConvertToConnectSchema() {
     // Given:
-    when(schemaTranslator.toColumns(any(), anyBoolean()))
+    when(schemaTranslator.toColumns(any(), anyBoolean(), anyBoolean()))
         .thenThrow(new RuntimeException("it went boom"));
 
     // When:
     final SchemaResult result = supplier
-        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -448,12 +451,12 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldReturnErrorFromGetKeySchemaIfCanNotConvertToConnectSchema() {
     // Given:
-    when(schemaTranslator.toColumns(any(), anyBoolean()))
+    when(schemaTranslator.toColumns(any(), anyBoolean(), anyBoolean()))
         .thenThrow(new RuntimeException("it went boom"));
 
     // When:
-    final SchemaResult result = supplier
-        .getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+    final SchemaResult result = supplier.getKeySchema(
+        TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -467,11 +470,11 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldReturnErrorFromGetKeySchemaOnMultipleColumns() {
     // Given:
-    when(schemaTranslator.toColumns(parsedSchema, true)).thenReturn(ImmutableList.of(column1, column2));
+    when(schemaTranslator.toColumns(parsedSchema, true, true)).thenReturn(ImmutableList.of(column1, column2));
 
     // When:
-    final SchemaResult result = supplier
-        .getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+    final SchemaResult result = supplier.getKeySchema(
+        TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -484,7 +487,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldRequestCorrectSchemaOnGetValueSchema() throws Exception {
     // When:
-    supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+    supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     verify(srClient).getLatestSchemaMetadata(TOPIC_NAME + "-value");
@@ -493,7 +496,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldRequestCorrectSchemaOnGetKeySchema() throws Exception {
     // When:
-    supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+    supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     verify(srClient).getLatestSchemaMetadata(TOPIC_NAME + "-key");
@@ -502,7 +505,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldRequestCorrectSchemaOnGetValueSchemaWithId() throws Exception {
     // When:
-    supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat);
+    supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of());
 
     // Then:
     verify(srClient).getSchemaBySubjectAndId(TOPIC_NAME + "-value", 42);
@@ -511,7 +514,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldRequestCorrectSchemaOnGetKeySchemaWithId() throws Exception {
     // When:
-    supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat);
+    supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     verify(srClient).getSchemaBySubjectAndId(TOPIC_NAME + "-key", 42);
@@ -520,18 +523,36 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldPassRightSchemaToFormat() {
     // When:
-    supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+    supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     verify(format).getSchemaTranslator(formatProperties);
-    verify(schemaTranslator).toColumns(parsedSchema, false);
+    verify(schemaTranslator).toColumns(parsedSchema, false, false);
+  }
+
+  @Test
+  public void shouldPassCorrectValueWrapping() {
+    // When:
+    supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+
+    // Then:
+    verify(schemaTranslator).toColumns(parsedSchema, false, true);
+  }
+
+  @Test
+  public void shouldPassCorrectKeyWrapping() {
+    // When:
+    supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+
+    // Then:
+    verify(schemaTranslator).toColumns(parsedSchema, true, true);
   }
 
   @Test
   public void shouldReturnSchemaFromGetValueSchemaIfFound() {
     // When:
     final SchemaResult result = supplier
-        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(not(Optional.empty())));
@@ -543,7 +564,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   public void shouldReturnSchemaFromGetKeySchemaIfFound() {
     // When:
     final SchemaResult result = supplier
-        .getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat);
+        .getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(not(Optional.empty())));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplierTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplierTest.java
@@ -94,7 +94,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     when(parsedSchema.canonicalString()).thenReturn(AVRO_SCHEMA);
 
     when(format.getSchemaTranslator(any())).thenReturn(schemaTranslator);
-    when(schemaTranslator.toColumns(eq(parsedSchema), anyBoolean(), anyBoolean()))
+    when(schemaTranslator.toColumns(eq(parsedSchema), any(), anyBoolean()))
         .thenReturn(ImmutableList.of(column1));
     when(schemaTranslator.name()).thenReturn("AVRO");
 
@@ -432,7 +432,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldReturnErrorFromGetValueSchemaIfCanNotConvertToConnectSchema() {
     // Given:
-    when(schemaTranslator.toColumns(any(), anyBoolean(), anyBoolean()))
+    when(schemaTranslator.toColumns(any(), any(), anyBoolean()))
         .thenThrow(new RuntimeException("it went boom"));
 
     // When:
@@ -451,7 +451,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldReturnErrorFromGetKeySchemaIfCanNotConvertToConnectSchema() {
     // Given:
-    when(schemaTranslator.toColumns(any(), anyBoolean(), anyBoolean()))
+    when(schemaTranslator.toColumns(any(), any(), anyBoolean()))
         .thenThrow(new RuntimeException("it went boom"));
 
     // When:
@@ -470,7 +470,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldReturnErrorFromGetKeySchemaOnMultipleColumns() {
     // Given:
-    when(schemaTranslator.toColumns(parsedSchema, true, true)).thenReturn(ImmutableList.of(column1, column2));
+    when(schemaTranslator.toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), true))
+        .thenReturn(ImmutableList.of(column1, column2));
 
     // When:
     final SchemaResult result = supplier.getKeySchema(
@@ -527,7 +528,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
 
     // Then:
     verify(format).getSchemaTranslator(formatProperties);
-    verify(schemaTranslator).toColumns(parsedSchema, false, false);
+    verify(schemaTranslator).toColumns(parsedSchema, SerdeFeatures.of(), false);
   }
 
   @Test
@@ -536,7 +537,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
-    verify(schemaTranslator).toColumns(parsedSchema, false, true);
+    verify(schemaTranslator).toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), false);
   }
 
   @Test
@@ -545,7 +546,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
-    verify(schemaTranslator).toColumns(parsedSchema, true, true);
+    verify(schemaTranslator).toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), true);
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_inference/6.1.0_1602822758149/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_inference/6.1.0_1602822758149/plan.json
@@ -1,0 +1,142 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ROWVAL STRUCT<F0 INTEGER>) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=1, WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWVAL` STRUCT<`F0` INTEGER>",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        },
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWVAL` STRUCT<`F0` INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              },
+              "valueFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "sourceSchema" : "`ROWVAL` STRUCT<`F0` INTEGER>"
+          },
+          "selectExpressions" : [ "ROWVAL AS ROWVAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_inference/6.1.0_1602822758149/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_inference/6.1.0_1602822758149/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1602822758149,
+  "path" : "query-validation-tests/avro.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ROWVAL` STRUCT<`F0` INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO",
+        "features" : [ "UNWRAP_SINGLES" ]
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ROWVAL` STRUCT<`F0` INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "deserialize anonymous struct - value - inference",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "F0" : 1
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : null
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ROWVAL" : {
+          "F0" : 1
+        }
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ROWVAL" : {
+          "F0" : null
+        }
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : null
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "ignored",
+        "fields" : [ {
+          "name" : "F0",
+          "type" : [ "null", "int" ]
+        } ]
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM INPUT WITH (kafka_topic='input_topic', value_format='AVRO', wrap_single_value=false);", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ROWVAL` STRUCT<`F0` INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ROWVAL` STRUCT<`F0` INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "partitions" : 1
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_inference/6.1.0_1602822758149/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_inference/6.1.0_1602822758149/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_no_inference/6.1.0_1602822758088/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_no_inference/6.1.0_1602822758088/plan.json
@@ -1,0 +1,142 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (FOO STRUCT<F0 INTEGER>) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`FOO` STRUCT<`F0` INTEGER>",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        },
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`FOO` STRUCT<`F0` INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              },
+              "valueFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "sourceSchema" : "`FOO` STRUCT<`F0` INTEGER>"
+          },
+          "selectExpressions" : [ "FOO AS FOO" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_no_inference/6.1.0_1602822758088/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_no_inference/6.1.0_1602822758088/spec.json
@@ -1,0 +1,134 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1602822758088,
+  "path" : "query-validation-tests/avro.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`FOO` STRUCT<`F0` INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO",
+        "features" : [ "UNWRAP_SINGLES" ]
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`FOO` STRUCT<`F0` INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "deserialize anonymous struct - value - no inference",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "F0" : 1
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "F0" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : null
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "FOO" : {
+          "F0" : 1
+        }
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "FOO" : {
+          "F0" : null
+        }
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : null
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "KsqlDataSourceSchema",
+        "namespace" : "io.confluent.ksql.avro_schemas",
+        "fields" : [ {
+          "name" : "F0",
+          "type" : [ "null", "int" ],
+          "default" : null
+        } ],
+        "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (foo STRUCT<F0 INT>) WITH (kafka_topic='input_topic', value_format='AVRO', wrap_single_value=false);", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` STRUCT<`F0` INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` STRUCT<`F0` INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_no_inference/6.1.0_1602822758088/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_struct_-_value_-_no_inference/6.1.0_1602822758088/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_deserialize_and_serialize_unwrapped_struct/6.1.0_1602822838224/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_deserialize_and_serialize_unwrapped_struct/6.1.0_1602822838224/plan.json
@@ -1,0 +1,144 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (FOO STRUCT<F1 STRING>) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`FOO` STRUCT<`F1` STRING>",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`FOO` STRUCT<`F1` STRING>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              },
+              "valueFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "sourceSchema" : "`FOO` STRUCT<`F1` STRING>"
+          },
+          "selectExpressions" : [ "FOO AS FOO" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "valueFeatures" : [ "UNWRAP_SINGLES" ]
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_deserialize_and_serialize_unwrapped_struct/6.1.0_1602822838224/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_deserialize_and_serialize_unwrapped_struct/6.1.0_1602822838224/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "6.1.0",
+  "timestamp" : 1602822838224,
+  "path" : "query-validation-tests/serdes.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`FOO` STRUCT<`F1` STRING>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`FOO` STRUCT<`F1` STRING>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "deserialize and serialize unwrapped struct",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "F1" : "bar"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "F1" : "bar"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (foo STRUCT<F1 STRING>) WITH (kafka_topic='input_topic', value_format='JSON', wrap_single_value=false);", "CREATE STREAM OUTPUT WITH (wrap_single_value=false) AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` STRUCT<`F1` STRING>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`FOO` STRUCT<`F1` STRING>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_deserialize_and_serialize_unwrapped_struct/6.1.0_1602822838224/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/serdes_-_deserialize_and_serialize_unwrapped_struct/6.1.0_1602822838224/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -385,6 +385,46 @@
       ]
     },
     {
+      "name": "deserialize anonymous struct - value - no inference",
+      "statements": [
+        "CREATE STREAM INPUT (foo STRUCT<F0 INT>) WITH (kafka_topic='input_topic', value_format='AVRO', wrap_single_value=false);",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"F0": 1}},
+        {"topic": "input_topic", "value": {"F0": null}},
+        {"topic": "input_topic", "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"FOO": {"F0": 1}}},
+        {"topic": "OUTPUT", "value": {"FOO": {"F0": null}}},
+        {"topic": "OUTPUT", "value": null}
+      ]
+    },
+    {
+      "name": "deserialize anonymous struct - value - inference",
+      "statements": [
+        "CREATE STREAM INPUT WITH (kafka_topic='input_topic', value_format='AVRO', wrap_single_value=false);",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "valueSchema": {"type": "record", "name": "ignored", "fields": [{"name": "F0", "type": ["null", "int"]}]}
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"F0": 1}},
+        {"topic": "input_topic", "value": {"F0": null}},
+        {"topic": "input_topic", "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"ROWVAL": {"F0": 1}}},
+        {"topic": "OUTPUT", "value": {"ROWVAL": {"F0": null}}},
+        {"topic": "OUTPUT", "value": null}
+      ]
+    },
+    {
       "name": "serialize anonymous struct - value",
       "statements": [
         "CREATE STREAM INPUT (foo STRUCT<F0 INT>) WITH (kafka_topic='input_topic', value_format='AVRO');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/serdes.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/serdes.json
@@ -122,6 +122,19 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "'WRAP_SINGLE_VALUE' is only valid for single-field value schemas"
       }
+    },
+    {
+      "name": "deserialize and serialize unwrapped struct",
+      "statements": [
+        "CREATE STREAM INPUT (foo STRUCT<F1 STRING>) WITH (kafka_topic='input_topic', value_format='JSON', wrap_single_value=false);",
+        "CREATE STREAM OUTPUT WITH (wrap_single_value=false) AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"F1": "bar"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"F1": "bar"}}
+      ]
     }
   ]
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/SchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/SchemaTranslator.java
@@ -40,11 +40,11 @@ public interface SchemaTranslator {
    * names and types.
    *
    * @param schema the {@code ParsedSchema} returned from Schema Registry
+   * @param serdeFeatures serde features associated with the request
    * @param isKey whether the schema being translated is a key schema
-   * @param unwrapSingle whether a single, unwrapped column should be returned
    * @return the list of columns the schema defines
    */
-  List<SimpleColumn> toColumns(ParsedSchema schema, boolean isKey, boolean unwrapSingle);
+  List<SimpleColumn> toColumns(ParsedSchema schema, SerdeFeatures serdeFeatures, boolean isKey);
 
   /**
    * Converts a {@link PersistenceSchema} into a Schema Registry's {@link ParsedSchema}.

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/SchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/SchemaTranslator.java
@@ -41,9 +41,10 @@ public interface SchemaTranslator {
    *
    * @param schema the {@code ParsedSchema} returned from Schema Registry
    * @param isKey whether the schema being translated is a key schema
+   * @param unwrapSingle whether a single, unwrapped column should be returned
    * @return the list of columns the schema defines
    */
-  List<SimpleColumn> toColumns(ParsedSchema schema, boolean isKey);
+  List<SimpleColumn> toColumns(ParsedSchema schema, boolean isKey, boolean unwrapSingle);
 
   /**
    * Converts a {@link PersistenceSchema} into a Schema Registry's {@link ParsedSchema}.

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslator.java
@@ -20,12 +20,14 @@ import static java.util.Objects.requireNonNull;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SimpleColumn;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.SchemaTranslator;
 import io.confluent.ksql.serde.SerdeFeature;
+import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.SerdeUtils;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
@@ -61,28 +63,24 @@ class ConnectFormatSchemaTranslator implements SchemaTranslator {
   @Override
   public List<SimpleColumn> toColumns(
       final ParsedSchema schema,
-      final boolean isKey,
-      final boolean unwrapSingle) {
+      final SerdeFeatures serdeFeatures,
+      final boolean isKey) {
+    SerdeUtils.throwOnUnsupportedFeatures(serdeFeatures, format.supportedFeatures());
+
     Schema connectSchema = connectSrTranslator.toConnectSchema(schema);
 
-    if (connectSchema.type() != Type.STRUCT || unwrapSingle) {
-      if (!format.supportsFeature(SerdeFeature.UNWRAP_SINGLES)) {
-        throw new KsqlException("Schema returned from schema registry is anonymous type, "
-            + "but format " + format.name() + " does not support anonymous types. "
-            + "schema: " + schema);
-      }
-
-      if (!unwrapSingle) {
-        if (isKey) {
-          throw new IllegalStateException("Key schemas are always unwrapped.");
-        }
-
-        throw new KsqlException("Schema returned from schema registry is anonymous type. "
-            + "To use this schema with ksqlDB, set 'WRAP_SINGLE_VALUE=false' in the "
-            + "WITH clause properties.");
-      }
-
+    if (serdeFeatures.enabled(SerdeFeature.UNWRAP_SINGLES)) {
       connectSchema = SerdeUtils.wrapSingle(connectSchema, isKey);
+    }
+
+    if (connectSchema.type() != Type.STRUCT) {
+      if (isKey) {
+        throw new IllegalStateException("Key schemas are always unwrapped.");
+      }
+
+      throw new KsqlException("Schema returned from schema registry is anonymous type. "
+          + "To use this schema with ksqlDB, set '" + CommonCreateConfigs.WRAP_SINGLE_VALUE
+          + "=false' in the WITH clause properties.");
     }
 
     final Schema rowSchema = connectKsqlTranslator.apply(connectSchema);

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslatorTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.util.KsqlException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -78,7 +79,6 @@ public class ConnectFormatSchemaTranslatorTest {
 
     translator = new ConnectFormatSchemaTranslator(format, formatProps, connectKsqlTranslator);
 
-    when(format.name()).thenReturn("TestFormat");
     when(innerTranslator.toConnectSchema(parsedSchema)).thenReturn(connectSchema);
   }
 
@@ -90,7 +90,7 @@ public class ConnectFormatSchemaTranslatorTest {
   @Test
   public void shouldPassConnectSchemaReturnedBySubclassToTranslator() {
     // When:
-    translator.toColumns(parsedSchema, false, false);
+    translator.toColumns(parsedSchema, SerdeFeatures.of(), false);
 
     // Then:
     verify(connectKsqlTranslator).apply(connectSchema);
@@ -105,7 +105,7 @@ public class ConnectFormatSchemaTranslatorTest {
     ));
 
     // When:
-    final List<SimpleColumn> result = translator.toColumns(parsedSchema, false, false);
+    final List<SimpleColumn> result = translator.toColumns(parsedSchema, SerdeFeatures.of(), false);
 
     // Then:
     assertThat(result, hasSize(2));
@@ -116,30 +116,14 @@ public class ConnectFormatSchemaTranslatorTest {
   }
 
   @Test
-  public void shouldThrowOnUnwrappedSchemaIfNotSupportedWhenBuildingColumns() {
-    // Given:
-    when(connectSchema.type()).thenReturn(Type.INT32);
-
-    // When:
-    final Exception e = assertThrows(KsqlException.class,
-        () -> translator.toColumns(parsedSchema, false, true)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), is("Schema returned from schema registry is anonymous type, "
-        + "but format TestFormat does not support anonymous types. "
-        + "schema: parsedSchema"));
-  }
-
-  @Test
   public void shouldThrowOnUnwrappedSchemaIfUnwrapSingleIsFalse() {
     // Given:
     when(connectSchema.type()).thenReturn(Type.INT32);
-    when(format.supportsFeature(SerdeFeature.UNWRAP_SINGLES)).thenReturn(true);
+    when(format.supportedFeatures()).thenReturn(Collections.singleton(SerdeFeature.UNWRAP_SINGLES));
 
     // When:
     final Exception e = assertThrows(KsqlException.class,
-        () -> translator.toColumns(parsedSchema, false, false)
+        () -> translator.toColumns(parsedSchema, SerdeFeatures.of(), false)
     );
 
     // Then:
@@ -167,11 +151,10 @@ public class ConnectFormatSchemaTranslatorTest {
   @Test
   public void shouldSupportBuildingColumnsFromPrimitiveValueSchema() {
     // Given:
-    when(connectSchema.type()).thenReturn(Type.INT32);
-    when(format.supportsFeature(SerdeFeature.UNWRAP_SINGLES)).thenReturn(true);
+    when(format.supportedFeatures()).thenReturn(Collections.singleton(SerdeFeature.UNWRAP_SINGLES));
 
     // When:
-    translator.toColumns(parsedSchema, false, true);
+    translator.toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), false);
 
     // Then:
     verify(connectKsqlTranslator).apply(SchemaBuilder.struct()
@@ -182,41 +165,10 @@ public class ConnectFormatSchemaTranslatorTest {
   @Test
   public void shouldSupportBuildingColumnsFromPrimitiveKeySchema() {
     // Given:
-    when(connectSchema.type()).thenReturn(Type.INT32);
-    when(format.supportsFeature(SerdeFeature.UNWRAP_SINGLES)).thenReturn(true);
+    when(format.supportedFeatures()).thenReturn(Collections.singleton(SerdeFeature.UNWRAP_SINGLES));
 
     // When:
-    translator.toColumns(parsedSchema, true, true);
-
-    // Then:
-    verify(connectKsqlTranslator).apply(SchemaBuilder.struct()
-        .field("ROWKEY", connectSchema)
-        .build());
-  }
-
-  @Test
-  public void shouldSupportBuildingColumnsFromPrimitiveStructValueSchema() {
-    // Given:
-    when(connectSchema.type()).thenReturn(Type.STRUCT);
-    when(format.supportsFeature(SerdeFeature.UNWRAP_SINGLES)).thenReturn(true);
-
-    // When:
-    translator.toColumns(parsedSchema, false, true);
-
-    // Then:
-    verify(connectKsqlTranslator).apply(SchemaBuilder.struct()
-        .field("ROWVAL", connectSchema)
-        .build());
-  }
-
-  @Test
-  public void shouldSupportBuildingColumnsFromPrimitiveStructKeySchema() {
-    // Given:
-    when(connectSchema.type()).thenReturn(Type.STRUCT);
-    when(format.supportsFeature(SerdeFeature.UNWRAP_SINGLES)).thenReturn(true);
-
-    // When:
-    translator.toColumns(parsedSchema, true, true);
+    translator.toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), true);
 
     // Then:
     verify(connectKsqlTranslator).apply(SchemaBuilder.struct()


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/6444

The cause of the bug is that the DefaultSchemaInjector always unwraps struct schemas (assuming that they're wrapped), ignoring any serde features that should cause it to not do so (specifically, `wrap_single_value=false`). This PR fixes the bug by passing serde features into the schema translator, which is admittedly hacky and ugly but I couldn't think of a way around this. 

### Testing done 

QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

