### PR TITLE
feat: support non-primitive types as keys

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -925,12 +925,19 @@
         "ksql.key.format.enabled": true
       },
       "statements": [
-        "CREATE STREAM INPUT (K ARRAY<VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');"
+        "CREATE STREAM INPUT (K ARRAY<VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Unsupported key schema: [`K` ARRAY<STRING> KEY]"
-      }
+      "inputs": [
+        {"topic": "input_topic", "key": ["foo"], "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": [null], "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": ["foo"], "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": [null], "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
     },
     {
       "name": "ARRAY - key - inference",
@@ -938,24 +945,169 @@
         "ksql.key.format.enabled": true
       },
       "statements": [
-        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');"
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
       "topics": [
         {
           "name": "input_topic",
-          "keySchema": {
-            "type": "array",
-            "items": "string"
-          },
+          "keySchema": {"type": "array", "items": ["null", "string"]},
           "keyFormat": "AVRO",
           "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
           "valueFormat": "AVRO"
         }
       ],
+      "inputs": [
+        {"topic": "input_topic", "key": ["foo"], "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": [null], "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": ["foo"], "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": [null], "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "MAP - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K MAP<STRING, INT> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": {"a": 1, "b": 2, "c": 3}, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": {"a": 1, "b": 2, "c": null}, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"a": 1, "b": 2, "c": 3}, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": {"a": 1, "b": 2, "c": null}, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "MAP - key - no inference - with coercion",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K MAP<STRING, STRING> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": {"a": 1, "b": 2, "c": 3}, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"a": "1", "b": "2", "c": "3"}, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "MAP - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "map", "values": ["null", "int"]},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": {"a": 1, "b": 2, "c": 3}, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": {"a": 1, "b": 2, "c": null}, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"a": 1, "b": 2, "c": 3}, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": {"a": 1, "b": 2, "c": null}, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "map with non-string keys fails - key - C*",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K MAP<INT, DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');"
+      ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Unsupported key schema: [`ROWKEY` ARRAY<STRING> KEY]"
+        "message": "Avro only supports MAPs with STRING keys"
       }
+    },
+    {
+      "name": "map with non-string keys fails - key - C*AS",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (k INT, v DOUBLE) WITH (kafka_topic='input_topic', value_format='AVRO');",
+        "CREATE STREAM OUTPUT WITH (key_format='AVRO') AS SELECT * FROM INPUT PARTITION BY MAP(k:=v);"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Avro only supports MAPs with STRING keys"
+      }
+    },
+    {
+      "name": "STRUCT - key - no inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K STRUCT<F1 VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": {"F1": "foo"}, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": {"F1": null}, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"F1": "foo"}, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": {"F1": null}, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
+    },
+    {
+      "name": "STRUCT - key - inference",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"name": "key", "type": "record", "fields": [{"name": "F1", "type": ["null", "string"]}]},
+          "keyFormat": "AVRO",
+          "valueSchema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": {"F1": "foo"}, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": {"F1": null}, "value": {"FOO": 10}},
+        {"topic": "input_topic", "key": null, "value": {"FOO": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"F1": "foo"}, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": {"F1": null}, "value": {"FOO": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"FOO": 10}}
+      ]
     },
     {
       "name": "INT - key - key and value inference",
@@ -1016,7 +1168,7 @@
       ]
     },
     {
-      "name": "map with non-string keys fails - C*",
+      "name": "map with non-string keys fails - value - C*",
       "statements": [
         "CREATE STREAM INPUT (foo MAP<INT, DOUBLE>) WITH (kafka_topic='input_topic', value_format='AVRO');"
       ],
@@ -1026,7 +1178,7 @@
       }
     },
     {
-      "name": "map with non-string keys fails - C*AS",
+      "name": "map with non-string keys fails - value - C*AS",
       "statements": [
         "CREATE STREAM INPUT (k INT, v DOUBLE) WITH (kafka_topic='input_topic', value_format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT MAP(k:=v) FROM INPUT;"

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/delimited.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/delimited.json
@@ -138,6 +138,87 @@
       }
     },
     {
+      "name": "ARRAY - C* - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K ARRAY<INT> KEY, foo INT) WITH (kafka_topic='input_topic', format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "ARRAY - C*AS - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (v INT) WITH (kafka_topic='input_topic', format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY ARRAY[v];"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "MAP - C* - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K MAP<INT, DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'MAP'"
+      }
+    },
+    {
+      "name": "MAP - C*AS - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY MAP(k:=v);"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'MAP'"
+      }
+    },
+    {
+      "name": "STRUCT - C* - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K STRUCT<F1 DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'STRUCT'"
+      }
+    },
+    {
+      "name": "STRUCT - C*AS - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (v DOUBLE) WITH (kafka_topic='input_topic', format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY STRUCT(k := v);"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'STRUCT'"
+      }
+    },
+    {
       "name": "deserialize anonymous primitive by default - value - DELIMITED",
       "comments": "DELIMITED supports anonymous primitives by default",
       "statements": [
@@ -354,7 +435,28 @@
       "outputs": []
     },
     {
-      "name": "MAP - C*",
+      "name": "ARRAY - C* - value",
+      "statements": [
+        "CREATE STREAM INPUT (foo ARRAY<INT>) WITH (kafka_topic='input_topic', value_format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "ARRAY - C*AS - value",
+      "statements": [
+        "CREATE STREAM INPUT (v INT) WITH (kafka_topic='input_topic', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT ARRAY[v] FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "MAP - C* - value",
       "statements": [
         "CREATE STREAM INPUT (foo MAP<INT, DOUBLE>) WITH (kafka_topic='input_topic', value_format='DELIMITED');"
       ],
@@ -364,7 +466,7 @@
       }
     },
     {
-      "name": "MAP - C*AS",
+      "name": "MAP - C*AS - value",
       "statements": [
         "CREATE STREAM INPUT (k INT, v DOUBLE) WITH (kafka_topic='input_topic', value_format='DELIMITED');",
         "CREATE STREAM OUTPUT AS SELECT MAP(k:=v) FROM INPUT;"
@@ -372,6 +474,27 @@
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "The 'DELIMITED' format does not support type 'MAP'"
+      }
+    },
+    {
+      "name": "STRUCT - C* - value",
+      "statements": [
+        "CREATE STREAM INPUT (foo STRUCT<F1 DOUBLE>) WITH (kafka_topic='input_topic', value_format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'STRUCT'"
+      }
+    },
+    {
+      "name": "STRUCT - C*AS - value",
+      "statements": [
+        "CREATE STREAM INPUT (v DOUBLE) WITH (kafka_topic='input_topic', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT STRUCT(k := v) FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'DELIMITED' format does not support type 'STRUCT'"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/json.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/json.json
@@ -278,13 +278,21 @@
     },
     {
       "name": "ARRAY - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
       "statements": [
-        "CREATE STREAM INPUT (K ARRAY<DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');"
+        "CREATE STREAM INPUT (K ARRAY<DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Unsupported key schema: [`K` ARRAY<DOUBLE> KEY]"
-      }
+      "inputs": [
+        {"topic": "input_topic", "key": [10.10], "value": {"V": 10}},
+        {"topic": "input_topic", "key": null, "value": {"V": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": [10.1], "value": {"V": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"V": 10}}
+      ]
     },
     {
       "name": "ARRAY - value - anonymous - deserialize",
@@ -318,13 +326,21 @@
     },
     {
       "name": "MAP - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
       "statements": [
-        "CREATE STREAM INPUT (K MAP<STRING, DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');"
+        "CREATE STREAM INPUT (K MAP<STRING, DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Unsupported key schema: [`K` MAP<STRING, DOUBLE> KEY]"
-      }
+      "inputs": [
+        {"topic": "input_topic", "key": {"a": 45.67}, "value": {"V": 10}},
+        {"topic": "input_topic", "key": null, "value": {"V": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"a": 45.67}, "value": {"V": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"V": 10}}
+      ]
     },
     {
       "name": "MAP - value - anonymous - deserialize",
@@ -358,13 +374,21 @@
     },
     {
       "name": "STRUCT - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
       "statements": [
-        "CREATE STREAM INPUT (K STRUCT<F DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');"
+        "CREATE STREAM INPUT (K STRUCT<F DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Unsupported key schema: [`K` STRUCT<`F` DOUBLE> KEY]"
-      }
+      "inputs": [
+        {"topic": "input_topic", "key": {"f": 45.67}, "value": {"V": 10}},
+        {"topic": "input_topic", "key": null, "value": {"V": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"F": 45.67}, "value": {"V": 10}},
+        {"topic": "OUTPUT", "key": null, "value": {"V": 10}}
+      ]
     },
     {
       "name": "STRUCT - value - anonymous - deserialize",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/kafka.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/kafka.json
@@ -66,7 +66,28 @@
       "outputs": [{"topic": "OUTPUT", "key": 1.1, "value": 2.2}]
     },
     {
-      "name": "MAP - C*",
+      "name": "ARRAY - C* - value",
+      "statements": [
+        "CREATE STREAM INPUT (foo ARRAY<INT>) WITH (kafka_topic='input_topic', value_format='KAFKA');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "ARRAY - C*AS - value",
+      "statements": [
+        "CREATE STREAM INPUT (v INT) WITH (kafka_topic='input_topic', value_format='KAFKA');",
+        "CREATE STREAM OUTPUT AS SELECT ARRAY[v] FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "MAP - C* - value",
       "statements": [
         "CREATE STREAM INPUT (foo MAP<INT, DOUBLE>) WITH (kafka_topic='input_topic', value_format='KAFKA');"
       ],
@@ -76,7 +97,7 @@
       }
     },
     {
-      "name": "MAP - C*AS",
+      "name": "MAP - C*AS - value",
       "statements": [
         "CREATE STREAM INPUT (k INT, v DOUBLE) WITH (kafka_topic='input_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT WITH (value_format='KAFKA') AS SELECT MAP(k:=v) FROM INPUT;"
@@ -84,6 +105,108 @@
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "The 'KAFKA' format does not support type 'MAP'"
+      }
+    },
+    {
+      "name": "STRUCT - C* - value",
+      "statements": [
+        "CREATE STREAM INPUT (foo STRUCT<F1 DOUBLE>) WITH (kafka_topic='input_topic', value_format='KAFKA');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'STRUCT'"
+      }
+    },
+    {
+      "name": "STRUCT - C*AS - value",
+      "statements": [
+        "CREATE STREAM INPUT (v DOUBLE) WITH (kafka_topic='input_topic', value_format='KAFKA');",
+        "CREATE STREAM OUTPUT AS SELECT STRUCT(k := v) FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'STRUCT'"
+      }
+    },
+    {
+      "name": "ARRAY - C* - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K ARRAY<INT> KEY, foo INT) WITH (kafka_topic='input_topic', format='KAFKA');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "ARRAY - C*AS - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (v INT) WITH (kafka_topic='input_topic', format='KAFKA');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY ARRAY[v];"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'ARRAY'"
+      }
+    },
+    {
+      "name": "MAP - C* - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K MAP<INT, DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='KAFKA');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'MAP'"
+      }
+    },
+    {
+      "name": "MAP - C*AS - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='KAFKA');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY MAP(k:=v);"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'MAP'"
+      }
+    },
+    {
+      "name": "STRUCT - C* - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K STRUCT<F1 DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='KAFKA');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'STRUCT'"
+      }
+    },
+    {
+      "name": "STRUCT - C*AS - key",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (v DOUBLE) WITH (kafka_topic='input_topic', format='KAFKA');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY STRUCT(k := v);"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "The 'KAFKA' format does not support type 'STRUCT'"
       }
     }
   ]


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/6447. This feature is currently hidden behind the `ksql.key.format.enabled` feature flag. I'm amazed this "just worked"... huge props to @big-andy-coates for setting up the codebase well!

### Testing done 

Lots of QTT.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

