### PR TITLE
build: temporarily disabling warnings as errors during compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
+        <!-- Temporarily disabling this because it is causing failures in packaging but not CI builds. -->
         <compile.warnings-flag>-Werror</compile.warnings-flag>
         <!-- Only used to provide login module implementation for tests -->
         <jetty.version>9.4.28.v20200408</jetty.version>


### PR DESCRIPTION
### Description 
The packaging build is failing because of warnings while compiling ksqldb-rest-module. These warnings do not happen locally or during the repo CI build. I am temporarily disabling the option to make these warnings fail the build. We will need to figure out why this only happens during packaging builds and then we can re-enable it.
```
[INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ ksqldb-rest-model ---
 [INFO] Changes detected - recompiling the module!
 [INFO] Compiling 84 source files to /tmp/confluent-artifacts-ZKaAVl/ksqldb/ksqldb-rest-model/target/classes
 [INFO] -------------------------------------------------------------
 [WARNING] COMPILATION WARNING : 
 [INFO] -------------------------------------------------------------
 [WARNING] No SupportedSourceVersion annotation found on io.sundr.builder.internal.processor.BuildableProcessor, returning RELEASE_6.
 [WARNING] Supported source version 'RELEASE_6' from annotation processor 'io.sundr.builder.internal.processor.BuildableProcessor' less than -source '1.8'
 [WARNING] No SupportedSourceVersion annotation found on io.sundr.builder.internal.processor.ExternalBuildableProcessor, returning RELEASE_6.
 [WARNING] Supported source version 'RELEASE_6' from annotation processor 'io.sundr.builder.internal.processor.ExternalBuildableProcessor' less than -source '1.8'
 [WARNING] No SupportedSourceVersion annotation found on io.sundr.resourcecify.internal.processor.ResourcecifyProcessor, returning RELEASE_6.
 [WARNING] Supported source version 'RELEASE_6' from annotation processor 'io.sundr.resourcecify.internal.processor.ResourcecifyProcessor' less than -source '1.8'
 [WARNING] No processor claimed any of these annotations: com.fasterxml.jackson.annotation.JsonProperty,com.fasterxml.jackson.annotation.JsonSubTypes,com.fasterxml.jackson.annotation.JsonTypeName,com.fasterxml.jackson.annotation.JsonTypeInfo,com.google.errorprone.annotations.Immutable,com.fasterxml.jackson.annotation.JsonValue,com.fasterxml.jackson.annotation.JsonCreator,com.fasterxml.jackson.annotation.JsonIgnore,com.fasterxml.jackson.annotation.JsonInclude,io.confluent.ksql.testing.EffectivelyImmutable,com.fasterxml.jackson.annotation.JsonIgnoreProperties
 [INFO] 7 warnings 
```

### Testing done 
I have tested that disabling this will make the build succeed.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

