### PR TITLE
chore: fix typo in use of closer

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
@@ -102,11 +102,11 @@ public class TopicDeleteInjector implements Injector {
       deleteTopic(source);
 
       final Closer closer = Closer.create();
-      deleteValueSubject(source);
-      deleteKeySubject(source);
+      closer.register(() -> deleteKeySubject(source));
+      closer.register(() -> deleteValueSubject(source));
       try {
         closer.close();
-      } catch (final RuntimeException e) {
+      } catch (final KsqlException e) {
         throw e;
       } catch (final Exception e) {
         throw new KsqlException(e);


### PR DESCRIPTION
### Description 

addresses https://github.com/confluentinc/ksql/pull/6449/files/437ef4bf08a9020d23f315306711d8e090e473aa#r506760845 (actually uses the closer 🤦 )

### Testing done 

Added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

