### PR TITLE
test: fix KsqlVersion so it supports new version format

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/KsqlVersion.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/KsqlVersion.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 public final class KsqlVersion implements Comparable<KsqlVersion> {
 
   private static final Pattern VERSION_PATTERN = Pattern
-      .compile("(\\d+)\\.(\\d+)(.\\d+)?(-SNAPSHOT)?");
+      .compile("(?<major>\\d+)\\.(?<minor>\\d+)(?<patch>.\\d+)?(?:-(SNAPSHOT|\\d+))?");
 
   @EffectivelyImmutable
   private static final Comparator<KsqlVersion> COMPARATOR =
@@ -57,11 +57,11 @@ public final class KsqlVersion implements Comparable<KsqlVersion> {
       );
     }
 
-    final int major = Integer.parseInt(matcher.group(1));
-    final int minor = Integer.parseInt(matcher.group(2));
-    final int patch = matcher.group(3) == null
+    final int major = Integer.parseInt(matcher.group("major"));
+    final int minor = Integer.parseInt(matcher.group("minor"));
+    final int patch = matcher.group("patch") == null
         ? 0
-        : Integer.parseInt(matcher.group(3).substring(1));
+        : Integer.parseInt(matcher.group("patch").substring(1));
 
     final SemanticVersion v = SemanticVersion.of(major, minor, patch);
     return new KsqlVersion(version, v, Long.MAX_VALUE);

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
@@ -65,6 +65,16 @@ public class KsqlVersionTest {
   }
 
   @Test
+  public void shouldParseWeirdNewFormat() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("5.4.1-0");
+
+    // Then:
+    assertThat(result.getName(), is("5.4.1-0"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(5, 4, 1)));
+  }
+
+  @Test
   public void shouldCompareUsingTimestamps() {
     // Given:
     final KsqlVersion v1 = KsqlVersion.parse("5.4.1").withTimestamp(123);

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
@@ -65,7 +65,7 @@ public class KsqlVersionTest {
   }
 
   @Test
-  public void shouldParseWeirdNewFormat() {
+  public void shouldParseNanoVersions() {
     // When:
     final KsqlVersion result = KsqlVersion.parse("5.4.1-0");
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanLoader.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanLoader.java
@@ -66,7 +66,7 @@ import org.w3c.dom.NodeList;
  */
 public final class TestCasePlanLoader {
 
-  private static final String CURRENT_VERSION = getFormattedVersionFromPomFile();
+  private static final KsqlVersion CURRENT_VERSION = getFormattedVersionFromPomFile();
   private static final KsqlConfig BASE_CONFIG = new KsqlConfig(TestExecutor.baseConfig());
   public static final Path PLANS_DIR = Paths.get("historical_plans");
 
@@ -131,7 +131,7 @@ public final class TestCasePlanLoader {
   ) {
     return buildStatementsInTestCase(
         PlannedTestUtils.buildPlannedTestCase(original),
-        original.getSpecNode().getVersion(),
+        KsqlVersion.parse(original.getSpecNode().getVersion()),
         original.getSpecNode().getTimestamp(),
         original.getPlanNode().getConfigs(),
         original.getSpecNode().getTestCase().name()
@@ -210,7 +210,7 @@ public final class TestCasePlanLoader {
 
   private static TestCasePlan buildStatementsInTestCase(
       final TestCase testCase,
-      final String version,
+      final KsqlVersion version,
       final long timestamp,
       final Map<String, String> configs,
       final String simpleTestName
@@ -234,7 +234,7 @@ public final class TestCasePlanLoader {
     );
 
     final TestCaseSpecNode spec = new TestCaseSpecNode(
-        version,
+        version.getVersion().toString(),
         timestamp,
         testCase.getOriginalFileName().toString(),
         testInfo.getSchemas(),
@@ -285,7 +285,8 @@ public final class TestCasePlanLoader {
     }
   }
 
-  private static String getFormattedVersionFromPomFile() {
+  @VisibleForTesting
+  static KsqlVersion getFormattedVersionFromPomFile() {
     try {
       final File pomFile = new File("pom.xml");
       final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -295,7 +296,7 @@ public final class TestCasePlanLoader {
       final NodeList versionNodeList = pomDoc.getElementsByTagName("version");
       final String versionName = versionNodeList.item(0).getTextContent();
 
-      return versionName.replaceAll("-SNAPSHOT?", "");
+      return KsqlVersion.parse(versionName.replaceAll("-SNAPSHOT?", ""));
     } catch (final Exception e) {
       throw new RuntimeException(e);
     }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanLoaderTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/TestCasePlanLoaderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.planned;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.confluent.ksql.test.model.KsqlVersion;
+import org.junit.Test;
+
+public class TestCasePlanLoaderTest {
+
+  @SuppressWarnings("unused")
+  @Test
+  public void shouldParseVersionInPomFile() {
+    // When:
+    final KsqlVersion version = TestCasePlanLoader.getFormattedVersionFromPomFile();
+
+    // Then: (did not throw)
+    assertThat(version, is(notNullValue()));
+  }
+}


### PR DESCRIPTION
### Description 

POM now has version set to `6.1.0-0`, which `KsqlVersion` couldn't handle.  This causes any attempt to generate new historical QTT test cases to fail.

- Updated `KsqlVersion` to be able to handle new format.
- Added unit test for new format.
- Added unit test to test against latest version in POM, so we pick this up earlier next time.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

