### PR TITLE
fix: Internal Server Error for /healthcheck endpoint in RBAC-enabled

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
@@ -50,10 +50,10 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
       final AuthenticationPlugin securityHandlerPlugin) {
     this.server = Objects.requireNonNull(server);
     this.securityHandlerPlugin = Objects.requireNonNull(securityHandlerPlugin);
-    // We add in all the paths that don't require authorization from
+    // We add in all the paths that don't require authentication/authorization from
     // KsqlAuthorizationProviderHandler
     final Set<String> unauthenticatedPaths = new HashSet<>(
-        KsqlAuthorizationProviderHandler.PATHS_WITHOUT_AUTHORIZATION);
+        KsqlAuthorizationProviderHandler.KSQL_AUTHENTICATION_SKIP_PATHS);
     // And then we add anything from the property authentication.skip.paths
     // This preserves the behaviour from the previous Jetty based implementation
     final List<String> unauthed = server.getConfig()

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.api.server.ServerUtils.convertCommaSeparatedWilc
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_UNAUTHORIZED;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.api.server.KsqlApiException;
 import io.confluent.ksql.api.server.Server;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
@@ -40,6 +41,8 @@ import java.util.regex.Pattern;
  * Handler that calls any authentication plugin
  */
 public class AuthenticationPluginHandler implements Handler<RoutingContext> {
+  public static final Set<String> KSQL_AUTHENTICATION_SKIP_PATHS = ImmutableSet
+      .of("/v1/metadata", "/v1/metadata/id", "/healthcheck");
 
   private final Server server;
   private final AuthenticationPlugin securityHandlerPlugin;
@@ -52,8 +55,7 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
     this.securityHandlerPlugin = Objects.requireNonNull(securityHandlerPlugin);
     // We add in all the paths that don't require authentication/authorization from
     // KsqlAuthorizationProviderHandler
-    final Set<String> unauthenticatedPaths = new HashSet<>(
-        KsqlAuthorizationProviderHandler.KSQL_AUTHENTICATION_SKIP_PATHS);
+    final Set<String> unauthenticatedPaths = new HashSet<>(KSQL_AUTHENTICATION_SKIP_PATHS);
     // And then we add anything from the property authentication.skip.paths
     // This preserves the behaviour from the previous Jetty based implementation
     final List<String> unauthed = server.getConfig()

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/KsqlAuthorizationProviderHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/KsqlAuthorizationProviderHandler.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.api.auth;
 
+import static io.confluent.ksql.api.auth.AuthenticationPluginHandler.KSQL_AUTHENTICATION_SKIP_PATHS;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 
-import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.security.KsqlAuthorizationProvider;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -25,15 +25,11 @@ import io.vertx.core.Promise;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
-import java.util.Set;
 
 /**
  * Handler that calls a KsqlAuthorizationProvider plugin that can be used for custom authorization
  */
 public class KsqlAuthorizationProviderHandler implements Handler<RoutingContext> {
-
-  public static final Set<String> KSQL_AUTHENTICATION_SKIP_PATHS = ImmutableSet
-      .of("/v1/metadata", "/v1/metadata/id", "/healthcheck");
 
   private final WorkerExecutor workerExecutor;
   private final KsqlAuthorizationProvider ksqlAuthorizationProvider;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/KsqlAuthorizationProviderHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/KsqlAuthorizationProviderHandler.java
@@ -32,7 +32,7 @@ import java.util.Set;
  */
 public class KsqlAuthorizationProviderHandler implements Handler<RoutingContext> {
 
-  public static final Set<String> PATHS_WITHOUT_AUTHORIZATION = ImmutableSet
+  public static final Set<String> KSQL_AUTHENTICATION_SKIP_PATHS = ImmutableSet
       .of("/v1/metadata", "/v1/metadata/id", "/healthcheck");
 
   private final WorkerExecutor workerExecutor;
@@ -49,7 +49,7 @@ public class KsqlAuthorizationProviderHandler implements Handler<RoutingContext>
 
     final String path = routingContext.normalisedPath();
 
-    if (PATHS_WITHOUT_AUTHORIZATION.contains(path)) {
+    if (KSQL_AUTHENTICATION_SKIP_PATHS.contains(path)) {
       routingContext.next();
       return;
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProvider.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProvider.java
@@ -57,11 +57,12 @@ public class DefaultKsqlSecurityContextProvider implements KsqlSecurityContextPr
     final Optional<Principal> principal = apiSecurityContext.getPrincipal();
     final Optional<String> authHeader = apiSecurityContext.getAuthToken();
 
-    // A user context is not necessary if a user context provider is not present or
-    // the user principal is missing. The missing principal was already validated by the
-    // Authentication and Authorization plugins before calling this method, which means the
-    // missing principal is a valid connection. For those cases, we create a default service
-    // context that the missing user can use.
+    // A user context is not necessary if a user context provider is not present or the user
+    // principal is missing. If a failed authentication attempt results in a missing principle,
+    // then the authentication plugin will have already failed the connection before calling
+    // this method. Therefore, if we've reached this method with a missing principle, then this
+    // must be a valid connection that does not require authentication.
+    // For these cases, we create a default service context that the missing user can use.
     final boolean requiresUserContext =
         securityExtension != null
             && securityExtension.getUserContextProvider().isPresent()

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -1014,7 +1014,7 @@ public final class KsqlRestApplication implements Executable {
         restConfig.getList(KsqlRestConfig.AUTHENTICATION_SKIP_PATHS_CONFIG)
     );
 
-    authenticationSkipPaths.addAll(KsqlAuthorizationProviderHandler.PATHS_WITHOUT_AUTHORIZATION);
+    authenticationSkipPaths.addAll(KsqlAuthorizationProviderHandler.KSQL_AUTHENTICATION_SKIP_PATHS);
 
     final Map<String, Object> restConfigs = restConfig.getOriginals();
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.api.utils.ReceiveStream;
 import io.confluent.ksql.api.utils.SendStream;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.rest.entity.PushQueryId;
+import io.confluent.ksql.util.AppInfo;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
@@ -52,6 +53,40 @@ public class ApiTest extends BaseApiTest {
   protected static final Logger log = LoggerFactory.getLogger(ApiTest.class);
 
   protected static final List<JsonObject> DEFAULT_INSERT_ROWS = generateInsertRows();
+
+  @Test
+  @CoreApiTest
+  public void shouldExecuteInfoRquest() throws Exception {
+    // When
+    HttpResponse<Buffer> response = sendGetRequest("/info");
+
+    // Then
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.statusMessage(), is("OK"));
+    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
+    assertThat(queryResponse.responseObject.getJsonObject("KsqlServerInfo").getString("version"),
+        is(AppInfo.getVersion()));
+    assertThat(queryResponse.responseObject.getJsonObject("KsqlServerInfo").getString("kafkaClusterId"),
+        is("kafka-cluster-id"));
+    assertThat(queryResponse.responseObject.getJsonObject("KsqlServerInfo").getString("ksqlServiceId"),
+        is("ksql-service-id"));
+  }
+
+  @Test
+  @CoreApiTest
+  public void shouldExecuteServerMetadataIdRequest() throws Exception {
+    // When
+    HttpResponse<Buffer> response = sendGetRequest("/v1/metadata/id");
+
+    // Then
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.statusMessage(), is("OK"));
+    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
+    assertThat(queryResponse.responseObject.getJsonObject("scope").getJsonObject("clusters")
+            .getString("kafka-cluster"), is("kafka-cluster-id"));
+    assertThat(queryResponse.responseObject.getJsonObject("scope").getJsonObject("clusters")
+            .getString("ksql-cluster"), is("ksql-service-id"));
+  }
 
   @Test
   @CoreApiTest

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -98,7 +98,7 @@ public class ApiTest extends BaseApiTest {
     requestBody.put("properties", properties);
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/query-stream", requestBody.toBuffer());
+    HttpResponse<Buffer> response = sendPostRequest("/query-stream", requestBody.toBuffer());
 
     // Then
     assertThat(response.statusCode(), is(200));
@@ -255,7 +255,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject requestBody = new JsonObject().put("foo", "bar");
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/query-stream", requestBody.toBuffer());
+    HttpResponse<Buffer> response = sendPostRequest("/query-stream", requestBody.toBuffer());
 
     // Then
     assertThat(response.statusCode(), is(400));
@@ -273,7 +273,7 @@ public class ApiTest extends BaseApiTest {
     testEndpoints.setRowsBeforePublisherError(DEFAULT_JSON_ROWS.size() - 1);
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/query-stream",
+    HttpResponse<Buffer> response = sendPostRequest("/query-stream",
         DEFAULT_PUSH_QUERY_REQUEST_BODY.toBuffer());
 
     // Then
@@ -320,7 +320,7 @@ public class ApiTest extends BaseApiTest {
 
     VertxCompletableFuture<HttpResponse<Void>> responseFuture = new VertxCompletableFuture<>();
     // Make the request to stream a query
-    sendRequest("/query-stream", (request) ->
+    sendPostRequest("/query-stream", (request) ->
         request
             .as(BodyCodec.pipe(writeStream))
             .sendJsonObject(DEFAULT_PUSH_QUERY_REQUEST_BODY, responseFuture)
@@ -349,7 +349,7 @@ public class ApiTest extends BaseApiTest {
 
     // Now send another request to close the query
     JsonObject closeQueryRequestBody = new JsonObject().put("queryId", queryId);
-    HttpResponse<Buffer> closeQueryResponse = sendRequest("/close-query",
+    HttpResponse<Buffer> closeQueryResponse = sendPostRequest("/close-query",
         closeQueryRequestBody.toBuffer());
     assertThat(closeQueryResponse.statusCode(), is(200));
 
@@ -370,7 +370,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject closeQueryRequestBody = new JsonObject().put("foo", "bar");
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/close-query",
+    HttpResponse<Buffer> response = sendPostRequest("/close-query",
         closeQueryRequestBody.toBuffer());
 
     // Then
@@ -390,7 +390,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject closeQueryRequestBody = new JsonObject().put("queryId", "xyzfasgf");
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/close-query",
+    HttpResponse<Buffer> response = sendPostRequest("/close-query",
         closeQueryRequestBody.toBuffer());
 
     // Then
@@ -415,7 +415,7 @@ public class ApiTest extends BaseApiTest {
     }
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/inserts-stream", requestBody);
+    HttpResponse<Buffer> response = sendPostRequest("/inserts-stream", requestBody);
 
     // Then
     assertThat(response.statusCode(), is(200));
@@ -446,7 +446,7 @@ public class ApiTest extends BaseApiTest {
     // When
 
     // Make an HTTP request but keep the request body and response streams open
-    sendRequest("/inserts-stream", (request) ->
+    sendPostRequest("/inserts-stream", (request) ->
         request
             .as(BodyCodec.pipe(writeStream))
             .sendStream(readStream, fut)
@@ -499,7 +499,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject requestBody = new JsonObject();
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/inserts-stream",
+    HttpResponse<Buffer> response = sendPostRequest("/inserts-stream",
         requestBody.toBuffer().appendString("\n"));
 
     // Then
@@ -529,7 +529,7 @@ public class ApiTest extends BaseApiTest {
 
     // When
 
-    HttpResponse<Buffer> response = sendRequest("/inserts-stream", requestBody);
+    HttpResponse<Buffer> response = sendPostRequest("/inserts-stream", requestBody);
 
     // Then
 
@@ -568,7 +568,7 @@ public class ApiTest extends BaseApiTest {
 
     // When
 
-    HttpResponse<Buffer> response = sendRequest("/inserts-stream", requestBody);
+    HttpResponse<Buffer> response = sendPostRequest("/inserts-stream", requestBody);
 
     // Then
 
@@ -793,7 +793,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject requestBody = new JsonObject().put("sql", query);
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/query-stream",
+    HttpResponse<Buffer> response = sendPostRequest("/query-stream",
         requestBody.toBuffer());
 
     // Then
@@ -813,7 +813,7 @@ public class ApiTest extends BaseApiTest {
     JsonObject requestBody = new JsonObject().put("sql", query);
 
     // When
-    HttpResponse<Buffer> response = sendRequest("/query-stream",
+    HttpResponse<Buffer> response = sendPostRequest("/query-stream",
         requestBody.toBuffer());
 
     // Then

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
@@ -612,7 +612,7 @@ public class AuthTest extends ApiTest {
     void run() throws Exception;
   }
 
-  public static class StringPrincipal implements Principal {
+  private static class StringPrincipal implements Principal {
 
     private final String name;
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
@@ -148,14 +148,14 @@ public class AuthTest extends ApiTest {
   }
 
   @Override
-  protected HttpResponse<Buffer> sendRequest(final WebClient client, final String uri,
+  protected HttpResponse<Buffer> sendPostRequest(final WebClient client, final String uri,
       final Buffer requestBody)
       throws Exception {
-    return sendRequestWithCreds(client, uri, requestBody, USER_WITH_ACCESS, USER_WITH_ACCESS_PWD);
+    return sendPostRequestWithCreds(client, uri, requestBody, USER_WITH_ACCESS, USER_WITH_ACCESS_PWD);
   }
 
   @Override
-  protected void sendRequest(
+  protected void sendPostRequest(
       final WebClient client,
       final String uri,
       final Consumer<HttpRequest<Buffer>> requestSender) {
@@ -353,7 +353,7 @@ public class AuthTest extends ApiTest {
       throws Exception {
     setupSecurityPlugin(USER_WITHOUT_ACCESS,
         () -> {
-          HttpResponse<Buffer> response = sendRequestWithNonBasicCredentials(client,
+          HttpResponse<Buffer> response = sendPostRequestWithNonBasicCredentials(client,
               "/query-stream", new JsonObject().put("sql", DEFAULT_PULL_QUERY).toBuffer(),
               "BEARER quydwquywdg");
           assertThat(response.statusCode(), is(200));
@@ -364,7 +364,7 @@ public class AuthTest extends ApiTest {
   public void shouldRejectRequestIfJaasConfiguredWIthNoSecurityPluginAndNotBasicAuth()
       throws Exception {
 
-    HttpResponse<Buffer> response = sendRequestWithNonBasicCredentials(client,
+    HttpResponse<Buffer> response = sendPostRequestWithNonBasicCredentials(client,
         "/query-stream", new JsonObject().put("sql", DEFAULT_PULL_QUERY).toBuffer(),
         "BEARER quydwquywdg");
     assertThat(response.statusCode(), is(401));
@@ -375,7 +375,7 @@ public class AuthTest extends ApiTest {
       final int expectedStatus, final String expectedMessage, final int expectedErrorCode)
       throws Exception {
     // When
-    HttpResponse<Buffer> response = sendRequestWithCreds(
+    HttpResponse<Buffer> response = sendPostRequestWithCreds(
         "/query-stream",
         DEFAULT_PUSH_QUERY_REQUEST_BODY.toBuffer(),
         username,
@@ -396,7 +396,7 @@ public class AuthTest extends ApiTest {
     JsonObject requestBody = new JsonObject().put("queryId", "foo");
 
     // When
-    HttpResponse<Buffer> response = sendRequestWithCreds(
+    HttpResponse<Buffer> response = sendPostRequestWithCreds(
         "/close-query",
         requestBody.toBuffer(),
         username,
@@ -422,7 +422,7 @@ public class AuthTest extends ApiTest {
     }
 
     // When
-    HttpResponse<Buffer> response = sendRequestWithCreds(
+    HttpResponse<Buffer> response = sendPostRequestWithCreds(
         "/inserts-stream",
         requestBody,
         username,
@@ -452,17 +452,17 @@ public class AuthTest extends ApiTest {
     return requestFuture.get();
   }
 
-  private HttpResponse<Buffer> sendRequestWithCreds(
+  private HttpResponse<Buffer> sendPostRequestWithCreds(
       final String uri,
       final Buffer requestBody,
       final String username,
       final String password
   ) throws Exception {
-    return sendRequestWithCreds(client, uri, requestBody, username, password);
+    return sendPostRequestWithCreds(client, uri, requestBody, username, password);
   }
 
   // auth header is omitted if username and password are null
-  private static HttpResponse<Buffer> sendRequestWithCreds(
+  private static HttpResponse<Buffer> sendPostRequestWithCreds(
       final WebClient client,
       final String uri,
       final Buffer requestBody,
@@ -478,7 +478,7 @@ public class AuthTest extends ApiTest {
     return requestFuture.get();
   }
 
-  private static HttpResponse<Buffer> sendRequestWithNonBasicCredentials(
+  private static HttpResponse<Buffer> sendPostRequestWithNonBasicCredentials(
       final WebClient client,
       final String uri,
       final Buffer requestBody,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.api.auth.AuthenticationPlugin;
 import io.confluent.ksql.api.server.KsqlApiException;
 import io.confluent.ksql.api.server.Server;
@@ -31,7 +30,6 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.security.KsqlAuthorizationProvider;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.security.KsqlUserContextProvider;
-import io.confluent.ksql.services.ConfiguredKafkaClientSupplier;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -50,7 +48,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -549,28 +546,13 @@ public class AuthTest extends ApiTest {
     stopServer();
     stopClient();
     AtomicReference<Boolean> authorizationCallReference = new AtomicReference<>(false);
-    AtomicReference<Boolean> userContextCallReference = new AtomicReference<>(false);
     this.authorizationProvider = (user, method, path) -> {
       authorizationCallReference.set(true);
-    };
-    this.userContextProvider = new KsqlUserContextProvider() {
-      @Override
-      public ConfiguredKafkaClientSupplier getKafkaClientSupplier(Principal principal) {
-        userContextCallReference.set(true);
-        return null;
-      }
-
-      @Override
-      public Supplier<SchemaRegistryClient> getSchemaRegistryClientFactory(Principal principal) {
-        userContextCallReference.set(true);
-        return null;
-      }
     };
     createServer(createServerConfig());
     client = createClient();
     action.run();
     assertThat("Should not call authorization", authorizationCallReference.get(), is(false));
-    assertThat("Should not call user context", userContextCallReference.get(), is(false));
   }
 
   private void shouldAllowAccessWithPermissionCheck(final String expectedUser,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
@@ -188,6 +189,17 @@ public class BaseApiTest {
     assertThat(writeStream.isEnded(), is(false));
 
     return new QueryResponse(writeStream.getBody().toString());
+  }
+
+  protected HttpResponse<Buffer> sendGetRequest(final String uri) throws Exception {
+    return sendGetRequest(client, uri);
+  }
+
+  protected HttpResponse<Buffer> sendGetRequest(final WebClient client, final String uri)
+      throws Exception {
+    VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
+    client.get(uri).send(requestFuture);
+    return requestFuture.get();
   }
 
   protected HttpResponse<Buffer> sendRequest(final String uri, final Buffer requestBody)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -48,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
@@ -168,7 +167,7 @@ public class BaseApiTest {
 
     ReceiveStream writeStream = new ReceiveStream(vertx);
 
-    sendRequest(client, "/query-stream",
+    sendPostRequest(client, "/query-stream",
         (request) -> request
             .as(BodyCodec.pipe(writeStream))
             .sendJsonObject(requestBody, ar -> {
@@ -202,13 +201,13 @@ public class BaseApiTest {
     return requestFuture.get();
   }
 
-  protected HttpResponse<Buffer> sendRequest(final String uri, final Buffer requestBody)
+  protected HttpResponse<Buffer> sendPostRequest(final String uri, final Buffer requestBody)
       throws Exception {
-    return sendRequest(client, uri, requestBody);
+    return sendPostRequest(client, uri, requestBody);
   }
 
-  protected HttpResponse<Buffer> sendRequest(final WebClient client, final String uri,
-      final Buffer requestBody)
+  protected HttpResponse<Buffer> sendPostRequest(final WebClient client, final String uri,
+                                                 final Buffer requestBody)
       throws Exception {
     VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
     client
@@ -217,11 +216,11 @@ public class BaseApiTest {
     return requestFuture.get();
   }
 
-  protected void sendRequest(final String uri, final Consumer<HttpRequest<Buffer>> requestSender) {
-    sendRequest(client, uri, requestSender);
+  protected void sendPostRequest(final String uri, final Consumer<HttpRequest<Buffer>> requestSender) {
+    sendPostRequest(client, uri, requestSender);
   }
 
-  protected void sendRequest(
+  protected void sendPostRequest(
       final WebClient client,
       final String uri,
       final Consumer<HttpRequest<Buffer>> requestSender) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/Http2OnlyStreamTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/Http2OnlyStreamTest.java
@@ -60,7 +60,7 @@ public class Http2OnlyStreamTest extends BaseApiTest {
   private void shouldRejectRequestUsingHttp11(final String uri, final JsonObject request)
       throws Exception {
     // When
-    HttpResponse<Buffer> response = sendRequest(uri, request.toBuffer());
+    HttpResponse<Buffer> response = sendPostRequest(uri, request.toBuffer());
 
     // Then
     assertThat(response.statusCode(), is(400));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/MaxQueriesTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/MaxQueriesTest.java
@@ -43,7 +43,7 @@ public class MaxQueriesTest extends BaseApiTest {
     for (int i = 0; i < MAX_QUERIES + 4; i++) {
 
       if (i >= MAX_QUERIES) {
-        HttpResponse<Buffer> response = sendRequest("/query-stream",
+        HttpResponse<Buffer> response = sendPostRequest("/query-stream",
             DEFAULT_PUSH_QUERY_REQUEST_BODY.toBuffer());
         assertThat(response.statusCode(), is(400));
         QueryResponse queryResponse = new QueryResponse(response.bodyAsString());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ServerStateTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ServerStateTest.java
@@ -54,7 +54,7 @@ public class ServerStateTest extends BaseApiTest {
       final String expectedMessage
   ) throws Exception {
     // When:
-    HttpResponse<Buffer> response = sendRequest(
+    HttpResponse<Buffer> response = sendPostRequest(
         "/query-stream",
         DEFAULT_PUSH_QUERY_REQUEST_BODY.toBuffer()
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -142,7 +142,8 @@ public class TestEndpoints implements Endpoints {
   }
 
   @Override
-  public CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext) {
+  public synchronized CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext) {
+    this.lastApiSecurityContext = apiSecurityContext;
     final ServerInfo entity = new ServerInfo(
         AppInfo.getVersion(), "kafka-cluster-id", "ksql-service-id");
     return CompletableFuture.completedFuture(EndpointResponse.ok(entity));
@@ -191,8 +192,9 @@ public class TestEndpoints implements Endpoints {
   }
 
   @Override
-  public CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
+  public synchronized CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
       ApiSecurityContext apiSecurityContext) {
+    this.lastApiSecurityContext = apiSecurityContext;
     final ServerClusterId entity = ServerClusterId.of("kafka-cluster-id", "ksql-service-id");
     return CompletableFuture.completedFuture(EndpointResponse.ok(entity));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -27,7 +27,12 @@ import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
+import io.confluent.ksql.rest.entity.ServerClusterId;
+import io.confluent.ksql.rest.entity.ServerInfo;
+import io.confluent.ksql.rest.entity.ServerMetadata;
 import io.confluent.ksql.rest.entity.StreamsList;
+import io.confluent.ksql.util.AppInfo;
+import io.confluent.ksql.util.KsqlConfig;
 import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
@@ -138,7 +143,9 @@ public class TestEndpoints implements Endpoints {
 
   @Override
   public CompletableFuture<EndpointResponse> executeInfo(ApiSecurityContext apiSecurityContext) {
-    return null;
+    final ServerInfo entity = new ServerInfo(
+        AppInfo.getVersion(), "kafka-cluster-id", "ksql-service-id");
+    return CompletableFuture.completedFuture(EndpointResponse.ok(entity));
   }
 
   @Override
@@ -186,7 +193,8 @@ public class TestEndpoints implements Endpoints {
   @Override
   public CompletableFuture<EndpointResponse> executeServerMetadataClusterId(
       ApiSecurityContext apiSecurityContext) {
-    return null;
+    final ServerClusterId entity = ServerClusterId.of("kafka-cluster-id", "ksql-service-id");
+    return CompletableFuture.completedFuture(EndpointResponse.ok(entity));
   }
 
   @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TlsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TlsTest.java
@@ -91,7 +91,7 @@ public class TlsTest extends ApiTest {
     JsonObject requestBody = new JsonObject().put("sql", DEFAULT_PULL_QUERY);
 
     // Given: sanity check that a query succeeds
-    HttpResponse<Buffer> response = sendRequest("/query-stream", requestBody.toBuffer());
+    HttpResponse<Buffer> response = sendPostRequest("/query-stream", requestBody.toBuffer());
     assertThat(response.statusCode(), is(200));
     assertThat(response.statusMessage(), is("OK"));
 
@@ -106,7 +106,7 @@ public class TlsTest extends ApiTest {
 
             try {
               // this should fail
-              sendRequest("/query-stream", requestBody.toBuffer());
+              sendPostRequest("/query-stream", requestBody.toBuffer());
               return "error: request should have failed but did not";
             } catch (Exception e) {
               assertThat(e,
@@ -128,7 +128,7 @@ public class TlsTest extends ApiTest {
             this.client = createClient();
 
             try {
-              return sendRequest("/query-stream", requestBody.toBuffer()).statusCode();
+              return sendPostRequest("/query-stream", requestBody.toBuffer()).statusCode();
             } catch (Exception e) {
               return 0;
             }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProviderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProviderTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.api.auth.ApiSecurityContext;
+import io.confluent.ksql.rest.client.KsqlClient;
+import io.confluent.ksql.rest.server.services.RestServiceContextFactory;
+import io.confluent.ksql.security.KsqlSecurityContext;
+import io.confluent.ksql.security.KsqlSecurityExtension;
+import io.confluent.ksql.security.KsqlUserContextProvider;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import java.security.Principal;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultKsqlSecurityContextProviderTest {
+  @Mock
+  private KsqlSecurityExtension securityExtension;
+  @Mock
+  private RestServiceContextFactory.DefaultServiceContextFactory defaultServiceContextFactory;
+  @Mock
+  private RestServiceContextFactory.UserServiceContextFactory userServiceContextFactory;
+  @Mock
+  private KsqlUserContextProvider userContextProvider;
+  @Mock
+  private ServiceContext defaultServiceContext;
+  @Mock
+  private ServiceContext userServiceContext;
+  @Mock
+  private KsqlConfig ksqlConfig;
+  @Mock
+  private SchemaRegistryClient schemaRegistryClientFactory;
+  @Mock
+  private KsqlClient ksqlClient;
+  @Mock
+  private Principal user1;
+  @Mock
+  private ApiSecurityContext apiSecurityContext;
+
+  private DefaultKsqlSecurityContextProvider ksqlSecurityContextProvider;
+
+  @Before
+  public void setup() {
+    ksqlSecurityContextProvider = new DefaultKsqlSecurityContextProvider(
+        securityExtension,
+        defaultServiceContextFactory,
+        userServiceContextFactory,
+        ksqlConfig,
+        () -> schemaRegistryClientFactory,
+        ksqlClient
+    );
+
+    when(apiSecurityContext.getPrincipal()).thenReturn(Optional.of(user1));
+    when(apiSecurityContext.getAuthToken()).thenReturn(Optional.empty());
+
+    when(defaultServiceContextFactory.create(any(), any(), any(), any()))
+        .thenReturn(defaultServiceContext);
+    when(userServiceContextFactory.create(any(), any(), any(), any(), any()))
+        .thenReturn(userServiceContext);
+  }
+
+  @Test
+  public void shouldCreateDefaultServiceContextIfUserContextProviderIsNotEnabled() {
+    // Given:
+    when(securityExtension.getUserContextProvider()).thenReturn(Optional.empty());
+
+    // When:
+    final KsqlSecurityContext ksqlSecurityContext =
+        ksqlSecurityContextProvider.provide(apiSecurityContext);
+
+    // Then:
+    assertThat(ksqlSecurityContext.getUserPrincipal(), is(Optional.of(user1)));
+    assertThat(ksqlSecurityContext.getServiceContext(), is(defaultServiceContext));
+  }
+
+  @Test
+  public void shouldCreateDefaultServiceContextIfUserPrincipalIsMissing() {
+    // Given:
+    when(securityExtension.getUserContextProvider()).thenReturn(Optional.of(userContextProvider));
+    when(apiSecurityContext.getPrincipal()).thenReturn(Optional.empty());
+
+    // When:
+    final KsqlSecurityContext ksqlSecurityContext =
+        ksqlSecurityContextProvider.provide(apiSecurityContext);
+
+    // Then:
+    assertThat(ksqlSecurityContext.getUserPrincipal(), is(Optional.empty()));
+    assertThat(ksqlSecurityContext.getServiceContext(), is(defaultServiceContext));
+  }
+
+  @Test
+  public void shouldCreateUserServiceContextIfUserContextProviderIsEnabled() {
+    // Given:
+    when(securityExtension.getUserContextProvider()).thenReturn(Optional.of(userContextProvider));
+
+    // When:
+    final KsqlSecurityContext ksqlSecurityContext =
+        ksqlSecurityContextProvider.provide(apiSecurityContext);
+
+    // Then:
+    verify(userServiceContextFactory)
+        .create(eq(ksqlConfig), eq(Optional.empty()), any(), any(), any());
+    assertThat(ksqlSecurityContext.getUserPrincipal(), is(Optional.of(user1)));
+    assertThat(ksqlSecurityContext.getServiceContext(), is(userServiceContext));
+  }
+
+  @Test
+  public void shouldPassAuthHeaderToDefaultFactory() {
+    // Given:
+    when(securityExtension.getUserContextProvider()).thenReturn(Optional.empty());
+    when(apiSecurityContext.getAuthToken()).thenReturn(Optional.of("some-auth"));
+
+    // When:
+    ksqlSecurityContextProvider.provide(apiSecurityContext);
+
+    // Then:
+    verify(defaultServiceContextFactory).create(any(), eq(Optional.of("some-auth")), any(), any());
+  }
+
+  @Test
+  public void shouldPassAuthHeaderToUserFactory() {
+    // Given:
+    when(securityExtension.getUserContextProvider()).thenReturn(Optional.of(userContextProvider));
+    when(apiSecurityContext.getAuthToken()).thenReturn(Optional.of("some-auth"));
+
+    // When:
+    ksqlSecurityContextProvider.provide(apiSecurityContext);
+
+    // Then:
+    verify(userServiceContextFactory)
+        .create(any(), eq(Optional.of("some-auth")), any(), any(), any());
+  }
+}


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/6479

Context:
There are endpoints in `KsqlServerEndpoints` that do not require a security context initialized. Some of these endpoints do not require authentication, so a security context should not be initialized because there is no `Principal` authenticated. 

The current Vert.x code in `KsqlServerEndpoints` attempted to initialize the security context on endpoints where the user was not authenticated. This caused an error when calling these endpoints even with valid credentials. The fix was just to prevent initializing the security contexts, which is unnecessary.

### Testing done 
Added unit tests.
Verified manually with Confluent RBAC library.

* `User:ksql` has valid credentials and has authorization to the server.
* `User:user1` has valid credentials but not authorization to the server.

1. Endpoints that required authentication only 
```
curl   http://localhost:8088/info | jq .
{
  "@type": "generic_error",
  "error_code": 40100,
  "message": "Failed authentication"
}

curl -u user1:user1  http://localhost:8088/info | jq .
{
  "KsqlServerInfo": {
    "version": "6.1.0-0",
    "kafkaClusterId": "Bj_7MIRSQ36T97mtEimh-A",
    "ksqlServiceId": "default_",
    "serverStatus": "RUNNING"
  }
}
```

2. Endpoints that do not require authentication
```
 curl http://localhost:8088/v1/metadata/id 2>/dev/null | jq .
{
  "scope": {
    "path": [],
    "clusters": {
      "kafka-cluster": "Bj_7MIRSQ36T97mtEimh-A",
      "ksql-cluster": "default_"
    }
  },
  "id": ""
}
```

3. Endpoints that require authentication and authorization
```
$ curl http://localhost:8088/info 2>/dev/null | jq .
{
  "@type": "generic_error",
  "error_code": 40100,
  "message": "Failed authentication"
}

$ curl -u user1:user1 http://localhost:8088/status 2>/dev/null | jq .
{
  "@type": "generic_error",
  "error_code": 40300,
  "message": "You are forbidden from using this cluster."
}

$ curl -u ksql:ksql http://localhost:8088/status 2>/dev/null | jq .
{
  "commandStatuses": {
    "stream/`KSQL_PROCESSING_LOG`/create": "SUCCESS"
  }
}
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

