### PR TITLE
test: fix QTT tests after upstream change

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1594233263741/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1594233263741/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.1.0_1594164260142/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.1.0_1594164260142/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1594233263917/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1594233263917/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.1.0_1594164260318/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.1.0_1594164260318/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1594233264114/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1594233264114/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.1.0_1594164260506/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.1.0_1594164260506/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-list.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-list.json
@@ -194,6 +194,8 @@
         {"topic": "S2", "key": 0,"value": {"COLLECTED": []}},
         {"topic": "S2", "key": 0,"value": {"COLLECTED": ["bar"]}},
         {"topic": "S2", "key": 100,"value": {"COLLECTED": []}},
+        {"topic": "S2", "key": 100,"value": {"COLLECTED": ["baz"]}},
+        {"topic": "S2", "key": 100,"value": {"COLLECTED": []}},
         {"topic": "S2", "key": 100,"value": {"COLLECTED": ["foo"]}}
       ]
     },


### PR DESCRIPTION
### Description 

One of several PRs to fix the broken master build. Full set needed for green build: [#6487, #6486,#6494]

There seems to have been an upstream change that means intermediate output is no longer being suppressed.  This is only affecting a single QTT test, (and its historic versions) The test was previously:

```json
{
      "name": "collect_list string table",
      "format": ["AVRO", "JSON", "PROTOBUF"],
      "statements": [
        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, VALUE varchar) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
        "CREATE TABLE S2 as SELECT ID, collect_list(value) as collected FROM test group by id;"
      ],
      "inputs": [
        {"topic": "test_topic", "key": 0,"value": {"VALUE": "foo"}},
        {"topic": "test_topic", "key": 100,"value": {"VALUE": "baz"}},
        {"topic": "test_topic", "key": 0,"value": {"VALUE": "bar"}},
        {"topic": "test_topic", "key": 100,"value": {"VALUE": "baz"}},
        {"topic": "test_topic", "key": 100,"value": {"VALUE": "foo"}}
      ],
      "outputs": [
        {"topic": "S2", "key": 0,"value": {"COLLECTED": ["foo"]}},
        {"topic": "S2", "key": 100,"value": {"COLLECTED": ["baz"]}},
        {"topic": "S2", "key": 0,"value": {"COLLECTED": []}},
        {"topic": "S2", "key": 0,"value": {"COLLECTED": ["bar"]}},
        {"topic": "S2", "key": 100,"value": {"COLLECTED": []}},
        {"topic": "S2", "key": 100,"value": {"COLLECTED": ["foo"]}}
      ]
    }
```

Where as now it needs to be:

```json
{
      "name": "collect_list string table",
      "format": ["AVRO", "JSON", "PROTOBUF"],
      "statements": [
        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, VALUE varchar) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
        "CREATE TABLE S2 as SELECT ID, collect_list(value) as collected FROM test group by id;"
      ],
      "inputs": [
        {"topic": "test_topic", "key": 0,"value": {"VALUE": "foo"}},
        {"topic": "test_topic", "key": 100,"value": {"VALUE": "baz"}},
        {"topic": "test_topic", "key": 0,"value": {"VALUE": "bar"}},
        {"topic": "test_topic", "key": 100,"value": {"VALUE": "baz"}},
        {"topic": "test_topic", "key": 100,"value": {"VALUE": "foo"}}
      ],
      "outputs": [
        {"topic": "S2", "key": 0,"value": {"COLLECTED": ["foo"]}},
        {"topic": "S2", "key": 100,"value": {"COLLECTED": ["baz"]}},
        {"topic": "S2", "key": 0,"value": {"COLLECTED": []}},
        {"topic": "S2", "key": 0,"value": {"COLLECTED": ["bar"]}},
        {"topic": "S2", "key": 100,"value": {"COLLECTED": []}},            <-- new output
        {"topic": "S2", "key": 100,"value": {"COLLECTED": ["baz"]}},  <-- new output
        {"topic": "S2", "key": 100,"value": {"COLLECTED": []}},
        {"topic": "S2", "key": 100,"value": {"COLLECTED": ["foo"]}}
      ]
    }
```

Question is... is this additional output expected?   cc @abbccdda 
