### PR TITLE
feat: support variable substitution in SQL statements

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.parser.SqlBaseParser.SetPropertyContext;
 import io.confluent.ksql.parser.SqlBaseParser.StatementContext;
 import io.confluent.ksql.parser.SqlBaseParser.UndefineVariableContext;
 import io.confluent.ksql.parser.SqlBaseParser.UnsetPropertyContext;
+import io.confluent.ksql.parser.VariableSubstitutor;
 import io.confluent.ksql.reactive.BaseSubscriber;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.client.KsqlRestClient;
@@ -341,8 +342,15 @@ public class Cli implements KsqlRequestExecutor, Closeable {
     }
   }
 
+  private List<ParsedStatement> substituteVariables(final List<ParsedStatement> statements) {
+    return statements.stream()
+        .map(stmt -> VariableSubstitutor.substitute(stmt, sessionVariables))
+        .flatMap(replacedSql -> KSQL_PARSER.parse(replacedSql).stream())
+        .collect(Collectors.toList());
+  }
+
   private void handleStatements(final String line) {
-    final List<ParsedStatement> statements = KSQL_PARSER.parse(line);
+    final List<ParsedStatement> statements = substituteVariables(KSQL_PARSER.parse(line));
 
     final StringBuilder consecutiveStatements = new StringBuilder();
     for (final ParsedStatement parsed : statements) {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -432,8 +432,27 @@ public class CliTest {
   }
 
   @Test
+  public void testDisableVariableSubstitution() {
+    // Given:
+    assertRunCommand(
+        "set '" + KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE + "' = 'false';", is(EMPTY_RESULT));
+    assertRunCommand("define topicName = '" + DELIMITED_TOPIC + "';", is(EMPTY_RESULT));
+
+    // When:
+    run("PRINT ${topicName} FROM BEGINNING INTERVAL 1 LIMIT 2;", localCli);
+
+    // Then:
+    assertThatEventually(() -> terminal.getOutputString(),
+        containsString("Failed to Describe Kafka Topic(s): [${topicName}]"));
+    assertThatEventually(() -> terminal.getOutputString(),
+        containsString("Caused by: This server does not host this topic-partition."));
+  }
+
+  @Test
   public void testVariableSubstitution() {
     // Given:
+    assertRunCommand(
+        "set '" + KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE + "' = 'true';", is(EMPTY_RESULT));
     assertRunCommand("define topicName = '" + DELIMITED_TOPIC + "';", is(EMPTY_RESULT));
 
     // When:

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -432,6 +432,23 @@ public class CliTest {
   }
 
   @Test
+  public void testVariableSubstitution() {
+    // Given:
+    assertRunCommand("define topicName = '" + DELIMITED_TOPIC + "';", is(EMPTY_RESULT));
+
+    // When:
+    run("PRINT ${topicName} FROM BEGINNING INTERVAL 1 LIMIT 2;", localCli);
+
+    // Then:
+    assertThatEventually(() -> terminal.getOutputString(),
+        containsString("Value format: KAFKA_STRING"));
+    assertThat(terminal.getOutputString(), containsString("Key format: KAFKA_STRING"));
+    assertThat(terminal.getOutputString(), containsString(", key: <null>, value: <null>"));
+    assertThat(terminal.getOutputString(),
+        containsString(", key: ITEM_1, value: home cinema"));
+  }
+
+  @Test
   public void testVariableDefineUndefine() {
     assertRunCommand("define var1 = '1';", is(EMPTY_RESULT));
     assertRunCommand("define var2 = '2';", is(EMPTY_RESULT));

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/LocalProperties.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/LocalProperties.java
@@ -67,6 +67,16 @@ public class LocalProperties {
   }
 
   /**
+   * Get a property value.
+   *
+   * @param property the name of the property
+   * @return the current value for the property, or {@code null} if it was not set.
+   */
+  public Object get(final String property) {
+    return props.get(property);
+  }
+
+  /**
    * @return an immutable Map of the currently set properties.
    */
   public Map<String, Object> toMap() {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -360,6 +360,12 @@ public class KsqlConfig extends AbstractConfig {
   private static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
       + "properties that KSQL users cannot override.";
 
+  public static final String KSQL_VARIABLE_SUBSTITUTION_ENABLE
+      = "ksql.variable.substitution.enable";
+  public static final boolean KSQL_VARIABLE_SUBSTITUTION_ENABLE_DEFAULT = true;
+  public static final String KSQL_VARIABLE_SUBSTITUTION_ENABLE_DOC
+      = "Enable variable substitution on SQL statements.";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -828,6 +834,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DOC
+        )
+        .define(
+            KSQL_VARIABLE_SUBSTITUTION_ENABLE,
+            Type.BOOLEAN,
+            KSQL_VARIABLE_SUBSTITUTION_ENABLE_DEFAULT,
+            Importance.LOW,
+            KSQL_VARIABLE_SUBSTITUTION_ENABLE_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/LocalPropertiesTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/LocalPropertiesTest.java
@@ -126,6 +126,11 @@ public class LocalPropertiesTest {
   }
 
   @Test
+  public void shouldGetCurrentValue() {
+    assertThat(propsWithMockParser.get("prop-1"), is("parsed-initial-val-1"));
+  }
+
+  @Test
   public void shouldSetNewValue() {
     // When:
     final Object oldValue = propsWithMockParser.set("new-prop", "new-val");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -29,7 +29,10 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
+
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -100,10 +103,18 @@ public interface KsqlExecutionContext {
    * <p>This provides some level of validation as well, e.g. ensuring sources and topics exist
    * in the metastore, etc.
    *
+   * <p>If variables are used in the statement, they will be replaced with the values found in
+   * {@code variablesMap}.
+   *
    * @param stmt the parsed statement.
+   * @param variablesMap a list of values for SQL variable substitution
    * @return the prepared statement.
    */
-  PreparedStatement<?> prepare(ParsedStatement stmt);
+  PreparedStatement<?> prepare(ParsedStatement stmt, Map<String, String> variablesMap);
+
+  default PreparedStatement<?> prepare(ParsedStatement stmt) {
+    return prepare(stmt, Collections.emptyMap());
+  }
 
   /**
    * Executes a query using the supplied service context.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.Closeable;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
@@ -177,8 +178,11 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   }
 
   @Override
-  public PreparedStatement<?> prepare(final ParsedStatement stmt) {
-    return primaryContext.prepare(stmt);
+  public PreparedStatement<?> prepare(
+      final ParsedStatement stmt,
+      final Map<String, String> variablesMap
+  ) {
+    return primaryContext.prepare(stmt, variablesMap);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.Sandbox;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -91,8 +92,11 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
   }
 
   @Override
-  public PreparedStatement<?> prepare(final ParsedStatement stmt) {
-    return engineContext.prepare(stmt);
+  public PreparedStatement<?> prepare(
+      final ParsedStatement stmt,
+      final Map<String, String> variablesMap
+  ) {
+    return engineContext.prepare(stmt, variablesMap);
   }
 
   @Override

--- a/ksqldb-parser/pom.xml
+++ b/ksqldb-parser/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+
         <!-- Required for running tests -->
 
         <dependency>

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -333,7 +333,8 @@ whenClause
     ;
 
 identifier
-    : IDENTIFIER             #unquotedIdentifier
+    : VARIABLE               #variableIdentifier
+    | IDENTIFIER             #unquotedIdentifier
     | QUOTED_IDENTIFIER      #quotedIdentifierAlternative
     | nonReserved            #unquotedIdentifier
     | BACKQUOTED_IDENTIFIER  #backQuotedIdentifier
@@ -364,6 +365,7 @@ literal
     | number                                                                         #numericLiteral
     | booleanValue                                                                   #booleanLiteral
     | STRING                                                                         #stringLiteral
+    | VARIABLE                                                                       #variableLiteral
     ;
 
 nonReserved

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+import static io.confluent.ksql.util.ParserUtil.getLocation;
+import static io.confluent.ksql.util.ParserUtil.isQuoted;
+import static io.confluent.ksql.util.ParserUtil.sanitize;
+import static io.confluent.ksql.util.ParserUtil.unquote;
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.ksql.parser.exception.ParseFailedException;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.commons.text.StringSubstitutor;
+
+public final class VariableSubstitutor {
+  private VariableSubstitutor() {
+  }
+
+  private static final Pattern VALID_IDENTIFIER_NAMES = Pattern.compile("[A-Za-z_][A-Za-z0-9_@]*");
+  public static final String PREFIX = "${";
+  public static final String SUFFIX = "}";
+
+  static class VariablesLookup {
+    public static Set<String> lookup(final String text) {
+      final Set<String> variables = new HashSet<>();
+
+      // Used only to lookup for variables
+      final StringSubstitutor substr = new StringSubstitutor(key -> {
+        variables.add(key);
+        return null;
+      });
+
+      substr.setVariablePrefix(PREFIX);
+      substr.setVariableSuffix(SUFFIX);
+      substr.replace(text); // Nothing is replaced. It just lookups for variables.
+
+      return variables;
+    }
+  }
+
+  public static String substitute(
+      final KsqlParser.ParsedStatement parsedStatement,
+      final Map<String, String> valueMap
+  ) {
+    final String statementText = parsedStatement.getStatementText();
+    final SqlSubstitutorVisitor visitor = new SqlSubstitutorVisitor(statementText, valueMap);
+    return visitor.replace(parsedStatement.getStatement());
+  }
+
+  // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
+  private static final class SqlSubstitutorVisitor extends SqlBaseBaseVisitor<Void> {
+    // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
+
+    private final String statementText;
+    private final Map<String, String> valueMap;
+
+    // Contains sanitized values for variable substitution
+    private Map<String, String> sanitizedValueMap;
+
+    SqlSubstitutorVisitor(final String statementText, final Map<String, String> valueMap) {
+      this.statementText = requireNonNull(statementText, "statementText");
+      this.valueMap = requireNonNull(valueMap, "valueMap");
+      this.sanitizedValueMap = new HashMap<>(valueMap.size());
+    }
+
+    public String replace(final SqlBaseParser.SingleStatementContext singleStatementContext) {
+      // walk the statement tree to validate and sanitize variables
+      visit(singleStatementContext);
+
+      // replace all variables with sanitized values
+      return StringSubstitutor.replace(statementText, sanitizedValueMap);
+    }
+
+    @Override
+    public Void visitStringLiteral(final SqlBaseParser.StringLiteralContext context) {
+      final String text = unquote(context.getText(), "\'");
+      for (String variableName : VariablesLookup.lookup(text)) {
+        if (valueMap.containsKey(variableName)) {
+          sanitizedValueMap.putIfAbsent(variableName, sanitize(valueMap.get(variableName)));
+        }
+      }
+
+      return null;
+    }
+
+    @Override
+    public Void visitVariableLiteral(final SqlBaseParser.VariableLiteralContext context) {
+      final String variableRef = context.getText();
+      final String variableName = unwrap(variableRef);
+      final String variableValue = valueMap.getOrDefault(variableName, variableRef);
+
+      throwIfInvalidLiteral(variableValue, getLocation(context));
+      sanitizedValueMap.putIfAbsent(variableName, sanitize(variableValue));
+      return null;
+    }
+
+    @Override
+    public Void visitVariableIdentifier(final SqlBaseParser.VariableIdentifierContext context) {
+      final String variableRef = context.getText();
+      final String variableName = unwrap(variableRef);
+      final String variableValue = valueMap.getOrDefault(variableName, variableRef);
+
+      throwIfInvalidIdentifier(variableValue, getLocation(context));
+      sanitizedValueMap.putIfAbsent(variableName, variableValue);
+      return null;
+    }
+
+    private String getIdentifierText(final String value) {
+      final char firstChar = value.charAt(0);
+      final char lastChar = value.charAt(value.length() - 1);
+
+      if (firstChar == '"' && lastChar == '"') {
+        return unquote(value, "\"");
+      } else if (firstChar == '`' && lastChar == '`') {
+        return unquote(value, "`");
+      } else {
+        return value;
+      }
+    }
+
+    static String unwrap(final String value) {
+      return value.substring(PREFIX.length(), value.length() - SUFFIX.length());
+    }
+
+    private void throwIfInvalidIdentifier(
+        final String value,
+        final Optional<NodeLocation> location
+    ) {
+      final String identifierText = getIdentifierText(value);
+
+      if (!VALID_IDENTIFIER_NAMES.matcher(identifierText).matches()) {
+        throw new ParseFailedException(
+            "Illegal argument at " + location.map(NodeLocation::toString).orElse("?")
+                + ". Identifier names may only contain alphanumeric values, '_' "
+                + "or not starting with '@'. Got: '" + value + "'",
+            statementText);
+      }
+    }
+
+    private void throwIfInvalidLiteral(
+        final String value,
+        final Optional<NodeLocation> location
+    ) {
+      // Strings are quoted
+      if (isQuoted(value, "'")) {
+        return;
+      }
+
+      // Booleans are unquoted
+      if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
+        return;
+      }
+
+      // Numbers are unquoted
+      if (isNumber(value)) {
+        return;
+      }
+
+      throw new ParseFailedException(
+          "Illegal argument at " + location.map(NodeLocation::toString).orElse("?")
+              + ". Got: '" + value + "'",
+          statementText);
+    }
+
+    @SuppressWarnings({"NPathComplexity", "CyclomaticComplexity", "BooleanExpressionComplexity"})
+    private boolean isNumber(final String value) {
+      try {
+        Long.parseLong(value);
+        return true;
+      } catch (final NumberFormatException e) {
+        // ignored. move to the next check
+      }
+
+      try {
+        final double d = Double.parseDouble(value);
+        if (!Double.isInfinite(d) && !Double.isNaN(d)) {
+          return true;
+        }
+      } catch (final NumberFormatException e) {
+        // ignored. move to the next check
+      }
+
+      try {
+        new BigDecimal(value);
+        return true;
+      } catch (final NumberFormatException e) {
+        // ignored. move to the next check
+      }
+
+      return false;
+    }
+  }
+}

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -150,8 +150,8 @@ public final class VariableSubstitutor {
       if (!VALID_IDENTIFIER_NAMES.matcher(identifierText).matches()) {
         throw new ParseFailedException(
             "Illegal argument at " + location.map(NodeLocation::toString).orElse("?")
-                + ". Identifier names may only contain alphanumeric values, '_' "
-                + "or not starting with '@'. Got: '" + value + "'",
+                + ". Identifier names cannot start with '@' and may only contain alphanumeric "
+                + "values and '_'. Got: '" + value + "'",
             statementText);
       }
     }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/exception/ParseFailedException.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/exception/ParseFailedException.java
@@ -23,6 +23,10 @@ public class ParseFailedException extends KsqlStatementException {
     super(message, "");
   }
 
+  public ParseFailedException(final String message, final String sqlStatement) {
+    super(message, sqlStatement);
+  }
+
   public ParseFailedException(
       final String message,
       final String sqlStatement,

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -1,0 +1,221 @@
+package io.confluent.ksql.parser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.Pair;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VariableSubstitutorTest {
+  private static final KsqlParser KSQL_PARSER = new DefaultKsqlParser();
+
+  @Test
+  public void shouldSubstituteVariableOnDescribe() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("identifier", "_id_");
+      put("quotedIdentifier", "\"_id_\"");
+      put("backQuotedIdentifier", "`_id_`");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        // DESCRIBE
+        Pair.of("DESCRIBE ${identifier};", "DESCRIBE _id_;"),
+        Pair.of("DESCRIBE ${quotedIdentifier};", "DESCRIBE \"_id_\";"),
+        Pair.of("DESCRIBE ${backQuotedIdentifier};", "DESCRIBE `_id_`;"),
+
+        // DESCRIBE EXTENDED
+        Pair.of("DESCRIBE EXTENDED ${identifier};", "DESCRIBE EXTENDED _id_;"),
+        Pair.of("DESCRIBE EXTENDED ${quotedIdentifier};", "DESCRIBE EXTENDED \"_id_\";"),
+        Pair.of("DESCRIBE EXTENDED ${backQuotedIdentifier};", "DESCRIBE EXTENDED `_id_`;"),
+
+        // DESCRIBE FUNCTION
+        Pair.of("DESCRIBE FUNCTION ${identifier};", "DESCRIBE FUNCTION _id_;"),
+        Pair.of("DESCRIBE FUNCTION ${quotedIdentifier};", "DESCRIBE FUNCTION \"_id_\";"),
+        Pair.of("DESCRIBE FUNCTION ${backQuotedIdentifier};", "DESCRIBE FUNCTION `_id_`;"),
+
+        // DESCRIBE CONNECTOR
+        Pair.of("DESCRIBE CONNECTOR ${identifier};", "DESCRIBE CONNECTOR _id_;"),
+        Pair.of("DESCRIBE CONNECTOR ${quotedIdentifier};", "DESCRIBE CONNECTOR \"_id_\";"),
+        Pair.of("DESCRIBE CONNECTOR ${backQuotedIdentifier};", "DESCRIBE CONNECTOR `_id_`;")
+    );
+
+    // When/Then
+    assertReplacedStatements(statements, variablesMap);
+  }
+
+  @Test
+  public void shouldThrowOnDescribeWhenInvalidVariables() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      // Attempts to use a keyword
+      put("identifier", "EXTENDED _id_");
+      put("quotedIdentifier", "EXTENDED \"_id_\"");
+      put("backQuotedIdentifier", "EXTENDED `_id_`");
+      put("singleQuoteIdentifier", "EXTENDED '_id_'");
+
+      // Attempts to use a keyword inside quotes
+      put("quotedIdentifier2", "\"EXTENDED _id_\"");
+      put("backQuotedIdentifier2", "`EXTENDED _id_`");
+      put("singleQuoteIdentifier2", "'EXTENDED _id_'");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        // DESCRIBE
+        Pair.of("DESCRIBE ${identifier};", "Got: 'EXTENDED _id_'"),
+        Pair.of("DESCRIBE ${quotedIdentifier};", "Got: 'EXTENDED \"_id_\"'"),
+        Pair.of("DESCRIBE ${backQuotedIdentifier};", "Got: 'EXTENDED `_id_`'"),
+        Pair.of("DESCRIBE ${singleQuoteIdentifier};", "Got: 'EXTENDED '_id_''"),
+        Pair.of("DESCRIBE ${quotedIdentifier2};", "Got: '\"EXTENDED _id_\"'"),
+        Pair.of("DESCRIBE ${backQuotedIdentifier2};", "Got: '`EXTENDED _id_`'"),
+        Pair.of("DESCRIBE ${singleQuoteIdentifier2};", "Got: ''EXTENDED _id_''")
+    );
+
+    assertThrowOnInvalidVariables(statements, variablesMap);
+  }
+
+  @Test
+  public void shouldSubstituteVariableOnInsert() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("identifier", "_id_");
+      put("num", "1");
+      put("dec", "0.32");
+      put("bool", "false");
+      put("str", "'john'");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        // INSERT VALUES
+        Pair.of("INSERT INTO ${identifier} VALUES (${num}, ${bool}, ${dec}, ${str});",
+            "INSERT INTO _id_ VALUES (1, false, 0.32, 'john');")
+    );
+
+    // When/Then
+    assertReplacedStatements(statements, variablesMap);
+  }
+
+  @Test
+  public void shouldSubstituteVariableOnCreate() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("identifier", "_id_");
+      put("quotedIdentifier", "\"_id_\"");
+      put("backQuotedIdentifier", "`_id_`");
+      put("topicName", "'name1'");
+      put("replicas", "3");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        // CREATE STREAM
+        Pair.of("CREATE STREAM ${identifier} WITH (kafka_topic=${topicName}, replicas=${replicas});",
+            "CREATE STREAM _id_ WITH (kafka_topic='name1', replicas=3);"),
+
+        Pair.of("CREATE STREAM ${quotedIdentifier} WITH (kafka_topic=${topicName}, replicas=${replicas});",
+            "CREATE STREAM \"_id_\" WITH (kafka_topic='name1', replicas=3);"),
+
+        Pair.of("CREATE STREAM ${backQuotedIdentifier} WITH (kafka_topic=${topicName}, replicas=${replicas});",
+            "CREATE STREAM `_id_` WITH (kafka_topic='name1', replicas=3);"),
+
+        Pair.of("CREATE STREAM ${backQuotedIdentifier} WITH (kafka_topic=${topicName}, replicas=${replicas});",
+            "CREATE STREAM `_id_` WITH (kafka_topic='name1', replicas=3);")
+    );
+
+    // When/Then
+    assertReplacedStatements(statements, variablesMap);
+  }
+
+  @Test
+  public void shouldSanitizeStatements() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("escapeQuote", "'t1', value_format='AVRO'");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        // CREATE
+        Pair.of("CREATE STREAM s1 WITH (kafka_topic=${escapeQuote});",
+            "CREATE STREAM s1 WITH (kafka_topic='t1'', value_format=''AVRO');")
+    );
+
+    // When/Then
+    assertReplacedStatements(statements, variablesMap);
+  }
+
+  @Test
+  public void shouldThrowOnSQLInjection() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("injectSchema", "s1 (id, name)");
+      put("injectValues", "1, 5");
+      put("injectWhere", "s1 WHERE id = 1");
+      put("injectExpression", "5 and id != 5");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        // INSERT
+        Pair.of("INSERT INTO ${injectSchema} VALUES (1);",
+            "Got: 's1 (id, name)'"),
+        Pair.of("INSERT INTO s1 VALUES (${injectValues});",
+            "Got: '1, 5'"),
+
+        // SELECT
+        Pair.of("SELECT * FROM ${injectWhere};",
+            "Got: 's1 WHERE id = 1'"),
+        Pair.of("SELECT * FROM s1 WHERE id = ${injectExpression};",
+            "5 and id != 5"),
+
+        // CREATE
+        Pair.of("CREATE STREAM ${injectSchema} WITH (kafka_topic='t1');",
+            "Got: 's1 (id, name)'")
+    );
+
+    // When/Then
+    assertThrowOnInvalidVariables(statements, variablesMap);
+  }
+
+  private void assertReplacedStatements(
+      final List<Pair<String, String>> statements,
+      final Map<String, String> variablesMap
+  ) {
+    for (Pair<String, String> stmt : statements) {
+      KsqlParser.ParsedStatement sqlStatement = KSQL_PARSER.parse(stmt.getLeft()).get(0);
+      String sqlReplaced = stmt.getRight();
+
+      // When
+      final String sqlResult = VariableSubstitutor.substitute(sqlStatement, variablesMap);
+
+      // Then
+      assertThat("Should replace: " + sqlStatement.getStatementText(), sqlResult, equalTo(sqlReplaced));
+    }
+  }
+
+  private void assertThrowOnInvalidVariables(
+      final List<Pair<String, String>> statements,
+      final Map<String, String> variablesMap
+  ) {
+    for (Pair<String, String> stmt : statements) {
+      KsqlParser.ParsedStatement sqlStatement = KSQL_PARSER.parse(stmt.getLeft()).get(0);
+      String sqlError = stmt.getRight();
+
+      // When
+      final Exception e = assertThrows(
+          Exception.class,
+          () -> VariableSubstitutor.substitute(sqlStatement, variablesMap)
+      );
+
+      // Then
+      assertThat("Should fail replace: " + sqlStatement.getStatementText(),
+          e.getMessage(), containsString(sqlError));
+    }
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RequestHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RequestHandler.java
@@ -74,7 +74,10 @@ public class RequestHandler {
   ) {
     final KsqlEntityList entities = new KsqlEntityList();
     for (final ParsedStatement parsed : statements) {
-      final PreparedStatement<?> prepared = ksqlEngine.prepare(parsed);
+      final PreparedStatement<?> prepared = ksqlEngine.prepare(
+          parsed,
+          sessionProperties.getSessionVariables()
+      );
       final ConfiguredStatement<?> configured = ConfiguredStatement.of(prepared,
           SessionConfig.of(ksqlConfig, sessionProperties.getMutableScopedProperties())
       );

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -104,7 +104,10 @@ public class RequestValidator {
 
     int numPersistentQueries = 0;
     for (final ParsedStatement parsed : statements) {
-      final PreparedStatement<?> prepared = ctx.prepare(parsed);
+      final PreparedStatement<?> prepared = ctx.prepare(
+          parsed,
+          sessionProperties.getSessionVariables()
+      );
       final ConfiguredStatement<?> configured = ConfiguredStatement.of(prepared,
           SessionConfig.of(ksqlConfig, sessionProperties.getMutableScopedProperties())
       );

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -36,6 +36,8 @@ import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -77,6 +79,17 @@ public class RequestValidator {
         distributedStatementValidator, "distributedStatementValidator");
   }
 
+  private boolean isVariableSubstitutionEnabled(final SessionProperties sessionProperties) {
+    final Object substitutionEnabled = sessionProperties.getMutableScopedProperties()
+        .get(KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE);
+
+    if (substitutionEnabled != null && substitutionEnabled instanceof Boolean) {
+      return (boolean) substitutionEnabled;
+    }
+
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE);
+  }
+
   /**
    * Validates the messages against a snapshot in time of the KSQL engine.
    *
@@ -106,7 +119,9 @@ public class RequestValidator {
     for (final ParsedStatement parsed : statements) {
       final PreparedStatement<?> prepared = ctx.prepare(
           parsed,
-          sessionProperties.getSessionVariables()
+          (isVariableSubstitutionEnabled(sessionProperties)
+              ? sessionProperties.getSessionVariables()
+              : Collections.emptyMap())
       );
       final ConfiguredStatement<?> configured = ConfiguredStatement.of(prepared,
           SessionConfig.of(ksqlConfig, sessionProperties.getMutableScopedProperties())

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RequestHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RequestHandlerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
@@ -120,6 +121,7 @@ public class RequestHandlerTest {
         );
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   @Test
   public void shouldCallPrepareStatementWithSessionVariables() {
     // Given
@@ -139,6 +141,7 @@ public class RequestHandlerTest {
     verify(sessionProperties).getSessionVariables();
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   @Test
   public void shouldCallPrepareStatementWithEmptySessionVariablesIfSubstitutionDisabled() {
     // Given

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -936,7 +936,7 @@ public class KsqlResourceTest {
     final String sqlWithTopic = "CREATE STREAM orders2 WITH(kafka_topic='orders2') AS SELECT * FROM orders1;";
 
     final PreparedStatement<?> statementWithTopic =
-        ksqlEngine.prepare(ksqlEngine.parse(sqlWithTopic).get(0));
+        ksqlEngine.prepare(ksqlEngine.parse(sqlWithTopic).get(0), Collections.emptyMap());
     final ConfiguredStatement<?> configuredStatement =
         ConfiguredStatement.of(statementWithTopic, SessionConfig.of(ksqlConfig, ImmutableMap.of())
         );
@@ -966,7 +966,7 @@ public class KsqlResourceTest {
     final String sqlWithTopic = "CREATE STREAM orders2 WITH(kafka_topic='orders2') AS SELECT * FROM orders1;";
 
     final PreparedStatement<?> statementWithTopic =
-        ksqlEngine.prepare(ksqlEngine.parse(sqlWithTopic).get(0));
+        ksqlEngine.prepare(ksqlEngine.parse(sqlWithTopic).get(0), Collections.emptyMap());
     final ConfiguredStatement<?> configured =
         ConfiguredStatement.of(statementWithTopic, SessionConfig.of(ksqlConfig, ImmutableMap.of())
         );
@@ -1020,6 +1020,31 @@ public class KsqlResourceTest {
     assertThat(e, exceptionStatusCode(is(BAD_REQUEST.code())));
     assertThat(e, exceptionErrorMessage(errorCode(is(Errors.ERROR_CODE_BAD_STATEMENT))));
     assertThat(e, exceptionStatementErrorMessage(errorMessage(is("boom"))));
+  }
+
+  @Test
+  public void shouldSupportVariableSubstitution() {
+    // Given:
+    final String csasRaw = "CREATE STREAM ${streamName} AS SELECT * FROM ${fromStream};";
+    final String csasSubstituted = "CREATE STREAM " + streamName + " AS SELECT * FROM test_stream;";
+
+
+    // When:
+    final List<CommandStatusEntity> results = makeMultipleRequest(
+        "DEFINE streamName = '" + streamName + "';\n"
+            + "DEFINE fromStream = 'test_stream';\n"
+            + csasRaw,
+        CommandStatusEntity.class);
+
+    // Then:
+    verify(commandStore).enqueueCommand(
+        argThat(is(commandIdWithString("stream/`" + streamName + "`/create"))),
+        argThat(is(commandWithStatement(csasSubstituted))),
+        any()
+    );
+
+    assertThat(results, hasSize(1));
+    assertThat(results.get(0).getStatementText(), is(csasSubstituted));
   }
 
   @Test
@@ -1409,8 +1434,10 @@ public class KsqlResourceTest {
 
     reset(sandbox);
     when(sandbox.getMetaStore()).thenReturn(metaStore);
-    when(sandbox.prepare(any()))
-        .thenAnswer(invocation -> realEngine.createSandbox(serviceContext).prepare(invocation.getArgument(0)));
+    when(sandbox.prepare(any(), any()))
+        .thenAnswer(invocation ->
+            realEngine.createSandbox(serviceContext)
+                .prepare(invocation.getArgument(0), Collections.emptyMap()));
     when(sandbox.plan(any(), any(ConfiguredStatement.class)))
         .thenThrow(new RuntimeException("internal error"));
 
@@ -2020,10 +2047,13 @@ public class KsqlResourceTest {
     ksqlEngine = mock(KsqlEngine.class);
     when(ksqlEngine.parse(any()))
         .thenAnswer(invocation -> realEngine.parse(invocation.getArgument(0)));
-    when(ksqlEngine.prepare(any()))
-        .thenAnswer(invocation -> realEngine.prepare(invocation.getArgument(0)));
-    when(sandbox.prepare(any()))
-        .thenAnswer(invocation -> realEngine.createSandbox(serviceContext).prepare(invocation.getArgument(0)));
+    when(ksqlEngine.prepare(any(), any()))
+        .thenAnswer(invocation ->
+            realEngine.prepare(invocation.getArgument(0), Collections.emptyMap()));
+    when(sandbox.prepare(any(), any()))
+        .thenAnswer(invocation ->
+            realEngine.createSandbox(serviceContext)
+                .prepare(invocation.getArgument(0), Collections.emptyMap()));
     when(sandbox.plan(any(), any())).thenAnswer(
         i -> KsqlPlan.ddlPlanCurrent(
             ((ConfiguredStatement<?>) i.getArgument(1)).getStatementText(),
@@ -2388,6 +2418,20 @@ public class KsqlResourceTest {
     final org.apache.avro.Schema avroSchema = parser.parse(ordersAvroSchemaStr);
     schemaRegistryClient.register(KsqlConstants.getSRSubject("orders-topic", false),
         new AvroSchema(avroSchema));
+  }
+
+  private static Matcher<CommandId> commandIdWithString(final String commandIdStr) {
+    return new TypeSafeMatcher<CommandId>() {
+      @Override
+      protected boolean matchesSafely(final CommandId commandId) {
+        return commandId.toString().equals(commandIdStr);
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText(commandIdStr);
+      }
+    };
   }
 
   private static Matcher<Command> commandWithStatement(final String statement) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -36,6 +36,7 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
@@ -121,6 +122,7 @@ public class RequestValidatorTest {
     givenRequestValidator(ImmutableMap.of());
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   @Test
   public void shouldCallPrepareStatementWithSessionVariables() {
     // Given
@@ -138,6 +140,7 @@ public class RequestValidatorTest {
     verify(sessionProperties).getSessionVariables();
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   @Test
   public void shouldCallPrepareStatementWithEmptySessionVariablesIfSubstitutionDisabled() {
     // Given

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -215,6 +215,10 @@ public final class KsqlRestClient implements Closeable {
     return localProperties.unset(property);
   }
 
+  public Object getProperty(final String property) {
+    return localProperties.get(property);
+  }
+
   private KsqlTarget target() {
     return client.target(getServerAddress());
   }

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <airlift.version>0.29</airlift.version>
         <airline.version>2.6.0</airline.version>
         <antlr.version>4.7</antlr.version>
+        <commons-text.version>1.8</commons-text.version>
         <csv.version>1.4</csv.version>
         <lang3.version>3.3.1</lang3.version>
         <guava.version>24.1.1-jre</guava.version>
@@ -414,6 +415,12 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${apache.io.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### Description 
This is part of [KLIP-38 - Variable Substitution](https://github.com/confluentinc/ksql/blob/master/design-proposals/klip-38-variable-substitution.md)

It implements variable substitution on SQL statements, both the Server-side and CLI-side. Variables are referenced in statements with the `${}` characters. For instance:

For the CLI-side, the scope is per-session. The following example will create the `s1` stream that reads from topic `t1`.
```
ksql> define topicName = 't1';
ksql> define streamName = 's1';
ksql> create stream ${streamName} with (kafka_topic='${topicName}');
```

For the server-side, the variable scope is seen per-request. The following example will create the `s1` stream that reads from topic `t1`.
Request 1 will create stream `s1` from topic `t1`:
```
{ 
  statement: "
    define topicName = 't1';
    create stream s1 with (kafka_topic='${topicName}');
  "
}
```

Request 2 will FAIL because `${topicName}` is not a valid topic name
```
{ 
  statement: "
    create stream s1 with (kafka_topic='${topicName}');
  "
}
```

Variable substitution can be enabled or disabled with the `ksql.variable.substitution.enable` configuration. It can be set in the `ksql-server.properties` or can be overridden from the CLI. By default is `true`.

**Implementation:**

A new `VariableSubstitutor` class is created that replaces variables wrapped in `${}` from a parsed statement (`ParsedStatement`). This `VarialbeSubstitutor` is called from the CLI to replace variables before sending to the Server; and from the `KsqlEngine.prepare()` too in case there are variables defined in the KSQL request.

During the CLI session, variables are substituted before sending the request to the Server. I initially thought of sending the `DEFINE` statements, but it was more work to identify the variables and create a new request with them. Doing it in the CLI saves some time on parsing.

I didn't do the substitution in the `AstBuilder` because there were several places I needed to change to provide substitution. If a new syntax was added in the future, the developer would have to know about variables and call the right `visit` or `ParserUtil` methods to get the variables substituted. Also, I needed to rewrite the statement text, which required more work in the builder for doing that. Having a simple `VariableSubstitutor` that returns the replaced statement text was simple.

Because substitution happens by replacing text, I had to make sure of escape the single-quote characters to avoid using variables for SQL injection. The escape is done in the `ParserUtil` when called by the `VariableSubstitutor`.

### Testing done 
Added unit tests
Verified manually

```
ksql> show streams;

 Stream Name         | Kafka Topic                 | Key Format | Value Format | Windowed 
------------------------------------------------------------------------------------------
 KSQL_PROCESSING_LOG | default_ksql_processing_log | KAFKA      | JSON         | false    
------------------------------------------------------------------------------------------
ksql> define topicName = 't1';
ksql> define streamName = 's1';
ksql> create stream ${streamName} (id int) with (kafka_topic='${topicName}', value_format='json', replicas=1, partitions=1);

 Message        
----------------
 Stream created 
----------------
sql> show streams;

 Stream Name         | Kafka Topic                 | Key Format | Value Format | Windowed 
------------------------------------------------------------------------------------------
 KSQL_PROCESSING_LOG | default_ksql_processing_log | KAFKA      | JSON         | false    
 S1                  | t1                          | KAFKA      | JSON         | false    
------------------------------------------------------------------------------------------
```
Server side
```
$ curl -X "POST" "http://localhost:8088/ksql" \
>      -H "Accept: application/vnd.ksql.v1+json" \
>      -d $'{
>   "ksql": "define topicName = \'t1\';define streamName = \'s3\';create stream ${streamName} (id int) with (kafka_topic=\'${topicName}\', value_format=\'json\');",
>   "streamsProperties": {}
> }' | jq .
[
  {
    "@type": "currentStatus",
    "statementText": "CREATE STREAM S3 (ID INTEGER) WITH (KAFKA_TOPIC='t1', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
    "commandId": "stream/`S3`/create",
    "commandStatus": {
      "status": "SUCCESS",
      "message": "Stream created",
      "queryId": null
    },
    "commandSequenceNumber": 36,
    "warnings": []
  }
]

```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

