### PR TITLE
test: allow RQTT to 'run until failure' (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -279,6 +279,7 @@ public class TestKsqlRestApp extends ExternalResource {
       throw new RuntimeException(e);
     }
     ksqlRestApplication = null;
+    lastCommandSequenceNumber = -1;
   }
 
   protected void initialize() {


### PR DESCRIPTION
### Description 

Fixes the `TestKsqlRestApp` so that you can shut it down and restart it and submit new requests without it failing because it 'timed out waiting for previous command to be handled', because it's not resetting the `lastCommandSequenceNumber` when the server is restarted.

This means you can configure intellj to run RQTT until failure.  Which is useful!

