### PR TITLE
chore: fix leaked executor

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -473,15 +473,23 @@ public final class KsqlRestApplication implements Executable {
     }
   }
 
-  @SuppressWarnings("checkstyle:NPathComplexity")
+  @SuppressWarnings({"checkstyle:NPathComplexity", "checkstyle:CyclomaticComplexity"})
   @Override
   public void shutdown() {
     log.info("ksqlDB shutdown called");
+
+    try {
+      pullQueryExecutor.close(Duration.ofSeconds(10));
+    } catch (final Exception e) {
+      log.error("Exception while waiting for Ksql Engine to close", e);
+    }
+
     try {
       pullQueryMetrics.ifPresent(PullQueryExecutorMetrics::close);
     } catch (final Exception e) {
       log.error("Exception while waiting for pull query metrics to close", e);
     }
+
     try {
       ksqlEngine.close();
     } catch (final Exception e) {
@@ -711,7 +719,7 @@ public final class KsqlRestApplication implements Executable {
         heartbeatAgent, lagReportingAgent);
 
     final PullQueryExecutor pullQueryExecutor = new PullQueryExecutor(
-        ksqlEngine, routingFilterFactory, ksqlConfig, ksqlEngine.getServiceId());
+        ksqlEngine, routingFilterFactory, ksqlConfig);
 
     final DenyListPropertyValidator denyListPropertyValidator = new DenyListPropertyValidator(
         ksqlConfig.getList(KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -140,7 +140,6 @@ public class StreamedQueryResourceTest {
   private static final String PULL_QUERY_STRING =
       "SELECT * FROM " + TOPIC_NAME + " WHERE ROWKEY='null';";
   private static final String PRINT_TOPIC = "Print TEST_TOPIC;";
-  private static final String SERVICE_ID = "service_id";
 
   private static final RoutingFilterFactory ROUTING_FILTER_FACTORY =
       (routingOptions, hosts, active, applicationQueryId, storeName, partition) ->
@@ -192,7 +191,7 @@ public class StreamedQueryResourceTest {
     securityContext = new KsqlSecurityContext(Optional.empty(), serviceContext);
 
     pullQueryExecutor = new PullQueryExecutor(
-        mockKsqlEngine, ROUTING_FILTER_FACTORY, VALID_CONFIG, SERVICE_ID);
+        mockKsqlEngine, ROUTING_FILTER_FACTORY, VALID_CONFIG);
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
         mockStatementParser,


### PR DESCRIPTION
### Description 

Ensures the `ExecutorService` in `PullQueryExecutor` is shutdown with the app.

This omission shouldn't cause issues in prod, but does in tests. Each test that starts the `PullQueryExecutor` was creating 100 threads and leaving them running.  Over the entire build that's a LOT of threads!

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

