### PR TITLE
feat: update ksql restore command to skip incompatible commands if flag set

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -89,8 +89,6 @@ public class CommandTopic {
       for (ConsumerRecord<byte[], byte[]> record : iterable) {
         try {
           backupRecord(record);
-        } catch (final KsqlException e) {
-          log.warn("Error encountered while backing up command.", e);
         } catch (final KsqlServerException e) {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
@@ -118,8 +116,6 @@ public class CommandTopic {
       for (final ConsumerRecord<byte[], byte[]> record : records) {
         try {
           backupRecord(record);
-        } catch (final KsqlException e) {
-          log.warn("Error encountered while backing up command.", e);
         } catch (final KsqlServerException e) {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.rest.server;
 
 import com.google.common.collect.Lists;
 import io.confluent.ksql.rest.server.computation.QueuedCommand;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlServerException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -86,10 +89,13 @@ public class CommandTopic {
       for (ConsumerRecord<byte[], byte[]> record : iterable) {
         try {
           backupRecord(record);
-        } catch (final Exception e) {
+        } catch (final KsqlException e) {
+          log.warn("Error encountered while backing up command.", e);
+        } catch (final KsqlServerException e) {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
               + "restored or all backup files are deleted.", e);
+          return records;
         }
         records.add(record);
       }
@@ -112,10 +118,13 @@ public class CommandTopic {
       for (final ConsumerRecord<byte[], byte[]> record : records) {
         try {
           backupRecord(record);
-        } catch (final Exception e) {
+        } catch (final KsqlException e) {
+          log.warn("Error encountered while backing up command.", e);
+        } catch (final KsqlServerException e) {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
               + "restored or all backup files are deleted.", e);
+          return restoreCommands;
         }
 
         if (record.value() == null) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -17,8 +17,7 @@ package io.confluent.ksql.rest.server;
 
 import com.google.common.collect.Lists;
 import io.confluent.ksql.rest.server.computation.QueuedCommand;
-import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.KsqlServerException;
+import io.confluent.ksql.rest.server.resources.CommandTopicCorruptionException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -89,7 +88,7 @@ public class CommandTopic {
       for (ConsumerRecord<byte[], byte[]> record : iterable) {
         try {
           backupRecord(record);
-        } catch (final KsqlServerException e) {
+        } catch (final CommandTopicCorruptionException e) {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
               + "restored or all backup files are deleted.", e);
@@ -116,7 +115,7 @@ public class CommandTopic {
       for (final ConsumerRecord<byte[], byte[]> record : records) {
         try {
           backupRecord(record);
-        } catch (final KsqlServerException e) {
+        } catch (final CommandTopicCorruptionException e) {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
               + "restored or all backup files are deleted.", e);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -90,7 +90,6 @@ public class CommandTopic {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
               + "restored or all backup files are deleted.", e);
-          return records;
         }
         records.add(record);
       }
@@ -117,7 +116,6 @@ public class CommandTopic {
           log.warn("Backup is out of sync with the current command topic. "
               + "Backups will not work until the previous command topic is "
               + "restored or all backup files are deleted.", e);
-          return restoreCommands;
         }
 
         if (record.value() == null) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -129,33 +129,12 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
     return false;
   }
 
-  private static void throwIfInvalidRecord(final ConsumerRecord<byte[], byte[]> record) {
-    try {
-      InternalTopicSerdes.deserializer(CommandId.class).deserialize(record.topic(), record.key());
-    } catch (final Exception e) {
-      throw new KsqlException(String.format(
-          "Failed to backup record because it cannot deserialize key: %s",
-          new String(record.key(), StandardCharsets.UTF_8)), e);
-    }
-
-    try {
-      InternalTopicSerdes.deserializer(Command.class).deserialize(record.topic(), record.value());
-    } catch (final Exception e) {
-      throw new KsqlException(String.format(
-          "Failed to backup record because it cannot deserialize value: %s",
-          new String(record.value(), StandardCharsets.UTF_8)), e
-      );
-    }
-  }
-
   @Override
   public void writeRecord(final ConsumerRecord<byte[], byte[]> record) {
     if (corruptionDetected) {
       throw new KsqlServerException(
           "Failed to write record due to out of sync command topic and backup file: " + record);
     }
-
-    throwIfInvalidRecord(record);
 
     if (isRestoring()) {
       if (isRecordInLatestReplay(record)) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -16,16 +16,12 @@
 package io.confluent.ksql.rest.server;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.confluent.ksql.rest.entity.CommandId;
-import io.confluent.ksql.rest.server.computation.Command;
-import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
+import io.confluent.ksql.rest.server.resources.CommandTopicCorruptionException;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
@@ -132,7 +128,7 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
   @Override
   public void writeRecord(final ConsumerRecord<byte[], byte[]> record) {
     if (corruptionDetected) {
-      throw new KsqlServerException(
+      throw new CommandTopicCorruptionException(
           "Failed to write record due to out of sync command topic and backup file: " + record);
     }
 
@@ -142,7 +138,7 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
         return;
       } else {
         corruptionDetected = true;
-        throw new KsqlServerException(
+        throw new CommandTopicCorruptionException(
             "Failed to write record due to out of sync command topic and backup file: " + record);
       }
     } else if (latestReplay.size() > 0) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 public class Command {
 
   @VisibleForTesting
-  static final int VERSION = 2;
+  public static final int VERSION = 2;
 
   private final String statement;
   private final Map<String, Object> overwriteProperties;
@@ -80,7 +80,7 @@ public class Command {
   }
 
   @VisibleForTesting
-  Command(
+  public Command(
       final String statement,
       final Map<String, Object> overwriteProperties,
       final Map<String, String> originalProperties,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.engine.KsqlPlan;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
-import io.confluent.ksql.rest.server.resources.IncomaptibleKsqlCommandVersionException;
+import io.confluent.ksql.rest.server.resources.IncompatibleKsqlCommandVersionException;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Collections;
 import java.util.Map;
@@ -97,7 +97,7 @@ public class Command {
     this.version = requireNonNull(version, "version");
 
     if (expectedVersion < version.orElse(0)) {
-      throw new IncomaptibleKsqlCommandVersionException(
+      throw new IncompatibleKsqlCommandVersionException(
           "Received a command from an incompatible command topic version. "
               + "Expected version less than or equal to " + expectedVersion
               + " but got " + version.orElse(0));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.rest.server.computation;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
-import io.confluent.ksql.rest.server.resources.IncomaptibleKsqlCommandVersionException;
+import io.confluent.ksql.rest.server.resources.IncompatibleKsqlCommandVersionException;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.TerminateCluster;
@@ -378,7 +378,7 @@ public class CommandRunner implements Closeable {
         incompatibleCommandChecker.accept(command);
         compatibleCommands.add(command);
       }
-    } catch (final SerializationException | IncomaptibleKsqlCommandVersionException e) {
+    } catch (final SerializationException | IncompatibleKsqlCommandVersionException e) {
       LOG.info("Incompatible command record detected when processing command topic", e);
       incompatibleCommandDetected = true;
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/CommandTopicCorruptionException.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/CommandTopicCorruptionException.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.rest.server.resources;
 
 import io.confluent.ksql.util.KsqlServerException;
 
-public class IncomaptibleKsqlCommandVersionException extends KsqlServerException {
+public class CommandTopicCorruptionException extends KsqlServerException {
 
-  public IncomaptibleKsqlCommandVersionException(final String message) {
+  public CommandTopicCorruptionException(final String message) {
     super(message);
   }
-  
+
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/IncompatibleKsqlCommandVersionException.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/IncompatibleKsqlCommandVersionException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import io.confluent.ksql.util.KsqlServerException;
+
+public class IncompatibleKsqlCommandVersionException extends KsqlServerException {
+
+  public IncompatibleKsqlCommandVersionException(final String message) {
+    super(message);
+  }
+  
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.server.BackupReplayFile;
 import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
-import io.confluent.ksql.rest.server.resources.IncomaptibleKsqlCommandVersionException;
+import io.confluent.ksql.rest.server.resources.IncompatibleKsqlCommandVersionException;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClientImpl;
@@ -132,7 +132,7 @@ public class KsqlRestoreCommandTopic {
       try {
         InternalTopicSerdes.deserializer(Command.class)
             .deserialize(null, record.getRight());
-      } catch (final SerializationException | IncomaptibleKsqlCommandVersionException e) {
+      } catch (final SerializationException | IncompatibleKsqlCommandVersionException e) {
         if (skipIncompatibleCommands) {
           incompatibleCommands.add(record.getRight());
           numFilteredCommands++;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -81,7 +81,7 @@ public class KsqlRestoreCommandTopic {
 
   public static List<Pair<byte[], byte[]>> loadBackup(
       final File file,
-      final RestoreOptions options,
+      final RestoreOptions restoreOptions,
       final KsqlConfig ksqlConfig
   ) throws IOException {
     final BackupReplayFile commandTopicBackupFile = BackupReplayFile.readOnly(file);
@@ -89,7 +89,7 @@ public class KsqlRestoreCommandTopic {
 
     records = checkValidCommands(
         records,
-        options.isSkipIncompatibleCommands(),
+        restoreOptions.isSkipIncompatibleCommands(),
         ksqlConfig);
 
     return records;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/RestoreOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/RestoreOptions.java
@@ -40,18 +40,18 @@ public class RestoreOptions {
           + "documentation for a list of available configs.")
   private String configFile;
 
-  @SuppressWarnings("unused") // Accessed via reflection
   @Option(
       name = {"--skip-incompatible-commands", "-s"},
       description = "This restore command can restore command topic commands that "
           + "are of version (" + io.confluent.ksql.rest.server.computation.Command.VERSION + ") "
           + "or lower. If true, the restore command will skip all incompatible commands."
-          + "If false, the restore command will restore the backup file as is.")
+          + "If false, the restore command will throw an "
+          + "exception when it encounters an incompatible command.")
   private boolean skipIncompatibleCommands = false;
 
   @Option(
-          name = {"--yes", "-y"},
-          description = "Automatic \"yes\" as answer to prompt and run non-interactively.")
+      name = {"--yes", "-y"},
+      description = "Automatic \"yes\" as answer to prompt and run non-interactively.")
   private boolean automaticYes = false;
 
   @SuppressWarnings("unused") // Accessed via reflection

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/RestoreOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/RestoreOptions.java
@@ -44,7 +44,10 @@ public class RestoreOptions {
       name = {"--skip-incompatible-commands", "-s"},
       description = "This restore command can restore command topic commands that "
           + "are of version (" + io.confluent.ksql.rest.server.computation.Command.VERSION + ") "
-          + "or lower. If true, the restore command will skip all incompatible commands."
+          + "or lower. If true, the restore command will skip all incompatible commands. "
+          + "For each incompatible command, the restore process will check if "
+          + "it contains a queryId. If it's present, the restore process will attempt "
+          + "to clean up internal topics and state stores for the query."
           + "If false, the restore command will throw an "
           + "exception when it encounters an incompatible command.")
   private boolean skipIncompatibleCommands = false;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/RestoreOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/RestoreOptions.java
@@ -42,8 +42,16 @@ public class RestoreOptions {
 
   @SuppressWarnings("unused") // Accessed via reflection
   @Option(
-      name = {"--yes", "-y"},
-      description = "Automatic \"yes\" as answer to prompt and run non-interactively.")
+      name = {"--skip-incompatible-commands", "-s"},
+      description = "This restore command can restore command topic commands that "
+          + "are of version (" + io.confluent.ksql.rest.server.computation.Command.VERSION + ") "
+          + "or lower. If true, the restore command will skip all incompatible commands."
+          + "If false, the restore command will restore the backup file as is.")
+  private boolean skipIncompatibleCommands = false;
+
+  @Option(
+          name = {"--yes", "-y"},
+          description = "Automatic \"yes\" as answer to prompt and run non-interactively.")
   private boolean automaticYes = false;
 
   @SuppressWarnings("unused") // Accessed via reflection
@@ -64,6 +72,10 @@ public class RestoreOptions {
 
   public boolean isAutomaticYes() {
     return automaticYes;
+  }
+
+  public boolean isSkipIncompatibleCommands() {
+    return skipIncompatibleCommands;
   }
 
   public static RestoreOptions parse(final String...args) throws IOException {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
@@ -37,7 +37,6 @@ import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
 import io.confluent.ksql.rest.server.restore.KsqlRestoreCommandTopic;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -114,7 +113,6 @@ public class RestoreCommandTopicIntegrationTest {
   public void teardown() {
     REST_APP.stop();
     TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
-    new File(String.valueOf(backupFile)).delete();
   }
 
   @After
@@ -244,7 +242,7 @@ public class RestoreCommandTopicIntegrationTest {
       final Path backUpFileLocation
   ) throws IOException {
     BackupReplayFile.writable(new File(String.valueOf(backUpFileLocation)))
-        .write(new ConsumerRecord<byte[], byte[]>(
+        .write(new ConsumerRecord<>(
             "",
             0,
             0L,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -162,40 +162,6 @@ public class CommandTopicBackupImplTest {
   }
 
   @Test
-  public void shouldThrowWhenRecordIsNotValidCommandId() {
-    // Given
-    commandTopicBackup.initialize();
-
-    // When
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> commandTopicBackup.writeRecord(new ConsumerRecord<>(
-        "topic1", 0, 0,
-            "stream/a/create/invalid".getBytes(StandardCharsets.UTF_8), command1.value())));
-
-    // Then
-    assertThat(e.getMessage(), containsString(
-        "Failed to backup record because it cannot deserialize key: stream/a/create/invalid"));
-  }
-
-  @Test
-  public void shouldThrowWhenRecordIsNotValidCommand() {
-    // Given
-    commandTopicBackup.initialize();
-
-    // When
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> commandTopicBackup.writeRecord(new ConsumerRecord<>(
-            "topic1", 0, 0, command1.key(),
-            "my command".getBytes(StandardCharsets.UTF_8))));
-
-    // Then
-    assertThat(e.getMessage(), containsString(
-        "Failed to backup record because it cannot deserialize value: my command"));
-  }
-
-  @Test
   public void shouldWriteCommandToBackupToReplayFile() throws IOException {
     // Given
     commandTopicBackup.initialize();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.rest.server.resources.CommandTopicCorruptionException;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
@@ -213,7 +214,7 @@ public class CommandTopicBackupImplTest {
     try {
       commandTopicBackup.writeRecord(command2);
       assertThat(true, is(false));
-    } catch (final KsqlServerException e) {
+    } catch (final CommandTopicCorruptionException e) {
       // This is expected so we do nothing
     }
     final BackupReplayFile currentReplayFile = commandTopicBackup.getReplayFile();
@@ -224,7 +225,7 @@ public class CommandTopicBackupImplTest {
     try {
       commandTopicBackup.writeRecord(command2);
       assertThat(true, is(false));
-    } catch (final KsqlServerException e) {
+    } catch (final CommandTopicCorruptionException e) {
       // This is expected so we do nothing
     }
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
@@ -29,8 +29,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.server.computation.QueuedCommand;
-import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.KsqlServerException;
+import io.confluent.ksql.rest.server.resources.CommandTopicCorruptionException;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Arrays;
@@ -105,10 +104,10 @@ public class CommandTopicTest {
   }
 
   @Test
-  public void shouldNotGetCommandsWhenKsqlServerExceptionWhenBackingUp() {
+  public void shouldNotGetCommandsWhenCommandTopicCorruptionWhenBackingUp() {
     // Given:
     when(commandConsumer.poll(any(Duration.class))).thenReturn(consumerRecords);
-    doNothing().doThrow(new KsqlServerException("error")).when(commandTopicBackup).writeRecord(any());
+    doNothing().doThrow(new CommandTopicCorruptionException("error")).when(commandTopicBackup).writeRecord(any());
 
     // When:
     final Iterable<ConsumerRecord<byte[], byte[]>> newCommands = commandTopic
@@ -122,7 +121,7 @@ public class CommandTopicTest {
   }
 
   @Test
-  public void shouldNotGetCommandsWhenKsqlServerExceptionIhBackupInRestore() {
+  public void shouldNotGetCommandsWhenCommandTopicCorruptionIhBackupInRestore() {
     // Given:
     when(commandConsumer.poll(any(Duration.class)))
         .thenReturn(someConsumerRecords(
@@ -131,7 +130,7 @@ public class CommandTopicTest {
         .thenReturn(someConsumerRecords(
             record3))
         .thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
-    doNothing().doThrow(new KsqlServerException("error")).when(commandTopicBackup).writeRecord(any());
+    doNothing().doThrow(new CommandTopicCorruptionException("error")).when(commandTopicBackup).writeRecord(any());
 
     // When:
     final List<QueuedCommand> queuedCommandList = commandTopic

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -38,7 +38,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.rest.Errors;
-import io.confluent.ksql.rest.server.resources.IncomaptibleKsqlCommandVersionException;
+import io.confluent.ksql.rest.server.resources.IncompatibleKsqlCommandVersionException;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.TerminateCluster;
@@ -276,7 +276,7 @@ public class CommandRunnerTest {
   public void shouldProcessPartialListOfCommandsOnIncompatibleCommandInRestore() {
     // Given:
     givenQueuedCommands(queuedCommand1, queuedCommand2, queuedCommand3);
-    doThrow(new IncomaptibleKsqlCommandVersionException("")).when(incompatibleCommandChecker).accept(queuedCommand3);
+    doThrow(new IncompatibleKsqlCommandVersionException("")).when(incompatibleCommandChecker).accept(queuedCommand3);
 
     // When:
     commandRunner.processPriorCommands();
@@ -299,7 +299,7 @@ public class CommandRunnerTest {
   public void shouldProcessPartialListOfCommandsOnIncompatibleCommandInFetch() {
     // Given:
     givenQueuedCommands(queuedCommand1, queuedCommand2, queuedCommand3);
-    doThrow(new IncomaptibleKsqlCommandVersionException("")).when(incompatibleCommandChecker).accept(queuedCommand3);
+    doThrow(new IncompatibleKsqlCommandVersionException("")).when(incompatibleCommandChecker).accept(queuedCommand3);
 
     // When:
     commandRunner.start();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-import io.confluent.ksql.rest.server.resources.IncomaptibleKsqlCommandVersionException;
+import io.confluent.ksql.rest.server.resources.IncompatibleKsqlCommandVersionException;
 import org.junit.Test;
 
 public class CommandTest {
@@ -66,7 +66,7 @@ public class CommandTest {
         ValueInstantiationException.class,
         () -> mapper.readValue(commandStr, Command.class)
     );
-    assertTrue(thrown.getCause() instanceof IncomaptibleKsqlCommandVersionException);
+    assertTrue(thrown.getCause() instanceof IncompatibleKsqlCommandVersionException);
   }
 
   @Test


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/issues/6305

Added a `-s` flag for skipping commands when restoring. If the flag isn't present, the restore command program will exit if it encounters errors deserializing commands from the command topic backup file. If it is present and true, it'll skip over the incompatible command instead. The program then prints out the number of skipped commands and tries to clean up any left over KafkaStreams internal topics and state stores if the skipped command was a query.

### Testing done 
Added integration test
Local manual test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

