### PR TITLE
chore: clarify self-join error message for n-way joins (MINOR)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -501,13 +501,15 @@ class Analyzer {
 
       final Optional<AliasedDataSource> existing = analysis.getSourceByName(source.getName());
       if (existing.isPresent()) {
-        throw new KsqlException(
-            "Can not join '"
+        final String errorMsg = analysis.getAllDataSources().size() > 1
+            ? "N-way joins do not support multiple occurrences of the same source. "
+                + "Source: '" + sourceName.toString(FormatOptions.noEscape()) + "'."
+            : "Can not join '"
                 + sourceName.toString(FormatOptions.noEscape())
                 + "' to '"
                 + existing.get().getDataSource().getName().toString(FormatOptions.noEscape())
-                + "': self joins are not yet supported."
-        );
+                + "': self joins are not yet supported.";
+        throw new KsqlException(errorMsg);
       }
       analysis.addDataSource(node.getAlias(), source);
       return node;

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -1056,6 +1056,19 @@
       "outputs": [
         {"topic": "OUTPUT", "key": 0, "value": {"S1_B": 1, "S2_A": 0, "S2_B": -1, "S3_A": 0, "S3_B": 9}, "timestamp":  12}
       ]
+    },
+    {
+      "name": "duplicate source",
+      "statements": [
+        "CREATE STREAM S1 (ID INT KEY, V0 bigint) WITH (kafka_topic='left_topic', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN T2 ON S1.ID = T2.ID JOIN T2 ON S1.V0 = T2.V0;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "N-way joins do not support multiple occurrences of the same source. Source: 'T2'"
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

Relates to https://github.com/confluentinc/ksql/issues/6484.

Currently, the error message for a query such as 
```
CREATE STREAM joined AS 
  SELECT * 
  FROM A
    LEFT JOIN B b1 ON A.b1_id = b1.id
    LEFT JOIN B b2 ON A.b2_id = b2.id;
```
is `Can not join 'B' to 'B': self joins are not yet supported.` which is misleading since the query is not actually a self-join. This PR updates the error message to `N-way joins do not support multiple occurrences of the same source. Source: 'B'`

### Testing done 

Unit + QTT.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

