### PR TITLE
docs: remove references to EMIT FINAL

### DIFF
--- a/docs/concepts/time-and-windows-in-ksqldb-queries.md
+++ b/docs/concepts/time-and-windows-in-ksqldb-queries.md
@@ -426,21 +426,3 @@ CREATE TABLE pageviews_per_region AS
 Note that the specified retention period should be larger than the sum of window size and any grace
 period.
 
-### Window Final Results
-
-In ksqlDB, windowed aggregations update their results continuously. As new data arrives for 
-a window, freshly computed results are emitted downstream. For many applications, this is ideal, 
-since fresh results are always available, and ksqlDB is designed to make programming 
-continuous computations seamless. However, some applications need to take action only on the final 
-result of a windowed computation. Common examples of this are sending alerts or delivering results 
-to a system that doesn’t support updates.
-
-Suppose that you have an hourly windowed count of events per user. If you want to send an alert 
-when a user has less than three events in an hour, you have a real challenge. All users would match 
-this condition at first, until they accrue enough events, so you can’t simply send an alert when 
-someone matches the condition; you have to wait until you know you won’t see any more events for a 
-particular window, and then send the alert.
-
-ksqlDB offers a clean way to define this logic: after defining your windowed aggregation, 
-you can suppress the intermediate results, emitting the final count for each user when the window 
-is closed.

--- a/docs/developer-guide/ksqldb-reference/quick-reference.md
+++ b/docs/developer-guide/ksqldb-reference/quick-reference.md
@@ -278,20 +278,6 @@ CREATE STREAM stream_name
   EMIT CHANGES;
 ```
 
-## EMIT FINAL
-Specify a push query with a suppressed output refinement in a SELECT statement on a 
-windowed aggregation. 
-For more information, see [Push Queries](../../concepts/queries/push).
-
-```sql
-CREATE TABLE table_name
-  AS SELECT  select_expr_with_aggregation [, ...]
-  FROM from_stream
-  [ WINDOW window_expression ]
-  [ GROUP BY grouping_expression ]
-  EMIT FINAL;
-```
-
 ## EXPLAIN
 Show the execution plan for a SQL expression or running query. For more
 information, see [EXPLAIN](../../ksqldb-reference/explain).

--- a/docs/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-push-query.md
@@ -211,8 +211,3 @@ ksqlDB supports the following output refinement types.
 This is the standard output refinement for push queries, for when we would like to see all changes 
 happening.
 
-#### FINAL
-
-This is for when we want to emit only the final result of a windowed aggregation, and suppress the 
-intermediate results until the window closes. Note that this output refinement is supported only 
-for windowed aggregations.

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -397,11 +397,6 @@ the pull query REST endpoint (by including it in the request e.g: `"streamsPrope
 By default, any amount of lag is allowed. For using this functionality, the server must be configured with `ksql.heartbeat.enable=true` and 
 `ksql.lag.reporting.enable=true`, so the servers can exchange lag information between themselves ahead of time, to validate pull queries against the allowed lag. 
 
-### ksql.suppress.buffer.size.bytes
-
-Bound the number of bytes that the buffer can use for suppression. Negative size means the buffer 
-will be unbounded. If the maximum capacity is exceeded, the query will be terminated.
-
 ksqlDB Server Settings
 ----------------------
 

--- a/docs/reference/sql/appendix.md
+++ b/docs/reference/sql/appendix.md
@@ -39,7 +39,6 @@ The following table shows all keywords in the language.
 | `EXPLAIN`      | show execution plan                   | `EXPLAIN <query-name>;` or `EXPLAIN <expression>;`                   |
 | `EXTENDED`     | list details for an object            | `DESCRIBE EXTENDED <stream-name>;`                                   |
 | `FALSE`        | Boolean value of false                |                                                                      |
-| `FINAL`        | specify pull query                    | `SELECT * FROM users EMIT FINAL;`                                    |
 | `FROM`         | specify record source for queries     | `SELECT * FROM users;`                                               |
 | `FULL`         | specify `FULL JOIN`                   | `CREATE TABLE t AS SELECT * FROM l FULL OUTER JOIN r ON l.ID = r.ID;`|
 | `FUNCTION`     | list details for a function           | `DESCRIBE FUNCTION <function-name>;`                                 |


### PR DESCRIPTION
fixes #6517 - we can revert this PR when we're ready to re-introduce suppress after finishing the AK side of the change