### PR TITLE
fix: clean up leaked admin client threads when issuing join query to query-stream endpoint

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -124,11 +124,22 @@ public class KsqlServerEndpoints implements Endpoints {
       final Context context,
       final WorkerExecutor workerExecutor,
       final ApiSecurityContext apiSecurityContext) {
-    return executeOnWorker(
-        () -> new QueryEndpoint(ksqlEngine, ksqlConfig, pullQueryExecutor, pullQueryMetrics)
-            .createQueryPublisher(sql, properties, context, workerExecutor,
-                ksqlSecurityContextProvider.provide(apiSecurityContext).getServiceContext()),
-        workerExecutor);
+    final KsqlSecurityContext ksqlSecurityContext = ksqlSecurityContextProvider
+        .provide(apiSecurityContext);
+    return executeOnWorker(() -> {
+      try {
+        return new QueryEndpoint(ksqlEngine, ksqlConfig, pullQueryExecutor, pullQueryMetrics)
+            .createQueryPublisher(
+                sql,
+                properties,
+                context,
+                workerExecutor,
+                ksqlSecurityContext.getServiceContext());
+      } finally {
+        ksqlSecurityContext.getServiceContext().close();
+      }
+    },
+    workerExecutor);
   }
 
   @Override


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/6367

Whenever a request is sent to either query endpoint, `DefaultApiSecurityContext.create(routingContext)` is called and a new service context is created. We're not closing the service context created in `createQueryPublisher` which causes the admin client created as part of the join query to never get closed, thus leaking the admin client thread.

### Testing done 
Manual testing with debugger, the number of admin client threads don't go up after repeatedly issuing join queries to the `query-stream` endpoint

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

