### PR TITLE
fix: '-e/-f' CLI parameters are not handling session variables correctly

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -220,10 +220,9 @@ public class Cli implements KsqlRequestExecutor, Closeable {
   public void runCommand(final String command) {
     RemoteServerSpecificCommand.validateClient(terminal.writer(), restClient);
     try {
-      // Handles the RUN SCRIPT command if found
-      if (!terminal.maybeHandleCliSpecificCommands(command)) {
-        handleLine(command);
-      }
+      // Commands executed by the '-e' parameter do not need to execute specific CLI
+      // commands. For RUN SCRIPT commands, users can use the '-f' command parameter.
+      handleLine(command);
     } catch (final EndOfFileException exception) {
       // Ignore - only used by runInteractively() to exit the CLI
     } catch (final Exception exception) {
@@ -354,22 +353,20 @@ public class Cli implements KsqlRequestExecutor, Closeable {
     return KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE_DEFAULT;
   }
 
-  private List<ParsedStatement> substituteVariables(final List<ParsedStatement> statements) {
+  private ParsedStatement substituteVariables(final ParsedStatement statement) {
     if (isVariableSubstitutionEnabled()) {
-      return statements.stream()
-          .map(stmt -> VariableSubstitutor.substitute(stmt, sessionVariables))
-          .flatMap(replacedSql -> KSQL_PARSER.parse(replacedSql).stream())
-          .collect(Collectors.toList());
+      final String replacedStmt = VariableSubstitutor.substitute(statement, sessionVariables);
+      return KSQL_PARSER.parse(replacedStmt).get(0);
     } else {
-      return statements;
+      return statement;
     }
   }
 
   private void handleStatements(final String line) {
-    final List<ParsedStatement> statements = substituteVariables(KSQL_PARSER.parse(line));
-
+    final List<ParsedStatement> statements = KSQL_PARSER.parse(line);
     final StringBuilder consecutiveStatements = new StringBuilder();
-    for (final ParsedStatement parsed : statements) {
+
+    statements.stream().map(this::substituteVariables).forEach(parsed -> {
       final StatementContext statementContext = parsed.getStatement().statement();
       final String statementText = parsed.getStatementText();
 
@@ -384,7 +381,8 @@ public class Cli implements KsqlRequestExecutor, Closeable {
 
         handler.handle(this, statementText, statementContext);
       }
-    }
+    });
+
     if (consecutiveStatements.length() != 0) {
       makeKsqlRequest(consecutiveStatements.toString());
     }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -149,8 +149,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
         remoteServerState::setRequestPipelining);
   }
 
-  @Override
-  public void makeKsqlRequest(final String statements) {
+  private void makeKsqlRequest(final String statements) {
     if (statements.isEmpty()) {
       return;
     }
@@ -304,13 +303,13 @@ public class Cli implements KsqlRequestExecutor, Closeable {
     terminal.close();
   }
 
-  void handleLine(final String line) {
+  public void handleLine(final String line) {
     final String trimmedLine = Optional.ofNullable(line).orElse("").trim();
     if (trimmedLine.isEmpty()) {
       return;
     }
 
-    handleStatements(trimmedLine);
+    executeStatements(trimmedLine);
   }
 
   /**
@@ -362,7 +361,8 @@ public class Cli implements KsqlRequestExecutor, Closeable {
     }
   }
 
-  private void handleStatements(final String line) {
+  @Override
+  public void executeStatements(final String line) {
     final List<ParsedStatement> statements = KSQL_PARSER.parse(line);
     final StringBuilder consecutiveStatements = new StringBuilder();
 

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/KsqlRequestExecutor.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/KsqlRequestExecutor.java
@@ -18,9 +18,9 @@ package io.confluent.ksql.cli;
 public interface KsqlRequestExecutor {
 
   /**
-   * Execute a request on the KSQL servers and handle the response.
+   * Handle and execute statements on the KSQL servers and handle the response.
    *
-   * @param body the request body.
+   * @param line the request statements separated by semi-colon.
    */
-  void makeKsqlRequest(String body);
+  void executeStatements(String line);
 }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/cmd/RunScript.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/cmd/RunScript.java
@@ -58,7 +58,7 @@ public final class RunScript implements CliSpecificCommand {
 
     final String filePath = args.get(0);
     final String content = loadScript(filePath);
-    requestExecutor.makeKsqlRequest(content);
+    requestExecutor.executeStatements(content);
   }
 
   private static String loadScript(final String filePath) {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -1035,6 +1035,19 @@ public class CliTest {
   }
 
   @Test
+  public void shouldSubstituteVariablesOnRunCommand()  {
+    // When:
+    localCli.runCommand(String.format(
+        "DEFINE var = '%s'; CREATE STREAM shouldRunCommand AS SELECT * FROM ${var};",
+        ORDER_DATA_PROVIDER.sourceName()
+    ));
+
+    // Then:
+    assertThat(terminal.getOutputString(),
+        containsString("Created query with ID CSAS_SHOULDRUNCOMMAND_1"));
+  }
+
+  @Test
   public void shouldRunScriptOnRunInteractively() throws Exception {
     // Given:
     final File scriptFile = TMP.newFile("script.sql");
@@ -1048,22 +1061,6 @@ public class CliTest {
 
     // When:
     localCli.runInteractively();
-
-    // Then:
-    assertThat(terminal.getOutputString(),
-        containsString("Created query with ID CSAS_SHOULDRUNSCRIPT"));
-  }
-
-  @Test
-  public void shouldRunScriptOnRunCommand() throws Exception {
-    // Given:
-    final File scriptFile = TMP.newFile("script.sql");
-    Files.write(scriptFile.toPath(), (""
-        + "CREATE STREAM shouldRunScript AS SELECT * FROM " + ORDER_DATA_PROVIDER.sourceName() + ";"
-        + "").getBytes(StandardCharsets.UTF_8));
-
-    // When:
-    localCli.runCommand("run script '" + scriptFile.getAbsolutePath() + "'");
 
     // Then:
     assertThat(terminal.getOutputString(),

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -1036,15 +1036,18 @@ public class CliTest {
 
   @Test
   public void shouldSubstituteVariablesOnRunCommand()  {
+    // Given:
+    final StringBuilder builder = new StringBuilder();
+    builder.append("SET '" + KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE + "' = 'true';");
+    builder.append("DEFINE var = '" + ORDER_DATA_PROVIDER.sourceName() + "';");
+    builder.append("CREATE STREAM shouldRunCommand AS SELECT * FROM ${var};");
+
     // When:
-    localCli.runCommand(String.format(
-        "DEFINE var = '%s'; CREATE STREAM shouldRunCommand AS SELECT * FROM ${var};",
-        ORDER_DATA_PROVIDER.sourceName()
-    ));
+    localCli.runCommand(builder.toString());
 
     // Then:
     assertThat(terminal.getOutputString(),
-        containsString("Created query with ID CSAS_SHOULDRUNCOMMAND_1"));
+        containsString("Created query with ID CSAS_SHOULDRUNCOMMAND"));
   }
 
   @Test

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RunScriptTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RunScriptTest.java
@@ -110,7 +110,7 @@ public class RunScriptTest {
     cmd.execute(ImmutableList.of(scriptFile.toString()), terminal);
 
     // Then:
-    verify(requestExecutor).makeKsqlRequest(FILE_CONTENT);
+    verify(requestExecutor).executeStatements(FILE_CONTENT);
   }
 
   @Test

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -50,7 +50,8 @@ import java.util.List;
     @JsonSubTypes.Type(value = ConnectorDescription.class, name = "connector_description"),
     @JsonSubTypes.Type(value = TypeList.class, name = "type_list"),
     @JsonSubTypes.Type(value = ErrorEntity.class, name = "error_entity"),
-    @JsonSubTypes.Type(value = WarningEntity.class, name = "warning_entity")
+    @JsonSubTypes.Type(value = WarningEntity.class, name = "warning_entity"),
+    @JsonSubTypes.Type(value = VariablesList.class, name = "variables")
 })
 public abstract class KsqlEntity {
   private final String statementText;

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/VariablesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/VariablesList.java
@@ -80,7 +80,7 @@ public class VariablesList extends KsqlEntity {
   @JsonCreator
   public VariablesList(
       @JsonProperty("statementText") final String statementText,
-      @JsonProperty("properties") final List<Variable> variables
+      @JsonProperty("variables") final List<Variable> variables
   ) {
     super(statementText);
     this.variables = variables == null ? Collections.emptyList() : ImmutableList.copyOf(variables);


### PR DESCRIPTION
### Description 

There are three fixes in this PR:
* fix: allow '-e' parameter to use variable substitution
* fix: SHOW VARIABLES is not working with RUN SCRIPT and '-f' parameter
* fix: RUN SCRIPT and '-f' parameter do not handle PRINT/SELECT queries

### Testing done 
Added unit tests and verified manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

