### PR TITLE
feat: add constraint to deny drop sources referenced by other CREATE_AS sources

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/SourceDescription.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/SourceDescription.java
@@ -86,8 +86,8 @@ public interface SourceDescription {
   String sqlStatement();
 
   /**
-   * Returns a list of sources that have a DROP constraint reference on this source. This DROP
-   * constraint does not allow to delete this source after all referenced sources are deleted.
+   * Returns a list of sources that have a DROP constraint reference on this source. This source
+   * cannot be dropped until all sources returned by this method are deleted.
    *
    * @return a list of sources
    */

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/SourceDescription.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/SourceDescription.java
@@ -85,4 +85,11 @@ public interface SourceDescription {
    */
   String sqlStatement();
 
+  /**
+   * Returns a list of sources that have a DROP constraint reference on this source. This DROP
+   * constraint does not allow to delete this source after all referenced sources are deleted.
+   *
+   * @return a list of sources
+   */
+  List<String> getSourceConstraints();
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -317,7 +317,10 @@ final class AdminResponseHandlers {
               ? Optional.empty()
               : Optional.of(source.getString("timestamp")),
           Optional.ofNullable(source.getString("windowType")),
-          source.getString("statement")
+          source.getString("statement"),
+          source.getJsonArray("sourceConstraints").stream()
+              .map(o -> (String)o)
+              .collect(Collectors.toList())
       ));
     } catch (Exception e) {
       return Optional.empty();

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/SourceDescriptionImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/SourceDescriptionImpl.java
@@ -35,6 +35,7 @@ public final class SourceDescriptionImpl implements SourceDescription {
   private final Optional<String> timestampColumn;
   private final Optional<String> windowType;
   private final String sqlStatement;
+  private final List<String> sourceConstraints;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   SourceDescriptionImpl(
@@ -48,7 +49,8 @@ public final class SourceDescriptionImpl implements SourceDescription {
       final List<QueryInfo> writeQueries,
       final Optional<String> timestampColumn,
       final Optional<String> windowType,
-      final String sqlStatement
+      final String sqlStatement,
+      final List<String> sourceConstraints
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.name = Objects.requireNonNull(name, "name");
@@ -62,6 +64,7 @@ public final class SourceDescriptionImpl implements SourceDescription {
     this.timestampColumn = Objects.requireNonNull(timestampColumn, "timestampColumn");
     this.windowType = Objects.requireNonNull(windowType, "windowType");
     this.sqlStatement = Objects.requireNonNull(sqlStatement, "sqlStatement");
+    this.sourceConstraints = Objects.requireNonNull(sourceConstraints, "sourceConstraints");
   }
 
   @Override
@@ -117,6 +120,11 @@ public final class SourceDescriptionImpl implements SourceDescription {
   @Override
   public String sqlStatement() {
     return sqlStatement;
+  }
+
+  @Override
+  public List<String> getSourceConstraints() {
+    return sourceConstraints;
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -923,6 +923,7 @@ public class ClientTest extends BaseApiTest {
             4,
             1,
             "statement",
+            Collections.emptyList(),
             Collections.emptyList()),
         Collections.emptyList());
     testEndpoints.setKsqlEndpointResponse(Collections.singletonList(entity));
@@ -1352,6 +1353,7 @@ public class ClientTest extends BaseApiTest {
             4,
             1,
             "sql",
+            Collections.emptyList(),
             Collections.emptyList()
         );
     final SourceDescriptionEntity entity = new SourceDescriptionEntity(

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -1354,7 +1355,7 @@ public class ClientTest extends BaseApiTest {
             1,
             "sql",
             Collections.emptyList(),
-            Collections.emptyList()
+            ImmutableList.of("s1", "s2")
         );
     final SourceDescriptionEntity entity = new SourceDescriptionEntity(
         "describe source;", sd, Collections.emptyList());
@@ -1386,6 +1387,7 @@ public class ClientTest extends BaseApiTest {
     assertThat(description.timestampColumn(), is(Optional.empty()));
     assertThat(description.windowType(), is(Optional.of("TUMBLING")));
     assertThat(description.sqlStatement(), is("sql"));
+    assertThat(description.getSourceConstraints(), hasItems("s1", "s2"));
   }
 
   protected Client createJavaClient() {

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/SourceDescriptionImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/SourceDescriptionImplTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.client.impl;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.api.client.QueryInfo.QueryType;
 import java.util.Collections;
@@ -40,7 +41,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql"),
+                "sql",
+                Collections.emptyList()),
             new SourceDescriptionImpl(
                 "name",
                 "type",
@@ -54,7 +56,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -70,7 +73,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -86,7 +90,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -102,7 +107,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -118,7 +124,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -134,7 +141,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -150,7 +158,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -166,7 +175,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -181,7 +191,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -196,7 +207,8 @@ public class SourceDescriptionImplTest {
                 Collections.emptyList(),
                 Optional.empty(),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -212,7 +224,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.of("timestamp"),
                 Optional.empty(),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -228,7 +241,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.of("window"),
-                "sql")
+                "sql",
+                Collections.emptyList())
         )
         .addEqualityGroup(
             new SourceDescriptionImpl(
@@ -244,7 +258,8 @@ public class SourceDescriptionImplTest {
                     Optional.of("name"), Optional.of("topic"))),
                 Optional.empty(),
                 Optional.empty(),
-                "other_sql")
+                "other_sql",
+                Collections.emptyList())
         )
         .testEquals();
   }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -535,6 +535,18 @@ public class Console implements Closeable {
     }
   }
 
+  private void printSourceConstraints(final List<String> sourceConstraints) {
+    if (!sourceConstraints.isEmpty()) {
+      writer().println(String.format(
+          "%n%-20s%n%-20s",
+          "Sources that have a DROP constraint on this source",
+          "--------------------------------------------------"
+      ));
+
+      sourceConstraints.forEach(sourceName -> writer().println(sourceName));
+    }
+  }
+
   private void printQueries(
       final List<RunningQuery> queries,
       final String type,
@@ -631,6 +643,8 @@ public class Console implements Closeable {
     writer().println("");
 
     printSchema(source.getWindowType(), source.getFields(), isTable);
+
+    printSourceConstraints(source.getSourceConstraints());
 
     printQueries(source.getReadQueries(), source.getType(), "read");
 

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -147,6 +147,7 @@ public class ConsoleTest {
       2,
       1,
       "statement",
+      Collections.emptyList(),
       Collections.emptyList());
 
   @Mock
@@ -529,6 +530,7 @@ public class ConsoleTest {
                 1,
                 1,
                 "sql statement",
+                Collections.emptyList(),
                 Collections.emptyList()),
             Collections.emptyList()
         )
@@ -661,7 +663,8 @@ public class ConsoleTest {
           + "    \"partitions\" : 1," + NEWLINE
           + "    \"replication\" : 1," + NEWLINE
           + "    \"statement\" : \"sql statement\"," + NEWLINE
-          + "    \"queryOffsetSummaries\" : [ ]" + NEWLINE
+          + "    \"queryOffsetSummaries\" : [ ]," + NEWLINE
+          + "    \"sourceConstraints\" : [ ]" + NEWLINE
           + "  }," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE
           + "} ]" + NEWLINE));
@@ -800,7 +803,8 @@ public class ConsoleTest {
           + "    \"partitions\" : 2," + NEWLINE
           + "    \"replication\" : 1," + NEWLINE
           + "    \"statement\" : \"statement\"," + NEWLINE
-          + "    \"queryOffsetSummaries\" : [ ]" + NEWLINE
+          + "    \"queryOffsetSummaries\" : [ ]," + NEWLINE
+          + "    \"sourceConstraints\" : [ ]" + NEWLINE
           + "  } ]," + NEWLINE
           + "  \"topics\" : [ \"a-jdbc-topic\" ]," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE
@@ -1104,7 +1108,8 @@ public class ConsoleTest {
                     new QueryOffsetSummary(
                         "consumer2",
                         ImmutableList.of())
-                )),
+                ),
+                ImmutableList.of("S1", "S2")),
             Collections.emptyList()
         ))
     );
@@ -1204,7 +1209,8 @@ public class ConsoleTest {
           + "    }, {" + NEWLINE
           + "      \"groupId\" : \"consumer2\"," + NEWLINE
           + "      \"topicSummaries\" : [ ]" + NEWLINE
-          + "    } ]" + NEWLINE
+          + "    } ]," + NEWLINE
+          + "    \"sourceConstraints\" : [ \"S1\", \"S2\" ]" + NEWLINE
           + "  }," + NEWLINE
           + "  \"warnings\" : [ ]" + NEWLINE
           + "} ]" + NEWLINE));
@@ -1223,6 +1229,11 @@ public class ConsoleTest {
           + " ROWKEY | VARCHAR(STRING)  (primary key) " + NEWLINE
           + " f_0    | VARCHAR(STRING)                " + NEWLINE
           + "-----------------------------------------" + NEWLINE
+          + "" + NEWLINE
+          + "Sources that have a DROP constraint on this source" + NEWLINE
+          + "--------------------------------------------------" + NEWLINE
+          + "S1" + NEWLINE
+          + "S2" + NEWLINE
           + "" + NEWLINE
           + "Queries that read from this TABLE" + NEWLINE
           + "-----------------------------------" + NEWLINE

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.execution.ddl.commands.DdlCommandResult;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metrics.StreamsErrorCollector;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
@@ -219,9 +220,11 @@ final class EngineContext {
   String executeDdl(
       final String sqlExpression,
       final DdlCommand command,
-      final boolean withQuery
+      final boolean withQuery,
+      final Set<SourceName> withQuerySources
   ) {
-    final DdlCommandResult result = ddlCommandExec.execute(sqlExpression, command, withQuery);
+    final DdlCommandResult result =
+        ddlCommandExec.execute(sqlExpression, command, withQuery, withQuerySources);
     if (!result.isSuccess()) {
       throw new KsqlStatementException(result.getMessage(), sqlExpression);
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -3,10 +3,12 @@ package io.confluent.ksql.ddl.commands;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.execution.ddl.commands.AlterSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
@@ -34,9 +36,14 @@ import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlReferentialIntegrityException;
 import io.confluent.ksql.util.MetaStoreFixture;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,9 +52,12 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 public class DdlCommandExecTest {
+  private static final Set<SourceName> NO_QUERY_SOURCES = Collections.emptySet(); 
   private static final String SQL_TEXT = "some ksql";
   private static final SourceName STREAM_NAME = SourceName.of("s1");
+  private static final SourceName OTHER_STREAM_NAME = SourceName.of("other-s1");
   private static final SourceName TABLE_NAME = SourceName.of("t1");
+  private static final SourceName OTHER_TABLE_NAME = SourceName.of("other-t1");
   private static final String TOPIC_NAME = "topic";
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("K0"), SqlTypes.BIGINT)
@@ -109,7 +119,7 @@ public class DdlCommandExecTest {
     givenCreateStream();
 
     // When:
-    cmdExec.execute(SQL_TEXT, createStream, false);
+    cmdExec.execute(SQL_TEXT, createStream, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(metaStore.getSource(STREAM_NAME).getSqlExpression(), is(SQL_TEXT));
@@ -119,11 +129,11 @@ public class DdlCommandExecTest {
   public void shouldAddStreamWithReplace() {
     // Given:
     givenCreateStream();
-    cmdExec.execute(SQL_TEXT, createStream, false);
+    cmdExec.execute(SQL_TEXT, createStream, false, NO_QUERY_SOURCES);
 
     // When:
     givenCreateStream(SCHEMA2, true);
-    cmdExec.execute(SQL_TEXT, createStream, false);
+    cmdExec.execute(SQL_TEXT, createStream, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(metaStore.getSource(STREAM_NAME).getSchema(), is(SCHEMA2));
@@ -135,10 +145,36 @@ public class DdlCommandExecTest {
     givenCreateStream();
 
     // When:
-    cmdExec.execute(SQL_TEXT, createStream, true);
+    cmdExec.execute(SQL_TEXT, createStream, true, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(metaStore.getSource(STREAM_NAME).isCasTarget(), is(true));
+  }
+
+  @Test
+  public void shouldThrowOnDropStreamWhenConstraintExist() {
+    // Given:
+    final CreateStreamCommand stream1 = buildCreateStream(SourceName.of("s1"), SCHEMA, false);
+    final CreateStreamCommand stream2 = buildCreateStream(SourceName.of("s2"), SCHEMA, false);
+    final CreateStreamCommand stream3 = buildCreateStream(SourceName.of("s3"), SCHEMA, false);
+    cmdExec.execute(SQL_TEXT, stream1, true, Collections.emptySet());
+    cmdExec.execute(SQL_TEXT, stream2, true, Collections.singleton(SourceName.of("s1")));
+    cmdExec.execute(SQL_TEXT, stream3, true, Collections.singleton(SourceName.of("s1")));
+
+    // When:
+    final DropSourceCommand dropStream = buildDropSourceCommand(SourceName.of("s1"));
+    final Exception e = assertThrows(
+        KsqlReferentialIntegrityException.class,
+        () -> cmdExec.execute(SQL_TEXT, dropStream, false, Collections.emptySet())
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Cannot drop s1."));
+    assertThat(e.getMessage(),
+        containsString("The following streams and/or tables read from this source: [s2, s3]."));
+    assertThat(e.getMessage(),
+        containsString("You need to drop them before dropping s1."));
   }
 
   @Test
@@ -147,7 +183,7 @@ public class DdlCommandExecTest {
     givenCreateStream();
 
     // When:
-    cmdExec.execute(SQL_TEXT, createStream, false);
+    cmdExec.execute(SQL_TEXT, createStream, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(
@@ -162,7 +198,7 @@ public class DdlCommandExecTest {
     givenCreateWindowedStream();
 
     // When:
-    cmdExec.execute(SQL_TEXT, createStream, false);
+    cmdExec.execute(SQL_TEXT, createStream, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(
@@ -177,7 +213,7 @@ public class DdlCommandExecTest {
     givenCreateWindowedTable();
 
     // When:
-    cmdExec.execute(SQL_TEXT, createTable, false);
+    cmdExec.execute(SQL_TEXT, createTable, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(
@@ -192,7 +228,7 @@ public class DdlCommandExecTest {
     givenCreateTable();
 
     // When:
-    cmdExec.execute(SQL_TEXT, createTable, false);
+    cmdExec.execute(SQL_TEXT, createTable, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(metaStore.getSource(TABLE_NAME).getSqlExpression(), is(SQL_TEXT));
@@ -204,7 +240,7 @@ public class DdlCommandExecTest {
     givenCreateTable();
 
     // When:
-    cmdExec.execute(SQL_TEXT, createTable, false);
+    cmdExec.execute(SQL_TEXT, createTable, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(
@@ -219,10 +255,36 @@ public class DdlCommandExecTest {
     givenCreateTable();
 
     // When:
-    cmdExec.execute(SQL_TEXT, createTable, true);
+    cmdExec.execute(SQL_TEXT, createTable, true, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(metaStore.getSource(TABLE_NAME).isCasTarget(), is(true));
+  }
+
+  @Test
+  public void shouldThrowOnDropTableWhenConstraintExist() {
+    // Given:
+    final CreateTableCommand table1 = buildCreateTable(SourceName.of("t1"));
+    final CreateTableCommand table2 = buildCreateTable(SourceName.of("t2"));
+    final CreateTableCommand table3 = buildCreateTable(SourceName.of("t3"));
+    cmdExec.execute(SQL_TEXT, table1, true, Collections.emptySet());
+    cmdExec.execute(SQL_TEXT, table2, true, Collections.singleton(SourceName.of("t1")));
+    cmdExec.execute(SQL_TEXT, table3, true, Collections.singleton(SourceName.of("t1")));
+
+    // When:
+    final DropSourceCommand dropStream = buildDropSourceCommand(SourceName.of("t1"));
+    final Exception e = assertThrows(
+        KsqlReferentialIntegrityException.class,
+        () -> cmdExec.execute(SQL_TEXT, dropStream, false, Collections.emptySet())
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Cannot drop t1."));
+    assertThat(e.getMessage(),
+        containsString("The following streams and/or tables read from this source: [t2, t3]."));
+    assertThat(e.getMessage(),
+        containsString("You need to drop them before dropping t1."));
   }
 
   @Test
@@ -231,7 +293,7 @@ public class DdlCommandExecTest {
     alterSource = new AlterSourceCommand(EXISTING_STREAM, DataSourceType.KSTREAM.getKsqlType(), NEW_COLUMNS);
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, alterSource, false);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, alterSource, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(result.isSuccess(), is(true));
@@ -245,7 +307,7 @@ public class DdlCommandExecTest {
     alterSource = new AlterSourceCommand(EXISTING_TABLE, DataSourceType.KTABLE.getKsqlType(), NEW_COLUMNS);
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, alterSource, false);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, alterSource, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(result.isSuccess(), is(true));
@@ -259,7 +321,8 @@ public class DdlCommandExecTest {
     alterSource = new AlterSourceCommand(STREAM_NAME, DataSourceType.KSTREAM.getKsqlType(), NEW_COLUMNS);
 
     // When:
-    final KsqlException e = assertThrows(KsqlException.class, () -> cmdExec.execute(SQL_TEXT, alterSource, false));
+    final KsqlException e = assertThrows(KsqlException.class,
+        () -> cmdExec.execute(SQL_TEXT, alterSource, false, NO_QUERY_SOURCES));
 
     // Then:
     assertThat(e.getMessage(), is("Source s1 does not exist."));
@@ -271,7 +334,8 @@ public class DdlCommandExecTest {
     alterSource = new AlterSourceCommand(EXISTING_STREAM, DataSourceType.KTABLE.getKsqlType(), NEW_COLUMNS);
 
     // When:
-    final KsqlException e = assertThrows(KsqlException.class, () -> cmdExec.execute(SQL_TEXT, alterSource, false));
+    final KsqlException e = assertThrows(KsqlException.class,
+        () -> cmdExec.execute(SQL_TEXT, alterSource, false, NO_QUERY_SOURCES));
 
     // Then:
     assertThat(e.getMessage(), is("Incompatible data source type is STREAM, but statement was ALTER TABLE"));
@@ -281,11 +345,12 @@ public class DdlCommandExecTest {
   public void shouldThrowOnAlterCAS() {
     // Given:
     givenCreateStream();
-    cmdExec.execute(SQL_TEXT, createStream, true);
+    cmdExec.execute(SQL_TEXT, createStream, true, NO_QUERY_SOURCES);
     alterSource = new AlterSourceCommand(STREAM_NAME, DataSourceType.KSTREAM.getKsqlType(), NEW_COLUMNS);
 
     // When:
-    final KsqlException e = assertThrows(KsqlException.class, () -> cmdExec.execute(SQL_TEXT, alterSource, false));
+    final KsqlException e = assertThrows(KsqlException.class,
+        () -> cmdExec.execute(SQL_TEXT, alterSource, false, NO_QUERY_SOURCES));
 
     // Then:
     assertThat(e.getMessage(), is("ALTER command is not supported for CREATE ... AS statements."));
@@ -295,11 +360,12 @@ public class DdlCommandExecTest {
   public void shouldThrowOnAddExistingColumn() {
     // Given:
     givenCreateStream();
-    cmdExec.execute(SQL_TEXT, createStream, false);
+    cmdExec.execute(SQL_TEXT, createStream, false, NO_QUERY_SOURCES);
     alterSource = new AlterSourceCommand(STREAM_NAME, DataSourceType.KSTREAM.getKsqlType(), SCHEMA2.columns());
 
     // When:
-    final KsqlException e = assertThrows(KsqlException.class, () -> cmdExec.execute(SQL_TEXT, alterSource, false));
+    final KsqlException e = assertThrows(KsqlException.class,
+        () -> cmdExec.execute(SQL_TEXT, alterSource, false, NO_QUERY_SOURCES));
 
     // Then:
     assertThat(e.getMessage(), is("Cannot add column `F1` to schema. A column with the same name already exists."));
@@ -311,7 +377,7 @@ public class DdlCommandExecTest {
     givenDropSourceCommand(STREAM_NAME);
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropSource, false);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropSource, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(result.isSuccess(), is(true));
@@ -325,7 +391,7 @@ public class DdlCommandExecTest {
     givenDropSourceCommand(STREAM_NAME);
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropSource, false);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropSource, false, NO_QUERY_SOURCES);
 
     // Then
     assertThat(result.isSuccess(), is(true));
@@ -338,7 +404,7 @@ public class DdlCommandExecTest {
   @Test
   public void shouldRegisterType() {
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, registerType, false);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, registerType, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat("Expected successful resolution", result.isSuccess());
@@ -351,7 +417,7 @@ public class DdlCommandExecTest {
     metaStore.registerType("type", SqlTypes.STRING);
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, registerType, false);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, registerType, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat("Expected successful resolution", result.isSuccess());
@@ -364,7 +430,7 @@ public class DdlCommandExecTest {
     metaStore.registerType("type", SqlTypes.STRING);
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropType, false);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropType, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat(metaStore.resolveType("type").isPresent(), is(false));
@@ -378,7 +444,7 @@ public class DdlCommandExecTest {
     metaStore.deleteType("type");
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropType, false);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropType, false, NO_QUERY_SOURCES);
 
     // Then:
     assertThat("Expected successful execution", result.isSuccess());
@@ -389,18 +455,23 @@ public class DdlCommandExecTest {
   public void shouldFailAddDuplicateStreamWithoutReplace() {
     // Given:
     givenCreateStream();
-    cmdExec.execute(SQL_TEXT, createStream, false);
+    cmdExec.execute(SQL_TEXT, createStream, false, NO_QUERY_SOURCES);
 
     // When:
     givenCreateStream(SCHEMA2, false);
-    final KsqlException e = assertThrows(KsqlException.class, () -> cmdExec.execute(SQL_TEXT, createStream, false));
+    final KsqlException e = assertThrows(KsqlException.class,
+        () -> cmdExec.execute(SQL_TEXT, createStream, false, NO_QUERY_SOURCES));
 
     // Then:
     assertThat(e.getMessage(), containsString("A stream with the same name already exists"));
   }
 
   private void givenDropSourceCommand(final SourceName name) {
-    dropSource = new DropSourceCommand(name);
+    dropSource = buildDropSourceCommand(name);
+  }
+
+  private DropSourceCommand buildDropSourceCommand(final SourceName name) {
+    return new DropSourceCommand(name);
   }
 
   private void givenCreateStream() {
@@ -408,8 +479,16 @@ public class DdlCommandExecTest {
   }
 
   private void givenCreateStream(final LogicalSchema schema, final boolean allowReplace) {
-    createStream = new CreateStreamCommand(
-        STREAM_NAME,
+    createStream = buildCreateStream(STREAM_NAME, schema, allowReplace);
+  }
+
+  private CreateStreamCommand buildCreateStream(
+      final SourceName streamName,
+      final LogicalSchema schema,
+      final boolean allowReplace
+  ) {
+    return new CreateStreamCommand(
+        streamName,
         schema,
         Optional.of(timestampColumn),
         "topic",
@@ -459,8 +538,12 @@ public class DdlCommandExecTest {
   }
 
   private void givenCreateTable() {
-    createTable = new CreateTableCommand(
-        TABLE_NAME,
+    createTable = buildCreateTable(TABLE_NAME);
+  }
+
+  private CreateTableCommand buildCreateTable(final SourceName sourceName) {
+    return new CreateTableCommand(
+        sourceName,
         SCHEMA,
         Optional.of(timestampColumn),
         TOPIC_NAME,

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStore.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStore.java
@@ -27,6 +27,8 @@ public interface MetaStore extends FunctionRegistry, TypeRegistry {
 
   Map<SourceName, DataSource> getAllDataSources();
 
+  Set<SourceName> getSourceConstraints(SourceName sourceName);
+
   Set<String> getQueriesWithSource(SourceName sourceName);
 
   Set<String> getQueriesWithSink(SourceName sourceName);

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.metastore;
 
+import com.google.common.collect.Iterables;
 import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -29,6 +30,7 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlReferentialIntegrityException;
+import io.vertx.core.impl.ConcurrentHashSet;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -43,6 +45,8 @@ import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 public final class MetaStoreImpl implements MutableMetaStore {
+  // these sources have a constraint that cannot be deleted until the references are dropped first
+  private final Map<SourceName, Set<SourceName>> dropConstraints = new ConcurrentHashMap<>();
 
   private final Map<SourceName, SourceInfo> dataSources = new ConcurrentHashMap<>();
   private final Object referentialIntegrityLock = new Object();
@@ -57,7 +61,8 @@ public final class MetaStoreImpl implements MutableMetaStore {
   private MetaStoreImpl(
       final Map<SourceName, SourceInfo> dataSources,
       final FunctionRegistry functionRegistry,
-      final TypeRegistry typeRegistry
+      final TypeRegistry typeRegistry,
+      final Map<SourceName, Set<SourceName>> dropConstraints
   ) {
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
     this.typeRegistry = new TypeRegistryImpl();
@@ -65,6 +70,12 @@ public final class MetaStoreImpl implements MutableMetaStore {
     dataSources.forEach((name, info) -> this.dataSources.put(name, info.copy()));
     typeRegistry.types()
         .forEachRemaining(type -> this.typeRegistry.registerType(type.getName(), type.getType()));
+
+    dropConstraints.forEach((source, references) -> {
+      final Set<SourceName> childSources = new ConcurrentHashSet<>();
+      childSources.addAll(references);
+      this.dropConstraints.put(source, childSources);
+    });
   }
 
   @Override
@@ -93,24 +104,27 @@ public final class MetaStoreImpl implements MutableMetaStore {
       });
     }
 
-    dataSources.put(dataSource.getName(), new SourceInfo(dataSource));
+    // Replace the dataSource if one exists, which may contain changes in the Schema, with
+    // a copy of the previous source info
+    dataSources.put(dataSource.getName(),
+        (existing != null) ? existing.copyWith(dataSource) : new SourceInfo(dataSource));
   }
 
   @Override
   public void deleteSource(final SourceName sourceName) {
     synchronized (referentialIntegrityLock) {
-      dataSources.compute(sourceName, (ignored, source) -> {
-        if (source == null) {
+      dataSources.compute(sourceName, (ignored, sourceInfo) -> {
+        if (sourceInfo == null) {
           throw new KsqlException(String.format("No data source with name %s exists.",
               sourceName.text()));
         }
 
-        final String sourceForQueriesMessage = source.referentialIntegrity
+        final String sourceForQueriesMessage = sourceInfo.referentialIntegrity
             .getSourceForQueries()
             .stream()
             .collect(Collectors.joining(", "));
 
-        final String sinkForQueriesMessage = source.referentialIntegrity
+        final String sinkForQueriesMessage = sourceInfo.referentialIntegrity
             .getSinkForQueries()
             .stream()
             .collect(Collectors.joining(", "));
@@ -127,9 +141,76 @@ public final class MetaStoreImpl implements MutableMetaStore {
                   sourceName.toString(FormatOptions.noEscape())));
         }
 
+        if (dropConstraints.containsKey(sourceName)) {
+          throw new KsqlReferentialIntegrityException(String.format(
+              "Cannot drop %s.%n"
+                  + "The following streams and/or tables read from this source: [%s].%n"
+                  + "You need to drop them before dropping %s.",
+              sourceName.text(),
+              dropConstraints.get(sourceName).stream().map(SourceName::text)
+                  .sorted().collect(Collectors.joining(", ")),
+              sourceName.text()
+          ));
+        }
+
+        // Remove drop constraints from the referenced sources
+        sourceInfo.references.stream().forEach(ref -> dropConstraint(ref, sourceName));
+
         return null;
       });
     }
+  }
+
+  @Override
+  public void addSourceReferences(
+      final SourceName sourceName,
+      final Set<SourceName> sourceReferences
+  ) {
+    synchronized (referentialIntegrityLock) {
+      if (sourceReferences.contains(sourceName)) {
+        throw new KsqlException(String.format("Source name '%s' should not be referenced itself.",
+            sourceName.text()));
+      }
+
+      Iterables.concat(Collections.singleton(sourceName), sourceReferences).forEach(name -> {
+        if (!dataSources.containsKey(name)) {
+          throw new KsqlException(
+              String.format("No data source with name '%s' exists.", name.text())
+          );
+        }
+      });
+
+      // add a constraint to the referenced sources to prevent deleting them
+      sourceReferences.forEach(s -> addConstraint(s, sourceName));
+
+      // add all references to the source
+      dataSources.get(sourceName).references.addAll(sourceReferences);
+    }
+  }
+
+  Set<SourceName> getSourceReferences(final SourceName sourceName) {
+    final SourceInfo sourceInfo = dataSources.get(sourceName);
+    if (sourceInfo == null) {
+      return Collections.emptySet();
+    }
+
+    return sourceInfo.references;
+  }
+
+  private void addConstraint(final SourceName source, final SourceName sourceWithReference) {
+    dropConstraints.computeIfAbsent(source, x -> ConcurrentHashMap.newKeySet())
+        .add(sourceWithReference);
+  }
+
+  private void dropConstraint(final SourceName source, final SourceName sourceWithReference) {
+    dropConstraints.computeIfPresent(source, (k , info) -> {
+      info.remove(sourceWithReference);
+      return (info.isEmpty()) ? null : info;
+    });
+  }
+
+  Set<SourceName> getSourceConstraints(final SourceName sourceName) {
+    return dropConstraints.getOrDefault(sourceName, Collections.emptySet());
   }
 
   @Override
@@ -203,7 +284,7 @@ public final class MetaStoreImpl implements MutableMetaStore {
   @Override
   public MutableMetaStore copy() {
     synchronized (referentialIntegrityLock) {
-      return new MetaStoreImpl(dataSources, functionRegistry, typeRegistry);
+      return new MetaStoreImpl(dataSources, functionRegistry, typeRegistry, dropConstraints);
     }
   }
 
@@ -293,9 +374,12 @@ public final class MetaStoreImpl implements MutableMetaStore {
   }
 
   private static final class SourceInfo {
-
     private final DataSource source;
     private final ReferentialIntegrityTableEntry referentialIntegrity;
+
+    // parent sources that this source references to; it is used to remove constraints from
+    // the parent table when this source is deleted
+    private final Set<SourceName> references = new ConcurrentHashSet<>();
 
     private SourceInfo(
         final DataSource source
@@ -306,14 +390,21 @@ public final class MetaStoreImpl implements MutableMetaStore {
 
     private SourceInfo(
         final DataSource source,
-        final ReferentialIntegrityTableEntry referentialIntegrity
+        final ReferentialIntegrityTableEntry referentialIntegrity,
+        final Set<SourceName> references
     ) {
       this.source = Objects.requireNonNull(source, "source");
       this.referentialIntegrity = referentialIntegrity.copy();
+      this.references.addAll(
+          Objects.requireNonNull(references, "references"));
     }
 
     public SourceInfo copy() {
-      return new SourceInfo(source, referentialIntegrity);
+      return copyWith(source);
+    }
+
+    public SourceInfo copyWith(final DataSource source) {
+      return new SourceInfo(source, referentialIntegrity, references);
     }
   }
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -209,7 +209,8 @@ public final class MetaStoreImpl implements MutableMetaStore {
     });
   }
 
-  Set<SourceName> getSourceConstraints(final SourceName sourceName) {
+  @Override
+  public Set<SourceName> getSourceConstraints(final SourceName sourceName) {
     return dropConstraints.getOrDefault(sourceName, Collections.emptySet());
   }
 

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MutableMetaStore.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MutableMetaStore.java
@@ -25,6 +25,8 @@ public interface MutableMetaStore extends MetaStore {
 
   void deleteSource(SourceName sourceName);
 
+  void addSourceReferences(SourceName sourceName, Set<SourceName> sourceReferences);
+
   void updateForPersistentQuery(
       String queryId,
       Set<SourceName> sourceNames,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -35,7 +35,8 @@ public final class SourceDescriptionFactory {
       final List<RunningQuery> readQueries,
       final List<RunningQuery> writeQueries,
       final Optional<TopicDescription> topicDescription,
-      final List<QueryOffsetSummary> offsetSummaries
+      final List<QueryOffsetSummary> offsetSummaries,
+      final List<String> sourceConstraints
   ) {
     return new SourceDescription(
         dataSource.getName().toString(FormatOptions.noEscape()),
@@ -60,6 +61,7 @@ public final class SourceDescriptionFactory {
         topicDescription.map(td -> td.partitions().size()).orElse(0),
         topicDescription.map(td -> td.partitions().get(0).replicas().size()).orElse(0),
         dataSource.getSqlExpression(),
-        offsetSummaries);
+        offsetSummaries,
+        sourceConstraints);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
@@ -132,6 +132,7 @@ public final class DescribeConnectorExecutor {
               ImmutableList.of(),
               ImmutableList.of(),
               Optional.empty(),
+              ImmutableList.of(),
               ImmutableList.of()))
           .collect(Collectors.toList());
     } else {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.execution;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
@@ -221,7 +222,9 @@ public final class ListSourceExecutor {
 
     Optional<org.apache.kafka.clients.admin.TopicDescription> topicDescription =
         Optional.empty();
-    List<QueryOffsetSummary> queryOffsetSummaries = new ArrayList<>();
+    List<QueryOffsetSummary> queryOffsetSummaries = Collections.emptyList();
+    List<String> sourceConstraints = Collections.emptyList();
+
     final List<KsqlWarning> warnings = new LinkedList<>();
     if (extended) {
       try {
@@ -229,6 +232,7 @@ public final class ListSourceExecutor {
             serviceContext.getTopicClient().describeTopic(dataSource.getKafkaTopicName())
         );
         queryOffsetSummaries = queryOffsetSummaries(ksqlConfig, serviceContext, writeQueries);
+        sourceConstraints = getSourceConstraints(name, ksqlEngine.getMetaStore());
       } catch (final KafkaException | KafkaResponseGetFailedException e) {
         warnings.add(new KsqlWarning("Error from Kafka: " + e.getMessage()));
       }
@@ -242,9 +246,19 @@ public final class ListSourceExecutor {
             readQueries,
             writeQueries,
             topicDescription,
-            queryOffsetSummaries
+            queryOffsetSummaries,
+            sourceConstraints
         )
     );
+  }
+
+  private static List<String> getSourceConstraints(
+      final SourceName sourceName,
+      final MetaStore metaStore
+  ) {
+    return metaStore.getSourceConstraints(sourceName).stream()
+        .map(SourceName::text)
+        .collect(Collectors.toList());
   }
 
   private static List<QueryOffsetSummary> queryOffsetSummaries(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
@@ -16,9 +16,11 @@
 package io.confluent.ksql.rest.entity;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
@@ -119,6 +121,7 @@ public class SourceDescriptionFactoryTest {
         Collections.emptyList(),
         Collections.emptyList(),
         Optional.empty(),
+        Collections.emptyList(),
         Collections.emptyList());
 
     // Then:
@@ -143,10 +146,31 @@ public class SourceDescriptionFactoryTest {
         Collections.emptyList(),
         Collections.emptyList(),
         Optional.empty(),
+        Collections.emptyList(),
         Collections.emptyList());
 
     // Then:
     assertThat(sourceDescription.getTimestamp(), is(""));
+  }
+
+  @Test
+  public void shouldReturnSourceConstraints() {
+    // Given:
+    final String kafkaTopicName = "kafka";
+    final DataSource dataSource = buildDataSource(kafkaTopicName, Optional.empty());
+
+    // When
+    final SourceDescription sourceDescription = SourceDescriptionFactory.create(
+        dataSource,
+        true,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Optional.empty(),
+        Collections.emptyList(),
+        ImmutableList.of("s1", "s2"));
+
+    // Then:
+    assertThat(sourceDescription.getSourceConstraints(), hasItems("s1", "s2"));
   }
 
   @Test
@@ -166,6 +190,7 @@ public class SourceDescriptionFactoryTest {
         Collections.emptyList(),
         Collections.emptyList(),
         Optional.empty(),
+        Collections.emptyList(),
         Collections.emptyList());
 
     // Then:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -58,6 +58,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+
 import org.apache.kafka.common.metrics.Metrics;
 import org.junit.rules.ExternalResource;
 
@@ -122,6 +124,15 @@ public class TemporaryEngine extends ExternalResource {
       final DataSourceType type,
       final String name
   ) {
+    return givenSource(type, name, Collections.emptySet());
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends DataSource> T givenSource(
+      final DataSourceType type,
+      final String name,
+      final Set<SourceName> sourceReferences
+      ) {
     givenKafkaTopic(name);
 
     final KsqlTopic topic = new KsqlTopic(
@@ -158,6 +169,7 @@ public class TemporaryEngine extends ExternalResource {
         throw new IllegalArgumentException(type.toString());
     }
     metaStore.putSource(source, false);
+    metaStore.addSourceReferences(source.getName(), sourceReferences);
 
     return (T) source;
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.easymock.EasyMock.niceMock;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.client.BasicCredentials;
@@ -29,6 +30,7 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.RunningQuery;
+import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
 import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
@@ -52,10 +54,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
@@ -234,11 +240,10 @@ public class TestKsqlRestApp extends ExternalResource {
 
       final Set<String> streams = getStreams(client);
       streams.removeAll(except);
-      dropStreams(streams, client);
-
       final Set<String> tables = getTables(client);
       tables.removeAll(except);
-      dropTables(tables, client);
+
+      dropSources(streams, tables, client);
     }
   }
 
@@ -410,28 +415,92 @@ public class TestKsqlRestApp extends ExternalResource {
         .collect(Collectors.toSet());
   }
 
-  private void dropStreams(final Set<String> streams, final KsqlRestClient client) {
-    for (final String stream : streams) {
-      final RestResponse<KsqlEntityList> res =
-          makeKsqlRequest(client, "DROP STREAM `" + stream + "`;");
+  private void dropSources(
+      final Set<String> streams,
+      final Set<String> tables,
+      final KsqlRestClient client
+  ) {
+    final Set<String> sourcesDropped = new HashSet<>(streams.size() + tables.size());
 
-      if (res.isErroneous()) {
-        throw new AssertionError("Failed to drop stream " + stream + "."
-            + " msg:" + res.getErrorMessage());
+    Iterables.concat(streams, tables).forEach(source -> {
+      if (!sourcesDropped.contains(source)) {
+        final Iterator<String> dropInOrder = getOrderedSourcesToDrop(source, client);
+        dropInOrder.forEachRemaining(s -> {
+          if (streams.contains(s)) {
+            dropStream(s, client);
+          } else {
+            dropTable(s, client);
+          }
+          sourcesDropped.add(s);
+        });
       }
+    });
+  }
+
+  private void dropStream(final String stream, final KsqlRestClient client) {
+    final RestResponse<KsqlEntityList> res =
+        makeKsqlRequest(client, "DROP STREAM `" + stream + "`;");
+
+    if (res.isErroneous()) {
+      throw new AssertionError("Failed to drop stream " + stream + "."
+          + " msg:" + res.getErrorMessage());
     }
   }
 
-  private void dropTables(final Set<String> tables, final KsqlRestClient client) {
-    for (final String table : tables) {
-      final RestResponse<KsqlEntityList> res =
-          makeKsqlRequest(client, "DROP TABLE `" + table + "`;");
+  private void dropTable(final String table, final KsqlRestClient client) {
+    final RestResponse<KsqlEntityList> res =
+        makeKsqlRequest(client, "DROP TABLE `" + table + "`;");
 
-      if (res.isErroneous()) {
-        throw new AssertionError("Failed to drop table " + table + "."
-            + " msg:" + res.getErrorMessage());
+    if (res.isErroneous()) {
+      throw new AssertionError("Failed to drop table " + table + "."
+          + " msg:" + res.getErrorMessage());
+    }
+  }
+
+  /**
+   * Returns an ordered list of sources to drop. Sources may have referenced sources that havea a
+   * DROP constraint against this source. If that's the case, this method walks through the each
+   * linked source and builds a list of sources that must be dropped in order.
+   *
+   * Example:
+   * - CREATE STREAM 'a';
+   * - CREATE STREAM 'b' AS SELECT FROM 'a';
+   * - CREATE STREAM 'c' AS SELECT FROM 'b';
+   *
+   * In the above example. the source 'a' has a drop constraint reference from 'b', and 'b' has
+   * a drop constraint reference from 'c'. Source 'a' cannot be dropped until all the child sources
+   * are dropped. This method will return a list with ['c', 'b', 'a'], which tells the caller to
+   * drop 'c' first, 'b' second, and 'a' third.
+   */
+  private Iterator<String> getOrderedSourcesToDrop(
+      final String source,
+      final KsqlRestClient client
+  ) {
+    final Set<String> visited = new LinkedHashSet<>();
+    final Stack<String> stack = new Stack<>();
+
+    stack.push(source);
+    while (!stack.isEmpty()) {
+      String s = stack.pop();
+      if (!visited.contains(s)) {
+        visited.add(s);
+
+        final RestResponse<KsqlEntityList> res =
+            makeKsqlRequest(client, "DESCRIBE EXTENDED `" + s + "`;");
+
+        if (res.isErroneous()) {
+          throw new AssertionError("Failed to describe stream " + s + "."
+              + " msg:" + res.getErrorMessage());
+        }
+
+        final List<String> sourceConstraints = ((SourceDescriptionEntity)(res.getResponse().get(0)))
+            .getSourceDescription().getSourceConstraints();
+
+        sourceConstraints.forEach(name -> stack.push(name));
       }
     }
+
+    return visited.stream().collect(Collectors.toCollection(LinkedList::new)).descendingIterator();
   }
 
   private RestResponse<KsqlEntityList> makeKsqlRequest(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -584,6 +584,17 @@ public class InteractiveStatementExecutorTest {
     // Terminate the queries using the stream/table
     terminateQueries();
 
+    // Drop user1pv stream, which is linked to the pageview stream.
+    // The user1pv query will be terminated during the drop.
+    final Command dropStreamCommand1 = commandWithPlan(
+        "drop stream user1pv;",
+        ksqlConfig.getAllConfigPropsWithSecretsObfuscated()
+    );
+    final CommandId dropStreamCommandId1 =
+        new CommandId(Type.STREAM, "_user1pv", CommandId.Action.DROP);
+    handleStatement(
+        statementExecutor, dropStreamCommand1, dropStreamCommandId1, Optional.empty(), 4);
+
     // Now drop should be successful
     final Command dropTableCommand2 = commandWithPlan(
         "drop table table1;",

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -16,9 +16,11 @@
 package io.confluent.ksql.rest.server.computation;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
@@ -674,6 +676,50 @@ public class RecoveryTest {
         "DROP STREAM B;"
     );
     shouldRecover(commands);
+  }
+
+  @Test
+  public void shouldRecoverDropWithSourceConstraintsFromOldMetastore() {
+    // Verify that an upgrade will not be affected if DROP commands are not in order.
+
+    // Create and Drop the stream just to get the QueuedCommand for the 'DROP STREAM A'
+    server1.submitCommands(
+        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
+        "DROP STREAM A;"
+    );
+
+    // Get the QueuedCommand for 'DROP STREAM A'
+    final QueuedCommand originalDropA = commands.get(1);
+    final QueuedCommand duplicateDropA = new QueuedCommand(
+        originalDropA.getCommandId(),
+        originalDropA.getCommand(),
+        Optional.empty(),
+        (long) commands.size()
+    );
+
+    // Now execute the real commands again, then add the 'DROP STREAM A' to the list to recover
+    server1.submitCommands(
+        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
+        "CREATE STREAM B AS SELECT * FROM A;",
+        "TERMINATE CSAS_B_3;"
+    );
+
+    // ksqlDB does not allow this because 'A' is used by 'B', even if the query has been terminated.
+    // However, if a ksqlDB upgrade is done, then this order can be possible. Make sure stream 'A'
+    // can be dropped before dropping 'B'.
+    commands.add(duplicateDropA);
+
+    final KsqlServer recovered = new KsqlServer(commands);
+    recovered.recover();
+
+    // Original server has both streams
+    assertThat(server1.ksqlEngine.getMetaStore().getAllDataSources().size(), is(2));
+    assertThat(server1.ksqlEngine.getMetaStore().getAllDataSources(), hasKey(SourceName.of("A")));
+    assertThat(server1.ksqlEngine.getMetaStore().getAllDataSources(), hasKey(SourceName.of("B")));
+
+    // Recovered server has only stream 'B'
+    assertThat(recovered.ksqlEngine.getMetaStore().getAllDataSources().size(), is(1));
+    assertThat(recovered.ksqlEngine.getMetaStore().getAllDataSources(), hasKey(SourceName.of("B")));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -35,6 +35,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
@@ -131,7 +132,8 @@ public class ListSourceExecutorTest {
   public void shouldShowStreamsExtended() {
     // Given:
     final KsqlStream<?> stream1 = engine.givenSource(DataSourceType.KSTREAM, "stream1");
-    final KsqlStream<?> stream2 = engine.givenSource(DataSourceType.KSTREAM, "stream2");
+    final KsqlStream<?> stream2 = engine.givenSource(DataSourceType.KSTREAM, "stream2",
+        ImmutableSet.of(SourceName.of("stream1")));
     engine.givenSource(DataSourceType.KTABLE, "table");
 
     // When:
@@ -151,13 +153,15 @@ public class ListSourceExecutorTest {
             ImmutableList.of(),
             ImmutableList.of(),
             Optional.of(topicWith1PartitionAndRfOf1),
-            ImmutableList.of()),
+            ImmutableList.of(),
+            ImmutableList.of("stream2")),
         SourceDescriptionFactory.create(
             stream2,
             true,
             ImmutableList.of(),
             ImmutableList.of(),
             Optional.of(topicWith1PartitionAndRfOf1),
+            ImmutableList.of(),
             ImmutableList.of())
     ));
   }
@@ -201,7 +205,8 @@ public class ListSourceExecutorTest {
   public void shouldShowTablesExtended() {
     // Given:
     final KsqlTable<?> table1 = engine.givenSource(DataSourceType.KTABLE, "table1");
-    final KsqlTable<?> table2 = engine.givenSource(DataSourceType.KTABLE, "table2");
+    final KsqlTable<?> table2 = engine.givenSource(DataSourceType.KTABLE, "table2",
+        ImmutableSet.of(SourceName.of("table1")));
     engine.givenSource(DataSourceType.KSTREAM, "stream");
 
     // When:
@@ -222,7 +227,8 @@ public class ListSourceExecutorTest {
             ImmutableList.of(),
             ImmutableList.of(),
             Optional.of(client.describeTopic(table1.getKafkaTopicName())),
-            ImmutableList.of()
+            ImmutableList.of(),
+            ImmutableList.of("table2")
         ),
         SourceDescriptionFactory.create(
             table2,
@@ -230,6 +236,7 @@ public class ListSourceExecutorTest {
             ImmutableList.of(),
             ImmutableList.of(),
             Optional.of(client.describeTopic(table1.getKafkaTopicName())),
+            ImmutableList.of(),
             ImmutableList.of()
         )
     ));
@@ -276,6 +283,7 @@ public class ListSourceExecutorTest {
                 queryStatusCount,
                 KsqlConstants.KsqlQueryType.PERSISTENT)),
             Optional.empty(),
+            ImmutableList.of(),
             ImmutableList.of())));
   }
 
@@ -339,6 +347,7 @@ public class ListSourceExecutorTest {
                             ImmutableList.of(),
                             ImmutableList.of(),
                             Optional.empty(),
+                            ImmutableList.of(),
                             ImmutableList.of()
                         )
                     )
@@ -426,6 +435,7 @@ public class ListSourceExecutorTest {
                 ImmutableList.of(),
                 ImmutableList.of(),
                 Optional.empty(),
+                ImmutableList.of(),
                 ImmutableList.of()
             )
         )

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -87,6 +87,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
 import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
@@ -178,6 +179,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -517,11 +519,13 @@ public class KsqlResourceTest {
             ksqlEngine.getMetaStore().getSource(SourceName.of("TEST_STREAM")),
             true, Collections.emptyList(), Collections.emptyList(),
             Optional.of(kafkaTopicClient.describeTopic("KAFKA_TOPIC_2")),
+            Collections.emptyList(),
             Collections.emptyList()),
         SourceDescriptionFactory.create(
             ksqlEngine.getMetaStore().getSource(SourceName.of("new_stream")),
             true, Collections.emptyList(), Collections.emptyList(),
             Optional.of(kafkaTopicClient.describeTopic("new_topic")),
+            Collections.emptyList(),
             Collections.emptyList()))
     );
   }
@@ -537,7 +541,7 @@ public class KsqlResourceTest {
 
     givenSource(
         DataSourceType.KTABLE, "new_table", "new_topic",
-        schema);
+        schema, ImmutableSet.of(SourceName.of("TEST_TABLE")));
 
     // When:
     final SourceDescriptionList descriptionList = makeSingleRequest(
@@ -549,11 +553,13 @@ public class KsqlResourceTest {
             ksqlEngine.getMetaStore().getSource(SourceName.of("TEST_TABLE")),
             true, Collections.emptyList(), Collections.emptyList(),
             Optional.of(kafkaTopicClient.describeTopic("KAFKA_TOPIC_1")),
-            Collections.emptyList()),
+            Collections.emptyList(),
+            ImmutableList.of("new_table")),
         SourceDescriptionFactory.create(
             ksqlEngine.getMetaStore().getSource(SourceName.of("new_table")),
             true, Collections.emptyList(), Collections.emptyList(),
             Optional.of(kafkaTopicClient.describeTopic("new_topic")),
+            Collections.emptyList(),
             Collections.emptyList()))
     );
   }
@@ -624,6 +630,7 @@ public class KsqlResourceTest {
         Collections.singletonList(queries.get(1)),
         Collections.singletonList(queries.get(0)),
         Optional.empty(),
+        Collections.emptyList(),
         Collections.emptyList());
 
     assertThat(description.getSourceDescription(), is(expectedDescription));
@@ -2354,6 +2361,16 @@ public class KsqlResourceTest {
       final String topicName,
       final LogicalSchema schema
   ) {
+    givenSource(type, sourceName, topicName, schema, Collections.emptySet());
+  }
+
+  private void givenSource(
+      final DataSourceType type,
+      final String sourceName,
+      final String topicName,
+      final LogicalSchema schema,
+      final Set<SourceName> sourceReferences
+  ) {
     final KsqlTopic ksqlTopic = new KsqlTopic(
         topicName,
         KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()), SerdeFeatures.of()),
@@ -2361,28 +2378,34 @@ public class KsqlResourceTest {
     );
 
     givenKafkaTopicExists(topicName);
-    if (type == DataSourceType.KSTREAM) {
-      metaStore.putSource(
-          new KsqlStream<>(
-              "statementText",
-              SourceName.of(sourceName),
-              schema,
-              Optional.empty(),
-              false,
-              ksqlTopic
-          ), false);
+    final DataSource source;
+    switch (type) {
+      case KSTREAM:
+        source = new KsqlStream<>(
+            "statementText",
+            SourceName.of(sourceName),
+            schema,
+            Optional.empty(),
+            false,
+            ksqlTopic
+        );
+        break;
+      case KTABLE:
+        source = new KsqlTable<>(
+            "statementText",
+            SourceName.of(sourceName),
+            schema,
+            Optional.empty(),
+            false,
+            ksqlTopic
+        );
+        break;
+      default:
+        throw new IllegalArgumentException(type.toString());
     }
-    if (type == DataSourceType.KTABLE) {
-      metaStore.putSource(
-          new KsqlTable<>(
-              "statementText",
-              SourceName.of(sourceName),
-              schema,
-              Optional.empty(),
-              false,
-              ksqlTopic
-          ), false);
-    }
+
+    metaStore.putSource(source, false);
+    metaStore.addSourceReferences(source.getName(), sourceReferences);
   }
 
   private static Properties getDefaultKsqlConfig() {

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -48,6 +48,7 @@ public class SourceDescription {
   private final int replication;
   private final String statement;
   private final List<QueryOffsetSummary> queryOffsetSummaries;
+  private final List<String> sourceConstraints;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   @JsonCreator
@@ -68,7 +69,9 @@ public class SourceDescription {
       @JsonProperty("partitions") final int partitions,
       @JsonProperty("replication") final int replication,
       @JsonProperty("statement") final String statement,
-      @JsonProperty("queryOffsetSummaries") final List<QueryOffsetSummary> queryOffsetSummaries) {
+      @JsonProperty("queryOffsetSummaries") final List<QueryOffsetSummary> queryOffsetSummaries,
+      @JsonProperty("sourceConstraints") final List<String> sourceConstraints
+  ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.name = Objects.requireNonNull(name, "name");
     this.windowType = Objects.requireNonNull(windowType, "windowType");
@@ -91,6 +94,8 @@ public class SourceDescription {
     this.statement = Objects.requireNonNull(statement, "statement");
     this.queryOffsetSummaries = ImmutableList.copyOf(
         Objects.requireNonNull(queryOffsetSummaries, "queryOffsetSummaries"));
+    this.sourceConstraints =
+        ImmutableList.copyOf(Objects.requireNonNull(sourceConstraints, "sourceConstraints"));
   }
 
   public String getStatement() {
@@ -161,6 +166,10 @@ public class SourceDescription {
     return queryOffsetSummaries;
   }
 
+  public List<String> getSourceConstraints() {
+    return sourceConstraints;
+  }
+
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   @Override
   public boolean equals(final Object o) {
@@ -188,7 +197,8 @@ public class SourceDescription {
         && Objects.equals(valueFormat, that.valueFormat)
         && Objects.equals(topic, that.topic)
         && Objects.equals(statement, that.statement)
-        && Objects.equals(queryOffsetSummaries, that.queryOffsetSummaries);
+        && Objects.equals(queryOffsetSummaries, that.queryOffsetSummaries)
+        && Objects.equals(sourceConstraints, that.sourceConstraints);
   }
 
   @Override
@@ -210,7 +220,8 @@ public class SourceDescription {
         partitions,
         replication,
         statement,
-        queryOffsetSummaries
+        queryOffsetSummaries,
+        sourceConstraints
     );
   }
 }

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -21,6 +21,8 @@ import io.confluent.ksql.model.WindowType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import io.confluent.ksql.name.SourceName;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -50,6 +52,7 @@ public class SourceDescriptionTest {
         final List<FieldInfo> fields = Collections.singletonList(fieldInfo);
         final List<QueryOffsetSummary> summaries = Collections.singletonList(
             new QueryOffsetSummary("g1", Collections.singletonList(summary)));
+        final List<String> sourceConstraints = Collections.emptyList();
 
         new EqualsTester()
             .addEqualityGroup(
@@ -57,124 +60,131 @@ public class SourceDescriptionTest {
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries),
+                    SOME_STRING, summaries, sourceConstraints),
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     "diff", Optional.of(WindowType.SESSION), readQueries, writeQueries, fields,
                     SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
+            )
+            .addEqualityGroup(
+                new SourceDescription(
+                    "diff", Optional.of(WindowType.SESSION), readQueries, writeQueries, fields,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
+                    SOME_STRING, summaries, ImmutableList.of("s1"))
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), ImmutableList.of(), writeQueries, fields,
                     SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, ImmutableList.of(), fields,
                     SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, ImmutableList.of(),
                     SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields,
                     SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, ImmutableList.of())
+                    SOME_STRING, ImmutableList.of(), sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, "diff",
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                      "diff", SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, "diff", SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, "diff",
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, "diff", SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     !SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, "diff", SOME_STRING, SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, "diff", SOME_INT, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT + 1, SOME_INT,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT + 1,
-                    SOME_STRING, summaries)
+                    SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
                     SOME_STRING, SOME_STRING, SOME_STRING,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
-                    "diff", summaries)
+                    "diff", summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
@@ -190,7 +200,8 @@ public class SourceDescriptionTest {
                                     new ConsumerPartitionOffsets(0, 1L, 100L, 99L)
                                 )
                             )
-                        )))))
+                        ))),
+                    sourceConstraints))
             .testEquals();
     }
   }


### PR DESCRIPTION
### Description 
This is partial implementation of [feat: terminate persistent query on DROP command](https://github.com/confluentinc/ksql/pull/6143)

The first commit of this PR was already reviewed in the above PR (https://github.com/confluentinc/ksql/pull/6143). This PR only adds extra work to:
* Return DROP source constraints from DESCRIBE EXTENDED
* Drop sources in order for Rest QTT cleanup methods

The change for this PR adds a constraint to a source to not delete it if it is referenced by another source. For instance:
```
ksql> create stream t1(id int) with (kafka_topic='t1');
ksql> create stream s1 as select * from t1;
ksql> terminate CSAS_S1_9;

ksql> drop stream t1;
Cannot drop T1.
The following streams and/or tables read from this source: [S1].
You need to drop them before dropping T1.

ksql> describe extended t1;
...
Sources that have a DROP constraint on this source
--------------------------------------------------
S1
...
```

Even if queries are terminated, the stream or table cannot be deleted until all sources that reference to it are deleted. This is a common approach in other DBs, which could keep constraints and references on tables thus avoiding deleting them leaving tables with an invalid link.

This feature was asked by https://github.com/confluentinc/ksql/pull/6143. The main reason of splitting the PR is for easy review the rest of the commits.

Commit #1 is already reviewed and approved. If you want you can review again, but you can opt-out, and review only Commit #2 and Commit #3, which add the list to the DESCRIBE EXTENDED and fixes the RQTT tests. The rest of the commits are just fixing a couple of tests.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

