### PR TITLE
chore: fix maven version on 6.1.x (MINOR)

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -19,6 +19,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.confluent</groupId>
     <artifactId>build-tools</artifactId>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
     <name>Build Tools</name>
 </project>

--- a/ksqldb-api-client/pom.xml
+++ b/ksqldb-api-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-api-client</artifactId>

--- a/ksqldb-api-reactive-streams-tck/pom.xml
+++ b/ksqldb-api-reactive-streams-tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-api-reactive-streams-tck</artifactId>

--- a/ksqldb-benchmark/pom.xml
+++ b/ksqldb-benchmark/pom.xml
@@ -47,7 +47,7 @@ questions.
   <parent>
     <groupId>io.confluent.ksql</groupId>
     <artifactId>ksqldb-parent</artifactId>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
   </parent>
 
   <artifactId>ksqldb-benchmark</artifactId>

--- a/ksqldb-cli/pom.xml
+++ b/ksqldb-cli/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-cli</artifactId>

--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-common</artifactId>

--- a/ksqldb-console-scripts/pom.xml
+++ b/ksqldb-console-scripts/pom.xml
@@ -22,7 +22,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/ksqldb-docker/pom.xml
+++ b/ksqldb-docker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>ksqldb-parent</artifactId>
     <groupId>io.confluent.ksql</groupId>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
   </parent>
 
   <artifactId>ksqldb-docker</artifactId>

--- a/ksqldb-engine-common/pom.xml
+++ b/ksqldb-engine-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.confluent.ksql</groupId>
     <artifactId>ksqldb-parent</artifactId>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
   </parent>
 
   <artifactId>ksqldb-engine-common</artifactId>

--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-engine</artifactId>

--- a/ksqldb-etc/pom.xml
+++ b/ksqldb-etc/pom.xml
@@ -22,7 +22,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/ksqldb-examples/pom.xml
+++ b/ksqldb-examples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-examples</artifactId>

--- a/ksqldb-execution/pom.xml
+++ b/ksqldb-execution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-execution</artifactId>

--- a/ksqldb-functional-tests/pom.xml
+++ b/ksqldb-functional-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.confluent.ksql</groupId>
     <artifactId>ksqldb-parent</artifactId>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ksqldb-metastore/pom.xml
+++ b/ksqldb-metastore/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-metastore</artifactId>

--- a/ksqldb-package/pom.xml
+++ b/ksqldb-package/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-package</artifactId>

--- a/ksqldb-parser/pom.xml
+++ b/ksqldb-parser/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-parser</artifactId>

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-rest-app</artifactId>

--- a/ksqldb-rest-client/pom.xml
+++ b/ksqldb-rest-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.confluent.ksql</groupId>
     <artifactId>ksqldb-parent</artifactId>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
   </parent>
 
   <artifactId>ksqldb-rest-client</artifactId>

--- a/ksqldb-rest-model/pom.xml
+++ b/ksqldb-rest-model/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-rest-model</artifactId>

--- a/ksqldb-rocksdb-config-setter/pom.xml
+++ b/ksqldb-rocksdb-config-setter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-rocksdb-config-setter</artifactId>

--- a/ksqldb-serde/pom.xml
+++ b/ksqldb-serde/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-serde</artifactId>

--- a/ksqldb-streams/pom.xml
+++ b/ksqldb-streams/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-streams</artifactId>

--- a/ksqldb-test-util/pom.xml
+++ b/ksqldb-test-util/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>ksqldb-parent</artifactId>
     <groupId>io.confluent.ksql</groupId>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ksqldb-tools/pom.xml
+++ b/ksqldb-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-tools</artifactId>

--- a/ksqldb-udf-quickstart/pom.xml
+++ b/ksqldb-udf-quickstart/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-udf-quickstart</artifactId>

--- a/ksqldb-udf/pom.xml
+++ b/ksqldb-udf/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-udf</artifactId>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
 
     <dependencies>
         <!-- Required for running tests -->

--- a/ksqldb-version-metrics-client/pom.xml
+++ b/ksqldb-version-metrics-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksqldb-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>ksqldb-version-metrics-client</artifactId>

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -67,15 +67,15 @@ th {
 <TR>
 <TD><A HREF="https://github.com/airlift/slice">slice-0.29</A></TD><TD>jar</TD><TD>0.29</TD><TD></TD></TR>
 <TR>
-<TD>common-config-6.2.0-0</TD><TD>jar</TD><TD>6.2.0-0</TD><TD></TD></TR>
+<TD>common-config-6.1.0-0</TD><TD>jar</TD><TD>6.1.0-0</TD><TD></TD></TR>
 <TR>
-<TD>common-utils-6.2.0-0</TD><TD>jar</TD><TD>6.2.0-0</TD><TD></TD></TR>
+<TD>common-utils-6.1.0-0</TD><TD>jar</TD><TD>6.1.0-0</TD><TD></TD></TR>
 <TR>
-<TD>kafka-avro-serializer-6.2.0-0</TD><TD>jar</TD><TD>6.2.0-0</TD><TD></TD></TR>
+<TD>kafka-avro-serializer-6.1.0-0</TD><TD>jar</TD><TD>6.1.0-0</TD><TD></TD></TR>
 <TR>
-<TD>kafka-connect-avro-converter-6.2.0-0</TD><TD>jar</TD><TD>6.2.0-0</TD><TD></TD></TR>
+<TD>kafka-connect-avro-converter-6.1.0-0</TD><TD>jar</TD><TD>6.1.0-0</TD><TD></TD></TR>
 <TR>
-<TD>kafka-schema-registry-client-6.2.0-0</TD><TD>jar</TD><TD>6.2.0-0</TD><TD></TD></TR>
+<TD>kafka-schema-registry-client-6.1.0-0</TD><TD>jar</TD><TD>6.1.0-0</TD><TD></TD></TR>
 <TR>
 <TD>ksql-engine-0.1-SNAPSHOT</TD><TD>jar</TD><TD>0.1-SNAPSHOT</TD><TD></TD></TR>
 <TR>
@@ -123,7 +123,7 @@ th {
 <TR>
 <TD>kafka-streams-0.11.0.0-cp1</TD><TD>jar</TD><TD></TD><TD><A HREF="LICENSE-kafka-streams-0.11.0.0-cp1.txt">included file</A></TD></TR>
 <TR>
-<TD>kafka_2.11-6.2.0-0-ccs</TD><TD>jar</TD><TD></TD><TD><A HREF="LICENSE-kafka_2.11-6.2.0-0-ccs.txt">included file</A></TD></TR>
+<TD>kafka_2.11-6.1.0-0-ccs</TD><TD>jar</TD><TD></TD><TD><A HREF="LICENSE-kafka_2.11-6.1.0-0-ccs.txt">included file</A></TD></TR>
 <TR>
 <TD>lz4-1.3.0</TD><TD>jar</TD><TD>1.3.0</TD><TD></TD></TR>
 <TR>

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>[6.2.0-0, 6.2.1-0)</version>
+        <version>[6.1.0-0, 6.1.1-0)</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
     <artifactId>ksqldb-parent</artifactId>
     <packaging>pom</packaging>
     <name>ksqldb-parent</name>
-    <version>6.2.0-0</version>
+    <version>6.1.0-0</version>
 
     <licenses>
         <license>
@@ -135,7 +135,7 @@
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
         <scala.version>2.13.2</scala.version>
         <apache.io.version>2.6</apache.io.version>
-        <io.confluent.ksql.version>6.2.0-0</io.confluent.ksql.version>
+        <io.confluent.ksql.version>6.1.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <kafka.version>v6.1.0-beta201006024150-hf-1</kafka.version>
     </properties>


### PR DESCRIPTION
### Description 

Merging master into 6.1.x in https://github.com/confluentinc/ksql/pull/6538 accidentally overrode maven versions on the 6.1.x branch with those on master as well. This PR restores the proper versions.

### Testing done 

Built locally with https://github.com/confluentinc/ksql/commit/f2b8d8397106110a51ec73a1c9601667775a6a7f reverted, as the branch builder is expected to fail otherwise.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

