### PR TITLE
fix: avoid RUN SCRIPT to override CLI session variables/properties

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/KsqlRequestExecutor.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/KsqlRequestExecutor.java
@@ -18,9 +18,9 @@ package io.confluent.ksql.cli;
 public interface KsqlRequestExecutor {
 
   /**
-   * Handle and execute statements on the KSQL servers and handle the response.
+   * Execute a request on the KSQL servers and handle the response.
    *
-   * @param line the request statements separated by semi-colon.
+   * @param body the request body.
    */
-  void executeStatements(String line);
+  void makeKsqlRequest(String body);
 }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/cmd/RunScript.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/cmd/RunScript.java
@@ -58,7 +58,7 @@ public final class RunScript implements CliSpecificCommand {
 
     final String filePath = args.get(0);
     final String content = loadScript(filePath);
-    requestExecutor.executeStatements(content);
+    requestExecutor.makeKsqlRequest(content);
   }
 
   private static String loadScript(final String filePath) {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RunScriptTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RunScriptTest.java
@@ -110,7 +110,7 @@ public class RunScriptTest {
     cmd.execute(ImmutableList.of(scriptFile.toString()), terminal);
 
     // Then:
-    verify(requestExecutor).executeStatements(FILE_CONTENT);
+    verify(requestExecutor).makeKsqlRequest(FILE_CONTENT);
   }
 
   @Test


### PR DESCRIPTION
### Description 
PR https://github.com/confluentinc/ksql/pull/6537 added a fix in RUN SCRIPT and '-f' parameter to allow the use of SELECT/PRINT statements. However, this causes the RUN SCRIPT to override variables and properties from the current CLI session, something wasn't supposed to do.

This PR fixes the issue with RUN SCRIPT by reverting the change (no PRINT/SELECT support), but leaving the PRINT/SELECT support with the '-f' command parameter. It is a temporary fix for 0.14 and 6.1.

A follow-up PR should be done for 0.15 to allow RUN SCRIPT support PRINT/SELECT, but without overriding variables and properties from the CLI (as KLIP-38 specifies).

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

