### PR TITLE
chore: revert "bump AK version to 6.1.0-beta201006024150-hf-1 (#6543)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
         <apache.io.version>2.6</apache.io.version>
         <io.confluent.ksql.version>6.1.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <kafka.version>v6.1.0-beta201006024150-hf-1</kafka.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 

Reverts https://github.com/confluentinc/ksql/pull/6543 in order to stabilize the build again. We can reapply when we're ready to cut the 0.14 RC.

### Testing done 

Will wait for build to pass before merging.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

