### PR TITLE
feat: add WITH clause and QUERY_ID property to INSERT INTO statements

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/InsertIntoConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/InsertIntoConfigs.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.config.ConfigDef;
  * 'With Clause' properties for 'INSERT INTO' statements.
  */
 public final class InsertIntoConfigs {
-  public static final String QUERY_ID_PROPERTY = "ID";
+  public static final String QUERY_ID_PROPERTY = "QUERY_ID";
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(
@@ -29,7 +29,11 @@ public final class InsertIntoConfigs {
           ConfigDef.Type.STRING,
           null,
           ConfigDef.Importance.LOW,
-          "Custom query ID to use for INSERT INTO queries"
+          "Optional query ID to use for INSERT INTO queries. This query ID will be "
+              + "displayed by `SHOW QUERIES`, and will also be used to terminate the query. "
+              + "If empty, the default 'INSERTQUERY_' prefix plus a number will be used. "
+              + "Queries IDs are case-insensitive. Queries IDs will be displayed in uppercase "
+              + "with `SHOW QUERIES`."
       );
 
   public static final ConfigMetaData CONFIG_METADATA = ConfigMetaData.of(CONFIG_DEF);

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/InsertIntoConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/InsertIntoConfigs.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.properties.with;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+/**
+ * 'With Clause' properties for 'INSERT INTO' statements.
+ */
+public final class InsertIntoConfigs {
+  public static final String QUERY_ID_PROPERTY = "ID";
+
+  private static final ConfigDef CONFIG_DEF = new ConfigDef()
+      .define(
+          QUERY_ID_PROPERTY,
+          ConfigDef.Type.STRING,
+          null,
+          ConfigDef.Importance.LOW,
+          "Custom query ID to use for INSERT INTO queries"
+      );
+
+  public static final ConfigMetaData CONFIG_METADATA = ConfigMetaData.of(CONFIG_DEF);
+
+  private InsertIntoConfigs() {
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -227,6 +227,11 @@ final class EngineExecutor {
         ksqlConfig.getBoolean(KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED),
         withQueryId
     );
+
+    if (engineContext.getPersistentQuery(queryId).isPresent()) {
+      throw new KsqlException(String.format("Query ID '%s' already exists.", queryId));
+    }
+
     final PhysicalPlan physicalPlan = queryEngine.buildPhysicalPlan(
         logicalPlan,
         config,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -129,7 +129,8 @@ final class EngineExecutor {
       final ConfiguredStatement<Query> statement,
       final boolean excludeTombstones
   ) {
-    final ExecutorPlans plans = planQuery(statement, statement.getStatement(), Optional.empty());
+    final ExecutorPlans plans = planQuery(statement, statement.getStatement(),
+        Optional.empty(), Optional.empty());
     final KsqlBareOutputNode outputNode = (KsqlBareOutputNode) plans.logicalPlan.getNode().get();
     final QueryExecutor executor = engineContext.createQueryExecutor(config, serviceContext);
 
@@ -169,7 +170,8 @@ final class EngineExecutor {
       final ExecutorPlans plans = planQuery(
           statement,
           queryContainer.getQuery(),
-          Optional.of(queryContainer.getSink())
+          Optional.of(queryContainer.getSink()),
+          queryContainer.getQueryId()
       );
 
       final KsqlStructuredDataOutputNode outputNode =
@@ -204,7 +206,8 @@ final class EngineExecutor {
   private ExecutorPlans planQuery(
       final ConfiguredStatement<?> statement,
       final Query query,
-      final Optional<Sink> sink) {
+      final Optional<Sink> sink,
+      final Optional<String> withQueryId) {
     final QueryEngine queryEngine = engineContext.createQueryEngine(serviceContext);
     final KsqlConfig ksqlConfig = config.getConfig(true);
     final OutputNode outputNode = QueryEngine.buildQueryLogicalPlan(
@@ -221,7 +224,8 @@ final class EngineExecutor {
         engineContext,
         engineContext.idGenerator(),
         outputNode,
-        ksqlConfig.getBoolean(KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED)
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED),
+        withQueryId
     );
     final PhysicalPlan physicalPlan = queryEngine.buildPhysicalPlan(
         logicalPlan,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -228,7 +228,7 @@ final class EngineExecutor {
         withQueryId
     );
 
-    if (engineContext.getPersistentQuery(queryId).isPresent()) {
+    if (withQueryId.isPresent() && engineContext.getPersistentQuery(queryId).isPresent()) {
       throw new KsqlException(String.format("Query ID '%s' already exists.", queryId));
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/StatementRewriter.java
@@ -434,7 +434,8 @@ public final class StatementRewriter<C> {
       return new InsertInto(
           node.getLocation(),
           node.getTarget(),
-          (Query) rewriter.apply(node.getQuery(), context)
+          (Query) rewriter.apply(node.getQuery(), context),
+          node.getProperties()
       );
     }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -345,6 +345,31 @@ public class KsqlEngineTest {
   }
 
   @Test
+  public void shouldExecuteInsertIntoWithCustomQueryId() {
+    // Given:
+    KsqlEngineTestUtil.execute(
+        serviceContext,
+        ksqlEngine,
+        "create stream bar as select * from orders;",
+        KSQL_CONFIG,
+        Collections.emptyMap()
+    );
+
+    // When:
+    final List<QueryMetadata> queries = KsqlEngineTestUtil.execute(
+        serviceContext,
+        ksqlEngine,
+        "insert into bar with (id='my_insert_id') select * from orders;",
+        KSQL_CONFIG,
+        Collections.emptyMap()
+    );
+
+    // Then:
+    assertThat(queries, hasSize(1));
+    assertThat(queries.get(0).getQueryId(), is(new QueryId("MY_INSERT_ID")));
+  }
+
+  @Test
   public void shouldExecuteInsertIntoStream() {
     // Given:
     KsqlEngineTestUtil.execute(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import io.confluent.ksql.parser.properties.with.InsertIntoProperties;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.CreateStream;
@@ -118,6 +119,8 @@ public class StatementRewriterTest {
   private CreateSourceAsProperties csasProperties;
   @Mock
   private RefinementInfo refinementInfo;
+  @Mock
+  private InsertIntoProperties insertIntoProperties;
   @Captor
   private ArgumentCaptor<Context<Object>> contextCaptor;
 
@@ -737,7 +740,7 @@ public class StatementRewriterTest {
   @Test
   public void shouldRewriteInsertInto() {
     // Given:
-    final InsertInto ii = new InsertInto(location, sourceName, query);
+    final InsertInto ii = new InsertInto(location, sourceName, query, insertIntoProperties);
     when(mockRewriter.apply(query, context)).thenReturn(rewrittenQuery);
 
     // When:
@@ -746,14 +749,14 @@ public class StatementRewriterTest {
     // Then:
     assertThat(
         rewritten,
-        equalTo(new InsertInto(location, sourceName, rewrittenQuery))
+        equalTo(new InsertInto(location, sourceName, rewrittenQuery, insertIntoProperties))
     );
   }
 
   @Test
   public void shouldRewriteInsertIntoWithPartitionBy() {
     // Given:
-    final InsertInto ii = new InsertInto(location, sourceName, query);
+    final InsertInto ii = new InsertInto(location, sourceName, query, insertIntoProperties);
     when(mockRewriter.apply(query, context)).thenReturn(rewrittenQuery);
     when(expressionRewriter.apply(expression, context)).thenReturn(rewrittenExpression);
 
@@ -767,7 +770,8 @@ public class StatementRewriterTest {
             new InsertInto(
                 location,
                 sourceName,
-                rewrittenQuery
+                rewrittenQuery,
+                insertIntoProperties
             )
         )
     );

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -77,7 +77,7 @@ statement
             (WITH tableProperties)? AS query                                #createTableAs
     | CREATE (SINK | SOURCE) CONNECTOR (IF NOT EXISTS)? identifier
              WITH tableProperties                                           #createConnector
-    | INSERT INTO sourceName query                                          #insertInto
+    | INSERT INTO sourceName (WITH tableProperties)? query                  #insertInto
     | INSERT INTO sourceName (columns)? VALUES values                       #insertValues
     | DROP STREAM (IF EXISTS)? sourceName (DELETE TOPIC)?                   #dropStream
     | DROP TABLE (IF EXISTS)? sourceName (DELETE TOPIC)?                    #dropTable

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -94,6 +94,7 @@ import io.confluent.ksql.parser.SqlBaseParser.TablePropertyContext;
 import io.confluent.ksql.parser.SqlBaseParser.WindowUnitContext;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import io.confluent.ksql.parser.properties.with.InsertIntoProperties;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.AlterOption;
@@ -352,10 +353,13 @@ public class AstBuilder {
     public Node visitInsertInto(final SqlBaseParser.InsertIntoContext context) {
       final SourceName targetName = ParserUtil.getSourceName(context.sourceName());
       final Query query = withinPersistentQuery(() -> visitQuery(context.query()));
+      final Map<String, Literal> properties = processTableProperties(context.tableProperties());
+
       return new InsertInto(
           getLocation(context),
           targetName,
-          query);
+          query,
+          InsertIntoProperties.from(properties));
     }
 
     @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -321,6 +321,16 @@ public final class SqlFormatter {
       builder.append("INSERT INTO ");
       builder.append(escapedName(node.getTarget()));
       builder.append(" ");
+
+      final String insertProps = node.getProperties().toString();
+      if (!insertProps.isEmpty()) {
+        builder
+            .append(" WITH (")
+            .append(insertProps)
+            .append(")");
+        builder.append(" ");
+      }
+
       process(node.getQuery(), indent);
       return null;
     }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/InsertIntoProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/InsertIntoProperties.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.properties.with;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.execution.expression.tree.Literal;
+import io.confluent.ksql.properties.with.InsertIntoConfigs;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Performs validation of a INSERT statement's WITH clause.
+ */
+@Immutable
+public final class InsertIntoProperties {
+  public static InsertIntoProperties none() {
+    return new InsertIntoProperties(Collections.emptyMap());
+  }
+
+  public static InsertIntoProperties from(final Map<String, Literal> literals) {
+    return new InsertIntoProperties(literals);
+  }
+
+  private final PropertiesConfig props;
+
+  private InsertIntoProperties(final Map<String, Literal> originals) {
+    this.props = new PropertiesConfig(InsertIntoConfigs.CONFIG_METADATA, originals);
+  }
+
+  public Optional<String> getQueryId() {
+    return Optional.ofNullable(props.getString(InsertIntoConfigs.QUERY_ID_PROPERTY))
+        .map(String::toUpperCase);
+  }
+
+  @Override
+  public String toString() {
+    return props.toString();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final InsertIntoProperties that = (InsertIntoProperties) o;
+    return Objects.equals(props, that.props);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(props);
+  }
+}

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -87,6 +88,11 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
   @Override
   public Sink getSink() {
     return Sink.of(getName(), true, isOrReplace(), getProperties());
+  }
+
+  @Override
+  public Optional<String> getQueryId() {
+    return Optional.empty();
   }
 
   @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
@@ -22,6 +22,8 @@ import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
+import io.confluent.ksql.parser.properties.with.InsertIntoProperties;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -32,26 +34,33 @@ public class InsertInto
 
   private final SourceName target;
   private final Query query;
+  private final InsertIntoProperties properties;
 
   public InsertInto(
       final SourceName target,
       final Query query
   ) {
-    this(Optional.empty(), target, query);
+    this(Optional.empty(), target, query, InsertIntoProperties.none());
   }
 
   public InsertInto(
       final Optional<NodeLocation> location,
       final SourceName target,
-      final Query query
+      final Query query,
+      final InsertIntoProperties properties
   ) {
     super(location);
     this.target = requireNonNull(target, "target");
     this.query = requireNonNull(query, "query");
+    this.properties = requireNonNull(properties, "properties");
   }
 
   public SourceName getTarget() {
     return target;
+  }
+
+  public InsertIntoProperties getProperties() {
+    return properties;
   }
 
   @Override
@@ -65,13 +74,18 @@ public class InsertInto
   }
 
   @Override
+  public Optional<String> getQueryId() {
+    return properties.getQueryId();
+  }
+
+  @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitInsertInto(this, context);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(target, query);
+    return Objects.hash(target, query, properties);
   }
 
   @Override
@@ -84,7 +98,8 @@ public class InsertInto
     }
     final InsertInto o = (InsertInto) obj;
     return Objects.equals(target, o.target)
-           && Objects.equals(query, o.query);
+           && Objects.equals(query, o.query)
+           && Objects.equals(properties, o.properties);
   }
 
   @Override
@@ -92,6 +107,7 @@ public class InsertInto
     return toStringHelper(this)
         .add("target", target)
         .add("query", query)
+        .add("properties", properties)
         .toString();
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/QueryContainer.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/QueryContainer.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.parser.tree;
 
+import java.util.Optional;
+
 /**
  * Indicates the statement contains a {@link Query}.
  */
@@ -33,4 +35,11 @@ public interface QueryContainer {
    * @return the sink info.
    */
   Sink getSink();
+
+  /**
+   * Return an optional query ID if specified by the user
+   *
+   * @return the optional query ID
+   */
+  Optional<String> getQueryId();
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/QueryContainer.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/QueryContainer.java
@@ -37,7 +37,8 @@ public interface QueryContainer {
   Sink getSink();
 
   /**
-   * Return an optional query ID if specified by the user
+   * Return an optional query ID if specified by the user. This query ID is used only by
+   * "INSERT INTO WITH (QUERY_ID='value')" statements.
    *
    * @return the optional query ID
    */

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/InsertIntoPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/InsertIntoPropertiesTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.properties.with;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.expression.tree.Literal;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.properties.with.InsertIntoConfigs;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class InsertIntoPropertiesTest {
+  @Test
+  public void shouldReturnOptionalEmptyForMissingProps() {
+    // When:
+    final InsertIntoProperties properties = InsertIntoProperties.from(Collections.emptyMap());
+
+    // Then:
+    assertThat(properties.getQueryId(), is(Optional.empty()));
+  }
+
+  @Test
+  public void shoulSetQueryId() {
+    // When:
+    final InsertIntoProperties properties = InsertIntoProperties.from(
+        ImmutableMap.<String, Literal>builder()
+            .put(InsertIntoConfigs.QUERY_ID_PROPERTY, new StringLiteral("my_insert_query_id"))
+            .build());
+
+    // Then:
+    assertThat(properties.getQueryId(), is(Optional.of("MY_INSERT_QUERY_ID")));
+  }
+}

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/InsertIntoTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/InsertIntoTest.java
@@ -15,12 +15,19 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Optional;
+
+import io.confluent.ksql.parser.properties.with.InsertIntoProperties;
+import io.confluent.ksql.query.QueryId;
 import org.junit.Test;
 
 public class InsertIntoTest {
@@ -29,6 +36,7 @@ public class InsertIntoTest {
   public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
   private static final SourceName SOME_NAME = SourceName.of("bob");
   private static final Query SOME_QUERY = mock(Query.class);
+  private static final InsertIntoProperties NO_PROPS = InsertIntoProperties.none();
 
   @Test
   public void shouldImplementHashCodeAndEqualsProperty() {
@@ -37,8 +45,8 @@ public class InsertIntoTest {
             // Note: At the moment location does not take part in equality testing
             new InsertInto(SOME_NAME, SOME_QUERY),
             new InsertInto(SOME_NAME, SOME_QUERY),
-            new InsertInto(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY),
-            new InsertInto(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_QUERY)
+            new InsertInto(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, NO_PROPS),
+            new InsertInto(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_QUERY, NO_PROPS)
         )
         .addEqualityGroup(
             new InsertInto(SourceName.of("jim"), SOME_QUERY)
@@ -46,6 +54,22 @@ public class InsertIntoTest {
         .addEqualityGroup(
             new InsertInto(SOME_NAME, mock(Query.class))
         )
+        .addEqualityGroup(
+            new InsertInto(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY,
+                InsertIntoProperties.from(ImmutableMap.of("id", new StringLiteral("insert1")))),
+            new InsertInto(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY,
+                InsertIntoProperties.from(ImmutableMap.of("id", new StringLiteral("insert1"))))
+        )
         .testEquals();
+  }
+
+  @Test
+  public void shouldReturnOptionalQueryId() {
+    // When:
+    final InsertInto insertInto = new InsertInto(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY,
+        InsertIntoProperties.from(ImmutableMap.of("ID", new StringLiteral("my_id"))));
+
+    // Then:
+    assertThat(insertInto.getQueryId(), is(Optional.of(new QueryId("MY_ID"))));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/InsertIntoTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/InsertIntoTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static io.confluent.ksql.properties.with.InsertIntoConfigs.QUERY_ID_PROPERTY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -27,6 +28,7 @@ import io.confluent.ksql.parser.NodeLocation;
 import java.util.Optional;
 
 import io.confluent.ksql.parser.properties.with.InsertIntoProperties;
+import io.confluent.ksql.properties.with.InsertIntoConfigs;
 import io.confluent.ksql.query.QueryId;
 import org.junit.Test;
 
@@ -56,9 +58,11 @@ public class InsertIntoTest {
         )
         .addEqualityGroup(
             new InsertInto(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY,
-                InsertIntoProperties.from(ImmutableMap.of("id", new StringLiteral("insert1")))),
+                InsertIntoProperties.from(
+                    ImmutableMap.of(QUERY_ID_PROPERTY, new StringLiteral("insert1")))),
             new InsertInto(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY,
-                InsertIntoProperties.from(ImmutableMap.of("id", new StringLiteral("insert1"))))
+                InsertIntoProperties.from(
+                    ImmutableMap.of(QUERY_ID_PROPERTY, new StringLiteral("insert1"))))
         )
         .testEquals();
   }
@@ -67,9 +71,10 @@ public class InsertIntoTest {
   public void shouldReturnOptionalQueryId() {
     // When:
     final InsertInto insertInto = new InsertInto(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY,
-        InsertIntoProperties.from(ImmutableMap.of("ID", new StringLiteral("my_id"))));
+        InsertIntoProperties.from(
+            ImmutableMap.of(QUERY_ID_PROPERTY, new StringLiteral("my_id"))));
 
     // Then:
-    assertThat(insertInto.getQueryId(), is(Optional.of(new QueryId("MY_ID"))));
+    assertThat(insertInto.getQueryId(), is(Optional.of("MY_ID")));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -631,6 +631,16 @@ public class RecoveryTest {
   }
 
   @Test
+  public void shouldRecoverInsertIntosWithCustomQueryId() {
+    server1.submitCommands(
+        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
+        "CREATE STREAM B (COLUMN STRING) WITH (KAFKA_TOPIC='B', VALUE_FORMAT='JSON', PARTITIONS=1);",
+        "INSERT INTO B WITH(QUERY_ID='MY_INSERT_ID') SELECT * FROM A;"
+    );
+    shouldRecover(commands);
+  }
+
+  @Test
   public void shouldRecoverInsertIntosRecreates() {
     server1.submitCommands(
         "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",


### PR DESCRIPTION
### Description 
Implements https://github.com/confluentinc/ksql/issues/6533

Add a `WITH` clause to the `INSERT/SELECT` statement to allow users specify a custom query QUERY_ID. 
For intance:
```
ksql> insert into s1 with (query_id='my_insert_id') select * from s1;

 Message                            
------------------------------------
 Created query with ID MY_INSERT_ID 
------------------------------------

ksql> show queries;

 Query ID     | Query Type | Status    | Sink Name | Sink Kafka Topic | Query String                                              
----------------------------------------------------------------------------------------------------------------------------------
 MY_INSERT_ID | PERSISTENT | RUNNING:1 | S1        | t1               | insert into s1 with (query_id='my_insert_id') select * from s1; 
----------------------------------------------------------------------------------------------------------------------------------
For detailed information on a Query run: EXPLAIN <Query ID>;

ksql> terminate my_insert_id;

 Message           
-------------------
 Query terminated. 
-------------------
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

