### PR TITLE
chore: fix findbugs errors

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.rest.server;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Ticker;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
@@ -35,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,18 +46,13 @@ import org.slf4j.LoggerFactory;
  * complete backup of the command_topic is created.
  */
 public class CommandTopicBackupImpl implements CommandTopicBackup {
+
   private static final Logger LOG = LoggerFactory.getLogger(CommandTopicBackupImpl.class);
-  private static final Ticker CURRENT_MILLIS_TICKER = new Ticker() {
-    @Override
-    public long read() {
-      return System.currentTimeMillis();
-    }
-  };
   private static final String PREFIX = "backup_";
 
   private final File backupLocation;
   private final String topicName;
-  private final Ticker ticker;
+  private final Supplier<Long> ticker;
 
   private BackupReplayFile replayFile;
   private List<Pair<byte[], byte[]>> latestReplay;
@@ -66,21 +61,22 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
 
   public CommandTopicBackupImpl(
       final String location,
-      final String topicName) {
-    this(location, topicName, CURRENT_MILLIS_TICKER);
+      final String topicName
+  ) {
+    this(location, topicName, System::currentTimeMillis);
   }
 
-  public CommandTopicBackupImpl(
+  @VisibleForTesting
+  CommandTopicBackupImpl(
       final String location,
       final String topicName,
-      final Ticker ticker
+      final Supplier<Long> ticker
   ) {
-    final File dir = new File(Objects.requireNonNull(location, "location"));
-    ensureDirectoryExists(dir);
-
-    this.backupLocation = dir;
+    this.backupLocation = new File(Objects.requireNonNull(location, "location"));
     this.topicName = Objects.requireNonNull(topicName, "topicName");
     this.ticker = Objects.requireNonNull(ticker, "ticker");
+
+    ensureDirectoryExists(backupLocation);
   }
 
   @Override
@@ -133,14 +129,13 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
     return false;
   }
 
-  private void throwIfInvalidRecord(final ConsumerRecord<byte[], byte[]> record) {
+  private static void throwIfInvalidRecord(final ConsumerRecord<byte[], byte[]> record) {
     try {
       InternalTopicSerdes.deserializer(CommandId.class).deserialize(record.topic(), record.key());
     } catch (final Exception e) {
       throw new KsqlException(String.format(
           "Failed to backup record because it cannot deserialize key: %s",
-          new String(record.key(), StandardCharsets.UTF_8), e
-      ));
+          new String(record.key(), StandardCharsets.UTF_8)), e);
     }
 
     try {
@@ -148,8 +143,8 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
     } catch (final Exception e) {
       throw new KsqlException(String.format(
           "Failed to backup record because it cannot deserialize value: %s",
-          new String(record.value(), StandardCharsets.UTF_8), e
-      ));
+          new String(record.value(), StandardCharsets.UTF_8)), e
+      );
     }
   }
 
@@ -193,18 +188,14 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
 
   @VisibleForTesting
   BackupReplayFile openOrCreateReplayFile() {
-    final Optional<BackupReplayFile> latestFile = latestReplayFile();
-    if (latestFile.isPresent()) {
-      return latestFile.get();
-    }
-
-    return newReplayFile();
+    return latestReplayFile()
+        .orElseGet(this::newReplayFile);
   }
 
   private BackupReplayFile newReplayFile() {
     return BackupReplayFile.writable(Paths.get(
         backupLocation.getAbsolutePath(),
-        String.format("%s%s_%s", PREFIX, topicName, ticker.read())
+        String.format("%s%s_%s", PREFIX, topicName, ticker.get())
     ).toFile());
   }
 
@@ -216,12 +207,11 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
     File latestBakFile = null;
     if (files != null) {
       long latestTs = 0;
-      for (int i = 0; i < files.length; i++) {
-        final File bakFile = files[i];
+      for (final File bakFile : files) {
         final String bakTimestamp = bakFile.getName().substring(prefixFilename.length());
 
         try {
-          final Long ts = Long.valueOf(bakTimestamp);
+          final long ts = Long.parseLong(bakTimestamp);
           if (ts > latestTs) {
             latestTs = ts;
             latestBakFile = bakFile;
@@ -230,17 +220,15 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
           LOG.warn(
               "Invalid timestamp '{}' found in backup replay file (file ignored): {}",
               bakTimestamp, bakFile.getName());
-          continue;
         }
       }
     }
 
-    return (latestBakFile != null)
-        ? Optional.of(BackupReplayFile.writable(latestBakFile))
-        : Optional.empty();
+    return Optional.ofNullable(latestBakFile)
+        .map(BackupReplayFile::writable);
   }
 
-  private void ensureDirectoryExists(final File backupsDir) {
+  private static void ensureDirectoryExists(final File backupsDir) {
     if (!backupsDir.exists()) {
       if (!backupsDir.mkdirs()) {
         throw new KsqlServerException("Couldn't create the backups directory: "

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -31,7 +31,6 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.ReservedInternalTopics;
-
 import java.io.Console;
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
-
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -88,8 +86,9 @@ public class KsqlRestoreCommandTopic {
       } catch (final Exception e) {
         throw new KsqlException(String.format(
             "Invalid CommandId string (line %d): %s",
-            n, new String(record.getLeft(), StandardCharsets.UTF_8), e
-        ));
+            n, new String(record.getLeft(), StandardCharsets.UTF_8)),
+            e
+        );
       }
 
       try {
@@ -98,8 +97,9 @@ public class KsqlRestoreCommandTopic {
       } catch (final Exception e) {
         throw new KsqlException(String.format(
             "Invalid Command string (line %d): %s",
-            n, new String(record.getRight(), StandardCharsets.UTF_8), e
-        ));
+            n, new String(record.getRight(), StandardCharsets.UTF_8)),
+            e
+        );
       }
     }
   }
@@ -135,12 +135,7 @@ public class KsqlRestoreCommandTopic {
     final Console console = System.console();
     final String decision = console.readLine();
 
-    switch (decision.toLowerCase()) {
-      case "yes":
-        return true;
-      default:
-        return false;
-    }
+    return "yes".equals(decision.toLowerCase());
   }
 
   /**

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Ticker;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
@@ -34,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Before;
 import org.junit.Rule;
@@ -47,12 +47,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class CommandTopicBackupImplTest {
   private static final String COMMAND_TOPIC_NAME = "command_topic";
 
-  private ConsumerRecord<byte[], byte[]> command1 = newStreamRecord("stream1");
-  private ConsumerRecord<byte[], byte[]> command2 = newStreamRecord("stream2");
-  private ConsumerRecord<byte[], byte[]> command3 = newStreamRecord("stream3");
+  private final ConsumerRecord<byte[], byte[]> command1 = newStreamRecord("stream1");
+  private final ConsumerRecord<byte[], byte[]> command2 = newStreamRecord("stream2");
+  private final ConsumerRecord<byte[], byte[]> command3 = newStreamRecord("stream3");
 
   @Mock
-  private Ticker ticker;
+  private Supplier<Long> ticker;
 
   @Rule
   public TemporaryFolder backupLocation = new TemporaryFolder();
@@ -70,7 +70,10 @@ public class CommandTopicBackupImplTest {
   }
 
   @SuppressWarnings("unchecked")
-  private ConsumerRecord<byte[], byte[]> newStreamRecord(final String key, final String value) {
+  private static ConsumerRecord<byte[], byte[]> newStreamRecord(
+      final String key,
+      final String value
+  ) {
     final ConsumerRecord<byte[], byte[]> consumerRecord = mock(ConsumerRecord.class);
 
     when(consumerRecord.key()).thenReturn(key.getBytes(StandardCharsets.UTF_8));
@@ -304,7 +307,7 @@ public class CommandTopicBackupImplTest {
   @Test
   public void shouldCreateNewReplayFileWhenNoBackupFilesExist() {
     // Given:
-    when(ticker.read()).thenReturn(123L);
+    when(ticker.get()).thenReturn(123L);
 
     // When:
     final BackupReplayFile replayFile = commandTopicBackup.openOrCreateReplayFile();


### PR DESCRIPTION
### Description 

Fix four findbugs (and clean up code a little)

question is... why is our build not failing, given we have findbugs errors?  Could it be that spotbugs is missing this check?

Update:

Ran `mvn spotbugs:check` locally without this fix and spotbugs did not report any issues... which is bad!

Here's an example of the error in question:

```java
    throw new KsqlException(String.format(
            "Invalid CommandId string (line %d): %s",
            n, new String(record.getLeft(), StandardCharsets.UTF_8), e
        ));
```

Note how `e` is unintentionally being passed as a third parameter to `String.format` rather than as a second parameter to the exception constructor.

Findbugs does find this error.
