### PR TITLE
fix: add back configs for setting TLS protocols and cipher suites

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -379,8 +379,15 @@ public class Server {
     final Password trustStorePassword = ksqlRestConfig
         .getPassword(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
     if (trustStorePath != null && !trustStorePath.isEmpty()) {
-      options.setTrustStoreOptions(
-          new JksOptions().setPath(trustStorePath).setPassword(trustStorePassword.value()));
+      final String trustStoreType =
+          ksqlRestConfig.getString(KsqlRestConfig.SSL_TRUSTSTORE_TYPE_CONFIG);
+      if (trustStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_JKS)) {
+        options.setTrustStoreOptions(
+            new JksOptions().setPath(trustStorePath).setPassword(trustStorePassword.value()));
+      } else if (trustStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_PKCS12)) {
+        options.setPfxTrustOptions(
+            new PfxOptions().setPath(trustStorePath).setPassword(trustStorePassword.value()));
+      }
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -136,6 +136,15 @@ public class KsqlRestConfig extends AbstractConfig {
           SSL_CLIENT_AUTHENTICATION_REQUIRED
       );
 
+  public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
+  protected static final String SSL_ENABLED_PROTOCOLS_DOC =
+      "The list of protocols enabled for SSL connections. Comma-separated list. "
+          + "If blank, the default of \"TLSv1,TLSv1.1,TLSv1.2\" will be used.";
+
+  public static final String SSL_CIPHER_SUITES_CONFIG = "ssl.cipher.suites";
+  protected static final String SSL_CIPHER_SUITES_DOC =
+      "A list of SSL cipher suites. If blank, the JVM default will be used.";
+
   public static final String SSL_KEYSTORE_RELOAD_CONFIG = "ssl.keystore.reload";
   protected static final String SSL_KEYSTORE_RELOAD_DOC =
       "Enable auto reload of ssl keystore.";
@@ -448,15 +457,25 @@ public class KsqlRestConfig extends AbstractConfig {
             "",
             Importance.MEDIUM,
             KSQL_SSL_KEYSTORE_ALIAS_EXTERNAL_DOC
-        )
-        .define(
+        ).define(
             KSQL_SSL_KEYSTORE_ALIAS_INTERNAL_CONFIG,
             Type.STRING,
             "",
             Importance.MEDIUM,
             KSQL_SSL_KEYSTORE_ALIAS_INTERNAL_DOC
-        )
-        .define(
+        ).define(
+            SSL_ENABLED_PROTOCOLS_CONFIG,
+            Type.LIST,
+            "",
+            Importance.MEDIUM,
+            SSL_ENABLED_PROTOCOLS_DOC
+        ).define(
+            SSL_CIPHER_SUITES_CONFIG,
+            Type.LIST,
+            "",
+            Importance.LOW,
+            SSL_CIPHER_SUITES_DOC
+        ).define(
             ADVERTISED_LISTENER_CONFIG,
             Type.STRING,
             null,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -139,7 +139,9 @@ public class KsqlRestConfig extends AbstractConfig {
   public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
   protected static final String SSL_ENABLED_PROTOCOLS_DOC =
       "The list of protocols enabled for SSL connections. Comma-separated list. "
-          + "If blank, the default of \"TLSv1,TLSv1.1,TLSv1.2\" will be used.";
+          + "If blank, the default from the Apache Kafka SslConfigs.java file will be used "
+          + "(see 'DEFAULT_SSL_ENABLED_PROTOCOLS' in "
+          + "https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java).";
 
   public static final String SSL_CIPHER_SUITES_CONFIG = "ssl.cipher.suites";
   protected static final String SSL_CIPHER_SUITES_DOC =
@@ -466,7 +468,7 @@ public class KsqlRestConfig extends AbstractConfig {
         ).define(
             SSL_ENABLED_PROTOCOLS_CONFIG,
             Type.LIST,
-            "",
+            SslConfigs.DEFAULT_SSL_ENABLED_PROTOCOLS,
             Importance.MEDIUM,
             SSL_ENABLED_PROTOCOLS_DOC
         ).define(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TlsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TlsTest.java
@@ -23,13 +23,16 @@ import static org.hamcrest.Matchers.is;
 
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.test.util.secure.ServerKeyStore;
+import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.JksOptions;
 import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import java.nio.file.attribute.FileTime;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -54,6 +57,7 @@ public class TlsTest extends ApiTest {
 
     Map<String, Object> config = new HashMap<>();
     config.put(KsqlRestConfig.LISTENERS_CONFIG, "https://localhost:0");
+    config.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, "TLSv1.2");
     config.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keyStorePath);
     config.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, keyStorePassword);
     config.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStorePath);
@@ -83,6 +87,31 @@ public class TlsTest extends ApiTest {
         setVerifyHost(false).
         setDefaultHost("localhost").
         setDefaultPort(server.getListeners().get(0).getPort());
+  }
+
+  @Test
+  public void shouldFailToUseDisabledTlsVersion() {
+    // Given
+    WebClientOptions clientOptions = createClientOptions()
+        .setEnabledSecureTransportProtocols(Collections.singleton("TLSv1.1"));
+    WebClient client = WebClient.create(vertx, clientOptions);
+
+    // When
+    JsonObject requestBody = new JsonObject().put("ksql", "show streams;");
+    VertxCompletableFuture<HttpResponse<Buffer>> requestFuture = new VertxCompletableFuture<>();
+    client
+        .post("/ksql")
+        .sendBuffer(requestBody.toBuffer(), requestFuture);
+
+    // Then
+    try {
+      requestFuture.get();
+    } catch (Exception e) {
+      assertThat(e,
+          instanceOf(ExecutionException.class)); // thrown from CompletableFuture.get()
+      assertThat(e.getMessage(), containsString(
+          "javax.net.ssl.SSLHandshakeException: Failed to create SSL connection"));
+    }
   }
 
   @Test

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.client;
 
+import com.google.common.base.Strings;
 import io.confluent.ksql.parser.json.KsqlTypesDeserializationModule;
 import io.confluent.ksql.properties.LocalProperties;
 import io.confluent.ksql.rest.ApiJsonMapper;
@@ -137,8 +138,10 @@ public final class KsqlClient implements AutoCloseable {
       final HttpClientOptions httpClientOptions,
       final boolean tls) {
     if (tls) {
-      httpClientOptions.setVerifyHost(false);
       httpClientOptions.setSsl(true);
+
+      configureHostVerification(clientProps, httpClientOptions);
+
       final String trustStoreLocation = clientProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
       if (trustStoreLocation != null) {
         final String suppliedTruststorePassword = clientProps
@@ -147,10 +150,10 @@ public final class KsqlClient implements AutoCloseable {
             .setPassword(suppliedTruststorePassword == null ? "" : suppliedTruststorePassword));
         final String keyStoreLocation = clientProps.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
         if (keyStoreLocation != null) {
-          final String suppliedKeyStorePassord = clientProps
+          final String suppliedKeyStorePassword = clientProps
               .get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
           httpClientOptions.setKeyStoreOptions(new JksOptions().setPath(keyStoreLocation)
-              .setPassword(suppliedKeyStorePassord == null ? "" : suppliedKeyStorePassord));
+              .setPassword(suppliedKeyStorePassword == null ? "" : suppliedKeyStorePassword));
         }
       }
     }
@@ -169,5 +172,25 @@ public final class KsqlClient implements AutoCloseable {
     } catch (VertxException e) {
       throw new KsqlRestClientException(e.getMessage(), e);
     }
+  }
+
+  private static void configureHostVerification(
+      final Map<String, String> clientProps,
+      final HttpClientOptions httpClientOptions
+  ) {
+    final String endpointIdentificationAlg =
+        clientProps.get(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
+    if (!Strings.isNullOrEmpty(endpointIdentificationAlg)) {
+      if (!endpointIdentificationAlg.toLowerCase().equals("https")) {
+        throw new IllegalArgumentException("Config '"
+            + SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG
+            + "' must be either 'https' or empty. Got: " + endpointIdentificationAlg);
+      }
+
+      httpClientOptions.setVerifyHost(true);
+      return;
+    }
+
+    httpClientOptions.setVerifyHost(false);
   }
 }


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/6555

Functionality of the configs `ssl.enabled.protocols` and `ssl.cipher.suites` were lost in the Jetty -> Vert.x migration. This PR adds back the functionality.

There were also some other configs that weren't migrated:
- `ssl.endpoint.identification.algorithm`: I'm not entirely clear on the expected behavior of this config, particularly because it's a client config, not a server config. If configured, ksqlDB properly passes the config to outgoing clients such as Kafka admin clients, producers, consumers, etc. This PR adds support for the config in the ksqlDB CLI, for use when connecting to ksqlDB. Is the config also meant to apply to ksqlDB intra-node clients? Currently, hostname verification is configured for these intra-node requests if (and only if) intra-node authentication is enabled and TLS mutual auth is requested.
- `ssl.protocol`, `ssl.provider`, `ssl.keymanager.algorithm` and `ssl.trustmanager.algorithm`: I don't see equivalents for these configs in Vert.x.

Open questions:
- What should the default value for `ssl.enabled.protocols` be? Vert.x defaults to allowing `{"TLSv1", "TLSv1.1", "TLSv1.2"}`, which differs from Jetty which does not allow `TLSv1` and `TLSv1.1` by default. If we choose to go with the Jetty defaults, are we OK with this breaking change on a patch release (either 6.0.1 or 6.0.2, pending release schedule)? Also, how will we keep our default up to date as the Jetty default changes?
- Relatedly, I don't think it makes sense to try to mirror the [Jetty default](https://www.eclipse.org/jetty/documentation/current/configuring-ssl.html) for `ssl.cipher.suites`. I think the Vert.x default of delegating to the JVM default makes more sense.
- What's the expected behavior of the `ssl.endpoint.identification.algorithm` config, discussed above?
- Do we know of use cases for the configs mentioned above, that have yet to be migrated?

TODOs:
- Docs update. This will be a separate PR so it is easier to cherry-pick across branches.
- Backport this change to 6.0.x.

### Testing done 

Manual + integration test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

