### PR TITLE
fix: allow reserved keywords on variables names

### DIFF
--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -343,7 +343,6 @@ identifier
 
 variableName
     : IDENTIFIER
-    | nonReserved
     ;
 
 variableValue

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SyntaxErrorValidator.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SyntaxErrorValidator.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.parser.SqlBaseParser.VariableNameContext;
+import io.confluent.ksql.util.ParserKeywordValidatorUtil;
+import io.confluent.ksql.util.ParserUtil;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.RuleContext;
+import org.antlr.v4.runtime.Token;
+
+/**
+ * This class is a syntax error validator used in the {@link DefaultKsqlParser} class, which
+ * validates errors during SQL parsing. It implements {@link BaseErrorListener} so it can be
+ * added as an error listener to the {@code SqlBaseLexer}.
+ * </p>
+ * This class is called for every error caused by ANTlr parsing. Some errors, like reserved keywords
+ * in identifiers for some statements, are valid and should be allowed in the syntax, and others
+ * errors should return a better error message.
+ */
+public class SyntaxErrorValidator extends BaseErrorListener {
+  private static final Pattern EXTRANEOUS_INPUT_PATTERN = Pattern.compile(
+      "extraneous input.*expecting.*");
+  private static final Pattern MISMATCHED_INPUT_PATTERN = Pattern.compile(
+      "mismatched input.*expecting.*");
+
+  // List of validators per ANTLr context.
+  private static final Map<Class<?>, BiFunction<String, RecognitionException, Boolean>>
+      ERROR_VALIDATORS = ImmutableMap.of(
+      VariableNameContext.class, SyntaxErrorValidator::isValidVariableName
+  );
+
+  /**
+   * Check if a variable name uses a SQL reserved keyword that should be valid as a variable.
+   * </p>
+   * Valid reserved keywords in identifiers are not easy to configure in ANTLr {@code SqlBase.g4}.
+   * ANTLr rules must specify what a reserved keyword is so they are allowed (see
+   * nonReservedKeyword in {@code SqlBase.g4}), but it is not scalable. There are too many keywords
+   * used in SqlBase.g4, and not all statements allow the same reserved keywords. This method
+   * checks against the whole list of symbolic names (or keywords) from ANTLr, and verifies the
+   * variable name matches those.
+   *
+   * @param errorMessage The error message thrown by ANTLr parsers.
+   * @param exception The exception that contains the offending token.
+   * @return True if a reserved keyword is a valid variable name; false otherwise.
+   */
+  private static boolean isValidVariableName(
+      final String errorMessage,
+      final RecognitionException exception
+  ) {
+    if (MISMATCHED_INPUT_PATTERN.matcher(errorMessage).matches()) {
+      if (exception.getOffendingToken() != null) {
+        return ParserKeywordValidatorUtil.getKsqlReservedWords()
+            .contains(exception.getOffendingToken().getText());
+      }
+    }
+
+    return false;
+  }
+
+  private static boolean validateErrorContext(
+      final RuleContext context,
+      final String errorMessage,
+      final RecognitionException exception
+  ) {
+    final BiFunction<String, RecognitionException, Boolean> validator =
+        ERROR_VALIDATORS.get(context.getClass());
+    if (validator == null) {
+      return false;
+    }
+
+    return validator.apply(errorMessage, exception);
+  }
+
+  private static boolean shouldIgnoreSyntaxError(
+      final String errorMessage,
+      final RecognitionException exception
+  ) {
+    if (exception.getCtx() != null) {
+      return validateErrorContext(exception.getCtx(), errorMessage, exception);
+    }
+
+    return false;
+  }
+
+  /**
+   * checks if the error is a reserved keyword error by checking the message and offendingSymbol
+   * @param message the error message
+   * @param offendingSymbol the symbol that caused the error
+   * @return
+   */
+  private static boolean isKeywordError(final String message, final String offendingSymbol) {
+    final Matcher m = EXTRANEOUS_INPUT_PATTERN.matcher(message);
+    return  m.find() && ParserUtil.isReserved(offendingSymbol);
+  }
+
+  @Override
+  public void syntaxError(
+      final Recognizer<?, ?> recognizer,
+      final Object offendingSymbol,
+      final int line,
+      final int charPositionInLine,
+      final String message,
+      final RecognitionException e
+  ) {
+    if (e != null && shouldIgnoreSyntaxError(message, e)) {
+      return;
+    }
+
+    if (offendingSymbol instanceof Token && isKeywordError(
+        message, ((Token) offendingSymbol).getText())) {
+      //Checks if the error is a reserved keyword error
+      final String tokenName = ((Token) offendingSymbol).getText();
+      final String newMessage =
+          "\"" + tokenName + "\" is a reserved keyword and it can't be used as an identifier."
+              + " You can use it as an identifier by escaping it as \'" + tokenName + "\' ";
+      throw new ParsingException(newMessage, e, line, charPositionInLine);
+    } else {
+      throw new ParsingException(message, e, line, charPositionInLine);
+    }
+  }
+}

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -56,8 +56,6 @@ public final class ParserUtil {
    * @see org.apache.kafka.streams.state.StoreBuilder#name
    */
   private static final Pattern VALID_SOURCE_NAMES = Pattern.compile("[a-zA-Z0-9_-]*");
-  public static final Pattern EXTRANEOUS_INPUT_PATTERN = Pattern.compile(
-          "extraneous input.*expecting.*");
 
   private static final LookupTranslator ESCAPE_SYMBOLS = new LookupTranslator(
       new String[][]{

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SyntaxErrorValidatorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SyntaxErrorValidatorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.parser.SqlBaseParser.CreateStreamContext;
+import io.confluent.ksql.parser.SqlBaseParser.VariableNameContext;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.RuleContext;
+import org.antlr.v4.runtime.Token;
+import org.easymock.EasyMockRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EasyMockRunner.class)
+public class SyntaxErrorValidatorTest {
+  private SyntaxErrorValidator syntaxErrorValidator = new SyntaxErrorValidator();
+
+  @Test
+  public void shouldAllowReservedKeywordsOnVariableName() {
+    // Given:
+    final String errorMessage = "mismatched input 'topic' expecting IDENTIFIER";
+    final RecognitionException exception =
+        givenException(mock(VariableNameContext.class), getToken("topic"));
+
+    // When/Then:
+    callSyntaxError(errorMessage, exception);
+  }
+
+  @Test
+  public void shouldThrowDefaultParsingExceptionIfExceptionIsNull() {
+    // Given:
+    final String errorMessage = "mismatched input 'topic' expecting IDENTIFIER";
+    final RecognitionException exception = null;
+
+    // When
+    final Exception e = assertThrows(
+        ParsingException.class,
+        () -> callSyntaxError(errorMessage, exception)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("mismatched input 'topic' expecting IDENTIFIER"));
+  }
+
+  @Test
+  public void shouldThrowDefaultParsingExceptionIfContextIsNull() {
+    // Given:
+    final String errorMessage = "mismatched input 'topic' expecting IDENTIFIER";
+    final RecognitionException exception = givenException(null, getToken("topic"));
+
+    // When
+    final Exception e = assertThrows(
+        ParsingException.class,
+        () -> callSyntaxError(errorMessage, exception)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("mismatched input 'topic' expecting IDENTIFIER"));
+  }
+
+  @Test
+  public void shouldThrowOnInvalidNonReservedKeywordVariableName() {
+    // Given:
+    final String errorMessage = "mismatched input '1' expecting IDENTIFIER";
+    final RecognitionException exception =
+        givenException(mock(VariableNameContext.class), getToken("1"));
+
+    // When
+    final Exception e = assertThrows(
+        ParsingException.class,
+        () -> callSyntaxError(errorMessage, exception)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("mismatched input '1' expecting IDENTIFIER"));
+  }
+
+  @Test
+  public void shouldThrowWhenReservedKeywordUsedAsIdentifierOnNoVariablesNames() {
+    // Given:
+    final String errorMessage = "extraneous input 'size' expecting IDENTIFIER";
+    final RecognitionException exception =
+        givenException(mock(CreateStreamContext.class), getToken("size"));
+
+    // When:
+    final Exception e = assertThrows(
+        ParsingException.class,
+        () -> callSyntaxError(errorMessage, exception)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("\"size\" is a reserved keyword and it can't be used as an identifier"));
+  }
+
+  private void callSyntaxError(final String errorMessage, final RecognitionException exception) {
+    syntaxErrorValidator.syntaxError(
+        null,
+        (exception != null) ? exception.getOffendingToken() : null,
+        0,
+        0,
+        errorMessage,
+        exception
+    );
+  }
+
+  private RecognitionException givenException(
+      final RuleContext context,
+      final Token offendingToken
+  ) {
+    final RecognitionException exception = mock(RecognitionException.class);
+    when(exception.getCtx()).thenReturn(context);
+    when(exception.getOffendingToken()).thenReturn(offendingToken);
+    return exception;
+  }
+
+  private Token getToken(final String text) {
+    final Token token = mock(Token.class);
+    when(token.getText()).thenReturn(text);
+    return token;
+  }
+}


### PR DESCRIPTION
### Description 
Issue: The `DEFINE/UNDEFINE` statements do not allow variables names that matches the symbolic names found in `SqlBase.g4`. For instance `define topic = 't1';` fails because `topic` is a reserved keyword. However, these should not be a problem for variables names. We  should allow any variable name.

The `SqlBase.g4` has a rule for `nonReservedKeyword` which I used initially, but this is not scalable. There are several missing keywords in that rule, and not all statements allow the same keywords as non-reserved. To scale this rule, I added an extra validation to the parser error listener to check if a syntax error is caused by a keyword being used as variable name. If so, then it returns silently without throwing any error, thus allowing the `define` and `undefine` statements to continue.

i.e.
```
# BEFORE
ksql> define topic = 'a';
line 1:8: mismatched input 'topic' expecting {'EMIT', 'CHANGES', 'FINAL', 'ESCAPE', 'INTEGER', 'DATE', 'TIME', 'TIMESTAMP', 'INTERVAL', 'YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND', 'ZONE', 'PARTITION', 'STRUCT', 'EXPLAIN', 'ANALYZE', 'TYPE', 'TYPES', 'SHOW', 'TABLES', 'COLUMNS', 'COLUMN', 'PARTITIONS', 'FUNCTIONS', 'FUNCTION', 'ARRAY', 'MAP', 'SET', 'RESET', 'SESSION', 'KEY', 'SINK', 'SOURCE', 'PRIMARY', 'REPLACE', 'ASSERT', 'ADD', 'ALTER', 'IF', IDENTIFIER}
Statement: define topic = 'a';
Caused by: line 1:8: mismatched input 'topic' expecting {'EMIT', 'CHANGES',
	'FINAL', 'ESCAPE', 'INTEGER', 'DATE', 'TIME', 'TIMESTAMP', 'INTERVAL', 'YEAR',
	'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND', 'ZONE', 'PARTITION', 'STRUCT',
	'EXPLAIN', 'ANALYZE', 'TYPE', 'TYPES', 'SHOW', 'TABLES', 'COLUMNS', 'COLUMN',
	'PARTITIONS', 'FUNCTIONS', 'FUNCTION', 'ARRAY', 'MAP', 'SET', 'RESET',
	'SESSION', 'KEY', 'SINK', 'SOURCE', 'PRIMARY', 'REPLACE', 'ASSERT', 'ADD',
	'ALTER', 'IF', IDENTIFIER}
Caused by: org.antlr.v4.runtime.InputMismatchException

# AFTER 
ksql> define topic = 'a';

ksql> show variables;

 Variable Name | Value 
-----------------------
 topic         | a     
-----------------------

ksql> undefine topic;
```

This fix allowed me to removed the undesired keywords from the error message.
```
sql> define 1 = 'a';
line 1:8: mismatched input '1' expecting IDENTIFIER
Statement: define 1 = 'a';
Caused by: line 1:8: mismatched input '1' expecting IDENTIFIER
Caused by: org.antlr.v4.runtime.InputMismatchException
```

The  validator is on `SyntaxErrorValidator`, which is used as an error listener for the parsers. I just copied the `syntaxError` implementation from `DefaultKsqlParser` to this class. We can add more validators in the future if we find another error that should be valid and is difficult to add as rule in `SqlBase.g4`. We can also add validators to format the error messages for a better user experience.

### Testing done 
Added unit tests
Verified manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

