### PR TITLE
fix: cannot reference variables in DEFINE statement

### DIFF
--- a/docs/developer-guide/variable-substitution.md
+++ b/docs/developer-guide/variable-substitution.md
@@ -86,6 +86,16 @@ ksqlDB doesn't add single-quotes to values during variable substitution. Also, y
 !!! note
     Variables are case-insensitive. A reference to `${replicas}` is the same as `${REPLICAS}`.
 
+Escape substitution variables
+-----------------------------
+
+If you want to escape a variable reference, so it is not substituted, then use double `$$` characters.
+```
+DEFINE format = 'AVRO';
+SELECT '$${format}' FROM stream;
+```
+The above query will become `SELECT '${format}' FROM stream`
+
 Context for substitution variables
 ----------------------------------
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -19,6 +19,22 @@ public class VariableSubstitutorTest {
   private static final KsqlParser KSQL_PARSER = new DefaultKsqlParser();
 
   @Test
+  public void shouldNotSubstituteWithEscapedVariables() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("env", "qa");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        Pair.of("DEFINE topicName = 'topic_$${env}';",
+            "DEFINE topicName = 'topic_${env}';")
+    );
+
+    // When/Then
+    assertReplacedStatements(statements, variablesMap);
+  }
+
+  @Test
   public void shouldSubstituteVariableOnDefine() {
     // Given
     final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -27,7 +27,26 @@ public class VariableSubstitutorTest {
 
     final List<Pair<String, String>> statements = Arrays.asList(
         Pair.of("DEFINE topicName = 'topic_$${env}';",
-            "DEFINE topicName = 'topic_${env}';")
+            "DEFINE topicName = 'topic_${env}';"),
+        Pair.of("DEFINE topicName = 'topic_$${${env}}';",
+            "DEFINE topicName = 'topic_${qa}';")
+    );
+
+    // When/Then
+    assertReplacedStatements(statements, variablesMap);
+  }
+
+  @Test
+  public void shouldSupportRecursiveVariableReplacement() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("env", "qa");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        // This case only shows that ${env} is replaced when inside a escaped variable reference
+        Pair.of("DEFINE topicName = 'topic_$${${env}}';",
+            "DEFINE topicName = 'topic_${qa}';")
     );
 
     // When/Then

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -19,6 +19,28 @@ public class VariableSubstitutorTest {
   private static final KsqlParser KSQL_PARSER = new DefaultKsqlParser();
 
   @Test
+  public void shouldSubstituteVariableOnDefine() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("env", "qa");
+      put("env_quoted", "\"qa\"");
+      put("env_backQuoted", "`qa`");
+    }}.build();
+
+    final List<Pair<String, String>> statements = Arrays.asList(
+        Pair.of("DEFINE topicName = 'topic_${env}';",
+            "DEFINE topicName = 'topic_qa';"),
+        Pair.of("DEFINE topicName = 'topic_${env_quoted}';",
+            "DEFINE topicName = 'topic_\"qa\"';"),
+        Pair.of("DEFINE topicName = 'topic_${env_backQuoted}';",
+            "DEFINE topicName = 'topic_`qa`';")
+    );
+
+    // When/Then
+    assertReplacedStatements(statements, variablesMap);
+  }
+
+  @Test
   public void shouldSubstituteVariableOnDescribe() {
     // Given
     final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{


### PR DESCRIPTION
### Description 
Issue: Variables cannot be referenced in the DEFINE statement. i.e.
```
ksql> define env = 'qa';
ksql> define topicName = 'topic_${env}';
ksql> show variables;

 Variable Name | Value    
--------------------------
 env           | qa       
 topicName     | topic_${env}
--------------------------
```

This PR fixes the above issue by looking at the `VariableValueContext` in the `VariableSubstitutor`, and replace any variables referenced there.

Example:
```
ksql> define env = 'qa';
ksql> define topicName = 'topic_${env}';
ksql> show variables;

 Variable Name | Value    
--------------------------
 env           | qa       
 topicName     | topic_qa 
--------------------------
```

### Testing done 
Added unit tests
Verified manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

