### PR TITLE
refactor: re-use CreateSourceFactory to create streams/tables for CREATE_AS statements

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -72,6 +72,7 @@ public class Analysis implements ImmutableAnalysis {
   private OptionalInt limitClause = OptionalInt.empty();
   private CreateSourceAsProperties withProperties = CreateSourceAsProperties.none();
   private final List<FunctionCall> tableFunctions = new ArrayList<>();
+  private boolean orReplace = false;
 
   public Analysis(final Optional<RefinementInfo> refinementInfo) {
     this(refinementInfo, SourceSchemas::new);
@@ -217,6 +218,15 @@ public class Analysis implements ImmutableAnalysis {
     // we know that the first data source to be visited in the Analyzer is
     // the "FROM" data source
     return allDataSources.get(0);
+  }
+
+  @Override
+  public boolean getOrReplace() {
+    return orReplace;
+  }
+
+  public void setOrReplace(final boolean orReplace) {
+    this.orReplace = orReplace;
   }
 
   void addDataSource(final SourceName alias, final DataSource dataSource) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -191,6 +191,8 @@ class Analyzer {
 
       analysis
           .setInto(Into.newSink(sink.getName(), topicName, windowInfo, keyFmtInfo, valueFmtInfo));
+
+      analysis.setOrReplace(sink.shouldReplace());
     }
 
     private FormatInfo buildKeyFormatInfo(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
@@ -72,4 +72,6 @@ public interface ImmutableAnalysis {
   SourceSchemas getFromSourceSchemas(boolean postAggregate);
 
   AliasedDataSource getFrom();
+
+  boolean getOrReplace();
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -245,6 +245,11 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
     return expression.map(this::rewrite);
   }
 
+  @Override
+  public boolean getOrReplace() {
+    return original.getOrReplace();
+  }
+
   private <T extends Expression> List<T> rewriteList(final List<T> expressions) {
     return expressions.stream()
         .map(this::rewrite)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.DropTypeCommand;
 import io.confluent.ksql.execution.ddl.commands.RegisterTypeCommand;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.DropType;
 import io.confluent.ksql.parser.tree.AlterSource;
 import io.confluent.ksql.parser.tree.CreateStream;
@@ -33,6 +34,7 @@ import io.confluent.ksql.parser.tree.DdlStatement;
 import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.RegisterType;
+import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.HandlerMaps;
 import io.confluent.ksql.util.HandlerMaps.ClassHandlerMapR2;
@@ -109,6 +111,15 @@ public class CommandFactories implements DdlCommandFactory {
             this,
             new CallInfo(sqlExpression, config),
             ddlStatement);
+  }
+
+  @Override
+  public DdlCommand create(final KsqlStructuredDataOutputNode outputNode) {
+    if (outputNode.getNodeOutputType() == DataSource.DataSourceType.KSTREAM) {
+      return createSourceFactory.createStreamCommand(outputNode);
+    } else {
+      return createSourceFactory.createTableCommand(outputNode);
+    }
   }
 
   private CreateStreamCommand handleCreateStream(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.parser.properties.with.SourcePropertiesUtil;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
@@ -85,6 +86,18 @@ public final class CreateSourceFactory {
     this.valueSerdeFactory = requireNonNull(valueSerdeFactory, "valueSerdeFactory");
   }
 
+  public CreateStreamCommand createStreamCommand(final KsqlStructuredDataOutputNode outputNode) {
+    return new CreateStreamCommand(
+        outputNode.getIntoSourceName(),
+        outputNode.getSchema(),
+        outputNode.getTimestampColumn(),
+        outputNode.getKsqlTopic().getKafkaTopicName(),
+        Formats.from(outputNode.getKsqlTopic()),
+        outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
+        Optional.of(outputNode.getOrReplace())
+    );
+  }
+
   public CreateStreamCommand createStreamCommand(
       final CreateStream statement,
       final KsqlConfig ksqlConfig
@@ -104,6 +117,18 @@ public final class CreateSourceFactory {
         buildFormats(schema, props, ksqlConfig),
         getWindowInfo(props),
         Optional.of(statement.isOrReplace())
+    );
+  }
+
+  public CreateTableCommand createTableCommand(final KsqlStructuredDataOutputNode outputNode) {
+    return new CreateTableCommand(
+        outputNode.getIntoSourceName(),
+        outputNode.getSchema(),
+        outputNode.getTimestampColumn(),
+        outputNode.getKsqlTopic().getKafkaTopicName(),
+        Formats.from(outputNode.getKsqlTopic()),
+        outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
+        Optional.of(outputNode.getOrReplace())
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
@@ -18,11 +18,16 @@ package io.confluent.ksql.ddl.commands;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.execution.ddl.commands.DdlCommand;
 import io.confluent.ksql.parser.tree.DdlStatement;
+import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 
 public interface DdlCommandFactory {
   DdlCommand create(
       String sqlExpression,
       DdlStatement ddlStatement,
       SessionConfig config
+  );
+
+  DdlCommand create(
+      KsqlStructuredDataOutputNode outputNode
   );
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.ddl.commands;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -29,7 +28,6 @@ import java.util.Objects;
 public final class DropSourceFactory {
   private final MetaStore metaStore;
 
-  @VisibleForTesting
   DropSourceFactory(final MetaStore metaStore) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.VariableSubstitutor;
 import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
+import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.query.QueryExecutor;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
@@ -244,6 +245,10 @@ final class EngineContext {
         statement,
         config
     );
+  }
+
+  DdlCommand createDdlCommand(final KsqlStructuredDataOutputNode outputNode) {
+    return ddlCommandFactory.create(outputNode);
   }
 
   String executeDdl(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -19,12 +19,8 @@ import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.config.SessionConfig;
-import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
-import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
-import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
 import io.confluent.ksql.execution.ddl.commands.DdlCommand;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.properties.with.SourcePropertiesUtil;
@@ -259,32 +255,7 @@ final class EngineExecutor {
       return Optional.empty();
     }
 
-    final Formats formats = Formats.from(outputNode.getKsqlTopic());
-
-    final CreateSourceCommand ddl;
-    if (outputNode.getNodeOutputType() == DataSourceType.KSTREAM) {
-      ddl = new CreateStreamCommand(
-          outputNode.getIntoSourceName(),
-          outputNode.getSchema(),
-          outputNode.getTimestampColumn(),
-          outputNode.getKsqlTopic().getKafkaTopicName(),
-          formats,
-          outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
-          Optional.of(outputNode.getOrReplace())
-      );
-    } else {
-      ddl = new CreateTableCommand(
-          outputNode.getIntoSourceName(),
-          outputNode.getSchema(),
-          outputNode.getTimestampColumn(),
-          outputNode.getKsqlTopic().getKafkaTopicName(),
-          formats,
-          outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
-          Optional.of(outputNode.getOrReplace())
-      );
-    }
-
-    return Optional.of(ddl);
+    return Optional.of(engineContext.createDdlCommand(outputNode));
   }
 
   private void validateExistingSink(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -197,7 +197,8 @@ public class LogicalPlanner {
         existingTopic,
         analysis.getLimitClause(),
         into.isCreate(),
-        into.getName()
+        into.getName(),
+        analysis.getOrReplace()
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -37,6 +37,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
   private final KsqlTopic ksqlTopic;
   private final boolean doCreateInto;
   private final SourceName intoSourceName;
+  private final boolean orReplace;
 
   public KsqlStructuredDataOutputNode(
       final PlanNodeId id,
@@ -46,13 +47,15 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       final KsqlTopic ksqlTopic,
       final OptionalInt limit,
       final boolean doCreateInto,
-      final SourceName intoSourceName
+      final SourceName intoSourceName,
+      final boolean orReplace
   ) {
     super(id, source, schema, limit, timestampColumn);
 
     this.ksqlTopic = requireNonNull(ksqlTopic, "ksqlTopic");
     this.doCreateInto = doCreateInto;
     this.intoSourceName = requireNonNull(intoSourceName, "intoSourceName");
+    this.orReplace = orReplace;
 
     validate(source, intoSourceName);
   }
@@ -67,6 +70,10 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
 
   public SourceName getIntoSourceName() {
     return intoSourceName;
+  }
+
+  public boolean getOrReplace() {
+    return orReplace;
   }
 
   @Override

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -142,7 +142,7 @@ public class KsqlStructuredDataOutputNodeTest {
     // Given:
     givenInsertIntoNode();
 
-    final KeyFormat keyFormat = KeyFormat.nonWindowed(
+    KeyFormat.nonWindowed(
         FormatInfo.of(
             FormatFactory.AVRO.name(),
             ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "key-name")
@@ -150,7 +150,7 @@ public class KsqlStructuredDataOutputNodeTest {
         SerdeFeatures.of()
     );
 
-    final ValueFormat valueFormat = ValueFormat.of(
+    ValueFormat.of(
         FormatInfo.of(
             FormatFactory.AVRO.name(),
             ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "name")


### PR DESCRIPTION
### Description 
Before this PR, the `CreateStreamCommand` creation code was redundant in the `EngineExecutor.maybeCreateSinkDdl` and the `CreateSourceFactory`. This PR moves the code from the `EngineExecutor` to the `CreateSourceFactory` to re-use part of the code there.

Right now, the PR doesn't re-use code. But it will be needed by https://github.com/confluentinc/ksql/pull/6073 so it checks if the stream or table command exists before creating it.

### Testing done 
Added unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

