### PR TITLE
Cosmetic doc fixes

### DIFF
--- a/docs/developer-guide/ksqldb-reference/operators.md
+++ b/docs/developer-guide/ksqldb-reference/operators.md
@@ -11,26 +11,6 @@ Operators
 
 ksqlDB supports the following operators in value expressions.
 
-  - [Arithmetic](#arithmetic)
-  - [Concatenation](#concatenation)
-  - [IN Operator](#in)
-  - [Source Dereference](#source-dereference)
-  - [Subscript](#subscript)
-  - [STRUCT dereference](#struct-dereference)
-
-The explanation for each operator includes a supporting example based on
-the following table:
-
-```sql
-CREATE TABLE USERS (
-    USERID BIGINT PRIMARY KEY,
-    FIRST_NAME STRING,
-    LAST_NAME STRING,
-    NICKNAMES ARRAY<STRING>,
-    ADDRESS STRUCT<STREET_NAME STRING, HOUSE_NUM INTEGER>
-) WITH (KAFKA_TOPIC='users', VALUE_FORMAT='AVRO');
-```
-
 Arithmetic
 ----------
 

--- a/docs/developer-guide/ksqldb-reference/operators.md
+++ b/docs/developer-guide/ksqldb-reference/operators.md
@@ -47,7 +47,7 @@ SELECT USERID,
   EMIT CHANGES;
 ```
 
-IN
+In
 --
 
 The IN operator enables specifying multiple values in a `WHERE` clause.

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -40,7 +40,7 @@ CREATE TABLE AGG AS
    GROUP BY ID;
 ```
 
-### CAST
+### `CAST`
 
 Since: -
 
@@ -52,13 +52,13 @@ Converts one type to another. The following casts are supported:
 
 | from | to | notes |
 |------|----|-------|
-| ANY  | STRING | Converts the type to its string representation. |
-| STRING | BOOLEAN | Any string that exactly matches `true`, case-insensitive, is converted to `true`. Any other value is converted to `false`. |
-| STRING | INT, BIGINT, DECIMAL, DOUBLE | Converts string representation of numbers to number types. Conversion will fail if text does not contain a number or the number does not fit in the indicated type. |
-| INT, BIGINT, DECIMAL, DOUBLE | INT, BIGINT, DECIMAL, DOUBLE | Convert between numeric types. Conversion can result in rounding |
-| ARRAY | ARRAY | (Since 0.14) Convert between arrays of different element types |   
-| MAP | MAP | (Since 0.14) Convert between maps of different key and value types |   
-| STRUCT | STRUCT | (Since 0.14) Convert between structs of different field types. Only fields that exist in the target STRUCT type are copied across. Any fields in the target type that don't exist in the source are set to `NULL`. Field name matching is case-sensitive. |
+| any  | `STRING` | Converts the type to its string representation. |
+| `VARCHAR` | `BOOLEAN` | Any string that exactly matches `true`, case-insensitive, is converted to `true`. Any other value is converted to `false`. |
+| `VARCHAR` | `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | Converts string representation of numbers to number types. Conversion will fail if text does not contain a number or the number does not fit in the indicated type. |
+| `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | Convert between numeric types. Conversion can result in rounding |
+| `ARRAY` | `ARRAY` | (Since 0.14) Convert between arrays of different element types |   
+| `MAP` | `MAP` | (Since 0.14) Convert between maps of different key and value types |   
+| `STRUCT` | `STRUCT` | (Since 0.14) Convert between structs of different field types. Only fields that exist in the target STRUCT type are copied across. Any fields in the target type that don't exist in the source are set to `NULL`. Field name matching is case-sensitive. |
 
 ### `CEIL`
 


### PR DESCRIPTION
### Description 

Originally intended to add `CAST` to the docs, but Andy beat me by a few hours. Made some cosmetic fixes along the way. For example, the preface in the Operators section had broken formatting, and was just duplicating what is in the right nav bar.

