### PR TITLE
fix: Check for index before removing value in undo of COLLECT_LIST

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
@@ -73,7 +73,7 @@ public final class CollectListUdaf {
       public List<T> undo(final T valueToUndo, final List<T> aggregateValue) {
         // A more ideal solution would remove the value which corresponded to the original insertion
         // but keeping track of that is more complex so we just remove the last value for now.
-        int lastIndex = aggregateValue.lastIndexOf(valueToUndo);
+        final int lastIndex = aggregateValue.lastIndexOf(valueToUndo);
         // If we cannot find the value, that means that we hit the limit and never inserted it, so
         // just return.
         if (lastIndex < 0) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udaf.array;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.confluent.ksql.function.udaf.TableUdaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
@@ -33,7 +34,8 @@ import java.util.List;
 )
 public final class CollectListUdaf {
 
-  private static final int LIMIT = 1000;
+  @VisibleForTesting
+  static final int LIMIT = 1000;
 
   private CollectListUdaf() {
     // just to make the checkstyle happy
@@ -69,7 +71,15 @@ public final class CollectListUdaf {
 
       @Override
       public List<T> undo(final T valueToUndo, final List<T> aggregateValue) {
-        aggregateValue.remove(aggregateValue.lastIndexOf(valueToUndo));
+        // A more ideal solution would remove the value which corresponded to the original insertion
+        // but keeping track of that is more complex so we just remove the last value for now.
+        int lastIndex = aggregateValue.lastIndexOf(valueToUndo);
+        // If we cannot find the value, that means that we hit the limit and never inserted it, so
+        // just return.
+        if (lastIndex < 0) {
+          return aggregateValue;
+        }
+        aggregateValue.remove(lastIndex);
         return aggregateValue;
       }
     };

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
@@ -15,10 +15,12 @@
 
 package io.confluent.ksql.function.udaf.array;
 
+import static io.confluent.ksql.function.udaf.array.CollectListUdaf.LIMIT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
 
 import io.confluent.ksql.function.udaf.TableUdaf;
@@ -71,6 +73,34 @@ public class CollectListUdafTest {
     assertThat(runningList, hasItem(1));
     assertThat(runningList, hasItem(1000));
     assertThat(runningList, not(hasItem(1001)));
+  }
+
+  @Test
+  public void shouldUndo() {
+    final TableUdaf<Integer, List<Integer>, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
+    final Integer[] values = new Integer[] {3, 4, 5, 3};
+    List<Integer> runningList = udaf.initialize();
+    for (final Integer i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    runningList = udaf.undo(4, runningList);
+    assertThat(runningList, contains(3, 5, 3));
+    runningList = udaf.undo(3, runningList);
+    assertThat(runningList, contains(3, 5));
+  }
+
+  @Test
+  public void shouldUndoAfterHittingLimit() {
+    final TableUdaf<Integer, List<Integer>, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
+    final Integer[] values = new Integer[] {3, 4, 5, 3};
+    List<Integer> runningList = udaf.initialize();
+    for (int i = 0; i < LIMIT; i++) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    runningList = udaf.aggregate(LIMIT + 1, runningList);
+    assertThat(LIMIT + 1, not(isIn(runningList)));
+    runningList = udaf.undo(LIMIT + 1, runningList);
+    assertThat(LIMIT + 1, not(isIn(runningList)));
   }
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
@@ -92,7 +92,6 @@ public class CollectListUdafTest {
   @Test
   public void shouldUndoAfterHittingLimit() {
     final TableUdaf<Integer, List<Integer>, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
-    final Integer[] values = new Integer[] {3, 4, 5, 3};
     List<Integer> runningList = udaf.initialize();
     for (int i = 0; i < LIMIT; i++) {
       runningList = udaf.aggregate(i, runningList);


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/6341

Adds a check for the index of the last value and does nothing if it's not found.

### Testing done 
Ran unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

