### PR TITLE
docs: use latest version for kafka-connect-jdbc (DOCS-5837)

### DIFF
--- a/docs/tutorials/embedded-connect.md
+++ b/docs/tutorials/embedded-connect.md
@@ -142,7 +142,7 @@ is via [Confluent Hub Client](https://docs.confluent.io/current/connect/managing
 To download the JDBC connector, use the following command, ensuring that the `confluent-hub-components` directory exists first:
 
 ```bash
-confluent-hub install --component-dir confluent-hub-components --no-prompt confluentinc/kafka-connect-jdbc:{{ site.cprelease }}
+confluent-hub install --component-dir confluent-hub-components --no-prompt confluentinc/kafka-connect-jdbc:latest
 ```
 This command downloads the JDBC connector into the directory `./confluent-hub-components`.
 


### PR DESCRIPTION
 This topic had the version of kafka-connect-jdbc set to `6.0.0`, but it should be `10.0.0`. I didn't want to hard-code the version, so I changed to use `latest`. 