### PR TITLE
chore: support arrays/maps with mismatched elements

### DIFF
--- a/docs/developer-guide/ksqldb-reference/index.md
+++ b/docs/developer-guide/ksqldb-reference/index.md
@@ -16,6 +16,7 @@ keywords: ksqldb, api, reference, function, operator, metadata, connector, query
 - [Operators](operators.md)
 - [Scalar Functions](scalar-functions.md)
 - [Table Functions](table-functions.md)
+- [Type Coercion](type-coercion.md)
 
 ## Streams and Tables
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -214,7 +214,7 @@ ARRAY[exp1, exp2, ...]
 
 Construct an array from a variable number of inputs.
 
-All parameters passed to the array function must be [coercible to a common Sql type][1]. 
+All elements must be [coercible to a common Sql type][1]. 
 
 ### `ARRAY_CONTAINS`
 
@@ -452,6 +452,8 @@ MAP(key VARCHAR := value, ...)
 ```
 
 Construct a map from specific key-value tuples.
+
+All values must be [coercible to a common Sql type][1].
 
 ### `MAP_KEYS`
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -2,7 +2,7 @@
 layout: page
 title: ksqlDB Scalar Functions
 tagline:  ksqlDB scalar functions for queries
-description: Scalar functions to use in  ksqlDB statements and queries
+description: Scalar functions to use in ksqlDB statements and queries
 keywords: ksqlDB, function, scalar
 ---
 
@@ -209,10 +209,12 @@ The square root of a value.
 Since: 0.7.0
 
 ```sql
-ARRAY[col1, col2, ...]
+ARRAY[exp1, exp2, ...]
 ```
 
 Construct an array from a variable number of inputs.
+
+All parameters passed to the array function must be [coercible to a common Sql type][1]. 
 
 ### `ARRAY_CONTAINS`
 
@@ -1247,3 +1249,5 @@ present or `url` is not a valid URI.
                                            
 - Input: `http://test.com?a=foo%20bar&b=baz` 
 - Output: `a=foo bar&b=baz`                  
+
+[1]: type-coercion.md#implicit-type-coercion

--- a/docs/developer-guide/ksqldb-reference/type-coercion.md
+++ b/docs/developer-guide/ksqldb-reference/type-coercion.md
@@ -1,0 +1,87 @@
+---
+layout: page
+title: Type Coercion and Casting
+tagline: Converting between ksqlDB types
+description: Understanding implicit and explicit type conversion.
+keywords: ksqldb, coercion, cast, types
+---
+
+ksqlDB supports both implicit and explicit conversion between [Sql types][1]. Explicit conversion
+is supported via the [`CAST` function][2], which supports a super-set of the conversions that 
+ksqlDB will perform using implicit type coercion on your behalf.
+
+## Implicit type coercion
+
+ksqlDB supports implicit type coercion that converts between related types. 
+
+### General rules
+
+* numeric types can be coerced to a wider numeric type. For example, an `INTEGER` expression can
+be coerced to a `BIGINT`, which can be coerced to a `DECIMAL`, which can be coerced to a `DOUBLE`.
+* `ARRAY` types can be coerced to any other `ARRAY` type where the source array's element type can
+be coerced to the target's.
+* `MAP` types can be coerced to any other `MAP` type where both the source map's key and value types
+can be coerced to the target's. 
+* `STRUCT` types can be coerced to any other `STRUCT` type where the types of any field that exists
+in both can be coerced.
+
+For example, given:
+
+```sql
+CREATE STREAM FOO (
+    A INT,
+    B BIGINT
+ ) WITH (...);
+
+SELECT * FROM FOO WHERE A > B; 
+```
+
+...the `A` in the expression `WHERE A > B` will be implicitly coerced to a `BIGINT` to allow the
+comparison with `B`.
+
+### Literal rules 
+
+Literal values support more lax and open coercion rules than other expression types:
+
+* All of the above general rules, plus:
+* any literal can be coerced to a `STRING`.
+* a `STRING` literal containing a number can be coerced to a numeric type wide enough to store the
+number. Where that type is a `DOUBLE` the result be inexact due to rounding.
+* a `STRING` literal containing a boolean value can be coerced to a `BOOLEAN`. Valid boolean values
+are `true`, `false`, `yes`, `no`, or any substring of these values that starts with the first 
+character. For example, `fal`, `y`. Comparison is case-insensitive.
+
+## Expression lists
+
+Where an operator or function takes multiple expressions of the same type, for example, the 
+`ARRAY` or other structured type constructors or the `IN` operator, the above coercion rules are 
+applied to ensure all expressions can be coerced to a common type.
+
+The common type is determined by inspecting each expression in order. If the first non-null element
+is a:
+ * `STRING`: then all other expressions must be coercible to `STRING`.
+ * Numeric: then all other expressions must be coercible to a number. The common type being the numeric
+ type wide enough to hold all numbers found in the list.
+ * `BOOLEAN`: then all other expressions must be coercible to `BOOLEAN`.
+ * `ARRAY`: then all other expressions must be `ARRAY`s and have element types that can be coerced 
+ to a common element type.
+ * `MAP`: then all other expressions must be `MAP`s and have key and value types that can be coerced
+ to a common key and value type. 
+ * `STRUCT`: then all other expressions must be `STRUCT`s. Common field names must have types that 
+ can be coerced to a common type. The common type will be a `STRUCT` with the super set of all 
+ fields.
+ 
+For example, the `IN` operator a single expression to compare to a list of other expressions. All
+expressions must be coercible to a single common type, which is used to perform the comparison: 
+
+```sql
+CREATE STREAM FOO (
+    A INT,
+    B BIGINT
+ ) WITH (...);
+
+SELECT * FROM FOO WHERE A IN [B, 10, '100', '3e2']; 
+```
+
+[1]: ../../concepts/schemas.md#sql-data-types
+[2]: scalar-functions.md#cast

--- a/docs/developer-guide/syntax-reference.md
+++ b/docs/developer-guide/syntax-reference.md
@@ -241,24 +241,11 @@ statement by using the syntax `ARRAY<ElementType>`. For example,
 `ARRAY<INT>` defines an array of integers.
 
 Also, you can output an array from a query by using a SELECT statement.
-The following example creates an array from a stream named `s1`. 
+The following example creates an array from a stream named `s1` using
+the [`ARRAY` constructor function](ksqldb-reference/scalar-functions.md#array).
 
 ```sql
-SELECT ARRAY[1, 2] FROM s1 EMIT CHANGES;
-```
-
-Starting in version 0.7.1, the built-in AS_ARRAY function syntax for
-creating arrays doesn't work. Replace AS_ARRAY with the ARRAY constructor
-syntax. For example, replace this legacy query:
-
-```sql
-CREATE STREAM OUTPUT AS SELECT cube_explode(as_array(col1, col2)) VAL1, ABS(col3) VAL2 FROM TEST;
-```
-
-With this query:
-
-```sql
-CREATE STREAM OUTPUT AS SELECT cube_explode(array[col1, col2]) VAL1, ABS(col3) VAL2 FROM TEST;
+SELECT ARRAY[s1.colA, s1.colB, s1.colC] FROM s1 EMIT CHANGES;
 ```
 
 ### Map

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -268,15 +268,18 @@ public final class DecimalUtil {
   }
 
   public static SqlType fromValue(final BigDecimal value) {
-    final BigDecimal bigDecimalZero = BigDecimal.ZERO;
+    // SqlDecimal does not support negative scale:
+    final BigDecimal decimal = value.scale() < 0
+        ? value.setScale(0, BigDecimal.ROUND_UNNECESSARY)
+        : value;
 
     /* When a BigDecimal has value 0, the built-in method precision() always returns 1. To account
     for this edge case, we just take the scale and add one and use that for the precision instead.
     */
-    if (value.compareTo(bigDecimalZero) == 0) {
-      return SqlTypes.decimal(value.scale() + 1, value.scale());
+    if (decimal.compareTo(BigDecimal.ZERO) == 0) {
+      return SqlTypes.decimal(decimal.scale() + 1, decimal.scale());
     }
-    return SqlTypes.decimal(value.precision(), value.scale());
+    return SqlTypes.decimal(decimal.precision(), Math.max(decimal.scale(), 0));
   }
 
   /**

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
@@ -682,4 +682,12 @@ public class DecimalUtilTest {
         is(SqlTypes.decimal(20, 0))
     );
   }
+
+  @Test
+  public void shouldConvertFromBigDecimalWithNegativeScale() {
+    assertThat(
+        DecimalUtil.fromValue(new BigDecimal("1e3")),
+        is(SqlTypes.decimal(4, 0))
+    );
+  }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -68,6 +68,7 @@ import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
+import io.confluent.ksql.execution.util.CoercionUtil;
 import io.confluent.ksql.execution.util.ExpressionTypeManager;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.GenericsUtil;
@@ -873,11 +874,15 @@ public class SqlToJavaVisitor {
         final CreateArrayExpression exp,
         final Void context
     ) {
+      final List<Expression> expressions = CoercionUtil
+          .coerceUserList(exp.getValues(), expressionTypeManager)
+          .expressions();
+
       final StringBuilder array = new StringBuilder("new ArrayBuilder(");
-      array.append(exp.getValues().size());
+      array.append(expressions.size());
       array.append((')'));
 
-      for (Expression value : exp.getValues()) {
+      for (Expression value : expressions) {
         array.append(".add(");
         array.append(process(value, context).getLeft());
         array.append(")");

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multiset;
+import com.google.common.collect.Streams;
 import io.confluent.ksql.execution.codegen.helpers.ArrayAccess;
 import io.confluent.ksql.execution.codegen.helpers.ArrayBuilder;
 import io.confluent.ksql.execution.codegen.helpers.CastEvaluator;
@@ -100,7 +101,6 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.function.Function;
@@ -111,6 +111,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
+@SuppressWarnings("UnstableApiUsage")
 public class SqlToJavaVisitor {
 
   public static final List<String> JAVA_IMPORTS = ImmutableList.of(
@@ -897,20 +898,24 @@ public class SqlToJavaVisitor {
         final CreateMapExpression exp,
         final Void context
     ) {
-      final StringBuilder map = new StringBuilder("new MapBuilder(");
-      map.append(exp.getMap().size());
-      map.append((')'));
+      final ImmutableMap<Expression, Expression> map = exp.getMap();
+      final List<Expression> keys = CoercionUtil
+          .coerceUserList(map.keySet(), expressionTypeManager)
+          .expressions();
 
-      for (Entry<Expression, Expression> entry: exp.getMap().entrySet()) {
-        map.append(".put(");
-        map.append(process(entry.getKey(), context).getLeft());
-        map.append(", ");
-        map.append(process(entry.getValue(), context).getLeft());
-        map.append(")");
-      }
+      final List<Expression> values = CoercionUtil
+          .coerceUserList(map.values(), expressionTypeManager)
+          .expressions();
+
+      final String entries = Streams.zip(
+          keys.stream(),
+          values.stream(),
+          (k, v) -> ".put(" + process(k, context).getLeft() + ", " + process(v, context).getLeft()
+              + ")"
+      ).collect(Collectors.joining());
 
       return new Pair<>(
-          "((Map)" + map.toString() + ".build())",
+          "((Map)new MapBuilder(" + map.size() + ")" + entries + ".build())",
           expressionTypeManager.getExpressionSqlType(exp));
     }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/InListEvaluator.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/InListEvaluator.java
@@ -102,7 +102,9 @@ public final class InListEvaluator {
             .collect(Collectors.toList()))
         .build();
 
-    final List<Expression> coerced = CoercionUtil.coerceUserList(nonNull, typeManager);
+    final List<Expression> coerced = CoercionUtil
+        .coerceUserList(nonNull, typeManager)
+        .expressions();
 
     return new InPredicate(
         predicate.getLocation(),

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/CoercionUtil.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/CoercionUtil.java
@@ -92,7 +92,7 @@ public final class CoercionUtil {
    * <p>Any non-literal expressions that don't match the common type, but which can be coerced, will
    * be wrapped in an explicit {@code CAST} to convert them to the required type.
    *
-   * <p>Coercion is performed in order. So the type type of the first non-null expression drives the
+   * <p>Coercion is performed in order. So the type of the first non-null expression drives the
    * common type. For example, if the first non-null expression is a string, then all other
    * expressions must be coercible to a string. If its numeric, then all other expressions must be
    * coercible to a number, etc.

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.execution.util;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
@@ -369,50 +370,27 @@ public class ExpressionTypeManager {
         final CreateMapExpression exp,
         final ExpressionTypeContext context
     ) {
-      if (exp.getMap().isEmpty()) {
+      final ImmutableMap<Expression, Expression> map = exp.getMap();
+      if (map.isEmpty()) {
         throw new KsqlException("Map constructor cannot be empty. Please supply at least one key "
             + "value pair (see https://github.com/confluentinc/ksql/issues/4239).");
       }
 
-      final List<SqlType> keyTypes = exp.getMap()
-          .keySet()
-          .stream()
-          .map(key -> {
-            process(key, context);
-            return context.getSqlType();
-          })
-          .collect(Collectors.toList());
+      final SqlType keyType = CoercionUtil
+          .coerceUserList(map.keySet(), ExpressionTypeManager.this)
+          .commonType()
+          .orElseThrow(() -> new KsqlException("Cannot construct a map with all NULL keys "
+              + "(see https://github.com/confluentinc/ksql/issues/4239). As a workaround, you may "
+              + "cast a NULL key to the desired type."));
 
-      if (keyTypes.stream().anyMatch(Objects::isNull)) {
-        throw new KsqlException("Map keys can not be NULL");
-      }
+      final SqlType valueType = CoercionUtil
+          .coerceUserList(map.values(), ExpressionTypeManager.this)
+          .commonType()
+          .orElseThrow(() -> new KsqlException("Cannot construct a map with all NULL values "
+              + "(see https://github.com/confluentinc/ksql/issues/4239). As a workaround, you may "
+              + "cast a NULL value to the desired type."));
 
-      final List<SqlType> valueTypes = exp.getMap()
-          .values()
-          .stream()
-          .map(val -> {
-            process(val, context);
-            return context.getSqlType();
-          })
-          .filter(Objects::nonNull)
-          .distinct()
-          .collect(Collectors.toList());
-
-      if (valueTypes.size() == 0) {
-        throw new KsqlException("Cannot construct a map with all NULL values "
-            + "(see https://github.com/confluentinc/ksql/issues/4239). As a workaround, you may "
-            + "cast a NULL value to the desired type.");
-      }
-
-      if (valueTypes.size() != 1) {
-        throw new KsqlException(
-            String.format(
-                "Cannot construct a map with mismatching value types (%s) from expression %s.",
-                valueTypes,
-                exp));
-      }
-
-      context.setSqlType(SqlMap.of(keyTypes.get(0), valueTypes.get(0)));
+      context.setSqlType(SqlMap.of(keyType, valueType));
       return null;
     }
 

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -432,7 +432,7 @@ public class ExpressionTypeManagerTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Cannot construct an array with mismatching types"));
+        "invalid input syntax for type BIGINT: \"foo\"."));
   }
 
   @Test

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -471,7 +471,7 @@ public class ExpressionTypeManagerTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Cannot construct a map with mismatching value types"));
+        "invalid input syntax for type BIGINT: \"bar\""));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_elements/6.2.0_1605526747071/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_elements/6.2.0_1605526747071/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, A INTEGER, B BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `A` INTEGER, `B` BIGINT",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.ID ID,\n  ARRAY[null, 10, '2e1', TEST.A, TEST.B] L\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `L` ARRAY<DECIMAL(19, 0)>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `A` INTEGER, `B` BIGINT"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "ARRAY[null, 10, '2e1', A, B] AS L" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_elements/6.2.0_1605526747071/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_elements/6.2.0_1605526747071/spec.json
@@ -1,0 +1,97 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1605526747071,
+  "path" : "query-validation-tests/create_array.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `A` INTEGER, `B` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `L` ARRAY<DECIMAL(19, 0)>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "construct a list from compatible mismatching elements",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "a" : 30,
+        "b" : 40
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "L" : [ null, 10, 20, 30, 40 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, a INT, b BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, ARRAY[null, 10, '2e1', a, b] as l FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `L` ARRAY<DECIMAL(19, 0)>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `A` INTEGER, `B` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_elements/6.2.0_1605526747071/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_elements/6.2.0_1605526747071/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_struct_elements/6.2.0_1605534307828/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_struct_elements/6.2.0_1605534307828/plan.json
@@ -1,0 +1,142 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (A INTEGER, B BIGINT) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`A` INTEGER, `B` BIGINT",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT ARRAY[null, STRUCT(X:=TEST.A, Y:=TEST.B), STRUCT(Y:=TEST.A, Z:=TEST.B)] L\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`L` ARRAY<STRUCT<`Y` BIGINT, `Z` BIGINT, `X` INTEGER>>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`A` INTEGER, `B` BIGINT"
+          },
+          "selectExpressions" : [ "ARRAY[null, STRUCT(X:=A, Y:=B), STRUCT(Y:=A, Z:=B)] AS L" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_struct_elements/6.2.0_1605534307828/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_struct_elements/6.2.0_1605534307828/spec.json
@@ -1,0 +1,105 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1605534307828,
+  "path" : "query-validation-tests/create_array.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`A` INTEGER, `B` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`L` ARRAY<STRUCT<`Y` BIGINT, `Z` BIGINT, `X` INTEGER>>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "construct a list from compatible mismatching struct elements",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "a" : 30,
+        "b" : 40
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "L" : [ null, {
+          "X" : 30,
+          "Y" : 40,
+          "Z" : null
+        }, {
+          "X" : null,
+          "Y" : 30,
+          "Z" : 40
+        } ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (a INT, b BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ARRAY[null, struct(x := a, y := b), struct(y := a, z:= b)] as l FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`L` ARRAY<STRUCT<`Y` BIGINT, `Z` BIGINT, `X` INTEGER>>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`A` INTEGER, `B` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_struct_elements/6.2.0_1605534307828/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_array_-_construct_a_list_from_compatible_mismatching_struct_elements/6.2.0_1605534307828/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_cast_null_key/6.2.0_1605533298115/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_cast_null_key/6.2.0_1605533298115/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, K1 STRING, K2 STRING, V1 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `K1` STRING, `K2` STRING, `V1` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.ID ID,\n  MAP(CAST(null AS STRING):=TEST.V1) M\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `M` MAP<STRING, INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `K1` STRING, `K2` STRING, `V1` INTEGER"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "MAP(CAST(null AS STRING):=V1) AS M" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_cast_null_key/6.2.0_1605533298115/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_cast_null_key/6.2.0_1605533298115/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1605533298115,
+  "path" : "query-validation-tests/create_map.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `K1` STRING, `K2` STRING, `V1` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `M` MAP<STRING, INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "create map from named tuples and cast null key",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "k1" : "foo",
+        "k2" : "bar",
+        "v1" : 10
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "M" : {
+          "null" : 10
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, k1 VARCHAR, k2 VARCHAR, v1 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, MAP(CAST(NULL AS STRING) := v1) as M FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `M` MAP<STRING, INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `K1` STRING, `K2` STRING, `V1` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_cast_null_key/6.2.0_1605533298115/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_cast_null_key/6.2.0_1605533298115/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_some_null_key/6.2.0_1605533298097/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_some_null_key/6.2.0_1605533298097/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, K1 STRING, K2 STRING, V1 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `K1` STRING, `K2` STRING, `V1` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.ID ID,\n  MAP(TEST.K1:=TEST.V1, null:=TEST.V1) M\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `M` MAP<STRING, INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `K1` STRING, `K2` STRING, `V1` INTEGER"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "MAP(K1:=V1, null:=V1) AS M" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_some_null_key/6.2.0_1605533298097/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_some_null_key/6.2.0_1605533298097/spec.json
@@ -1,0 +1,101 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1605533298097,
+  "path" : "query-validation-tests/create_map.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `K1` STRING, `K2` STRING, `V1` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `M` MAP<STRING, INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "create map from named tuples and some null key",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "k1" : "foo",
+        "k2" : "bar",
+        "v1" : 10
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "M" : {
+          "foo" : 10,
+          "null" : 10
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, k1 VARCHAR, k2 VARCHAR, v1 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT ID, MAP(k1:=v1, NULL:=v1) as M FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `M` MAP<STRING, INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `K1` STRING, `K2` STRING, `V1` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_some_null_key/6.2.0_1605533298097/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_and_some_null_key/6.2.0_1605533298097/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_compatible_mismatching_types/6.2.0_1605533536984/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_compatible_mismatching_types/6.2.0_1605533536984/plan.json
@@ -1,0 +1,142 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K1 STRING, K2 STRING, V1 BOOLEAN) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K1` STRING, `K2` STRING, `V1` BOOLEAN",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT MAP(TEST.K1:=TEST.V1, TEST.K2:='true', 10:='no') M\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`M` MAP<STRING, BOOLEAN>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`K1` STRING, `K2` STRING, `V1` BOOLEAN"
+          },
+          "selectExpressions" : [ "MAP(K1:=V1, K2:='true', 10:='no') AS M" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_compatible_mismatching_types/6.2.0_1605533536984/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_compatible_mismatching_types/6.2.0_1605533536984/spec.json
@@ -1,0 +1,120 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1605533536984,
+  "path" : "query-validation-tests/create_map.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K1` STRING, `K2` STRING, `V1` BOOLEAN",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`M` MAP<STRING, BOOLEAN>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "create map from named tuples compatible mismatching types",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "k1" : "a",
+        "k2" : "b",
+        "v1" : true
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "k1" : "a",
+        "k2" : "b",
+        "v1" : false
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "M" : {
+          "a" : true,
+          "b" : true,
+          "10" : false
+        }
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "M" : {
+          "a" : false,
+          "b" : true,
+          "10" : false
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (k1 VARCHAR, k2 VARCHAR, v1 BOOLEAN) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT MAP(k1:=v1, k2:='true', 10:='no') as M FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`M` MAP<STRING, BOOLEAN>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`K1` STRING, `K2` STRING, `V1` BOOLEAN",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_compatible_mismatching_types/6.2.0_1605533536984/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/create_map_-_create_map_from_named_tuples_compatible_mismatching_types/6.2.0_1605533536984/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_array_-_valid/6.2.0_1605533873225/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_array_-_valid/6.2.0_1605533873225/plan.json
@@ -1,0 +1,149 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (VAL0 ARRAY<BIGINT>, VAL1 ARRAY<BIGINT>, VAL2 ARRAY<INTEGER>) WITH (FORMAT='JSON', KAFKA_TOPIC='input_topic');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`VAL0` ARRAY<BIGINT>, `VAL1` ARRAY<BIGINT>, `VAL2` ARRAY<INTEGER>",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT INPUT.VAL0 VAL0\nFROM INPUT INPUT\nWHERE (INPUT.VAL0 IN (ARRAY[1, 2], ARRAY[5, 123456789000], ARRAY['3', null], INPUT.VAL1, INPUT.VAL2))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`VAL0` ARRAY<BIGINT>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "input_topic",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "JSON"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "sourceSchema" : "`VAL0` ARRAY<BIGINT>, `VAL1` ARRAY<BIGINT>, `VAL2` ARRAY<INTEGER>"
+            },
+            "filterExpression" : "(VAL0 IN (ARRAY[1, 2], ARRAY[5, 123456789000], ARRAY['3', null], VAL1, VAL2))"
+          },
+          "selectExpressions" : [ "VAL0 AS VAL0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_array_-_valid/6.2.0_1605533873225/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_array_-_valid/6.2.0_1605533873225/spec.json
@@ -1,0 +1,151 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1605533873225,
+  "path" : "query-validation-tests/in.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`VAL0` ARRAY<BIGINT>, `VAL1` ARRAY<BIGINT>, `VAL2` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "JSON"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`VAL0` ARRAY<BIGINT>",
+      "keyFormat" : {
+        "format" : "JSON"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "array - valid",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 1, 2 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 1 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 1, 2, 3 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 3, 4 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 4, 5 ],
+        "VAL1" : [ 4, 5 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 5, 123456789000 ]
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 3, null ]
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 1, 2 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 4, 5 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 5, 123456789000 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL0" : [ 3, null ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (VAL0 ARRAY<BIGINT>, VAL1 ARRAY<BIGINT>, VAL2 ARRAY<INT>) WITH (kafka_topic='input_topic', format='JSON');", "CREATE STREAM OUTPUT AS SELECT VAL0 FROM INPUT WHERE VAL0 IN (ARRAY[1,2],ARRAY[5,123456789000],ARRAY['3',null], VAL1, VAL2);" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL0` ARRAY<BIGINT>, `VAL1` ARRAY<BIGINT>, `VAL2` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL0` ARRAY<BIGINT>",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_array_-_valid/6.2.0_1605533873225/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_array_-_valid/6.2.0_1605533873225/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_map_-_valid/6.2.0_1605533873325/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_map_-_valid/6.2.0_1605533873325/plan.json
@@ -1,0 +1,149 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID MAP<STRING, BIGINT>) WITH (FORMAT='JSON', KAFKA_TOPIC='input_topic');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` MAP<STRING, BIGINT>",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nWHERE (INPUT.ID IN (MAP('a':=1), MAP('b':=5, 'c':=123456789000), MAP('c':=CAST(null AS BIGINT))))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` MAP<STRING, BIGINT>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "input_topic",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "JSON"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "sourceSchema" : "`ID` MAP<STRING, BIGINT>"
+            },
+            "filterExpression" : "(ID IN (MAP('a':=1), MAP('b':=5, 'c':=123456789000), MAP('c':=CAST(null AS BIGINT))))"
+          },
+          "selectExpressions" : [ "ID AS ID" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_map_-_valid/6.2.0_1605533873325/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_map_-_valid/6.2.0_1605533873325/spec.json
@@ -1,0 +1,149 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1605533873325,
+  "path" : "query-validation-tests/in.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` MAP<STRING, BIGINT>",
+      "keyFormat" : {
+        "format" : "JSON"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` MAP<STRING, BIGINT>",
+      "keyFormat" : {
+        "format" : "JSON"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "map - valid",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "ID" : {
+          "a" : 1
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "ID" : {
+          "a" : 1,
+          "b" : 2
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "ID" : { }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "ID" : {
+          "b" : 5,
+          "c" : 123456789000
+        }
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "ID" : {
+          "c" : null
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ID" : {
+          "a" : 1
+        }
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ID" : {
+          "b" : 5,
+          "c" : 123456789000
+        }
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "ID" : {
+          "c" : null
+        }
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID MAP<STRING, BIGINT>) WITH (kafka_topic='input_topic', format='JSON');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT WHERE ID IN (MAP('a':=1), MAP('b':=5,'c':=123456789000), MAP('c':=CAST(null AS BIGINT)));" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` MAP<STRING, BIGINT>",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` MAP<STRING, BIGINT>",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_map_-_valid/6.2.0_1605533873325/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/in_-_map_-_valid/6.2.0_1605533873325/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/create_array.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/create_array.json
@@ -54,14 +54,27 @@
       }
     },
     {
-      "name": "construct a list from mismatching elements",
+      "name": "construct a list from compatible mismatching elements",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, a INT, b BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, ARRAY[null, 10, '2e1', a, b] as l FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"a": 30, "b": 40}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"L": [null, 10, 20, 30, 40]}}
+      ]
+    },
+    {
+      "name": "construct a list from incompatible mismatching elements",
       "statements": [
         "CREATE STREAM TEST (ID STRING KEY, a INT, b INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT ID, ARRAY[1, 1E0] as l FROM TEST;"
+        "CREATE STREAM OUTPUT AS SELECT ID, ARRAY[1, 'not a number'] as l FROM TEST;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Cannot construct an array with mismatching types ([INTEGER, DOUBLE]) from expression ARRAY[1, 1E0]"
+        "message": "invalid input syntax for type INTEGER: \"not a number\""
       }
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/create_array.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/create_array.json
@@ -64,7 +64,12 @@
       ],
       "outputs": [
         {"topic": "OUTPUT", "value": {"L": [null, 10, 20, 30, 40]}}
-      ]
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ID STRING KEY, L ARRAY<DECIMAL(19, 0)>"}
+        ]
+      }
     },
     {
       "name": "construct a list from compatible mismatching struct elements",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/create_array.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/create_array.json
@@ -67,6 +67,19 @@
       ]
     },
     {
+      "name": "construct a list from compatible mismatching struct elements",
+      "statements": [
+        "CREATE STREAM TEST (a INT, b BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ARRAY[null, struct(x := a, y := b), struct(y := a, z:= b)] as l FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"a": 30, "b": 40}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"L": [null, {"X": 30, "Y": 40, "Z": null}, {"X": null, "Y": 30, "Z": 40}]}}
+      ]
+    },
+    {
       "name": "construct a list from incompatible mismatching elements",
       "statements": [
         "CREATE STREAM TEST (ID STRING KEY, a INT, b INT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/create_map.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/create_map.json
@@ -36,14 +36,29 @@
       ]
     },
     {
-      "name": "create map from named tuples mismatching types",
+      "name": "create map from named tuples compatible mismatching types",
+      "statements": [
+        "CREATE STREAM TEST (k1 VARCHAR, k2 VARCHAR, v1 BOOLEAN) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT MAP(k1:=v1, k2:='true', 10:='no') as M FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"k1": "a", "k2": "b", "v1": true}},
+        {"topic": "test_topic", "value": {"k1": "a", "k2": "b", "v1": false}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"M": {"a": true, "b": true, "10": false}}},
+        {"topic": "OUTPUT", "value": {"M": {"a": false, "b": true, "10": false}}}
+      ]
+    },
+    {
+      "name": "create map from named tuples incompatible mismatching types",
       "statements": [
         "CREATE STREAM TEST (ID STRING KEY, k1 VARCHAR, k2 VARCHAR, v1 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT ID, MAP(k1:=v1, k2:='hello') as M FROM TEST;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Cannot construct a map with mismatching value types ([INTEGER, STRING]) from expression MAP(K1:=V1, K2:='hello')."
+        "message": "invalid input syntax for type INTEGER: \"hello\"."
       }
     },
     {
@@ -71,18 +86,31 @@
       ]
     },
     {
-      "name": "create map from named tuples and null key",
+      "name": "create map from named tuples and all null key",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, k1 VARCHAR, k2 VARCHAR, v1 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ID, MAP(null:=v1) as M FROM TEST;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Cannot construct a map with all NULL keys"
+      }
+    },
+    {
+      "name": "create map from named tuples and some null key",
       "statements": [
         "CREATE STREAM TEST (ID STRING KEY, k1 VARCHAR, k2 VARCHAR, v1 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT ID, MAP(k1:=v1, NULL:=v1) as M FROM TEST;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Map keys can not be NULL"
-      }
+      "inputs": [
+        {"topic": "test_topic", "value": {"k1": "foo", "k2": "bar", "v1": 10}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"M": {"foo": 10, "null": 10}}}
+      ]
     },
     {
-      "name": "create map from named tuples and null string key",
+      "name": "create map from named tuples and cast null key",
       "statements": [
         "CREATE STREAM TEST (ID STRING KEY, k1 VARCHAR, k2 VARCHAR, v1 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT ID, MAP(CAST(NULL AS STRING) := v1) as M FROM TEST;"

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/in.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/in.json
@@ -369,16 +369,19 @@
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT WHERE VAL0 IN (true, 10, '10.1', 10.30, VAL1);"
       ],
       "inputs": [
-        {"topic": "input_topic", "value": {"VAL0": "10", "VAL1": null}},
-        {"topic": "input_topic", "value": {}},
-        {"topic": "input_topic", "value": {}},
-        {"topic": "input_topic", "value": {}},
-        {"topic": "input_topic", "value": {}},
-        {"topic": "input_topic", "value": {}},
-        {"topic": "input_topic", "value": {}}
+        {"topic": "input_topic", "value": {"VAL0": "true"}},
+        {"topic": "input_topic", "value": {"VAL0": "10"}},
+        {"topic": "input_topic", "value": {"VAL0": "10.1"}},
+        {"topic": "input_topic", "value": {"VAL0": "10.3"}},
+        {"topic": "input_topic", "value": {"VAL0": "10.30"}},
+        {"topic": "input_topic", "value": {"VAL0": "hello", "VAL1": "hello"}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "value": {"VAL0": "10", "VAL1": null}}
+        {"topic": "OUTPUT", "value": {"VAL0": "true", "VAL1": null}},
+        {"topic": "OUTPUT", "value": {"VAL0": "10", "VAL1": null}},
+        {"topic": "OUTPUT", "value": {"VAL0": "10.1", "VAL1": null}},
+        {"topic": "OUTPUT", "value": {"VAL0": "10.30", "VAL1": null}},
+        {"topic": "OUTPUT", "value": {"VAL0": "hello", "VAL1": "hello"}}
       ]
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/in.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/in.json
@@ -397,10 +397,9 @@
     },
     {
       "name": "array - valid",
-      "comments": "CAST required until https://github.com/confluentinc/ksql/issues/6470 fixed",
       "statements": [
         "CREATE STREAM INPUT (VAL0 ARRAY<BIGINT>, VAL1 ARRAY<BIGINT>, VAL2 ARRAY<INT>) WITH (kafka_topic='input_topic', format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT VAL0 FROM INPUT WHERE VAL0 IN (ARRAY[1,2],ARRAY[CAST(5 AS BIGINT),123456789000],ARRAY['3',null], VAL1, CAST(VAL2 AS ARRAY<BIGINT>));"
+        "CREATE STREAM OUTPUT AS SELECT VAL0 FROM INPUT WHERE VAL0 IN (ARRAY[1,2],ARRAY[5,123456789000],ARRAY['3',null], VAL1, VAL2);"
       ],
       "inputs": [
         {"topic": "input_topic", "value": {"VAL0": [1,2]}},
@@ -483,10 +482,9 @@
     },
     {
       "name": "map - valid",
-      "comments": "CAST required until https://github.com/confluentinc/ksql/issues/6470 fixed",
       "statements": [
         "CREATE STREAM INPUT (ID MAP<STRING, BIGINT>) WITH (kafka_topic='input_topic', format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT WHERE ID IN (MAP('a':=1), MAP('b':=CAST(5 AS BIGINT),'c':=123456789000), MAP('c':=CAST(null AS BIGINT)));"
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT WHERE ID IN (MAP('a':=1), MAP('b':=5,'c':=123456789000), MAP('c':=CAST(null AS BIGINT)));"
       ],
       "inputs": [
         {"topic": "input_topic", "value": {"ID": {"a": 1}}},


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/6470

Also contains a few edge case fixes for the general cast of coercing lists of expressions.

- 1st commit fixes `ARRAY` constructor.
- 2nd commit fixes `MAP` constructor.
- 3rd commit removes now unnecessary casts from `in.json`
- 4th commit adds test covering coercion of array of structs where structs have different fields and field types.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

