### PR TITLE
docs: cherry-pick: use site var for kafka-connect-jdbc version (DOCS-5870)

### DIFF
--- a/docs/tutorials/embedded-connect.md
+++ b/docs/tutorials/embedded-connect.md
@@ -142,7 +142,7 @@ is via [Confluent Hub Client](https://docs.confluent.io/current/connect/managing
 To download the JDBC connector, use the following command, ensuring that the `confluent-hub-components` directory exists first:
 
 ```bash
-confluent-hub install --component-dir confluent-hub-components --no-prompt confluentinc/kafka-connect-jdbc:{{ site.cprelease }}
+confluent-hub install --component-dir confluent-hub-components --no-prompt confluentinc/kafka-connect-jdbc:{{ site.jdbc_connector_version }}
 ```
 This command downloads the JDBC connector into the directory `./confluent-hub-components`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -227,3 +227,4 @@ extra:
         scalaversion: 2.12
         version: 6.0
         voluble_version: 0.3.1
+        jdbc_connector_version: 10.0.0


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/6614 to 0.13.x-ksqldb.