### PR TITLE
docs: bump Scala version to 2.13 (DOCS-5875)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,7 +224,7 @@ extra:
         release: 0.14.0
         cprelease: 6.0.0
         releasepostbranch: 6.0.0-post
-        scalaversion: 2.12
+        scalaversion: 2.13
         version: 6.0
         voluble_version: 0.3.1
         jdbc_connector_version: 10.0.0


### PR DESCRIPTION
To be consistent with conf.py in the CP docs repo.