### PR TITLE
chore: support complex key pull queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericExpressionResolver.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericExpressionResolver.java
@@ -40,7 +40,11 @@ import java.util.function.Supplier;
  * Builds a Java object, coerced to the desired type, from an arbitrary SQL
  * expression that does not reference any source data.
  */
-class GenericExpressionResolver {
+public class GenericExpressionResolver {
+
+  // GenericExpressionResolver doesn't accept any column references, so we don't
+  // actually need the schema, but the CodeGenRunner expects on to be passed in
+  private static final LogicalSchema NO_COLUMNS = LogicalSchema.builder().build();
 
   private static final Supplier<String> IGNORED_MSG = () -> "";
   private static final ProcessingLogger THROWING_LOGGER = errorMessage -> {
@@ -49,21 +53,18 @@ class GenericExpressionResolver {
 
   private final SqlType fieldType;
   private final ColumnName fieldName;
-  private final LogicalSchema schema;
   private final SqlValueCoercer sqlValueCoercer = DefaultSqlValueCoercer.STRICT;
   private final FunctionRegistry functionRegistry;
   private final KsqlConfig config;
 
-  GenericExpressionResolver(
+  public GenericExpressionResolver(
       final SqlType fieldType,
       final ColumnName fieldName,
-      final LogicalSchema schema,
       final FunctionRegistry functionRegistry,
       final KsqlConfig config
   ) {
     this.fieldType = Objects.requireNonNull(fieldType, "fieldType");
     this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
-    this.schema = Objects.requireNonNull(schema, "schema");
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
     this.config = Objects.requireNonNull(config, "config");
   }
@@ -80,7 +81,7 @@ class GenericExpressionResolver {
           CodeGenRunner.compileExpression(
               expression,
               "insert value",
-              schema,
+              NO_COLUMNS,
               config,
               functionRegistry
           );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
@@ -145,7 +145,6 @@ public class GenericRecordFactory {
       final Object value = new GenericExpressionResolver(
           columnType,
           column,
-          schema,
           functionRegistry,
           config
       ).resolve(valueExp);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
@@ -146,8 +146,8 @@ public class GenericRecordFactory {
           columnType,
           column,
           functionRegistry,
-          config
-      ).resolve(valueExp);
+          config,
+          "insert value").resolve(valueExp);
 
       values.put(column, value);
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
@@ -222,7 +222,7 @@ public class PullPhysicalPlanBuilder {
   }
 
   private SelectOperator translateFilterNode(final FilterNode logicalNode) {
-    whereInfo = WhereInfo.extractWhereInfo(analysis, persistentQueryMetadata);
+    whereInfo = WhereInfo.extractWhereInfo(analysis, persistentQueryMetadata, metaStore, config);
     return new SelectOperator(logicalNode);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
-import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.analyzer.PullQueryValidator;
 import io.confluent.ksql.engine.generic.GenericExpressionResolver;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
@@ -22,8 +22,10 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
+import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.analyzer.PullQueryValidator;
+import io.confluent.ksql.engine.generic.GenericExpressionResolver;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -35,6 +37,7 @@ import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
@@ -42,6 +45,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.GrammaticalJoiner;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.timestamp.PartialStringToTimestampParser;
@@ -91,7 +95,9 @@ public final class WhereInfo {
 
   public static WhereInfo extractWhereInfo(
       final ImmutableAnalysis analysis,
-      final PersistentQueryMetadata query
+      final PersistentQueryMetadata query,
+      final MetaStore metaStore,
+      final KsqlConfig config
   ) {
     final boolean windowed = query.getResultTopic().getKeyFormat().isWindowed();
 
@@ -110,9 +116,21 @@ public final class WhereInfo {
     final List<Object> keys;
     if (keyComparison.size() > 0) {
       keys = ImmutableList.of(
-          extractKeyWhereClause(keyComparison, windowed, query.getLogicalSchema()));
+          extractKeyWhereClause(
+              keyComparison,
+              windowed,
+              query.getLogicalSchema(),
+              metaStore,
+              config)
+      );
     } else {
-      keys = extractKeysFromInPredicate(inPredicate, windowed, query.getLogicalSchema());
+      keys = extractKeysFromInPredicate(
+          inPredicate,
+          windowed,
+          query.getLogicalSchema(),
+          metaStore,
+          config
+      );
     }
 
     if (!windowed) {
@@ -170,51 +188,75 @@ public final class WhereInfo {
   private static List<Object> extractKeysFromInPredicate(
       final List<InPredicate> inPredicates,
       final boolean windowed,
-      final LogicalSchema schema
+      final LogicalSchema schema,
+      final MetaStore metaStore,
+      final KsqlConfig config
   ) {
-    final InPredicate inPredicate = Iterables.getOnlyElement(inPredicates);
-    final List<Object> result = new ArrayList<>();
-    for (Expression expression : inPredicate.getValueList().getValues()) {
-      if (!(expression instanceof Literal)) {
-        throw new KsqlException("Only comparison to literals is currently supported: "
-                                    + inPredicate);
-      }
-      if (expression instanceof NullLiteral) {
-        throw new KsqlException("Primary key columns can not be NULL: " + inPredicate);
-      }
-      final Object value = ((Literal) expression).getValue();
-      result.add(coerceKey(schema, value, windowed));
+    final InPredicate inPredicate = Iterables.getLast(inPredicates);
+    if (schema.key().size() != 1) {
+      throw invalidWhereClauseException("Only single KEY column supported", windowed);
     }
-    return result;
+
+    final Column keyColumn = schema.key().get(0);
+    return inPredicate.getValueList()
+        .getValues()
+        .stream()
+        .map(expression -> resolveKey(expression, keyColumn, metaStore, config, inPredicate))
+        .collect(Collectors.toList());
   }
 
   private static Object extractKeyWhereClause(
       final List<ComparisonExpression> comparisons,
       final boolean windowed,
-      final LogicalSchema schema
+      final LogicalSchema schema,
+      final MetaStore metaStore,
+      final KsqlConfig config
   ) {
-    if (comparisons.size() != 1) {
-      throw invalidWhereClauseException("Multiple bounds on key column", windowed);
-    }
-
-    final ComparisonExpression comparison = comparisons.get(0);
+    final ComparisonExpression comparison = Iterables.getLast(comparisons);
     if (comparison.getType() != Type.EQUAL) {
       final ColumnName keyColumn = Iterables.getOnlyElement(schema.key()).name();
       throw invalidWhereClauseException("Bound on '" + keyColumn.text()
-                                            + "' must currently be '='", windowed);
+          + "' must currently be '='", windowed);
     }
 
     final Expression other = getNonColumnRefSide(comparison);
-    if (!(other instanceof Literal)) {
-      throw new KsqlException("Ony comparison to literals is currently supported: " + comparison);
+    final Column keyColumn = schema.key().get(0);
+    return resolveKey(other, keyColumn, metaStore, config, comparison);
+  }
+
+
+  private static Object resolveKey(
+      final Expression exp,
+      final Column keyColumn,
+      final MetaStore metaStore,
+      final KsqlConfig config,
+      final Expression errorMessageHint
+  ) {
+    final Object obj;
+    if (exp instanceof NullLiteral) {
+      obj = null;
+    } else if (exp instanceof Literal) {
+      // skip the GenericExpressionResolver because this is
+      // a critical code path executed once-per-query
+      obj = ((Literal) exp).getValue();
+    } else {
+      obj = new GenericExpressionResolver(
+          keyColumn.type(),
+          keyColumn.name(),
+          metaStore,
+          config,
+          "pull query"
+      ).resolve(exp);
     }
 
-    if (other instanceof NullLiteral) {
-      throw new KsqlException("Primary key columns can not be NULL: " + comparison);
+    if (obj == null) {
+      throw new KsqlException("Primary key columns can not be NULL: " + errorMessageHint);
     }
 
-    final Object right = ((Literal) other).getValue();
-    return coerceKey(schema, right, windowed);
+    return DefaultSqlValueCoercer.STRICT.coerce(obj, keyColumn.type())
+        .orElseThrow(() -> new KsqlException("'" + obj + "' can not be converted "
+            + "to the type of the key column: " + keyColumn.toString(FormatOptions.noEscape())))
+        .orElse(null);
   }
 
   private enum ComparisonTarget {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/generic/GenericExpressionResolverTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/generic/GenericExpressionResolverTest.java
@@ -1,0 +1,94 @@
+package io.confluent.ksql.engine.generic;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
+import io.confluent.ksql.execution.expression.tree.NullLiteral;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.function.TestFunctionRegistry;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * NOTE: most of the funcitonal test coverage is in DefaultSqlValueCoercerTest
+ * or ExpressionMetadataTest, this test class just covers the functionality
+ * in the GenericExpressionResolver
+ */
+public class GenericExpressionResolverTest {
+
+  private static final ColumnName FIELD_NAME = ColumnName.of("FOO");
+
+  private final FunctionRegistry registry = TestFunctionRegistry.INSTANCE.get();
+  private final KsqlConfig config = new KsqlConfig(ImmutableMap.of());
+
+  @Test
+  public void shouldResolveArbitraryExpressions() {
+    // Given:
+    final SqlType type = SqlTypes.struct().field("FOO", SqlTypes.STRING).build();
+    final Expression exp = new CreateStructExpression(ImmutableList.of(
+        new Field("FOO", new FunctionCall(
+            FunctionName.of("CONCAT"),
+            ImmutableList.of(
+                new StringLiteral("bar"),
+                new StringLiteral("baz"))
+        ))
+    ));
+
+    // When:
+    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config).resolve(exp);
+
+    // Then:
+    assertThat(o, is(new Struct(
+        SchemaBuilder.struct().field("FOO", Schema.OPTIONAL_STRING_SCHEMA).optional().build()
+    ).put("FOO", "barbaz")));
+  }
+
+  @Test
+  public void shouldResolveNullLiteral() {
+    // Given:
+    final SqlType type = SqlTypes.STRING;
+    final Expression exp = new NullLiteral();
+
+    // When:
+    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config).resolve(exp);
+
+    // Then:
+    assertThat(o, Matchers.nullValue());
+  }
+
+  @Test
+  public void shouldThrowIfCannotCoerce() {
+    // Given:
+    final SqlType type = SqlTypes.array(SqlTypes.INTEGER);
+    final Expression exp = new IntegerLiteral(1);
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> new GenericExpressionResolver(type, FIELD_NAME, registry, config).resolve(exp));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Expected type ARRAY<INTEGER> for field `FOO` but got INTEGER(1)"));
+  }
+
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/generic/GenericExpressionResolverTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/generic/GenericExpressionResolverTest.java
@@ -54,7 +54,7 @@ public class GenericExpressionResolverTest {
     ));
 
     // When:
-    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config).resolve(exp);
+    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value").resolve(exp);
 
     // Then:
     assertThat(o, is(new Struct(
@@ -69,7 +69,7 @@ public class GenericExpressionResolverTest {
     final Expression exp = new NullLiteral();
 
     // When:
-    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config).resolve(exp);
+    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value").resolve(exp);
 
     // Then:
     assertThat(o, Matchers.nullValue());
@@ -84,7 +84,7 @@ public class GenericExpressionResolverTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new GenericExpressionResolver(type, FIELD_NAME, registry, config).resolve(exp));
+        () -> new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value").resolve(exp));
 
     // Then:
     assertThat(e.getMessage(), containsString("Expected type ARRAY<INTEGER> for field `FOO` but got INTEGER(1)"));

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1918,7 +1918,7 @@
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
-        "SELECT * FROM AGGREGATE WHERE ID IN (COUNT + 1);"
+        "SELECT * FROM AGGREGATE WHERE ID IN (2, COUNT + 1, 3);"
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1914,6 +1914,19 @@
       }
     },
     {
+      "name": "IN: fail on column reference key",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID IN (COUNT + 1);"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Unsupported column reference in pull query: (COUNT + 1)",
+        "status": 400
+      }
+    },
+    {
       "name": "non-windowed - function in where clause",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1216,19 +1216,6 @@
       }
     },
     {
-      "name": "fail on non-literal key",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
-        "SELECT * FROM AGGREGATE WHERE ID=CAST(1 AS INT);"
-      ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Ony comparison to literals is currently supported: (ID = CAST(1 AS INTEGER))",
-        "status": 400
-      }
-    },
-    {
       "name": "on stream",
       "statements": [
         "CREATE STREAM S1 (ID INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -1927,17 +1914,90 @@
       }
     },
     {
-      "name": "IN: fail on non-literal key",
+      "name": "non-windowed - function in where clause",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT ID, COUNT, ROWTIME FROM AGGREGATE WHERE ID=CONCAT('1','0');"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `COUNT` BIGINT, `ROWTIME` BIGINT"}},
+          {"row":{"columns":["10", 1, 12365]}}
+        ]}
+      ]
+    },
+    {
+      "name": "non-windowed - array keys",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (ID ARRAY<STRING> KEY, IGNORED INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT ID, COUNT, ROWTIME FROM AGGREGATE WHERE ID=ARRAY['1','0'];"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": ["1", "1"], "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": ["1", "0"], "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` ARRAY<STRING> KEY, `COUNT` BIGINT, `ROWTIME` BIGINT"}},
+          {"row":{"columns":[["1", "0"], 1, 12365]}}
+        ]}
+      ]
+    },
+    {
+      "name": "non-windowed - struct keys",
+      "properties": {
+        "ksql.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (ID STRUCT<f1 STRING, f2 STRING> KEY, IGNORED INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT ID, COUNT, ROWTIME FROM AGGREGATE WHERE ID=STRUCT(F1:='1',F2:='0');"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": {"F1": "1", "F2": "1"}, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": {"F1": "1", "F2": "0"}, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRUCT<`F1` STRING, `F2` STRING> KEY, `COUNT` BIGINT, `ROWTIME` BIGINT"}},
+          {"row":{"columns":[{"F1": "1", "F2": "0"}, 1, 12365]}}
+        ]}
+      ]
+    },
+    {
+      "name": "IN: support non-literal key",
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
-        "SELECT * FROM AGGREGATE WHERE ID IN (CAST(1 AS INTEGER));"
+        "SELECT * FROM AGGREGATE WHERE ID IN (CAST(10 AS INTEGER));"
       ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Only comparison to literals is currently supported: (ID IN (CAST(1 AS INTEGER)))",
-        "status": 400
-      }
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 10, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 1]}}
+        ]}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

fixes #6602 

Supports key-lookups for keys that are not just literals. This is necessary for the generic key work being done because we will expose keys that are not just primitives, but can also be arrays and structs.

Note that maps are not tested because of #6621, we may consider just prohibiting maps from being keys altogether. I will port this over after #6375 is merged.

### Testing done 

- new unit tests
- new RQTT tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

