### PR TITLE
fix: KeyQueryMetadata not available on Pull query after stream is created

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/LocalProperties.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/LocalProperties.java
@@ -77,6 +77,25 @@ public class LocalProperties {
   }
 
   /**
+   * Get a property value.
+   *
+   * @param property the name of the property
+   * @return the current value for the property, or {@code defaultValue} if it was not set.
+   */
+  public Integer getInt(final String property, final Integer defaultValue) {
+    final Object val = props.get(property);
+    if (val == null) {
+      return defaultValue;
+    }
+
+    if (val instanceof String) {
+      return Integer.valueOf((String) val);
+    }
+
+    return (Integer) val;
+  }
+
+  /**
    * @return an immutable Map of the currently set properties.
    */
   public Map<String, Object> toMap() {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -366,6 +366,18 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_VARIABLE_SUBSTITUTION_ENABLE_DOC
       = "Enable variable substitution on SQL statements.";
 
+  public static final String KSQL_RETRIABLE_REQUESTS_MAX_RETRIES
+      = "ksql.retriable.requests.max.retries";
+  public static final int KSQL_RETRIABLE_REQUESTS_MAX_RETRIES_DEFAULT = 10;
+  private static final String KSQL_RETRIABLE_REQUESTS_MAX_RETRIES_DOC = "Maximum number of "
+      + "attempts to execute from client requests before failing a retriable statement.";
+
+  public static final String KSQL_RETRIABLE_REQUESTS_SLEEP_MS
+      = "ksql.retriable.requests.sleep.ms";
+  public static final int KSQL_RETRIABLE_REQUESTS_SLEEP_MS_DEFAULT = 1000;
+  private static final String KSQL_RETRIABLE_REQUESTS_SLEEP_MS_DOC = "Time (in milliseconds) to "
+      + "wait before retry a failed retriable statement.";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -841,6 +853,20 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_VARIABLE_SUBSTITUTION_ENABLE_DEFAULT,
             Importance.LOW,
             KSQL_VARIABLE_SUBSTITUTION_ENABLE_DOC
+        )
+        .define(
+            KSQL_RETRIABLE_REQUESTS_MAX_RETRIES,
+            Type.INT,
+            KSQL_RETRIABLE_REQUESTS_MAX_RETRIES_DEFAULT,
+            Importance.LOW,
+            KSQL_RETRIABLE_REQUESTS_MAX_RETRIES_DOC
+        )
+        .define(
+            KSQL_RETRIABLE_REQUESTS_SLEEP_MS,
+            Type.INT,
+            KSQL_RETRIABLE_REQUESTS_SLEEP_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_RETRIABLE_REQUESTS_SLEEP_MS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/ResourceUnavailableException.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/ResourceUnavailableException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+public class ResourceUnavailableException extends RuntimeException {
+  public ResourceUnavailableException(final Exception e) {
+    super(e);
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/LocalPropertiesTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/LocalPropertiesTest.java
@@ -131,6 +131,21 @@ public class LocalPropertiesTest {
   }
 
   @Test
+  public void shouldGetIntegerValue() {
+    // Given:
+    when(parser.parse("millis", "1")).thenReturn("1");
+    propsWithMockParser.set("millis", "1");
+
+    // When/Then
+    assertThat(propsWithMockParser.getInt("millis", 0), is(1));
+  }
+
+  @Test
+  public void shouldGetDefaultIntegerValue() {
+    assertThat(propsWithMockParser.getInt("not-found", 5), is(5));
+  }
+
+  @Test
   public void shouldSetNewValue() {
     // When:
     final Object oldValue = propsWithMockParser.set("new-prop", "new-val");

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -103,6 +103,7 @@ import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.ResourceUnavailableException;
 import io.confluent.ksql.util.timestamp.PartialStringToTimestampParser;
 import java.time.Duration;
 import java.time.Instant;
@@ -447,9 +448,11 @@ public final class PullQueryExecutor {
     for (KsqlPartitionLocation location : locations) {
       // If one of the partitions required is out of nodes, then we cannot continue.
       if (round >= location.getNodes().size()) {
-        throw new MaterializationException(String.format(
+        throw new ResourceUnavailableException(
+            new MaterializationException(String.format(
             "Unable to execute pull query: %s. Exhausted standby hosts to try.",
-            statement.getStatementText()));
+            statement.getStatementText()))
+        );
       }
       final KsqlNode nextHost = location.getNodes().get(round);
       groupedByHost.computeIfAbsent(nextHost, h -> new ArrayList<>()).add(location);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
@@ -68,6 +68,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
+import io.confluent.ksql.util.ResourceUnavailableException;
 import org.apache.kafka.common.utils.Time;
 import org.junit.Before;
 import org.junit.Rule;
@@ -287,7 +289,7 @@ public class PullQueryExecutorTest {
       List<List<KsqlPartitionLocation>> locationsQueried = new ArrayList<>();
 
       final Exception e = assertThrows(
-          MaterializationException.class,
+          ResourceUnavailableException.class,
           () -> PullQueryExecutor.handlePullQuery(
               statement, executionContext, serviceContext, routingOptions, (l) -> {
                 locationsQueried.add(l);

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
@@ -66,6 +66,9 @@ public final class Errors {
   public static final int ERROR_CODE_SERVER_SHUTTING_DOWN =
       toErrorCode(SERVICE_UNAVAILABLE.code()) + 3;
 
+  public static final int ERROR_CODE_RESOURCE_NOT_READY =
+      toErrorCode(SERVICE_UNAVAILABLE.code()) + 4;
+
   public static final int ERROR_CODE_SERVER_ERROR =
       toErrorCode(INTERNAL_SERVER_ERROR.code());
   
@@ -142,6 +145,17 @@ public final class Errors {
         .status(BAD_REQUEST.code())
         .entity(new KsqlStatementErrorMessage(
             ERROR_CODE_BAD_STATEMENT, t, statementText, entities))
+        .build();
+  }
+
+  public static EndpointResponse resourceNotReady(
+      final String msg,
+      final String statementText
+  ) {
+    return EndpointResponse.create()
+        .status(SERVICE_UNAVAILABLE.code())
+        .entity(new KsqlStatementErrorMessage(
+            ERROR_CODE_RESOURCE_NOT_READY, msg, statementText, new KsqlEntityList()))
         .build();
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.execution.streams.RoutingOptions;
 import io.confluent.ksql.execution.streams.materialization.Locator;
 import io.confluent.ksql.execution.streams.materialization.MaterializationException;
 import io.confluent.ksql.util.KsqlHostInfo;
+import io.confluent.ksql.util.ResourceUnavailableException;
 import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
@@ -91,8 +92,11 @@ final class KsLocator implements Locator {
       if (metadata == KeyQueryMetadata.NOT_AVAILABLE) {
         LOG.debug("KeyQueryMetadata not available for state store {} and key {}",
             stateStoreName, key);
-        throw new MaterializationException(String.format(
-            "KeyQueryMetadata not available for state store %s and key %s", stateStoreName, key));
+
+        throw new ResourceUnavailableException(
+            new MaterializationException(String.format(
+            "KeyQueryMetadata not available for state store %s and key %s", stateStoreName, key))
+        );
       }
 
       LOG.debug("Handling pull query for key {} in partition {} of state store {}.",

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -45,6 +45,8 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import io.confluent.ksql.util.ResourceUnavailableException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -158,7 +160,7 @@ public class KsLocatorTest {
 
     // When:
     final Exception e = assertThrows(
-        MaterializationException.class,
+        ResourceUnavailableException.class,
         () -> locator.locate(ImmutableList.of(SOME_KEY), routingOptions, routingFilterFactoryActive)
     );
 


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/6249

A KeyQueryMetadata.NOT_AVAILABLE is usually caused when resources (hosts/streams) are not ready to access the state store. You can see this error when executing a pull query right after the stream is created. It takes some time for the streams to create the materialization in all the hosts.

To fix this issue, the clients must retry the pull query after some time in order to access the state store. This PR allows clients to retry requests that are marked as `ERROR_CODE_RESOURCE_NOT_READY` for a maximum number of retries and for some waiting time between retries.

By default, a request will wait for 500ms between retries and up to 10 retries. Users can configure this with the following config:
```
ksql> set 'ksql.retriable.requests.max.retries'='5';
ksql> set 'ksql.retriable.requests.sleep.ms'='1000';
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

