### PR TITLE
chore: suppress deprecation UncaughtExceptionHandler

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -76,6 +76,7 @@ public abstract class QueryMetadata {
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   @VisibleForTesting
+  @SuppressWarnings("deprecation") // https://github.com/confluentinc/ksql/issues/6639
   QueryMetadata(
       final String statementString,
       final LogicalSchema logicalSchema,
@@ -183,6 +184,7 @@ public abstract class QueryMetadata {
     return statementString;
   }
 
+  @SuppressWarnings("deprecation") // https://github.com/confluentinc/ksql/issues/6639
   public void setUncaughtExceptionHandler(final UncaughtExceptionHandler handler) {
     this.uncaughtExceptionHandler = handler;
     kafkaStreams.setUncaughtExceptionHandler(handler);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -133,6 +133,7 @@ public class PersistentQueryMetadataTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // https://github.com/confluentinc/ksql/issues/6639
   public void shouldRestartKafkaStreams() {
     final KafkaStreams newKafkaStreams = mock(KafkaStreams.class);
     final MaterializationProvider newMaterializationProvider = mock(MaterializationProvider.class);
@@ -148,7 +149,8 @@ public class PersistentQueryMetadataTest {
     // Then:
     final InOrder inOrder = inOrder(kafkaStreams, newKafkaStreams);
     inOrder.verify(kafkaStreams).close(any());
-    inOrder.verify(newKafkaStreams).setUncaughtExceptionHandler(any());
+    inOrder.verify(newKafkaStreams).setUncaughtExceptionHandler(
+        any(Thread.UncaughtExceptionHandler.class));
     inOrder.verify(newKafkaStreams).start();
 
     assertThat(query.getKafkaStreams(), is(newKafkaStreams));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -121,6 +121,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("deprecation") // https://github.com/confluentinc/ksql/issues/6639
 public class StreamedQueryResourceTest {
 
   private static final Duration DISCONNECT_CHECK_INTERVAL = Duration.ofMillis(1000);
@@ -568,7 +569,7 @@ public class StreamedQueryResourceTest {
     // Definitely want to make sure that the Kafka Streams instance has been closed and cleaned up
     verify(mockKafkaStreams).start();
     // called on init and when setting uncaught exception handler manually
-    verify(mockKafkaStreams, times(2)).setUncaughtExceptionHandler(any());
+    verify(mockKafkaStreams, times(2)).setUncaughtExceptionHandler(any(Thread.UncaughtExceptionHandler.class));
     verify(mockKafkaStreams).cleanUp();
     verify(mockKafkaStreams).close(Duration.ofMillis(closeTimeout));
 


### PR DESCRIPTION
### Description 

Fixes the build. Streams is not yet ready for migrating to the new API, but since we're building off master we're picking up this deprecation. AK might revert the `@Deprecated` for this method and we can revert this PR after that build is picked up in kafka-ccs.

https://github.com/confluentinc/ksql/issues/6639 tracks reverting it

### Testing done 

Built it

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

