### PR TITLE
chore: emit metrics with ksql.service.id in metrics tag

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -41,6 +41,8 @@ public final class KsqlConstants {
   public static final String DOT = ".";
   public static final String STRUCT_FIELD_REF = "->";
 
+  public static final String KSQL_SERVICE_ID_METRICS_TAG = "ksql_service_id";
+
   public enum KsqlQueryType {
     PERSISTENT,
     PUSH

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/ReservedInternalTopics.java
@@ -29,7 +29,8 @@ public final class ReservedInternalTopics {
 
   // These constant should not be part of KsqlConfig.SYSTEM_INTERNAL_TOPICS_CONFIG because they're
   // not configurable.
-  public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
+  public static final String CONFLUENT_PREFIX = "_confluent-";
+  public static final String KSQL_INTERNAL_TOPIC_PREFIX = CONFLUENT_PREFIX + "ksql-";
   public static final String KSQL_COMMAND_TOPIC_SUFFIX = "command_topic";
   public static final String KSQL_CONFIGS_TOPIC_SUFFIX = "configs";
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -25,7 +25,6 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -101,9 +100,10 @@ public class KsqlEngineMetrics implements Closeable {
     this.metricGroupName = metricGroupPrefix + METRIC_GROUP_POST_FIX;
     this.customMetricsTags = customMetricsTags;
 
-    final Map<String, String> metricsTags = new HashMap<>(customMetricsTags);
-    metricsTags.put(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlEngine.getServiceId());
-    this.newCustomMetricsTags = ImmutableMap.copyOf(metricsTags);
+    this.newCustomMetricsTags = ImmutableMap.<String, String>builder()
+        .putAll(customMetricsTags)
+        .put(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlEngine.getServiceId())
+        .build();
     this.metricsExtension = metricsExtension;
 
     this.metrics = metrics;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -15,15 +15,17 @@
 
 package io.confluent.ksql.internal;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,8 +61,10 @@ public class KsqlEngineMetrics implements Closeable {
   private final Sensor messageConsumptionByQuery;
   private final Sensor errorRate;
 
-  private final String ksqlServiceId;
+  private final String ksqlServiceIdLegacyPrefix;
+  private final String ksqlServicePrefix;
   private final Map<String, String> customMetricsTags;
+  private final Map<String, String> newCustomMetricsTags;
   private final Optional<KsqlMetricsExtension> metricsExtension;
 
   private final KsqlEngine ksqlEngine;
@@ -88,13 +92,18 @@ public class KsqlEngineMetrics implements Closeable {
       final Optional<KsqlMetricsExtension> metricsExtension
   ) {
     this.ksqlEngine = ksqlEngine;
-    this.ksqlServiceId = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
+    this.ksqlServiceIdLegacyPrefix = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
         + ksqlEngine.getServiceId();
+    this.ksqlServicePrefix = ReservedInternalTopics.CONFLUENT_PREFIX;
     this.sensors = new ArrayList<>();
     this.countMetrics = new ArrayList<>();
     this.metricGroupPrefix = Objects.requireNonNull(metricGroupPrefix, "metricGroupPrefix");
     this.metricGroupName = metricGroupPrefix + METRIC_GROUP_POST_FIX;
     this.customMetricsTags = customMetricsTags;
+
+    final Map<String, String> metricsTags = new HashMap<>(customMetricsTags);
+    metricsTags.put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, ksqlEngine.getServiceId());
+    this.newCustomMetricsTags = ImmutableMap.copyOf(metricsTags);
     this.metricsExtension = metricsExtension;
 
     this.metrics = metrics;
@@ -298,15 +307,19 @@ public class KsqlEngineMetrics implements Closeable {
       final KsqlMetric metric) {
     // legacy
     sensor.add(
-        metrics.metricName(ksqlServiceId + metric.name(), metricGroupName, metric.description()),
+        metrics.metricName(
+            metric.name(),
+            ksqlServiceIdLegacyPrefix + metricGroupName,
+            metric.description(),
+            customMetricsTags),
         metric.statSupplier().get());
-    // new
+    // new metrics with service id in tag
     sensor.add(
         metrics.metricName(
             metric.name(),
-            ksqlServiceId + metricGroupName,
+            ksqlServicePrefix + metricGroupName,
             metric.description(),
-            customMetricsTags),
+            newCustomMetricsTags),
         metric.statSupplier().get());
   }
 
@@ -346,16 +359,16 @@ public class KsqlEngineMetrics implements Closeable {
     final String name = state + "-queries";
     // legacy
     configureGaugeForState(
-        ksqlServiceId + metricGroupName + "-" + name,
-        metricGroupName,
-        Collections.emptyMap(),
+        name,
+        ksqlServiceIdLegacyPrefix + metricGroupName,
+        customMetricsTags,
         state
     );
-    // new
+    // new metrics with service id in tag
     configureGaugeForState(
         name,
-        ksqlServiceId + metricGroupName,
-        customMetricsTags,
+        ksqlServicePrefix + metricGroupName,
+        newCustomMetricsTags,
         state
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.internal;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.io.Closeable;
@@ -102,7 +102,7 @@ public class KsqlEngineMetrics implements Closeable {
     this.customMetricsTags = customMetricsTags;
 
     final Map<String, String> metricsTags = new HashMap<>(customMetricsTags);
-    metricsTags.put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, ksqlEngine.getServiceId());
+    metricsTags.put(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlEngine.getServiceId());
     this.newCustomMetricsTags = ImmutableMap.copyOf(metricsTags);
     this.metricsExtension = metricsExtension;
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -31,7 +31,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.ConsumerCollector;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.metrics.ProducerCollector;
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.ReservedInternalTopics;
@@ -74,7 +74,7 @@ public class KsqlEngineMetricsTest {
   private static final Map<String, String> CUSTOM_TAGS_WITH_SERVICE_ID = ImmutableMap.of(
       "tag1", "value1",
           "tag2", "value2",
-          KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID);
+          KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, KSQL_SERVICE_ID);
 
   @Mock
   private KsqlEngine ksqlEngine;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.ConsumerCollector;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.metrics.ProducerCollector;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.ReservedInternalTopics;
@@ -66,9 +67,14 @@ public class KsqlEngineMetricsTest {
   private static final String METRIC_GROUP = "testGroup";
   private KsqlEngineMetrics engineMetrics;
   private static final String KSQL_SERVICE_ID = "test-ksql-service-id";
-  private static final String metricNamePrefix = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
+  private static final String legacyMetricNamePrefix = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
       + KSQL_SERVICE_ID;
+  private static final String metricNamePrefix = ReservedInternalTopics.CONFLUENT_PREFIX;
   private static final Map<String, String> CUSTOM_TAGS = ImmutableMap.of("tag1", "value1", "tag2", "value2");
+  private static final Map<String, String> CUSTOM_TAGS_WITH_SERVICE_ID = ImmutableMap.of(
+      "tag1", "value1",
+          "tag2", "value2",
+          KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID);
 
   @Mock
   private KsqlEngine ksqlEngine;
@@ -130,7 +136,7 @@ public class KsqlEngineMetricsTest {
         .then(returnQueriesInState(3, State.CREATED));
 
     final long value = getLongMetricValue("CREATED-queries");
-    final long legacyValue = getLongMetricValueLegacy("testGroup-query-stats-CREATED-queries");
+    final long legacyValue = getLongMetricValueLegacy("CREATED-queries");
 
     assertThat(value, equalTo(3L));
     assertThat(legacyValue, equalTo(3L));
@@ -142,7 +148,7 @@ public class KsqlEngineMetricsTest {
         .then(returnQueriesInState(3, State.RUNNING));
 
     final long value = getLongMetricValue("RUNNING-queries");
-    final long legacyValue = getLongMetricValueLegacy("testGroup-query-stats-RUNNING-queries");
+    final long legacyValue = getLongMetricValueLegacy("RUNNING-queries");
 
     assertThat(value, equalTo(3L));
     assertThat(legacyValue, equalTo(3L));
@@ -154,7 +160,7 @@ public class KsqlEngineMetricsTest {
         .then(returnQueriesInState(3, State.REBALANCING));
 
     final long value = getLongMetricValue("REBALANCING-queries");
-    final long legacyValue = getLongMetricValueLegacy("testGroup-query-stats-REBALANCING-queries");
+    final long legacyValue = getLongMetricValueLegacy("REBALANCING-queries");
 
     assertThat(value, equalTo(3L));
     assertThat(legacyValue, equalTo(3L));
@@ -166,7 +172,7 @@ public class KsqlEngineMetricsTest {
         .then(returnQueriesInState(3, State.PENDING_SHUTDOWN));
 
     final long value = getLongMetricValue("PENDING_SHUTDOWN-queries");
-    final long legacyValue = getLongMetricValueLegacy("testGroup-query-stats-PENDING_SHUTDOWN-queries");
+    final long legacyValue = getLongMetricValueLegacy("PENDING_SHUTDOWN-queries");
 
     assertThat(value, equalTo(3L));
     assertThat(legacyValue, equalTo(3L));
@@ -178,7 +184,7 @@ public class KsqlEngineMetricsTest {
         .then(returnQueriesInState(3, State.ERROR));
 
     final long value = getLongMetricValue("ERROR-queries");
-    final long legacyValue = getLongMetricValueLegacy("testGroup-query-stats-ERROR-queries");
+    final long legacyValue = getLongMetricValueLegacy("ERROR-queries");
 
     assertThat(value, equalTo(3L));
     assertThat(legacyValue, equalTo(3L));
@@ -190,7 +196,7 @@ public class KsqlEngineMetricsTest {
         .then(returnQueriesInState(4, State.NOT_RUNNING));
 
     final long value = getLongMetricValue("NOT_RUNNING-queries");
-    final long legacyValue = getLongMetricValueLegacy("testGroup-query-stats-NOT_RUNNING-queries");
+    final long legacyValue = getLongMetricValueLegacy("NOT_RUNNING-queries");
 
     assertThat(value, equalTo(4L));
     assertThat(legacyValue, equalTo(4L));
@@ -284,7 +290,7 @@ public class KsqlEngineMetricsTest {
     return Double.parseDouble(
         metrics.metric(
             metrics.metricName(
-                metricName, metricNamePrefix + METRIC_GROUP + "-query-stats", CUSTOM_TAGS)
+                metricName, metricNamePrefix + METRIC_GROUP + "-query-stats", CUSTOM_TAGS_WITH_SERVICE_ID)
         ).metricValue().toString()
     );
   }
@@ -294,17 +300,17 @@ public class KsqlEngineMetricsTest {
     return Long.parseLong(
         metrics.metric(
             metrics.metricName(
-                metricName, metricNamePrefix + METRIC_GROUP + "-query-stats", CUSTOM_TAGS)
+                metricName, metricNamePrefix + METRIC_GROUP + "-query-stats", CUSTOM_TAGS_WITH_SERVICE_ID)
         ).metricValue().toString()
     );
   }
-
+  
   private double getMetricValueLegacy(final String metricName) {
     final Metrics metrics = engineMetrics.getMetrics();
     return Double.parseDouble(
         metrics.metric(
             metrics.metricName(
-                metricNamePrefix + metricName, METRIC_GROUP + "-query-stats")
+                metricName, legacyMetricNamePrefix + METRIC_GROUP + "-query-stats", CUSTOM_TAGS)
         ).metricValue().toString()
     );
   }
@@ -314,7 +320,7 @@ public class KsqlEngineMetricsTest {
     return Long.parseLong(
         metrics.metric(
             metrics.metricName(
-                metricNamePrefix + metricName, METRIC_GROUP + "-query-stats")
+                metricName, legacyMetricNamePrefix + METRIC_GROUP + "-query-stats", CUSTOM_TAGS)
         ).metricValue().toString()
     );
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetrics.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetrics.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.rest.server.computation;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.io.Closeable;
 import java.util.Collections;
@@ -80,14 +80,14 @@ public class CommandRunnerMetrics implements Closeable {
         "status",
         ReservedInternalTopics.CONFLUENT_PREFIX + metricGroupName,
         "The status of the commandRunner thread as it processes the command topic.",
-        Collections.singletonMap(KsqlConfig.KSQL_SERVICE_ID_CONFIG, ksqlServiceId)
+        Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlServiceId)
     );
 
     this.commandRunnerDegradedReasonMetricName = metrics.metricName(
         "degraded-reason",
         ReservedInternalTopics.CONFLUENT_PREFIX + metricGroupName,
         "The reason for why the commandRunner thread is in a DEGRADED state.",
-        Collections.singletonMap(KsqlConfig.KSQL_SERVICE_ID_CONFIG, ksqlServiceId)
+        Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlServiceId)
     );
 
     this.metrics.addMetric(commandRunnerStatusMetricNameLegacy, (Gauge<String>)

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorMetrics.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorMetrics.java
@@ -15,14 +15,19 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.metrics.MeasurableStat;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
@@ -51,8 +56,10 @@ public class PullQueryExecutorMetrics implements Closeable {
   private final Sensor requestSizeSensor;
   private final Sensor responseSizeSensor;
   private final Metrics metrics;
+  private final Map<String, String> legacyCustomMetricsTags;
   private final Map<String, String> customMetricsTags;
-  private final String ksqlServiceId;
+  private final String ksqlServiceIdLegacyPrefix;
+  private final String ksqlServicePrefix;
   private final Time time;
 
   public PullQueryExecutorMetrics(
@@ -60,9 +67,15 @@ public class PullQueryExecutorMetrics implements Closeable {
       final Map<String, String> customMetricsTags,
       final Time time
   ) {
-    this.ksqlServiceId = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
+    this.ksqlServiceIdLegacyPrefix = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
         + ksqlServiceId;
-    this.customMetricsTags = Objects.requireNonNull(customMetricsTags, "customMetricsTags");
+    this.legacyCustomMetricsTags = Objects.requireNonNull(customMetricsTags, "customMetricsTags");
+
+    this.ksqlServicePrefix = ReservedInternalTopics.CONFLUENT_PREFIX;
+    final Map<String, String> metricsTags = new HashMap<>(customMetricsTags);
+    metricsTags.put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, ksqlServiceId);
+    this.customMetricsTags = ImmutableMap.copyOf(metricsTags);
+
     this.time = Objects.requireNonNull(time, "time");
     this.metrics = MetricCollectors.getMetrics();
     this.sensors = new ArrayList<>();
@@ -119,22 +132,40 @@ public class PullQueryExecutorMetrics implements Closeable {
   private Sensor configureLocalRequestsSensor() {
     final Sensor sensor = metrics.sensor(
         PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-local");
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-local-count",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Count of local pull query requests",
-            customMetricsTags
-        ),
+    
+    // legacy
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-local-count",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Count of local pull query requests",
+        legacyCustomMetricsTags,
         new WindowedCount()
     );
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-local-rate",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Rate of local pull query requests",
-            customMetricsTags
-        ),
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-local-rate",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of local pull query requests",
+        legacyCustomMetricsTags,
+        new Rate()
+    );
+
+    // new metrics with ksql service id in tags
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-local-count",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Count of local pull query requests",
+        customMetricsTags,
+        new WindowedCount()
+    );
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-local-rate",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of local pull query requests",
+        customMetricsTags,
         new Rate()
     );
     sensors.add(sensor);
@@ -144,24 +175,43 @@ public class PullQueryExecutorMetrics implements Closeable {
   private Sensor configureRemoteRequestsSensor() {
     final Sensor sensor = metrics.sensor(
         PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-remote");
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-remote-count",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Count of remote pull query requests",
-            customMetricsTags
-        ),
+
+    // legacy
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-remote-count",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Count of remote pull query requests",
+        legacyCustomMetricsTags,
         new WindowedCount()
     );
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-remote-rate",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Rate of remote pull query requests",
-            customMetricsTags
-        ),
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-remote-rate",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of remote pull query requests",
+        legacyCustomMetricsTags,
         new Rate()
     );
+    
+    // new metrics with ksql service in tags
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-remote-count",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Count of remote pull query requests",
+        customMetricsTags,
+        new WindowedCount()
+    );
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-remote-rate",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of remote pull query requests",
+        customMetricsTags,
+        new Rate()
+    );
+
     sensors.add(sensor);
     return sensor;
   }
@@ -169,15 +219,27 @@ public class PullQueryExecutorMetrics implements Closeable {
   private Sensor configureRateSensor() {
     final Sensor sensor = metrics.sensor(
         PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-rate");
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-rate",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Rate of pull query requests",
-            customMetricsTags
-        ),
+    
+    // legacy
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-rate",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of pull query requests",
+        legacyCustomMetricsTags,
         new Rate()
     );
+
+    // new metrics with ksql service id in tags
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-rate",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of pull query requests",
+        customMetricsTags,
+        new Rate()
+    );
+    
     sensors.add(sensor);
     return sensor;
   }
@@ -185,22 +247,39 @@ public class PullQueryExecutorMetrics implements Closeable {
   private Sensor configureErrorRateSensor() {
     final Sensor sensor = metrics.sensor(
         PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-error-rate");
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-error-rate",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Rate of erroneous pull query requests",
-            customMetricsTags
-        ),
+    // legacy
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-error-rate",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of erroneous pull query requests",
+        legacyCustomMetricsTags,
         new Rate()
     );
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-error-total",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Total number of erroneous pull query requests",
-            customMetricsTags
-        ),
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-error-total",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Total number of erroneous pull query requests",
+        legacyCustomMetricsTags,
+        new WindowedCount()
+    );
+
+    // new metrics with ksql service id in tags
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-error-rate",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Rate of erroneous pull query requests",
+        customMetricsTags,
+        new Rate()
+    );
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-error-total",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Total number of erroneous pull query requests",
+        customMetricsTags,
         new WindowedCount()
     );
 
@@ -211,42 +290,79 @@ public class PullQueryExecutorMetrics implements Closeable {
   private Sensor configureRequestSensor() {
     final Sensor sensor = metrics.sensor(
         PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-latency");
+    // legacy
     sensor.add(
         metrics.metricName(
             PULL_REQUESTS + "-latency-avg",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
+            ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
             "Average time for a pull query request",
-            customMetricsTags
+            legacyCustomMetricsTags
         ),
         new Avg()
     );
     sensor.add(
         metrics.metricName(
             PULL_REQUESTS + "-latency-max",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
+            ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
             "Max time for a pull query request",
-            customMetricsTags
+            legacyCustomMetricsTags
         ),
         new Max()
     );
     sensor.add(
         metrics.metricName(
             PULL_REQUESTS + "-latency-min",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
+            ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
             "Min time for a pull query request",
-            customMetricsTags
+            legacyCustomMetricsTags
         ),
         new Min()
     );
     sensor.add(
         metrics.metricName(
             PULL_REQUESTS + "-total",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
+            ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
             "Total number of pull query request",
-            customMetricsTags
+            legacyCustomMetricsTags
         ),
         new WindowedCount()
     );
+
+    // new metrics with ksql service id in tags
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-latency-avg",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Average time for a pull query request",
+        customMetricsTags,
+        new Avg()
+    );
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-latency-max",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Max time for a pull query request",
+        customMetricsTags,
+        new Max()
+    );
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-latency-min",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Min time for a pull query request",
+        customMetricsTags,
+        new Min()
+    );
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-total",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Total number of pull query request",
+        customMetricsTags,
+        new WindowedCount()
+    );
+
+    // legacy percentiles
     sensor.add(new Percentiles(
         100,
         0,
@@ -254,29 +370,61 @@ public class PullQueryExecutorMetrics implements Closeable {
         BucketSizing.CONSTANT,
         new Percentile(metrics.metricName(
             PULL_REQUESTS + "-distribution-50",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
+            ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+            "Latency distribution",
+            legacyCustomMetricsTags
+        ), 50.0),
+        new Percentile(metrics.metricName(
+            PULL_REQUESTS + "-distribution-75",
+            ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+            "Latency distribution",
+            legacyCustomMetricsTags
+        ), 75.0),
+        new Percentile(metrics.metricName(
+            PULL_REQUESTS + "-distribution-90",
+            ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+            "Latency distribution",
+            legacyCustomMetricsTags
+        ), 90.0),
+        new Percentile(metrics.metricName(
+            PULL_REQUESTS + "-distribution-99",
+            ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+            "Latency distribution",
+            legacyCustomMetricsTags
+        ), 99.0)
+        ));
+    
+    // new percentile metrics with ksql service id in tag
+    sensor.add(new Percentiles(
+        100,
+        0,
+        1000,
+        BucketSizing.CONSTANT,
+        new Percentile(metrics.metricName(
+            PULL_REQUESTS + "-distribution-50",
+            ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
             "Latency distribution",
             customMetricsTags
         ), 50.0),
         new Percentile(metrics.metricName(
             PULL_REQUESTS + "-distribution-75",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
+            ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
             "Latency distribution",
             customMetricsTags
         ), 75.0),
         new Percentile(metrics.metricName(
             PULL_REQUESTS + "-distribution-90",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
+            ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
             "Latency distribution",
             customMetricsTags
         ), 90.0),
         new Percentile(metrics.metricName(
             PULL_REQUESTS + "-distribution-99",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
+            ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
             "Latency distribution",
             customMetricsTags
         ), 99.0)
-        ));
+    ));
 
     sensors.add(sensor);
     return sensor;
@@ -285,13 +433,23 @@ public class PullQueryExecutorMetrics implements Closeable {
   private Sensor configureRequestSizeSensor() {
     final Sensor sensor = metrics.sensor(
         PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-request-size");
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-request-size",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Size in bytes of pull query request",
-            customMetricsTags
-        ),
+    // legacy
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-request-size",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Size in bytes of pull query request",
+        legacyCustomMetricsTags,
+        new CumulativeSum()
+    );
+
+    // new metrics with ksql service id in tags
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-request-size",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Size in bytes of pull query request",
+        customMetricsTags,
         new CumulativeSum()
     );
 
@@ -302,17 +460,46 @@ public class PullQueryExecutorMetrics implements Closeable {
   private Sensor configureResponseSizeSensor() {
     final Sensor sensor = metrics.sensor(
         PULL_QUERY_METRIC_GROUP + "-" + PULL_REQUESTS + "-response-size");
-    sensor.add(
-        metrics.metricName(
-            PULL_REQUESTS + "-response-size",
-            ksqlServiceId + PULL_QUERY_METRIC_GROUP,
-            "Size in bytes of pull query response",
-            customMetricsTags
-        ),
+    // legacy
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-response-size",
+        ksqlServiceIdLegacyPrefix + PULL_QUERY_METRIC_GROUP,
+        "Size in bytes of pull query response",
+        legacyCustomMetricsTags,
+        new CumulativeSum()
+    );
+
+    // new metrics with ksql service id in tags
+    addSensor(
+        sensor,
+        PULL_REQUESTS + "-response-size",
+        ksqlServicePrefix + PULL_QUERY_METRIC_GROUP,
+        "Size in bytes of pull query response",
+        customMetricsTags,
         new CumulativeSum()
     );
 
     sensors.add(sensor);
     return sensor;
+  }
+
+  private void addSensor(
+          final Sensor sensor,
+          final String metricName,
+          final String groupName,
+          final String description,
+          final Map<String, String> metricsTags,
+          final MeasurableStat measureableStat
+  ) {
+    sensor.add(
+        metrics.metricName(
+            metricName,
+            groupName,
+            description,
+            metricsTags
+        ),
+        measureableStat
+    );
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorMetrics.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorMetrics.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.rest.server.execution;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -73,7 +73,7 @@ public class PullQueryExecutorMetrics implements Closeable {
 
     this.ksqlServicePrefix = ReservedInternalTopics.CONFLUENT_PREFIX;
     final Map<String, String> metricsTags = new HashMap<>(customMetricsTags);
-    metricsTags.put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, ksqlServiceId);
+    metricsTags.put(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlServiceId);
     this.customMetricsTags = ImmutableMap.copyOf(metricsTags);
 
     this.time = Objects.requireNonNull(time, "time");

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetricsTest.java
@@ -21,11 +21,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
+
+import io.confluent.ksql.util.KsqlConfig;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Metrics;
@@ -34,16 +37,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommandRunnerMetricsTest {
 
-  private static final MetricName METRIC_NAME_1 =
+  private static final MetricName METRIC_NAME_1_LEGACY =
       new MetricName("bob", "g1", "d1", ImmutableMap.of());
-  private static final MetricName METRIC_NAME_2 =
+  private static final MetricName METRIC_NAME_2_LEGACY =
       new MetricName("jill", "g1", "d2", ImmutableMap.of());
+
+  private static final MetricName METRIC_NAME_1 =
+      new MetricName("dob", "g1", "d1", ImmutableMap.of());
+  private static final MetricName METRIC_NAME_2 =
+      new MetricName("bill", "g1", "d2", ImmutableMap.of());
   private static final String KSQL_SERVICE_ID = "kcql-1-";
 
   @Mock
@@ -58,12 +67,14 @@ public class CommandRunnerMetricsTest {
   @Before
   public void setUp() {
     when(metrics.metricName(any(), any(), any(), anyMap()))
+        .thenReturn(METRIC_NAME_1_LEGACY)
+        .thenReturn(METRIC_NAME_2_LEGACY)
         .thenReturn(METRIC_NAME_1)
         .thenReturn(METRIC_NAME_2);
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.RUNNING);
     when(commandRunner.getCommandRunnerDegradedReason()).thenReturn(CommandRunner.CommandRunnerDegradedReason.NONE);
 
-    commandRunnerMetrics = new CommandRunnerMetrics(metrics, commandRunner, KSQL_SERVICE_ID, "rest");
+    commandRunnerMetrics = new CommandRunnerMetrics(metrics, commandRunner, KSQL_SERVICE_ID, "ksql-rest");
   }
 
   @Test
@@ -72,15 +83,27 @@ public class CommandRunnerMetricsTest {
     // Listener created in setup
 
     // Then:
-    verify(metrics).metricName("status", "_confluent-ksql-kcql-1-rest-command-runner",
-            "The status of the commandRunner thread as it processes the command topic.",
-            Collections.emptyMap());
-    verify(metrics).metricName("degraded-reason", "_confluent-ksql-kcql-1-rest-command-runner",
-            "The reason for why the commandRunner thread is in a DEGRADED state.",
-            Collections.emptyMap());
+    // legacy metrics with ksql service id in the metric name
+    final InOrder inOrder = inOrder(metrics);
+    inOrder.verify(metrics).metricName("status", "_confluent-ksql-kcql-1-ksql-rest-command-runner",
+        "The status of the commandRunner thread as it processes the command topic.",
+        Collections.emptyMap());
+    inOrder.verify(metrics).metricName("degraded-reason", "_confluent-ksql-kcql-1-ksql-rest-command-runner",
+        "The reason for why the commandRunner thread is in a DEGRADED state.",
+        Collections.emptyMap());
+    
+    // new metrics with ksql service id in tags
+    inOrder.verify(metrics).metricName("status", "_confluent-ksql-rest-command-runner",
+        "The status of the commandRunner thread as it processes the command topic.",
+        Collections.singletonMap(KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID));
+    inOrder.verify(metrics).metricName("degraded-reason", "_confluent-ksql-rest-command-runner",
+        "The reason for why the commandRunner thread is in a DEGRADED state.",
+        Collections.singletonMap(KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID));
 
-    verify(metrics).addMetric(eq(METRIC_NAME_1), isA(Gauge.class));
-    verify(metrics).addMetric(eq(METRIC_NAME_2), isA(Gauge.class));
+    inOrder.verify(metrics).addMetric(eq(METRIC_NAME_1_LEGACY), isA(Gauge.class));
+    inOrder.verify(metrics).addMetric(eq(METRIC_NAME_2_LEGACY), isA(Gauge.class));
+    inOrder.verify(metrics).addMetric(eq(METRIC_NAME_1), isA(Gauge.class));
+    inOrder.verify(metrics).addMetric(eq(METRIC_NAME_2), isA(Gauge.class));
   }
 
   @Test
@@ -90,6 +113,7 @@ public class CommandRunnerMetricsTest {
 
     // Then:
     assertThat(commandRunnerStatusGaugeValue(), is(CommandRunner.CommandRunnerStatus.RUNNING.name()));
+    assertThat(commandRunnerStatusGaugeValueLegacy(), is(CommandRunner.CommandRunnerStatus.RUNNING.name()));
   }
 
   @Test
@@ -99,6 +123,7 @@ public class CommandRunnerMetricsTest {
 
     // Then:
     assertThat(commandRunnerStatusGaugeValue(), is(CommandRunner.CommandRunnerStatus.ERROR.name()));
+    assertThat(commandRunnerStatusGaugeValueLegacy(), is(CommandRunner.CommandRunnerStatus.ERROR.name()));
   }
 
   @Test
@@ -108,6 +133,7 @@ public class CommandRunnerMetricsTest {
 
     // Then:
     assertThat(commandRunnerStatusGaugeValue(), is(CommandRunner.CommandRunnerStatus.DEGRADED.name()));
+    assertThat(commandRunnerStatusGaugeValueLegacy(), is(CommandRunner.CommandRunnerStatus.DEGRADED.name()));
   }
 
   @Test
@@ -117,6 +143,7 @@ public class CommandRunnerMetricsTest {
 
     // Then:
     assertThat(commandRunnerDegradedReasonGaugeValue(), is(CommandRunner.CommandRunnerDegradedReason.NONE.name()));
+    assertThat(commandRunnerDegradedReasonGaugeValueLegacy(), is(CommandRunner.CommandRunnerDegradedReason.NONE.name()));
   }
 
   @Test
@@ -126,6 +153,7 @@ public class CommandRunnerMetricsTest {
 
     // Then:
     assertThat(commandRunnerDegradedReasonGaugeValue(), is(CommandRunner.CommandRunnerDegradedReason.CORRUPTED.name()));
+    assertThat(commandRunnerDegradedReasonGaugeValueLegacy(), is(CommandRunner.CommandRunnerDegradedReason.CORRUPTED.name()));
   }
 
   @Test
@@ -135,6 +163,7 @@ public class CommandRunnerMetricsTest {
 
     // Then:
     assertThat(commandRunnerDegradedReasonGaugeValue(), is(CommandRunner.CommandRunnerDegradedReason.INCOMPATIBLE_COMMAND.name()));
+    assertThat(commandRunnerDegradedReasonGaugeValueLegacy(), is(CommandRunner.CommandRunnerDegradedReason.INCOMPATIBLE_COMMAND.name()));
   }
 
   @Test
@@ -143,6 +172,8 @@ public class CommandRunnerMetricsTest {
     commandRunnerMetrics.close();
 
     // Then:
+    verify(metrics).removeMetric(METRIC_NAME_1_LEGACY);
+    verify(metrics).removeMetric(METRIC_NAME_2_LEGACY);
     verify(metrics).removeMetric(METRIC_NAME_1);
     verify(metrics).removeMetric(METRIC_NAME_2);
   }
@@ -154,6 +185,16 @@ public class CommandRunnerMetricsTest {
 
   private String commandRunnerDegradedReasonGaugeValue() {
     verify(metrics).addMetric(eq(METRIC_NAME_2), gaugeCaptor.capture());
+    return gaugeCaptor.getValue().value(null, 0L);
+  }
+
+  private String commandRunnerStatusGaugeValueLegacy() {
+    verify(metrics).addMetric(eq(METRIC_NAME_1_LEGACY), gaugeCaptor.capture());
+    return gaugeCaptor.getValue().value(null, 0L);
+  }
+
+  private String commandRunnerDegradedReasonGaugeValueLegacy() {
+    verify(metrics).addMetric(eq(METRIC_NAME_2_LEGACY), gaugeCaptor.capture());
     return gaugeCaptor.getValue().value(null, 0L);
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerMetricsTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Metrics;
@@ -95,10 +95,10 @@ public class CommandRunnerMetricsTest {
     // new metrics with ksql service id in tags
     inOrder.verify(metrics).metricName("status", "_confluent-ksql-rest-command-runner",
         "The status of the commandRunner thread as it processes the command topic.",
-        Collections.singletonMap(KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID));
+        Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, KSQL_SERVICE_ID));
     inOrder.verify(metrics).metricName("degraded-reason", "_confluent-ksql-rest-command-runner",
         "The reason for why the commandRunner thread is in a DEGRADED state.",
-        Collections.singletonMap(KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID));
+        Collections.singletonMap(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, KSQL_SERVICE_ID));
 
     inOrder.verify(metrics).addMetric(eq(METRIC_NAME_1_LEGACY), isA(Gauge.class));
     inOrder.verify(metrics).addMetric(eq(METRIC_NAME_2_LEGACY), isA(Gauge.class));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorMetricsTest.java
@@ -28,7 +28,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
 import java.util.Map;
 
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Time;
@@ -47,7 +47,7 @@ public class PullQueryExecutorMetricsTest {
   private static final Map<String, String> CUSTOM_TAGS = ImmutableMap
       .of("tag1", "value1", "tag2", "value2");
   private static final Map<String, String> CUSTOM_TAGS_WITH_SERVICE_ID = ImmutableMap
-          .of("tag1", "value1", "tag2", "value2", KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID);
+      .of("tag1", "value1", "tag2", "value2", KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, KSQL_SERVICE_ID);
 
   @Mock
   private KsqlEngine ksqlEngine;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorMetricsTest.java
@@ -27,6 +27,9 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
 import java.util.Map;
+
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Time;
 import org.junit.After;
@@ -43,6 +46,8 @@ public class PullQueryExecutorMetricsTest {
   private static final String KSQL_SERVICE_ID = "test-ksql-service-id";
   private static final Map<String, String> CUSTOM_TAGS = ImmutableMap
       .of("tag1", "value1", "tag2", "value2");
+  private static final Map<String, String> CUSTOM_TAGS_WITH_SERVICE_ID = ImmutableMap
+          .of("tag1", "value1", "tag2", "value2", KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID);
 
   @Mock
   private KsqlEngine ksqlEngine;
@@ -56,7 +61,7 @@ public class PullQueryExecutorMetricsTest {
     when(ksqlEngine.getServiceId()).thenReturn(KSQL_SERVICE_ID);
     when(time.nanoseconds()).thenReturn(6000L);
 
-    pullMetrics =   new PullQueryExecutorMetrics(ksqlEngine.getServiceId(), CUSTOM_TAGS, time);
+    pullMetrics = new PullQueryExecutorMetrics(ksqlEngine.getServiceId(), CUSTOM_TAGS, time);
   }
 
   @After
@@ -83,10 +88,14 @@ public class PullQueryExecutorMetricsTest {
     // When:
     final double value = getMetricValue("-local-count");
     final double rate = getMetricValue("-local-rate");
+    final double legacyValue = getMetricValueLegacy("-local-count");
+    final double legacyRate = getMetricValueLegacy("-local-rate");
 
     // Then:
     assertThat(value, equalTo(1.0));
     assertThat(rate, closeTo(0.03, 0.001));
+    assertThat(legacyValue, equalTo(1.0));
+    assertThat(legacyRate, closeTo(0.03, 0.001));
   }
 
   @Test
@@ -97,10 +106,14 @@ public class PullQueryExecutorMetricsTest {
     // When:
     final double value = getMetricValue("-remote-count");
     final double rate = getMetricValue("-remote-rate");
+    final double legacyValue = getMetricValueLegacy("-remote-count");
+    final double legacyRate = getMetricValueLegacy("-remote-rate");
 
     // Then:
     assertThat(value, equalTo(1.0));
     assertThat(rate, closeTo(0.03, 0.001));
+    assertThat(legacyValue, equalTo(1.0));
+    assertThat(legacyRate, closeTo(0.03, 0.001));
   }
 
   @Test
@@ -111,10 +124,14 @@ public class PullQueryExecutorMetricsTest {
     // When:
     final double value = getMetricValue("-error-total");
     final double rate = getMetricValue("-error-rate");
+    final double legacyValue = getMetricValueLegacy("-error-total");
+    final double legacyRate = getMetricValueLegacy("-error-rate");
 
     // Then:
     assertThat(value, equalTo(1.0));
     assertThat(rate, closeTo(0.03, 0.001));
+    assertThat(legacyValue, equalTo(1.0));
+    assertThat(legacyRate, closeTo(0.03, 0.001));
   }
 
   @Test
@@ -126,9 +143,11 @@ public class PullQueryExecutorMetricsTest {
 
     // When:
     final double rate = getMetricValue("-rate");
+    final double legacyRate = getMetricValueLegacy("-rate");
 
     // Then:
     assertThat(rate, closeTo(0.03, 0.001));
+    assertThat(legacyRate, closeTo(0.03, 0.001));
   }
 
   @Test
@@ -141,21 +160,41 @@ public class PullQueryExecutorMetricsTest {
     final double max = getMetricValue("-latency-max");
     final double min = getMetricValue("-latency-min");
     final double total = getMetricValue("-total");
+    final double legacyAvg = getMetricValueLegacy("-latency-avg");
+    final double legacyMax = getMetricValueLegacy("-latency-max");
+    final double legacyMin = getMetricValueLegacy("-latency-min");
+    final double legacyTotal = getMetricValueLegacy("-total");
 
     // Then:
     assertThat(avg, is(3.0));
     assertThat(min, is(3.0));
     assertThat(max, is(3.0));
     assertThat(total, is(1.0));
+    assertThat(legacyAvg, is(3.0));
+    assertThat(legacyMin, is(3.0));
+    assertThat(legacyMax, is(3.0));
+    assertThat(legacyTotal, is(1.0));
   }
 
   private double getMetricValue(final String metricName) {
     final Metrics metrics = pullMetrics.getMetrics();
-    return Double.valueOf(
+    return Double.parseDouble(
         metrics.metric(
             metrics.metricName(
                 "pull-query-requests" + metricName,
-                "_confluent-ksql-" + ksqlEngine.getServiceId()+ "pull-query",
+                ReservedInternalTopics.CONFLUENT_PREFIX + "pull-query",
+                CUSTOM_TAGS_WITH_SERVICE_ID)
+        ).metricValue().toString()
+    );
+  }
+
+  private double getMetricValueLegacy(final String metricName) {
+    final Metrics metrics = pullMetrics.getMetrics();
+    return Double.parseDouble(
+        metrics.metric(
+            metrics.metricName(
+                "pull-query-requests" + metricName,
+                ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX + ksqlEngine.getServiceId()+ "pull-query",
                 CUSTOM_TAGS)
         ).metricValue().toString()
     );


### PR DESCRIPTION
### Description 
Addresses https://github.com/confluentinc/ksql/issues/5948
We'll keep the legacy metrics with the ksql service id in the metric name for now so as to not break existing monitoring/metrics collection. Once those have been updated,  the old metrics can be removed at a later date.

The old legacy metrics were removed also.

Old bean name:
`io.confluent.ksql.metrics:type=_confluent-ksql-default_ksql-engine-query-stats`

New bean name:
`io.confluent.ksql.metrics:type=_confluent-ksql-engine-query-stats,ksql_service_id=default_`

### Testing done 
Unit test
Looked at metrics in jconsole and verified that there are two sets of metric, one with new naming scheme and one with old

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

