### PR TITLE
refactor: remove unused validation code

### DIFF
--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlArray.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlArray.java
@@ -18,12 +18,8 @@ package io.confluent.ksql.schema.ksql.types;
 import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.schema.ksql.JavaToSqlTypeConverter;
-import io.confluent.ksql.schema.utils.DataException;
 import io.confluent.ksql.schema.utils.FormatOptions;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.IntStream;
 
 @Immutable
 public final class SqlArray extends SqlType {
@@ -41,31 +37,6 @@ public final class SqlArray extends SqlType {
 
   public SqlType getItemType() {
     return itemType;
-  }
-
-  @Override
-  public void validateValue(final Object value) {
-    if (value == null) {
-      return;
-    }
-
-    if (!(value instanceof List)) {
-      final SqlBaseType sqlBaseType = JavaToSqlTypeConverter.instance()
-          .toSqlType(value.getClass());
-
-      throw new DataException("Expected ARRAY, got " + sqlBaseType);
-    }
-
-    final List<?> array = (List<?>) value;
-
-    IntStream.range(0, array.size()).forEach(idx -> {
-      try {
-        final Object element = array.get(idx);
-        itemType.validateValue(element);
-      } catch (final DataException e) {
-        throw new DataException("ARRAY element " + (idx + 1) + ": " + e.getMessage(), e);
-      }
-    });
   }
 
   @Override

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlDecimal.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlDecimal.java
@@ -16,11 +16,8 @@
 package io.confluent.ksql.schema.ksql.types;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.schema.ksql.JavaToSqlTypeConverter;
-import io.confluent.ksql.schema.utils.DataException;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.schema.utils.SchemaException;
-import java.math.BigDecimal;
 import java.util.Objects;
 
 @Immutable
@@ -57,29 +54,6 @@ public final class SqlDecimal extends SqlType {
 
   public int getScale() {
     return scale;
-  }
-
-  @Override
-  public void validateValue(final Object value) {
-    if (value == null) {
-      return;
-    }
-
-    if (!(value instanceof BigDecimal)) {
-      final SqlBaseType sqlBaseType = JavaToSqlTypeConverter.instance()
-          .toSqlType(value.getClass());
-
-      throw new DataException("Expected DECIMAL, got " + sqlBaseType);
-    }
-
-    final BigDecimal decimal = (BigDecimal) value;
-    if (decimal.precision() != precision) {
-      throw new DataException("Expected " + this + ", got precision " + decimal.precision());
-    }
-
-    if (decimal.scale() != scale) {
-      throw new DataException("Expected " + this + ", got scale " + decimal.scale());
-    }
   }
 
   @Override

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlMap.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlMap.java
@@ -18,10 +18,7 @@ package io.confluent.ksql.schema.ksql.types;
 import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.schema.ksql.JavaToSqlTypeConverter;
-import io.confluent.ksql.schema.utils.DataException;
 import io.confluent.ksql.schema.utils.FormatOptions;
-import java.util.Map;
 import java.util.Objects;
 
 @Immutable
@@ -46,36 +43,6 @@ public final class SqlMap extends SqlType {
 
   public SqlType getValueType() {
     return valueType;
-  }
-
-  @Override
-  public void validateValue(final Object value) {
-    if (value == null) {
-      return;
-    }
-
-    if (!(value instanceof Map)) {
-      final SqlBaseType sqlBaseType = JavaToSqlTypeConverter.instance()
-          .toSqlType(value.getClass());
-
-      throw new DataException("Expected MAP, got " + sqlBaseType);
-    }
-
-    final Map<?, ?> map = (Map<?, ?>) value;
-
-    map.forEach((k, v) -> {
-      try {
-        keyType.validateValue(k);
-      } catch (final DataException e) {
-        throw new DataException("MAP key: " + e.getMessage(), e);
-      }
-
-      try {
-        valueType.validateValue(v);
-      } catch (final DataException e) {
-        throw new DataException("MAP value for key '" + k + "': " + e.getMessage(), e);
-      }
-    });
   }
 
   @Override

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
@@ -18,8 +18,6 @@ package io.confluent.ksql.schema.ksql.types;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.schema.ksql.JavaToSqlTypeConverter;
-import io.confluent.ksql.schema.utils.DataException;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.schema.utils.SchemaException;
 import java.util.Objects;
@@ -76,20 +74,6 @@ public final class SqlPrimitiveType extends SqlType {
 
   private SqlPrimitiveType(final SqlBaseType baseType) {
     super(baseType);
-  }
-
-  @Override
-  public void validateValue(final Object value) {
-    if (value == null) {
-      return;
-    }
-
-    final SqlBaseType actualType = JavaToSqlTypeConverter.instance()
-        .toSqlType(value.getClass());
-
-    if (!baseType().equals(actualType)) {
-      throw new DataException("Expected " + baseType() + ", got " + actualType);
-    }
   }
 
   @Override

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
@@ -20,10 +20,8 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.schema.ksql.JavaToSqlTypeConverter;
 import io.confluent.ksql.schema.utils.DataException;
 import io.confluent.ksql.schema.utils.FormatOptions;
-import io.confluent.ksql.types.KsqlStruct;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,25 +56,6 @@ public final class SqlStruct extends SqlType {
 
   public Optional<Field> field(final String name) {
     return Optional.ofNullable(byName.get(name));
-  }
-
-  @Override
-  public void validateValue(final Object value) {
-    if (value == null) {
-      return;
-    }
-
-    if (!(value instanceof KsqlStruct)) {
-      final SqlBaseType sqlBaseType = JavaToSqlTypeConverter.instance()
-          .toSqlType(value.getClass());
-
-      throw new DataException("Expected STRUCT, got " + sqlBaseType);
-    }
-
-    final KsqlStruct struct = (KsqlStruct)value;
-    if (!struct.schema().equals(this)) {
-      throw new DataException("Expected " + this + ", got " + struct.schema());
-    }
   }
 
   @Override

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlType.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlType.java
@@ -35,7 +35,5 @@ public abstract class SqlType {
     return baseType;
   }
 
-  public abstract void validateValue(Object value);
-
   public abstract String toString(FormatOptions formatOptions);
 }

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/types/KsqlStruct.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/types/KsqlStruct.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.types;
 
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.types.Field;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.utils.DataException;
@@ -31,10 +32,11 @@ import java.util.function.BiConsumer;
  *
  * <p>Note: this is not yet a released / used feature of ksqlDB.
  */
-@EffectivelyImmutable
+@Immutable
 public final class KsqlStruct {
 
   private final SqlStruct schema;
+  @EffectivelyImmutable
   private final ImmutableList<Optional<?>> values;
 
   public static Builder builder(final SqlStruct schema) {
@@ -121,7 +123,6 @@ public final class KsqlStruct {
 
     public Builder set(final String field, final Optional<?> value) {
       final FieldInfo info = getField(field, schema);
-      info.field.type().validateValue(value.orElse(null));
       values.set(info.index, value);
       return this;
     }

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlArrayTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlArrayTest.java
@@ -16,14 +16,9 @@
 package io.confluent.ksql.schema.ksql.types;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
-import io.confluent.ksql.schema.utils.DataException;
-import java.util.Arrays;
 import org.junit.Test;
 
 public class SqlArrayTest {
@@ -57,53 +52,5 @@ public class SqlArrayTest {
             + SOME_TYPE.toString()
             + ">"
     ));
-  }
-
-  @Test
-  public void shouldThrowIfNotValueList() {
-    // Given:
-    final SqlArray schema = SqlTypes.array(SqlTypes.BIGINT);
-
-    // Where:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(10L)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("Expected ARRAY, got BIGINT"));
-  }
-
-  @Test
-  public void shouldThrowIfAnyElementInValueNotElementType() {
-    // Given:
-    final SqlArray schema = SqlTypes.array(SqlTypes.BIGINT);
-
-    // Where:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(ImmutableList.of(11L, 9))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("ARRAY element 2: Expected BIGINT, got INT"));
-  }
-
-  @Test
-  public void shouldNotThrowWhenValidatingNullValue() {
-    // Given:
-    final SqlArray schema = SqlTypes.array(SqlTypes.BIGINT);
-
-    // When:
-    schema.validateValue(null);
-  }
-
-  @Test
-  public void shouldValidateValue() {
-    // Given:
-    final SqlArray schema = SqlTypes.array(SqlTypes.BIGINT);
-
-    // When:
-    schema.validateValue(Arrays.asList(19L, null));
   }
 }

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlDecimalTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlDecimalTest.java
@@ -16,15 +16,11 @@
 package io.confluent.ksql.schema.ksql.types;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
-import io.confluent.ksql.schema.utils.DataException;
 import io.confluent.ksql.schema.utils.SchemaException;
-import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Objects;
 import org.hamcrest.MatcherAssert;
@@ -76,69 +72,6 @@ public class SqlDecimalTest {
   @Test
   public void shouldImplementToString() {
     assertThat(SqlDecimal.of(10, 2).toString(), is("DECIMAL(10, 2)"));
-  }
-
-  @Test
-  public void shouldThrowIfValueNotDecimal() {
-    // Given:
-    final SqlDecimal schema = SqlTypes.decimal(4, 1);
-
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(10L)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("Expected DECIMAL, got BIGINT"));
-  }
-
-  @Test
-  public void shouldThrowIfValueHasWrongPrecision() {
-    // Given:
-    final SqlDecimal schema = SqlTypes.decimal(4, 1);
-
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(new BigDecimal("1234.5"))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("Expected DECIMAL(4, 1), got precision 5"));
-  }
-
-  @Test
-  public void shouldThrowIfValueHasWrongScale() {
-    // Given:
-    final SqlDecimal schema = SqlTypes.decimal(4, 1);
-
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(new BigDecimal("12.50"))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("Expected DECIMAL(4, 1), got scale 2"));
-  }
-
-  @Test
-  public void shouldNotThrowWhenValidatingNullValue() {
-    // Given:
-    final SqlDecimal schema = SqlTypes.decimal(4, 1);
-
-    // When:
-    schema.validateValue(null);
-  }
-
-  @Test
-  public void shouldValidateValue() {
-    // Given:
-    final SqlDecimal schema = SqlTypes.decimal(4, 1);
-
-    // When:
-    schema.validateValue(new BigDecimal("123.0"));
   }
 
   @Test

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlMapTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlMapTest.java
@@ -16,15 +16,9 @@
 package io.confluent.ksql.schema.ksql.types;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
-import io.confluent.ksql.schema.utils.DataException;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 
 public class SqlMapTest {
@@ -61,72 +55,5 @@ public class SqlMapTest {
   @Test
   public void shouldImplementToString() {
     assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).toString(), is("MAP<DOUBLE, INTEGER>"));
-  }
-
-  @Test
-  public void shouldThrowIfValueNotMap() {
-    // Given:
-    final SqlMap schema = SqlTypes.map(SqlTypes.STRING, SqlTypes.BIGINT);
-
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(10L)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("Expected MAP, got BIGINT"));
-  }
-
-  @Test
-  public void shouldThrowIfAnyKeyInValueNotKeyType() {
-    // Given:
-    final SqlMap schema = SqlTypes.map(SqlTypes.STRING, SqlTypes.BIGINT);
-
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(ImmutableMap.of("first", 9L, 2, 9L))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("MAP key: Expected STRING, got INT"));
-  }
-
-  @Test
-  public void shouldThrowIfAnyValueInValueNotValueType() {
-    // Given:
-    final SqlMap schema = SqlTypes.map(SqlTypes.STRING, SqlTypes.BIGINT);
-
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(ImmutableMap.of("1", 11L, "2", 9))
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("MAP value for key '2': Expected BIGINT, got INT"));
-  }
-
-  @Test
-  public void shouldNotThrowWhenValidatingNullValue() {
-    // Given:
-    final SqlMap schema = SqlTypes.map(SqlTypes.STRING, SqlTypes.BIGINT);
-
-    // When:
-    schema.validateValue(null);
-  }
-
-  @Test
-  public void shouldValidateValue() {
-    // Given:
-    final SqlMap schema = SqlTypes.map(SqlTypes.STRING, SqlTypes.BIGINT);
-    final Map<Object, Object> mapWithNull = new HashMap<>();
-    mapWithNull.put("valid", 44L);
-    mapWithNull.put(null, 44L);
-    mapWithNull.put("v", null);
-
-    // When:
-    schema.validateValue(mapWithNull);
   }
 }

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveTypeTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveTypeTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
-import io.confluent.ksql.schema.utils.DataException;
 import io.confluent.ksql.schema.utils.SchemaException;
 import java.util.List;
 import java.util.Set;
@@ -179,40 +178,5 @@ public class SqlPrimitiveTypeTest {
       // Then:
       assertThat(SqlPrimitiveType.of(type).toString(), is(type.toString()));
     });
-  }
-
-  @Test
-  public void shoudlValidatePrimitiveTypes() {
-    SqlPrimitiveType.of(SqlBaseType.BOOLEAN).validateValue(true);
-    SqlPrimitiveType.of(SqlBaseType.INTEGER).validateValue(19);
-    SqlPrimitiveType.of(SqlBaseType.BIGINT).validateValue(33L);
-    SqlPrimitiveType.of(SqlBaseType.DOUBLE).validateValue(45.0D);
-    SqlPrimitiveType.of(SqlBaseType.STRING).validateValue("");
-  }
-
-  @SuppressWarnings("UnnecessaryBoxing")
-  @Test
-  public void shouldValidateBoxedTypes() {
-    SqlPrimitiveType.of(SqlBaseType.BOOLEAN).validateValue(Boolean.FALSE);
-    SqlPrimitiveType.of(SqlBaseType.INTEGER).validateValue(Integer.valueOf(19));
-    SqlPrimitiveType.of(SqlBaseType.BIGINT).validateValue(Long.valueOf(33L));
-    SqlPrimitiveType.of(SqlBaseType.DOUBLE).validateValue(Double.valueOf(45.0D));
-  }
-
-  @Test
-  public void shouldValidateNullValue() {
-    SqlPrimitiveType.of(SqlBaseType.BOOLEAN).validateValue(null);
-  }
-
-  @Test
-  public void shouldFailValidationForWrongType() {
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> SqlPrimitiveType.of(SqlBaseType.BOOLEAN).validateValue(10)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString("Expected BOOLEAN, got INT"));
   }
 }

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.schema.utils.DataException;
 import io.confluent.ksql.schema.utils.FormatOptions;
-import io.confluent.ksql.types.KsqlStruct;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -153,78 +152,6 @@ public class SqlStructTest {
             + ", `F1` " + SqlTypes.array(SqlTypes.DOUBLE)
             + ">"
     ));
-  }
-
-  @Test
-  public void shouldThrowIfValueNotStruct() {
-    // Given:
-    final SqlStruct schema = SqlTypes.struct()
-        .field("f0", SqlTypes.BIGINT)
-        .build();
-
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(10L)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "Expected STRUCT, got BIGINT"
-    ));
-  }
-
-  @Test
-  public void shouldThrowIfValueHasSchema() {
-    // Given:
-    final SqlStruct schema = SqlTypes.struct()
-        .field("f0", SqlTypes.BIGINT)
-        .build();
-
-    final SqlStruct mismatching = SqlTypes.struct()
-        .field("f0", SqlTypes.DOUBLE)
-        .build();
-
-    final KsqlStruct value = KsqlStruct.builder(mismatching)
-        .set("f0", Optional.of(10.0D))
-        .build();
-
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> schema.validateValue(value)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "Expected STRUCT<`f0` BIGINT>, got STRUCT<`f0` DOUBLE>"
-    ));
-  }
-
-  @Test
-  public void shouldNotThrowWhenValidatingNullValue() {
-    // Given:
-    final SqlStruct schema = SqlTypes.struct()
-        .field("f0", SqlTypes.BIGINT)
-        .build();
-
-    // When:
-    schema.validateValue(null);
-  }
-
-  @Test
-  public void shouldValidateValue() {
-    // Given:
-    final SqlStruct schema = SqlTypes.struct()
-        .field("f0", SqlTypes.BIGINT)
-        .build();
-
-    final KsqlStruct value = KsqlStruct.builder(schema)
-        .set("f0", Optional.of(10L))
-        .build();
-
-    // When:
-    schema.validateValue(value);
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/types/KsqlStructTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/types/KsqlStructTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.types;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.inOrder;
 
@@ -79,16 +80,17 @@ public class KsqlStructTest {
   }
 
   @Test
-  public void shouldThrowIfValueWrongType() {
-    // When:
-    final DataException e = assertThrows(
-        DataException.class,
-        () -> KsqlStruct.builder(SCHEMA)
-            .set("f0", Optional.of("field is BIGINT, so won't like this"))
-    );
+  public void shouldNotThrowOnValueWrongTypeAsTypeCheckingEverySetIsTooExpensive() {
+    // Given:
+    final Optional<String> value = Optional.of("field is BIGINT and the value is STRING");
 
-    // Then:
-    assertThat(e.getMessage(), containsString("Expected BIGINT, got STRING"));
+    // When:
+    final KsqlStruct struct = KsqlStruct.builder(SCHEMA)
+        .set("f0", value)
+        .build();
+
+    // Then (did not throw):
+    assertThat(struct.values().get(0), is(value));
   }
 
   @Test


### PR DESCRIPTION
### Description 

`KsqlStruct` is not yet used. However, the code calls `validateValue` when setting the value of a field. This check is not free and is on the critical path.  ksqlDB is strongly typed, so the only way the type would be wrong would be if a function or deserializer where returning incorrect data, i.e. a bug.  We should not pay the production runtime cost of checking _every_ field we set during _every_ record we process.

Rather than validate here, we should add a `-debug` option to ksqlDB that validates the returned data from deserializers and functions against the expected schema, as suggested here: https://github.com/confluentinc/ksql/issues/3624#issuecomment-729532558

### Testing done 

not production code.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

