### PR TITLE
fix: fix error categorization on NPE from streams

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.query;
 
 import io.confluent.ksql.query.QueryError.Type;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,8 +83,9 @@ public final class RegexClassifier implements QueryErrorClassifier {
   }
 
   private boolean matches(final Throwable e) {
-    return pattern.matcher(e.getClass().getName()).matches()
-        || pattern.matcher(e.getMessage()).matches();
+    final boolean clsMatches = pattern.matcher(e.getClass().getName()).matches();
+    final boolean msgMatches = e.getMessage() != null && pattern.matcher(e.getMessage()).matches();
+    return clsMatches || msgMatches;
   }
 
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.query;
 
 import io.confluent.ksql.query.QueryError.Type;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -159,19 +159,24 @@ public abstract class QueryMetadata {
   protected void uncaughtHandler(final Thread t, final Throwable e) {
     QueryError.Type errorType = Type.UNKNOWN;
     try {
+      errorType = errorClassifier.classify(e);
+    } catch (final Exception classificationException) {
+      LOG.error("Error classifying unhandled exception", classificationException);
+      throw classificationException;
+    } finally {
+      // If error classification throws then we consider the error to be an UNKNOWN error.
+      // We notify listeners and add the error to the errors queue in the finally block to ensure
+      // all listeners and consumers of the error queue (e.g. the API) can see the error. Similarly,
+      // log in finally block to make sure that if there's ever an error in the classification
+      // we still get this in our logs.
       final QueryError queryError =
           new QueryError(
               System.currentTimeMillis(),
               Throwables.getStackTraceAsString(e),
-              errorClassifier.classify(e)
+              errorType
           );
-      errorType = queryError.getType();
-
       queryStateListener.ifPresent(lis -> lis.onError(queryError));
       queryErrors.add(queryError);
-    } finally {
-      // log in finally block to make sure that if there's ever an error in the classification
-      // we still get this in our logs
       LOG.error("Unhandled exception caught in streams thread {}. ({})", t.getName(), errorType, e);
     }
   }


### PR DESCRIPTION
Fixes error categorization when streams exits due to an internal NPE
- fixes the regex categorizer to correctly handle NPEs. NPEs have null
  descriptions, so this patch changes the categorizer to ignore the
  description if its null.
- fixes the uncaught handler to categorize errors as UNKNOWN if the
  categorizer throws