### PR TITLE
Pull query thread leak

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -164,10 +164,12 @@ final class EngineExecutor {
           ksqlConfig,
           analysis,
           statement);
-      final HARouting routing = new HARouting(
+
+      try (HARouting routing = new HARouting(
           ksqlConfig, physicalPlan, routingFilterFactory, routingOptions, statement, serviceContext,
-          physicalPlan.getOutputSchema(), physicalPlan.getQueryId(), pullQueryMetrics);
-      return routing.handlePullQuery();
+          physicalPlan.getOutputSchema(), physicalPlan.getQueryId(), pullQueryMetrics)) {
+        return routing.handlePullQuery();
+      }
     } catch (final Exception e) {
       pullQueryMetrics.ifPresent(metrics -> metrics.recordErrorRate(1));
       throw new KsqlStatementException(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -107,6 +108,13 @@ public class HARoutingTest {
         ksqlConfig, pullPhysicalPlan, routingFilterFactory, routingOptions, statement,
         serviceContext, logicalSchema, queryId, Optional.empty(), routeQuery);
 
+  }
+
+  @After
+  public void tearDown() {
+    if (haRouting != null) {
+      haRouting.close();
+    }
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.test.rest;
 
 
+import static io.confluent.ksql.test.util.ThreadTestUtil.filterBuilder;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -27,6 +28,8 @@ import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.test.loader.JsonTestLoader;
 import io.confluent.ksql.test.loader.TestFile;
 import io.confluent.ksql.test.model.TestFileContext;
+import io.confluent.ksql.test.util.ThreadTestUtil;
+import io.confluent.ksql.test.util.ThreadTestUtil.ThreadSnapshot;
 import io.confluent.ksql.test.utils.TestUtils;
 import io.confluent.ksql.util.KsqlConfig;
 import java.nio.file.Path;
@@ -35,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import kafka.zookeeper.ZooKeeperClientException;
@@ -94,6 +98,8 @@ public class RestQueryTranslationTest {
       .around(TEST_HARNESS)
       .around(REST_APP);
 
+  private static final AtomicReference<ThreadSnapshot> STARTING_THREADS = new AtomicReference<>();
+
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
     return JsonTestLoader.of(TEST_DIR, RqttTestFile.class)
@@ -103,7 +109,7 @@ public class RestQueryTranslationTest {
   }
 
   @Rule
-  public final Timeout timeout = Timeout.seconds(30);
+  public final Timeout timeout = Timeout.seconds(60);
 
   private final RestTestCase testCase;
 
@@ -121,6 +127,17 @@ public class RestQueryTranslationTest {
     REST_APP.closePersistentQueries();
     REST_APP.dropSourcesExcept();
     TEST_HARNESS.getKafkaCluster().deleteAllTopics(TestKsqlRestApp.getCommandTopicName());
+
+    if (STARTING_THREADS.get() == null) {
+      // Only set once one full run completed to ensure all persistent threads created:
+      STARTING_THREADS.set(ThreadTestUtil.threadSnapshot(filterBuilder()
+          .excludeTerminated()
+          // There is a pool of ksql worker threads that grows over time, but is capped.
+          .nameMatches(name -> !name.startsWith("ksql-workers"))
+          .build()));
+    } else {
+      STARTING_THREADS.get().assertSameThreads();
+    }
   }
 
   @Test

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/AssertEventually.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/AssertEventually.java
@@ -63,11 +63,33 @@ public final class AssertEventually {
       final Supplier<? extends T> actualSupplier,
       final Matcher<? super T> expected
   ) {
+    return assertThatEventually(() -> message, actualSupplier, expected);
+  }
+
+  public static <T> T assertThatEventually(
+      final Supplier<String> message,
+      final Supplier<? extends T> actualSupplier,
+      final Matcher<? super T> expected
+  ) {
     return assertThatEventually(message, actualSupplier, expected, FailOnException);
   }
 
   public static <T> T assertThatEventually(
       final String message,
+      final Supplier<? extends T> actualSupplier,
+      final Matcher<? super T> expected,
+      final ExceptionHandling exceptionHandling
+  ) {
+    return assertThatEventually(
+        () -> message,
+        actualSupplier,
+        expected,
+        exceptionHandling
+    );
+  }
+
+  public static <T> T assertThatEventually(
+      final Supplier<String> message,
       final Supplier<? extends T> actualSupplier,
       final Matcher<? super T> expected,
       final ExceptionHandling exceptionHandling
@@ -101,6 +123,24 @@ public final class AssertEventually {
       final ExceptionHandling exceptionHandling
   ) {
     return assertThatEventually(
+        () -> message,
+        actualSupplier,
+        expected,
+        timeout,
+        unit,
+        exceptionHandling
+    );
+  }
+
+  public static <T> T assertThatEventually(
+      final Supplier<String> message,
+      final Supplier<? extends T> actualSupplier,
+      final Matcher<? super T> expected,
+      final long timeout,
+      final TimeUnit unit,
+      final ExceptionHandling exceptionHandling
+  ) {
+    return assertThatEventually(
         message,
         actualSupplier,
         expected,
@@ -119,12 +159,12 @@ public final class AssertEventually {
       final long maxPausePeriodMs
   ) {
     return assertThatEventually(
-        message, actualSupplier, expected, DEFAULT_TIMEOUT_MS, MILLISECONDS,
+        () -> message, actualSupplier, expected, DEFAULT_TIMEOUT_MS, MILLISECONDS,
         initialPausePeriodMs, maxPausePeriodMs);
   }
 
   public static <T> T assertThatEventually(
-      final String message,
+      final Supplier<String> message,
       final Supplier<? extends T> actualSupplier,
       final Matcher<? super T> expected,
       final long timeout,
@@ -145,7 +185,7 @@ public final class AssertEventually {
   }
 
   public static <T> T assertThatEventually(
-      final String message,
+      final Supplier<String> message,
       final Supplier<? extends T> actualSupplier,
       final Matcher<? super T> expected,
       final long timeout,
@@ -179,7 +219,7 @@ public final class AssertEventually {
       }
 
       final T actual = actualSupplier.get();
-      assertThat(message, actual, expected);
+      assertThat(message.get(), actual, expected);
       return actual;
     } catch (final InterruptedException e) {
       throw new RuntimeException(e);

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/ThreadTestUtil.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/ThreadTestUtil.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.util;
+
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
+import static java.util.Objects.requireNonNull;
+import static org.hamcrest.Matchers.is;
+
+import java.lang.Thread.State;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public final class ThreadTestUtil {
+
+  private ThreadTestUtil() {
+  }
+
+  public static ThreadFilterBuilder filterBuilder() {
+    return new ThreadFilterBuilder();
+  }
+
+  public static ThreadSnapshot threadSnapshot(
+      final Predicate<Entry<Thread, StackTraceElement[]>> predicate
+  ) {
+    final Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces().entrySet().stream()
+        .filter(predicate)
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    return new ThreadSnapshot(threads, predicate);
+  }
+
+  public static String detailsOfNewThreads(
+      final Set<Thread> previousThreads,
+      final Map<Thread, StackTraceElement[]> currentThreads
+  ) {
+    return difference(previousThreads, currentThreads).entrySet().stream()
+        .sorted(Comparator.comparing(e -> e.getKey().getName()))
+        .map(e -> formatThreadInfo(e.getKey(), e.getValue()))
+        .collect(Collectors.joining(System.lineSeparator() + System.lineSeparator()));
+  }
+
+  public static Map<Thread, StackTraceElement[]> difference(
+      final Set<Thread> previousThreads,
+      final Map<Thread, StackTraceElement[]> currentThreads
+  ) {
+    final Map<Thread, StackTraceElement[]> difference = new HashMap<>(currentThreads);
+    difference.keySet().removeAll(previousThreads);
+    return difference;
+  }
+
+  private static String formatThreadInfo(
+      final Thread thread,
+      final StackTraceElement[] stackTrace
+  ) {
+    return "New Thead: " + thread.getName() + " (" + thread.getState() + ")"
+        + System.lineSeparator()
+        + "StackTrace: "
+        + System.lineSeparator()
+        + Arrays.stream(stackTrace)
+        .map(frame -> "\t" + frame)
+        .collect(Collectors.joining(System.lineSeparator()));
+  }
+
+  public static class ThreadSnapshot {
+
+    private final Map<Thread, StackTraceElement[]> threads;
+    private final Predicate<Entry<Thread, StackTraceElement[]>> predicate;
+
+    public ThreadSnapshot(
+        final Map<Thread, StackTraceElement[]> threads,
+        final Predicate<Entry<Thread, StackTraceElement[]>> predicate
+    ) {
+      this.threads = requireNonNull(threads, "threads");
+      this.predicate = requireNonNull(predicate, "predicate");
+    }
+
+    public Map<Thread, StackTraceElement[]> getThreads() {
+      return threads;
+    }
+
+    public String detailsOfNewThreads(final ThreadSnapshot previous) {
+      return ThreadTestUtil.detailsOfNewThreads(previous.threads.keySet(), threads);
+    }
+
+    public void assertSameThreads() {
+      // Give threads a chance to die...
+      assertThatEventually(
+          () -> "Active thead-count is on the up: "
+              + "is there new ExecutorService that's not being shutdown somewhere?"
+              + System.lineSeparator()
+              + threadSnapshot(predicate).detailsOfNewThreads(this),
+          () -> difference(threads.keySet(), threadSnapshot(predicate).getThreads())
+              .keySet()
+              .size(),
+          is(0)
+      );
+    }
+  }
+
+  public static final class ThreadFilterBuilder {
+
+    private Predicate<Entry<Thread, StackTraceElement[]>> predicate = e -> true;
+
+    private ThreadFilterBuilder() {
+      this.excludeJunitThread()
+          .excludeJmxServerThreads()
+          .excludeJdkThreads();
+    }
+
+    public ThreadFilterBuilder excludeTerminated() {
+      filter(e -> e.getKey().getState() != State.TERMINATED);
+      return this;
+    }
+
+    public ThreadFilterBuilder nameMatches(final Predicate<String> namePredicate) {
+      filter(e -> namePredicate.test(e.getKey().getName()));
+      return this;
+    }
+
+    public ThreadFilterBuilder filter(final Predicate<Entry<Thread, StackTraceElement[]>> f) {
+      predicate = predicate.and(f);
+      return this;
+    }
+
+    public Predicate<Entry<Thread, StackTraceElement[]>> build() {
+      return predicate;
+    }
+
+    public ThreadFilterBuilder excludeJunitThread() {
+      nameMatches(name -> !name.equals("Time-limited test"));
+      return this;
+    }
+
+    public ThreadFilterBuilder excludeJmxServerThreads() {
+      nameMatches(name -> !name.startsWith("JMX server connection"));
+      nameMatches(name -> !name.startsWith("Attach Listener"));
+      nameMatches(name -> !name.startsWith("RMI Scheduler"));
+      nameMatches(name -> !name.startsWith("RMI TCP Accept"));
+      nameMatches(name -> !name.startsWith("RMI TCP Connection"));
+      return this;
+    }
+
+    public ThreadFilterBuilder excludeJdkThreads() {
+      nameMatches(name -> !name.equals("executor-Heartbeat"));
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
### Description 

This fixes a leaked executor service with 100 threads that is being created once-per-request for pull queries.

1. The first commit fixes the leaked executor.
2. The second enhances RQTT to (hopefully) catch such errors in the future (this is the second such bug in quick succession).

This bug was stopping RQTT running locally for me, because the JVM was running out of resources.

**IMPORTANT**:  It looks to my untrained eye that the current pull query code is creating an executor with 100 threads **_on each request_**. (HARouting is created per-request).  Even with the code now closing down the executor, surely this isn't what we want?

### Testing done 

**Minimal**

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

