### PR TITLE
fix: don't create threads per request

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 /**
  * The context in which statements can be executed.
@@ -155,7 +154,6 @@ public interface KsqlExecutionContext {
       ConfiguredStatement<Query> statement,
       RoutingFilterFactory routingFilterFactory,
       RoutingOptions routingOptions,
-      ExecutorService executorService,
       Optional<PullQueryExecutorMetrics> pullQueryMetrics
   );
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 /**
  * The context in which statements can be executed.
@@ -154,6 +155,7 @@ public interface KsqlExecutionContext {
       ConfiguredStatement<Query> statement,
       RoutingFilterFactory routingFilterFactory,
       RoutingOptions routingOptions,
+      ExecutorService executorService,
       Optional<PullQueryExecutorMetrics> pullQueryMetrics
   );
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.query.QueryId;
@@ -152,6 +153,7 @@ public interface KsqlExecutionContext {
   PullQueryResult executePullQuery(
       ServiceContext serviceContext,
       ConfiguredStatement<Query> statement,
+      HARouting routing,
       RoutingFilterFactory routingFilterFactory,
       RoutingOptions routingOptions,
       Optional<PullQueryExecutorMetrics> pullQueryMetrics

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -140,6 +140,7 @@ final class EngineExecutor {
    */
   PullQueryResult executePullQuery(
       final ConfiguredStatement<Query> statement,
+      final HARouting routing,
       final RoutingFilterFactory routingFilterFactory,
       final RoutingOptions routingOptions,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics
@@ -164,10 +165,9 @@ final class EngineExecutor {
           ksqlConfig,
           analysis,
           statement);
-      final HARouting routing = HARouting.getHARoutingInstance(
-          routingFilterFactory, routingOptions, serviceContext, pullQueryMetrics, ksqlConfig);
       return routing.handlePullQuery(
-          physicalPlan, statement, physicalPlan.getOutputSchema(), physicalPlan.getQueryId());
+          physicalPlan, statement, routingOptions, physicalPlan.getOutputSchema(),
+          physicalPlan.getQueryId());
     } catch (final Exception e) {
       pullQueryMetrics.ifPresent(metrics -> metrics.recordErrorRate(1));
       throw new KsqlStatementException(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -68,7 +68,6 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 /**
@@ -143,7 +142,6 @@ final class EngineExecutor {
       final ConfiguredStatement<Query> statement,
       final RoutingFilterFactory routingFilterFactory,
       final RoutingOptions routingOptions,
-      final ExecutorService executorService,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics
   ) {
 
@@ -166,11 +164,10 @@ final class EngineExecutor {
           ksqlConfig,
           analysis,
           statement);
-      final HARouting routing = new HARouting(
-          physicalPlan, routingFilterFactory, routingOptions, statement, serviceContext,
-          physicalPlan.getOutputSchema(), physicalPlan.getQueryId(), executorService,
-          pullQueryMetrics);
-      return routing.handlePullQuery();
+      final HARouting routing = HARouting.getHARoutingInstance(
+          routingFilterFactory, routingOptions, serviceContext, pullQueryMetrics, ksqlConfig);
+      return routing.handlePullQuery(
+          physicalPlan, statement, physicalPlan.getOutputSchema(), physicalPlan.getQueryId());
     } catch (final Exception e) {
       pullQueryMetrics.ifPresent(metrics -> metrics.recordErrorRate(1));
       throw new KsqlStatementException(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -52,7 +52,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -269,7 +268,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       final ConfiguredStatement<Query> statement,
       final RoutingFilterFactory routingFilterFactory,
       final RoutingOptions routingOptions,
-      final ExecutorService executorService,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics
   ) {
     return EngineExecutor
@@ -282,7 +280,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
             statement,
             routingFilterFactory,
             routingOptions,
-            executorService,
             pullQueryMetrics
         );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.query.QueryId;
@@ -266,6 +267,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   public PullQueryResult executePullQuery(
       final ServiceContext serviceContext,
       final ConfiguredStatement<Query> statement,
+      final HARouting routing,
       final RoutingFilterFactory routingFilterFactory,
       final RoutingOptions routingOptions,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics
@@ -278,6 +280,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
         )
         .executePullQuery(
             statement,
+            routing,
             routingFilterFactory,
             routingOptions,
             pullQueryMetrics

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -268,6 +269,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       final ConfiguredStatement<Query> statement,
       final RoutingFilterFactory routingFilterFactory,
       final RoutingOptions routingOptions,
+      final ExecutorService executorService,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics
   ) {
     return EngineExecutor
@@ -280,6 +282,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
             statement,
             routingFilterFactory,
             routingOptions,
+            executorService,
             pullQueryMetrics
         );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.query.QueryId;
@@ -162,6 +163,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
   public PullQueryResult executePullQuery(
       final ServiceContext serviceContext,
       final ConfiguredStatement<Query> statement,
+      final HARouting routing,
       final RoutingFilterFactory routingFilterFactory,
       final RoutingOptions routingOptions,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics
@@ -172,6 +174,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
         statement.getSessionConfig()
     ).executePullQuery(
         statement,
+        routing,
         routingFilterFactory,
         routingOptions,
         pullQueryMetrics

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 /**
  * An execution context that can execute statements without changing the core engine's state
@@ -165,7 +164,6 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
       final ConfiguredStatement<Query> statement,
       final RoutingFilterFactory routingFilterFactory,
       final RoutingOptions routingOptions,
-      final ExecutorService executorService,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics
   ) {
     return EngineExecutor.create(
@@ -176,7 +174,6 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
         statement,
         routingFilterFactory,
         routingOptions,
-        executorService,
         pullQueryMetrics
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 /**
  * An execution context that can execute statements without changing the core engine's state
@@ -164,6 +165,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
       final ConfiguredStatement<Query> statement,
       final RoutingFilterFactory routingFilterFactory,
       final RoutingOptions routingOptions,
+      final ExecutorService executorService,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics
   ) {
     return EngineExecutor.create(
@@ -174,6 +176,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
         statement,
         routingFilterFactory,
         routingOptions,
+        executorService,
         pullQueryMetrics
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
@@ -249,7 +249,6 @@ public final class HARouting implements AutoCloseable {
       pullQueryMetrics
           .ifPresent(queryExecutorMetrics -> queryExecutorMetrics.recordLocalRequests(1));
       rows = pullPhysicalPlan.execute(locations);
-      System.out.println("-----> Rows = " + rows + " locations = " + locations + " node=" + node) ;
     } else {
       LOG.debug("Query {} routed to host {} at timestamp {}.",
                 statement.getStatementText(), node.location(), System.currentTimeMillis());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.physical.pull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.confluent.ksql.execution.streams.RoutingFilter.RoutingFilterFactory;
 import io.confluent.ksql.execution.streams.RoutingOptions;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlNode;
@@ -86,7 +87,8 @@ public final class HARouting implements AutoCloseable {
         Objects.requireNonNull(routingFilterFactory, "routingFilterFactory");
     this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
     this.executorService = Executors.newFixedThreadPool(
-        ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG));
+        ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG),
+        new ThreadFactoryBuilder().setNameFormat("pull-query-executor-%d").build());
     this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics, "pullQueryMetrics");
     this.routeQuery = Objects.requireNonNull(routeQuery);
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
@@ -43,7 +43,6 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -104,8 +103,7 @@ public class HARoutingTest {
     when(location4.getNodes()).thenReturn(ImmutableList.of(node2, node1));
     when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG)).thenReturn(1);
     haRouting = new HARouting(
-        routingFilterFactory, routingOptions, serviceContext,
-        Optional.empty(), ksqlConfig, routeQuery);
+        routingFilterFactory, serviceContext, Optional.empty(), ksqlConfig, routeQuery);
 
   }
 
@@ -144,7 +142,7 @@ public class HARoutingTest {
         });
 
     // When:
-    PullQueryResult result = haRouting.handlePullQuery(pullPhysicalPlan, statement, logicalSchema, queryId);
+    PullQueryResult result = haRouting.handlePullQuery(pullPhysicalPlan, statement, routingOptions, logicalSchema, queryId);
 
     // Then:
     verify(routeQuery).routeQuery(eq(node1), any(), any(), any(), any(), any(), any(), any(), any());
@@ -194,7 +192,7 @@ public class HARoutingTest {
     });
 
     // When:
-    PullQueryResult result = haRouting.handlePullQuery(pullPhysicalPlan, statement, logicalSchema, queryId);
+    PullQueryResult result = haRouting.handlePullQuery(pullPhysicalPlan, statement, routingOptions, logicalSchema, queryId);
 
     // Then:
     verify(routeQuery).routeQuery(eq(node1), any(), any(), any(), any(), any(), any(), any(), any());
@@ -246,7 +244,7 @@ public class HARoutingTest {
     // When:
     final Exception e = assertThrows(
         MaterializationException.class,
-        () -> haRouting.handlePullQuery(pullPhysicalPlan, statement, logicalSchema, queryId)
+        () -> haRouting.handlePullQuery(pullPhysicalPlan, statement, routingOptions, logicalSchema, queryId)
     );
 
     // Then:
@@ -279,7 +277,7 @@ public class HARoutingTest {
     // When:
     final Exception e = assertThrows(
         MaterializationException.class,
-        () -> haRouting.handlePullQuery(pullPhysicalPlan, statement, logicalSchema, queryId)
+        () -> haRouting.handlePullQuery(pullPhysicalPlan, statement, routingOptions, logicalSchema, queryId)
     );
 
     // Then:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
@@ -39,10 +39,10 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.KsqlConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,8 +82,6 @@ public class HARoutingTest {
   @Mock
   private RoutingFilterFactory routingFilterFactory;
   @Mock
-  private KsqlConfig ksqlConfig;
-  @Mock
   private PullPhysicalPlan pullPhysicalPlan;
   @Mock
   private Materialization materialization;
@@ -101,12 +99,10 @@ public class HARoutingTest {
     when(location2.getNodes()).thenReturn(ImmutableList.of(node2, node1));
     when(location3.getNodes()).thenReturn(ImmutableList.of(node1, node2));
     when(location4.getNodes()).thenReturn(ImmutableList.of(node2, node1));
-    when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG))
-        .thenReturn(1);
 
     haRouting = new HARouting(
-        ksqlConfig, pullPhysicalPlan, routingFilterFactory, routingOptions, statement,
-        serviceContext, logicalSchema, queryId, Optional.empty(), routeQuery);
+        pullPhysicalPlan, routingFilterFactory, routingOptions, statement, serviceContext,
+        logicalSchema, queryId, Executors.newFixedThreadPool(1), Optional.empty(), routeQuery);
 
   }
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -134,6 +134,8 @@ public class RestQueryTranslationTest {
           .excludeTerminated()
           // There is a pool of ksql worker threads that grows over time, but is capped.
           .nameMatches(name -> !name.startsWith("ksql-workers"))
+          // There is a pool for HARouting worker threads that grows over time, but is capped to 100
+          .nameMatches(name -> !name.startsWith("pull-query-executor"))
           .build()));
     } else {
       STARTING_THREADS.get().assertSameThreads();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.utils.Time;
 
@@ -59,19 +60,22 @@ public class QueryEndpoint {
   private final RoutingFilterFactory routingFilterFactory;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RateLimiter rateLimiter;
+  private final ExecutorService pullExecutorService;
 
   public QueryEndpoint(
       final KsqlEngine ksqlEngine,
       final KsqlConfig ksqlConfig,
       final RoutingFilterFactory routingFilterFactory,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final ExecutorService pullExecutorService
   ) {
     this.ksqlEngine = ksqlEngine;
     this.ksqlConfig = ksqlConfig;
     this.routingFilterFactory = routingFilterFactory;
     this.pullQueryMetrics = pullQueryMetrics;
     this.rateLimiter = rateLimiter;
+    this.pullExecutorService = pullExecutorService;
   }
 
   public QueryPublisher createQueryPublisher(
@@ -133,6 +137,7 @@ public class QueryEndpoint {
         statement,
         routingFilterFactory,
         routingOptions,
+        pullExecutorService,
         pullQueryMetrics
     );
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.rest.entity.TableRows;
@@ -59,19 +60,22 @@ public class QueryEndpoint {
   private final RoutingFilterFactory routingFilterFactory;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RateLimiter rateLimiter;
+  private final HARouting routing;
 
   public QueryEndpoint(
       final KsqlEngine ksqlEngine,
       final KsqlConfig ksqlConfig,
       final RoutingFilterFactory routingFilterFactory,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final HARouting routing
   ) {
     this.ksqlEngine = ksqlEngine;
     this.ksqlConfig = ksqlConfig;
     this.routingFilterFactory = routingFilterFactory;
     this.pullQueryMetrics = pullQueryMetrics;
     this.rateLimiter = rateLimiter;
+    this.routing = routing;
   }
 
   public QueryPublisher createQueryPublisher(
@@ -131,6 +135,7 @@ public class QueryEndpoint {
     final PullQueryResult result = ksqlEngine.executePullQuery(
         serviceContext,
         statement,
+        routing,
         routingFilterFactory,
         routingOptions,
         pullQueryMetrics

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.utils.Time;
 
@@ -60,22 +59,19 @@ public class QueryEndpoint {
   private final RoutingFilterFactory routingFilterFactory;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RateLimiter rateLimiter;
-  private final ExecutorService pullExecutorService;
 
   public QueryEndpoint(
       final KsqlEngine ksqlEngine,
       final KsqlConfig ksqlConfig,
       final RoutingFilterFactory routingFilterFactory,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
-      final RateLimiter rateLimiter,
-      final ExecutorService pullExecutorService
+      final RateLimiter rateLimiter
   ) {
     this.ksqlEngine = ksqlEngine;
     this.ksqlConfig = ksqlConfig;
     this.routingFilterFactory = routingFilterFactory;
     this.pullQueryMetrics = pullQueryMetrics;
     this.rateLimiter = rateLimiter;
-    this.pullExecutorService = pullExecutorService;
   }
 
   public QueryPublisher createQueryPublisher(
@@ -137,7 +133,6 @@ public class QueryEndpoint {
         statement,
         routingFilterFactory,
         routingOptions,
-        pullExecutorService,
         pullQueryMetrics
     );
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -732,8 +732,8 @@ public final class KsqlRestApplication implements Executable {
         Time.SYSTEM))
         : Optional.empty();
 
-    final HARouting pullQueryRouting = new HARouting(routingFilterFactory, serviceContext, pullQueryMetrics,
-                                            ksqlConfig);
+    final HARouting pullQueryRouting = new HARouting(
+        routingFilterFactory, serviceContext, pullQueryMetrics, ksqlConfig);
 
     final StreamedQueryResource streamedQueryResource = new StreamedQueryResource(
         ksqlEngine,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.streams.RoutingFilter.RoutingFilterFactory;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
@@ -82,6 +83,7 @@ public class KsqlServerEndpoints implements Endpoints {
   private final WSQueryEndpoint wsQueryEndpoint;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RateLimiter rateLimiter;
+  private final HARouting routing;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumber
   public KsqlServerEndpoints(
@@ -100,7 +102,8 @@ public class KsqlServerEndpoints implements Endpoints {
       final ServerMetadataResource serverMetadataResource,
       final WSQueryEndpoint wsQueryEndpoint,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final HARouting routing
   ) {
 
     // CHECKSTYLE_RULES.ON: ParameterNumber
@@ -121,6 +124,7 @@ public class KsqlServerEndpoints implements Endpoints {
     this.wsQueryEndpoint = Objects.requireNonNull(wsQueryEndpoint);
     this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics);
     this.rateLimiter = Objects.requireNonNull(rateLimiter);
+    this.routing = Objects.requireNonNull(routing);
   }
 
   @Override
@@ -134,7 +138,7 @@ public class KsqlServerEndpoints implements Endpoints {
     return executeOnWorker(() -> {
       try {
         return new QueryEndpoint(
-            ksqlEngine, ksqlConfig, routingFilterFactory, pullQueryMetrics, rateLimiter)
+            ksqlEngine, ksqlConfig, routingFilterFactory, pullQueryMetrics, rateLimiter, routing)
             .createQueryPublisher(
                 sql,
                 properties,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -57,7 +57,6 @@ import io.vertx.core.json.JsonObject;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.reactivestreams.Subscriber;
@@ -83,7 +82,6 @@ public class KsqlServerEndpoints implements Endpoints {
   private final WSQueryEndpoint wsQueryEndpoint;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RateLimiter rateLimiter;
-  private final ExecutorService pullExecutorService;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumber
   public KsqlServerEndpoints(
@@ -102,8 +100,7 @@ public class KsqlServerEndpoints implements Endpoints {
       final ServerMetadataResource serverMetadataResource,
       final WSQueryEndpoint wsQueryEndpoint,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
-      final RateLimiter rateLimiter,
-      final ExecutorService pullExecutorService
+      final RateLimiter rateLimiter
   ) {
 
     // CHECKSTYLE_RULES.ON: ParameterNumber
@@ -124,7 +121,6 @@ public class KsqlServerEndpoints implements Endpoints {
     this.wsQueryEndpoint = Objects.requireNonNull(wsQueryEndpoint);
     this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics);
     this.rateLimiter = Objects.requireNonNull(rateLimiter);
-    this.pullExecutorService = Objects.requireNonNull(pullExecutorService, "pullExecutorService");
   }
 
   @Override
@@ -138,8 +134,7 @@ public class KsqlServerEndpoints implements Endpoints {
     return executeOnWorker(() -> {
       try {
         return new QueryEndpoint(
-            ksqlEngine, ksqlConfig, routingFilterFactory, pullQueryMetrics,
-            rateLimiter, pullExecutorService)
+            ksqlEngine, ksqlConfig, routingFilterFactory, pullQueryMetrics, rateLimiter)
             .createQueryPublisher(
                 sql,
                 properties,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -57,6 +57,7 @@ import io.vertx.core.json.JsonObject;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.reactivestreams.Subscriber;
@@ -82,6 +83,7 @@ public class KsqlServerEndpoints implements Endpoints {
   private final WSQueryEndpoint wsQueryEndpoint;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RateLimiter rateLimiter;
+  private final ExecutorService pullExecutorService;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumber
   public KsqlServerEndpoints(
@@ -100,7 +102,8 @@ public class KsqlServerEndpoints implements Endpoints {
       final ServerMetadataResource serverMetadataResource,
       final WSQueryEndpoint wsQueryEndpoint,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final ExecutorService pullExecutorService
   ) {
 
     // CHECKSTYLE_RULES.ON: ParameterNumber
@@ -121,6 +124,7 @@ public class KsqlServerEndpoints implements Endpoints {
     this.wsQueryEndpoint = Objects.requireNonNull(wsQueryEndpoint);
     this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics);
     this.rateLimiter = Objects.requireNonNull(rateLimiter);
+    this.pullExecutorService = Objects.requireNonNull(pullExecutorService, "pullExecutorService");
   }
 
   @Override
@@ -134,7 +138,8 @@ public class KsqlServerEndpoints implements Endpoints {
     return executeOnWorker(() -> {
       try {
         return new QueryEndpoint(
-            ksqlEngine, ksqlConfig, routingFilterFactory, pullQueryMetrics, rateLimiter)
+            ksqlEngine, ksqlConfig, routingFilterFactory, pullQueryMetrics,
+            rateLimiter, pullExecutorService)
             .createQueryPublisher(
                 sql,
                 properties,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -54,7 +53,6 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
   private final long startTimeNanos;
   private final RoutingFilterFactory routingFilterFactory;
   private final RateLimiter rateLimiter;
-  private final ExecutorService pullExecutorService;
 
   @VisibleForTesting
   PullQueryPublisher(
@@ -64,8 +62,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final long startTimeNanos,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter,
-      final ExecutorService pullExecutorService
+      final RateLimiter rateLimiter
   ) {
     this.ksqlEngine = requireNonNull(ksqlEngine, "ksqlEngine");
     this.serviceContext = requireNonNull(serviceContext, "serviceContext");
@@ -74,7 +71,6 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
     this.startTimeNanos = startTimeNanos;
     this.routingFilterFactory = requireNonNull(routingFilterFactory, "routingFilterFactory");
     this.rateLimiter = requireNonNull(rateLimiter, "rateLimiter");
-    this.pullExecutorService = requireNonNull(pullExecutorService, "pullExecutorService");
   }
 
   @Override
@@ -95,7 +91,6 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
               query,
               routingFilterFactory,
               routingOptions,
-              pullExecutorService,
               pullQueryMetrics
           );
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -53,6 +54,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
   private final long startTimeNanos;
   private final RoutingFilterFactory routingFilterFactory;
   private final RateLimiter rateLimiter;
+  private final ExecutorService pullExecutorService;
 
   @VisibleForTesting
   PullQueryPublisher(
@@ -62,7 +64,8 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final long startTimeNanos,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final ExecutorService pullExecutorService
   ) {
     this.ksqlEngine = requireNonNull(ksqlEngine, "ksqlEngine");
     this.serviceContext = requireNonNull(serviceContext, "serviceContext");
@@ -71,6 +74,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
     this.startTimeNanos = startTimeNanos;
     this.routingFilterFactory = requireNonNull(routingFilterFactory, "routingFilterFactory");
     this.rateLimiter = requireNonNull(rateLimiter, "rateLimiter");
+    this.pullExecutorService = requireNonNull(pullExecutorService, "pullExecutorService");
   }
 
   @Override
@@ -91,6 +95,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
               query,
               routingFilterFactory,
               routingOptions,
+              pullExecutorService,
               pullQueryMetrics
           );
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.internal.PullQueryExecutorMetrics;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
@@ -90,6 +91,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RoutingFilterFactory routingFilterFactory;
   private final RateLimiter rateLimiter;
+  private final HARouting routing;
+
   private KsqlConfig ksqlConfig;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
@@ -104,7 +107,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final HARouting routing
   ) {
     this(
         ksqlEngine,
@@ -118,7 +122,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
         denyListPropertyValidator,
         pullQueryMetrics,
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        routing
     );
   }
 
@@ -137,7 +142,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final HARouting routing
   ) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
     this.statementParser = Objects.requireNonNull(statementParser, "statementParser");
@@ -156,6 +162,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
     this.routingFilterFactory =
         Objects.requireNonNull(routingFilterFactory, "routingFilterFactory");
     this.rateLimiter = Objects.requireNonNull(rateLimiter, "rateLimiter");
+    this.routing = Objects.requireNonNull(routing, "routing");
   }
 
   @Override
@@ -311,6 +318,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
     final PullQueryResult result = ksqlEngine.executePullQuery(
         serviceContext,
         configured,
+        routing,
         routingFilterFactory,
         routingOptions,
         pullQueryMetrics

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -65,7 +65,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
@@ -92,7 +91,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
   private final RoutingFilterFactory routingFilterFactory;
   private final RateLimiter rateLimiter;
   private KsqlConfig ksqlConfig;
-  private final ExecutorService pullExecutorService;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public StreamedQueryResource(
@@ -106,8 +104,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter,
-      final ExecutorService pullExecutorService
+      final RateLimiter rateLimiter
   ) {
     this(
         ksqlEngine,
@@ -121,8 +118,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
         denyListPropertyValidator,
         pullQueryMetrics,
         routingFilterFactory,
-        rateLimiter,
-        pullExecutorService
+        rateLimiter
     );
   }
 
@@ -141,8 +137,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter,
-      final ExecutorService pullExecutorService
+      final RateLimiter rateLimiter
   ) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
     this.statementParser = Objects.requireNonNull(statementParser, "statementParser");
@@ -161,7 +156,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
     this.routingFilterFactory =
         Objects.requireNonNull(routingFilterFactory, "routingFilterFactory");
     this.rateLimiter = Objects.requireNonNull(rateLimiter, "rateLimiter");
-    this.pullExecutorService = Objects.requireNonNull(pullExecutorService, "pullExecutorService");
   }
 
   @Override
@@ -319,7 +313,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
         configured,
         routingFilterFactory,
         routingOptions,
-        pullExecutorService,
         pullQueryMetrics
     );
     final TableRows tableRows = new TableRows(
@@ -447,5 +440,4 @@ public class StreamedQueryResource implements KsqlConfigurable {
   private static GenericRow toGenericRow(final List<?> values) {
     return new GenericRow().appendAll(values);
   }
-
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -50,6 +50,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.utils.Time;
@@ -76,6 +77,7 @@ public class WSQueryEndpoint {
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RoutingFilterFactory routingFilterFactory;
   private final RateLimiter rateLimiter;
+  private final ExecutorService pullExecutorService;
 
   private WebSocketSubscriber<?> subscriber;
 
@@ -94,7 +96,8 @@ public class WSQueryEndpoint {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final ExecutorService pullExecutorService
   ) {
     this(
         ksqlConfig,
@@ -112,7 +115,8 @@ public class WSQueryEndpoint {
         denyListPropertyValidator,
         pullQueryMetrics,
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        pullExecutorService
     );
   }
 
@@ -134,7 +138,8 @@ public class WSQueryEndpoint {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final ExecutorService pullExecutorService
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.statementParser = Objects.requireNonNull(statementParser, "statementParser");
@@ -158,6 +163,7 @@ public class WSQueryEndpoint {
     this.routingFilterFactory = Objects.requireNonNull(
         routingFilterFactory, "routingFilterFactory");
     this.rateLimiter = Objects.requireNonNull(rateLimiter, "rateLimiter");
+    this.pullExecutorService = Objects.requireNonNull(pullExecutorService, "pullExecutorService");
   }
 
   public void executeStreamQuery(final ServerWebSocket webSocket, final MultiMap requestParams,
@@ -291,7 +297,8 @@ public class WSQueryEndpoint {
           pullQueryMetrics,
           startTimeNanos,
           routingFilterFactory,
-          rateLimiter
+          rateLimiter,
+          pullExecutorService
       );
     } else {
       pushQueryPublisher.start(
@@ -355,7 +362,8 @@ public class WSQueryEndpoint {
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final long startTimeNanos,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final ExecutorService pullExecutorService
   ) {
     new PullQueryPublisher(
         ksqlEngine,
@@ -364,7 +372,8 @@ public class WSQueryEndpoint {
         pullQueryMetrics,
         startTimeNanos,
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        pullExecutorService
     ).subscribe(streamSubscriber);
   }
 
@@ -401,7 +410,8 @@ public class WSQueryEndpoint {
         Optional<PullQueryExecutorMetrics> pullQueryMetrics,
         long startTimeNanos,
         RoutingFilterFactory routingFilterFactory,
-        RateLimiter rateLimiter);
+        RateLimiter rateLimiter,
+        ExecutorService pullExecutorService);
 
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.Errors;
@@ -76,6 +77,7 @@ public class WSQueryEndpoint {
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RoutingFilterFactory routingFilterFactory;
   private final RateLimiter rateLimiter;
+  private final HARouting routing;
 
   private WebSocketSubscriber<?> subscriber;
 
@@ -94,7 +96,8 @@ public class WSQueryEndpoint {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final HARouting routing
   ) {
     this(
         ksqlConfig,
@@ -112,7 +115,8 @@ public class WSQueryEndpoint {
         denyListPropertyValidator,
         pullQueryMetrics,
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        routing
     );
   }
 
@@ -134,7 +138,8 @@ public class WSQueryEndpoint {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final HARouting routing
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.statementParser = Objects.requireNonNull(statementParser, "statementParser");
@@ -158,6 +163,7 @@ public class WSQueryEndpoint {
     this.routingFilterFactory = Objects.requireNonNull(
         routingFilterFactory, "routingFilterFactory");
     this.rateLimiter = Objects.requireNonNull(rateLimiter, "rateLimiter");
+    this.routing = Objects.requireNonNull(routing, "routing");
   }
 
   public void executeStreamQuery(final ServerWebSocket webSocket, final MultiMap requestParams,
@@ -291,7 +297,8 @@ public class WSQueryEndpoint {
           pullQueryMetrics,
           startTimeNanos,
           routingFilterFactory,
-          rateLimiter
+          rateLimiter,
+          routing
       );
     } else {
       pushQueryPublisher.start(
@@ -355,7 +362,8 @@ public class WSQueryEndpoint {
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final long startTimeNanos,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter
+      final RateLimiter rateLimiter,
+      final HARouting routing
   ) {
     new PullQueryPublisher(
         ksqlEngine,
@@ -364,7 +372,8 @@ public class WSQueryEndpoint {
         pullQueryMetrics,
         startTimeNanos,
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        routing
     ).subscribe(streamSubscriber);
   }
 
@@ -401,7 +410,9 @@ public class WSQueryEndpoint {
         Optional<PullQueryExecutorMetrics> pullQueryMetrics,
         long startTimeNanos,
         RoutingFilterFactory routingFilterFactory,
-        RateLimiter rateLimiter);
+        RateLimiter rateLimiter,
+        HARouting routing
+        );
 
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -50,7 +50,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.utils.Time;
@@ -77,7 +76,6 @@ public class WSQueryEndpoint {
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RoutingFilterFactory routingFilterFactory;
   private final RateLimiter rateLimiter;
-  private final ExecutorService pullExecutorService;
 
   private WebSocketSubscriber<?> subscriber;
 
@@ -96,8 +94,7 @@ public class WSQueryEndpoint {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter,
-      final ExecutorService pullExecutorService
+      final RateLimiter rateLimiter
   ) {
     this(
         ksqlConfig,
@@ -115,8 +112,7 @@ public class WSQueryEndpoint {
         denyListPropertyValidator,
         pullQueryMetrics,
         routingFilterFactory,
-        rateLimiter,
-        pullExecutorService
+        rateLimiter
     );
   }
 
@@ -138,8 +134,7 @@ public class WSQueryEndpoint {
       final DenyListPropertyValidator denyListPropertyValidator,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter,
-      final ExecutorService pullExecutorService
+      final RateLimiter rateLimiter
   ) {
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.statementParser = Objects.requireNonNull(statementParser, "statementParser");
@@ -163,7 +158,6 @@ public class WSQueryEndpoint {
     this.routingFilterFactory = Objects.requireNonNull(
         routingFilterFactory, "routingFilterFactory");
     this.rateLimiter = Objects.requireNonNull(rateLimiter, "rateLimiter");
-    this.pullExecutorService = Objects.requireNonNull(pullExecutorService, "pullExecutorService");
   }
 
   public void executeStreamQuery(final ServerWebSocket webSocket, final MultiMap requestParams,
@@ -297,8 +291,7 @@ public class WSQueryEndpoint {
           pullQueryMetrics,
           startTimeNanos,
           routingFilterFactory,
-          rateLimiter,
-          pullExecutorService
+          rateLimiter
       );
     } else {
       pushQueryPublisher.start(
@@ -362,8 +355,7 @@ public class WSQueryEndpoint {
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final long startTimeNanos,
       final RoutingFilterFactory routingFilterFactory,
-      final RateLimiter rateLimiter,
-      final ExecutorService pullExecutorService
+      final RateLimiter rateLimiter
   ) {
     new PullQueryPublisher(
         ksqlEngine,
@@ -372,8 +364,7 @@ public class WSQueryEndpoint {
         pullQueryMetrics,
         startTimeNanos,
         routingFilterFactory,
-        rateLimiter,
-        pullExecutorService
+        rateLimiter
     ).subscribe(streamSubscriber);
   }
 
@@ -410,8 +401,7 @@ public class WSQueryEndpoint {
         Optional<PullQueryExecutorMetrics> pullQueryMetrics,
         long startTimeNanos,
         RoutingFilterFactory routingFilterFactory,
-        RateLimiter rateLimiter,
-        ExecutorService pullExecutorService);
+        RateLimiter rateLimiter);
 
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -44,12 +44,14 @@ import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.UserDataProvider;
+import io.vertx.core.net.SocketAddress;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.common.security.JaasUtils;
@@ -115,8 +117,12 @@ public class PullQueryFunctionalTest {
       SerdeFeatures.of()
   );
 
+  private static final BiFunction<Integer, String, SocketAddress> LOCALHOST_FACTORY =
+      (port, host) -> SocketAddress.inetSocketAddress(port, "localhost");
+
   private static final TestKsqlRestApp REST_APP_0 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withEnabledKsqlClient()
       .withBasicCredentials(USER_WITH_ACCESS, USER_WITH_ACCESS_PWD)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir())
@@ -134,6 +140,7 @@ public class PullQueryFunctionalTest {
 
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withEnabledKsqlClient()
       .withBasicCredentials(USER_WITH_ACCESS, USER_WITH_ACCESS_PWD)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir())
@@ -241,6 +248,7 @@ public class PullQueryFunctionalTest {
 
     // When:
     final List<StreamedRow> rows_0 = makePullQueryRequest(REST_APP_0, sql);
+    System.out.println("-----> Final result= " + rows_0);
     final List<StreamedRow> rows_1 = makePullQueryRequest(REST_APP_1, sql);
 
     // Then:
@@ -277,7 +285,9 @@ public class PullQueryFunctionalTest {
     // When:
 
     final List<StreamedRow> rows_0 = makePullQueryRequest(REST_APP_0, sql);
+    System.out.println("-----> Final result= " + rows_0);
     final List<StreamedRow> rows_1 = makePullQueryRequest(REST_APP_1, sql);
+    System.out.println("-----> Final result= " + rows_1);
 
     // Then:
     assertThat(rows_0, hasSize(HEADER + 3));
@@ -286,7 +296,7 @@ public class PullQueryFunctionalTest {
     Set<String> hosts = rows_0.subList(1, rows_0.size()).stream()
         .map(sr -> sr.getSourceHost().map(KsqlHostInfoEntity::toString).orElse("unknown"))
         .collect(Collectors.toSet());
-    assertThat(hosts, containsInAnyOrder("localhost:8188", "localhost:8189"));
+    assertThat(hosts, containsInAnyOrder("localhost:8188"));
     List<List<?>> rows = rows_0.subList(1, rows_0.size()).stream()
         .map(sr -> sr.getRow().get().getColumns())
         .collect(Collectors.toList());
@@ -317,7 +327,9 @@ public class PullQueryFunctionalTest {
 
     // When:
     final List<StreamedRow> rows_0 = makePullQueryRequest(REST_APP_0, sql);
+    System.out.println("-----> Final result= " + rows_0);
     final List<StreamedRow> rows_1 = makePullQueryRequest(REST_APP_1, sql);
+    System.out.println("-----> Final result= " + rows_1);
 
     // Then:
     assertThat(rows_0, hasSize(HEADER + 3));
@@ -326,7 +338,7 @@ public class PullQueryFunctionalTest {
     Set<String> hosts = rows_0.subList(1, rows_0.size()).stream()
         .map(sr -> sr.getSourceHost().map(KsqlHostInfoEntity::toString).orElse("unknown"))
         .collect(Collectors.toSet());
-    assertThat(hosts, containsInAnyOrder("localhost:8188", "localhost:8189"));
+    assertThat(hosts, containsInAnyOrder("localhost:8188"));
     List<List<?>> rows = rows_0.subList(1, rows_0.size()).stream()
         .map(sr -> sr.getRow().get().getColumns())
         .collect(Collectors.toList());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -54,7 +54,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import kafka.zookeeper.ZooKeeperClientException;
-import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -123,14 +122,8 @@ public class PullQueryFunctionalTest {
   private static final TestKsqlRestApp REST_APP_0 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withEnabledKsqlClient()
-      .withBasicCredentials(USER_WITH_ACCESS, USER_WITH_ACCESS_PWD)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir())
-      .withProperty(KsqlRestConfig.AUTHENTICATION_METHOD_CONFIG,
-          KsqlRestConfig.AUTHENTICATION_METHOD_BASIC)
-      .withProperty(KsqlRestConfig.AUTHENTICATION_REALM_CONFIG, PROPS_JAAS_REALM)
-      .withProperty(KsqlRestConfig.AUTHENTICATION_ROLES_CONFIG, KSQL_CLUSTER_ID)
-      .withProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, JAAS_CONFIG.jaasFile().toString())
       .withProperty(KsqlRestConfig.INTERNAL_LISTENER_CONFIG, "http://localhost:8188")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8188")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
@@ -141,14 +134,8 @@ public class PullQueryFunctionalTest {
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withEnabledKsqlClient()
-      .withBasicCredentials(USER_WITH_ACCESS, USER_WITH_ACCESS_PWD)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir())
-      .withProperty(KsqlRestConfig.AUTHENTICATION_METHOD_CONFIG,
-          KsqlRestConfig.AUTHENTICATION_METHOD_BASIC)
-      .withProperty(KsqlRestConfig.AUTHENTICATION_REALM_CONFIG, PROPS_JAAS_REALM)
-      .withProperty(KsqlRestConfig.AUTHENTICATION_ROLES_CONFIG, KSQL_CLUSTER_ID)
-      .withProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, JAAS_CONFIG.jaasFile().toString())
       .withProperty(KsqlRestConfig.INTERNAL_LISTENER_CONFIG, "http://localhost:8189")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8189")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
@@ -285,9 +272,7 @@ public class PullQueryFunctionalTest {
     // When:
 
     final List<StreamedRow> rows_0 = makePullQueryRequest(REST_APP_0, sql);
-    System.out.println("-----> Final result= " + rows_0);
     final List<StreamedRow> rows_1 = makePullQueryRequest(REST_APP_1, sql);
-    System.out.println("-----> Final result= " + rows_1);
 
     // Then:
     assertThat(rows_0, hasSize(HEADER + 3));
@@ -296,7 +281,7 @@ public class PullQueryFunctionalTest {
     Set<String> hosts = rows_0.subList(1, rows_0.size()).stream()
         .map(sr -> sr.getSourceHost().map(KsqlHostInfoEntity::toString).orElse("unknown"))
         .collect(Collectors.toSet());
-    assertThat(hosts, containsInAnyOrder("localhost:8188"));
+    assertThat(hosts, containsInAnyOrder("localhost:8188", "localhost:8189"));
     List<List<?>> rows = rows_0.subList(1, rows_0.size()).stream()
         .map(sr -> sr.getRow().get().getColumns())
         .collect(Collectors.toList());
@@ -327,9 +312,7 @@ public class PullQueryFunctionalTest {
 
     // When:
     final List<StreamedRow> rows_0 = makePullQueryRequest(REST_APP_0, sql);
-    System.out.println("-----> Final result= " + rows_0);
     final List<StreamedRow> rows_1 = makePullQueryRequest(REST_APP_1, sql);
-    System.out.println("-----> Final result= " + rows_1);
 
     // Then:
     assertThat(rows_0, hasSize(HEADER + 3));
@@ -338,7 +321,7 @@ public class PullQueryFunctionalTest {
     Set<String> hosts = rows_0.subList(1, rows_0.size()).stream()
         .map(sr -> sr.getSourceHost().map(KsqlHostInfoEntity::toString).orElse("unknown"))
         .collect(Collectors.toSet());
-    assertThat(hosts, containsInAnyOrder("localhost:8188"));
+    assertThat(hosts, containsInAnyOrder("localhost:8188","localhost:8189"));
     List<List<?>> rows = rows_0.subList(1, rows_0.size()).stream()
         .map(sr -> sr.getRow().get().getColumns())
         .collect(Collectors.toList());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -69,7 +69,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.streams.StreamsConfig;
@@ -144,8 +143,6 @@ public class KsqlRestApplicationTest {
   private RoutingFilterFactory routingFilterFactory;
   @Mock
   private RateLimiter rateLimiter;
-  @Mock
-  private ExecutorService pullExecutorService;
 
   @Mock
   private Vertx vertx;
@@ -506,8 +503,7 @@ public class KsqlRestApplicationTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter,
-        pullExecutorService
+        rateLimiter
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogServerUtils;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
@@ -143,6 +144,8 @@ public class KsqlRestApplicationTest {
   private RoutingFilterFactory routingFilterFactory;
   @Mock
   private RateLimiter rateLimiter;
+  @Mock
+  private HARouting haRouting;
 
   @Mock
   private Vertx vertx;
@@ -503,7 +506,8 @@ public class KsqlRestApplicationTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        haRouting
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -69,6 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.streams.StreamsConfig;
@@ -143,6 +144,8 @@ public class KsqlRestApplicationTest {
   private RoutingFilterFactory routingFilterFactory;
   @Mock
   private RateLimiter rateLimiter;
+  @Mock
+  private ExecutorService pullExecutorService;
 
   @Mock
   private Vertx vertx;
@@ -503,7 +506,8 @@ public class KsqlRestApplicationTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        pullExecutorService
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.streams.RoutingFilter.RoutingFilterFactory;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.Errors;
@@ -78,7 +79,8 @@ public class WSQueryEndpointTest {
         denyListPropertyValidator,
         Optional.empty(),
         mock(RoutingFilterFactory.class),
-        mock(RateLimiter.class)
+        mock(RateLimiter.class),
+        mock(HARouting.class)
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -41,7 +41,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,8 +78,7 @@ public class WSQueryEndpointTest {
         denyListPropertyValidator,
         Optional.empty(),
         mock(RoutingFilterFactory.class),
-        mock(RateLimiter.class),
-        mock(ExecutorService.class)
+        mock(RateLimiter.class)
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -41,6 +41,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,7 +79,8 @@ public class WSQueryEndpointTest {
         denyListPropertyValidator,
         Optional.empty(),
         mock(RoutingFilterFactory.class),
-        mock(RateLimiter.class)
+        mock(RateLimiter.class),
+        mock(ExecutorService.class)
     );
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.streams.RoutingFilter.RoutingFilterFactory;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.StreamedRow;
@@ -88,6 +89,8 @@ public class PullQueryPublisherTest {
   private SessionConfig sessionConfig;
   @Mock
   private KsqlConfig ksqlConfig;
+  @Mock
+  private HARouting haRouting;
 
   @Captor
   private ArgumentCaptor<Subscription> subscriptionCaptor;
@@ -104,7 +107,8 @@ public class PullQueryPublisherTest {
         Optional.empty(),
         TIME_NANOS,
         routingFilterFactory,
-        create(1));
+        create(1),
+        haRouting);
 
 
     when(statement.getStatementText()).thenReturn("");
@@ -115,7 +119,7 @@ public class PullQueryPublisherTest {
     when(pullQueryResult.getSchema()).thenReturn(PULL_SCHEMA);
     when(pullQueryResult.getTableRows()).thenReturn(tableRows);
     when(pullQueryResult.getSourceNodes()).thenReturn(Optional.empty());
-    when(engine.executePullQuery(any(), any(), any(), any(), any()))
+    when(engine.executePullQuery(any(), any(), any(), any(), any(), any()))
         .thenReturn(pullQueryResult);
 
     doAnswer(callRequestAgain()).when(subscriber).onNext(any());
@@ -140,7 +144,7 @@ public class PullQueryPublisherTest {
 
     // Then:
     verify(engine).executePullQuery(
-        eq(serviceContext), eq(statement), eq(routingFilterFactory), any(), eq(Optional.empty()));
+        eq(serviceContext), eq(statement), eq(haRouting), eq(routingFilterFactory), any(), eq(Optional.empty()));
   }
 
   @Test
@@ -154,7 +158,7 @@ public class PullQueryPublisherTest {
     // Then:
     verify(subscriber).onNext(any());
     verify(engine).executePullQuery(
-        eq(serviceContext), eq(statement), eq(routingFilterFactory), any(), eq(Optional.empty()));
+        eq(serviceContext), eq(statement), eq(haRouting), eq(routingFilterFactory), any(), eq(Optional.empty()));
   }
 
   @Test
@@ -189,7 +193,7 @@ public class PullQueryPublisherTest {
     // Given:
     givenSubscribed();
     final Throwable e = new RuntimeException("Boom!");
-    when(engine.executePullQuery(any(), any(), any(), any(), any())).thenThrow(e);
+    when(engine.executePullQuery(any(), any(), any(), any(), any(), any())).thenThrow(e);
 
     // When:
     subscription.request(1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -45,8 +45,6 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,8 +88,6 @@ public class PullQueryPublisherTest {
   private SessionConfig sessionConfig;
   @Mock
   private KsqlConfig ksqlConfig;
-  @Mock
-  private ExecutorService executorService;
 
   @Captor
   private ArgumentCaptor<Subscription> subscriptionCaptor;
@@ -108,8 +104,7 @@ public class PullQueryPublisherTest {
         Optional.empty(),
         TIME_NANOS,
         routingFilterFactory,
-        create(1),
-        executorService);
+        create(1));
 
 
     when(statement.getStatementText()).thenReturn("");
@@ -120,7 +115,7 @@ public class PullQueryPublisherTest {
     when(pullQueryResult.getSchema()).thenReturn(PULL_SCHEMA);
     when(pullQueryResult.getTableRows()).thenReturn(tableRows);
     when(pullQueryResult.getSourceNodes()).thenReturn(Optional.empty());
-    when(engine.executePullQuery(any(), any(), any(), any(), any(), any()))
+    when(engine.executePullQuery(any(), any(), any(), any(), any()))
         .thenReturn(pullQueryResult);
 
     doAnswer(callRequestAgain()).when(subscriber).onNext(any());
@@ -145,7 +140,7 @@ public class PullQueryPublisherTest {
 
     // Then:
     verify(engine).executePullQuery(
-        eq(serviceContext), eq(statement), eq(routingFilterFactory), any(), eq(executorService), eq(Optional.empty()));
+        eq(serviceContext), eq(statement), eq(routingFilterFactory), any(), eq(Optional.empty()));
   }
 
   @Test
@@ -159,7 +154,7 @@ public class PullQueryPublisherTest {
     // Then:
     verify(subscriber).onNext(any());
     verify(engine).executePullQuery(
-        eq(serviceContext), eq(statement), eq(routingFilterFactory), any(), eq(executorService), eq(Optional.empty()));
+        eq(serviceContext), eq(statement), eq(routingFilterFactory), any(), eq(Optional.empty()));
   }
 
   @Test
@@ -194,7 +189,7 @@ public class PullQueryPublisherTest {
     // Given:
     givenSubscribed();
     final Throwable e = new RuntimeException("Boom!");
-    when(engine.executePullQuery(any(), any(), any(), any(), any(), any())).thenThrow(e);
+    when(engine.executePullQuery(any(), any(), any(), any(), any())).thenThrow(e);
 
     // When:
     subscription.request(1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -109,7 +109,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -221,8 +220,7 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter,
-        Executors.newFixedThreadPool(1)
+        rateLimiter
     );
 
     testResource.configure(VALID_CONFIG);
@@ -303,11 +301,10 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        pullQueryRateLimiter,
-        Executors.newFixedThreadPool(1)
+        pullQueryRateLimiter
     );
     testResource.configure(VALID_CONFIG);
-    when(mockKsqlEngine.executePullQuery(any(), any(), any(), any(), any(), any())).thenReturn(pullQueryResult);
+    when(mockKsqlEngine.executePullQuery(any(), any(), any(), any(), any())).thenReturn(pullQueryResult);
     when(pullQueryResult.getTableRows()).thenReturn(Collections.emptyList());
     when(pullQueryResult.getSchema()).thenReturn(schema);
     when(pullQueryResult.getQueryId()).thenReturn(queryId);
@@ -349,8 +346,7 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter,
-        Executors.newFixedThreadPool(1)
+        rateLimiter
     );
 
     // When:
@@ -513,8 +509,7 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter,
-        Executors.newFixedThreadPool(1)
+        rateLimiter
       );
     final Map<String, Object> props = new HashMap<>(ImmutableMap.of(
         StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -59,6 +59,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.query.BlockingRowQueue;
@@ -186,6 +187,8 @@ public class StreamedQueryResourceTest {
   private PullQueryResult pullQueryResult;
   @Mock
   private LogicalSchema schema;
+  @Mock
+  private HARouting haRouting;
 
   private StreamedQueryResource testResource;
   private PreparedStatement<Statement> invalid;
@@ -220,7 +223,8 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        haRouting
     );
 
     testResource.configure(VALID_CONFIG);
@@ -301,10 +305,11 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        pullQueryRateLimiter
+        pullQueryRateLimiter,
+        haRouting
     );
     testResource.configure(VALID_CONFIG);
-    when(mockKsqlEngine.executePullQuery(any(), any(), any(), any(), any())).thenReturn(pullQueryResult);
+    when(mockKsqlEngine.executePullQuery(any(), any(), any(), any(), any(), any())).thenReturn(pullQueryResult);
     when(pullQueryResult.getTableRows()).thenReturn(Collections.emptyList());
     when(pullQueryResult.getSchema()).thenReturn(schema);
     when(pullQueryResult.getQueryId()).thenReturn(queryId);
@@ -346,7 +351,8 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        haRouting
     );
 
     // When:
@@ -509,7 +515,8 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        haRouting
       );
     final Map<String, Object> props = new HashMap<>(ImmutableMap.of(
         StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -109,6 +109,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -220,7 +221,8 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        Executors.newFixedThreadPool(1)
     );
 
     testResource.configure(VALID_CONFIG);
@@ -301,10 +303,11 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        pullQueryRateLimiter
+        pullQueryRateLimiter,
+        Executors.newFixedThreadPool(1)
     );
     testResource.configure(VALID_CONFIG);
-    when(mockKsqlEngine.executePullQuery(any(), any(), any(), any(), any())).thenReturn(pullQueryResult);
+    when(mockKsqlEngine.executePullQuery(any(), any(), any(), any(), any(), any())).thenReturn(pullQueryResult);
     when(pullQueryResult.getTableRows()).thenReturn(Collections.emptyList());
     when(pullQueryResult.getSchema()).thenReturn(schema);
     when(pullQueryResult.getQueryId()).thenReturn(queryId);
@@ -346,7 +349,8 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        Executors.newFixedThreadPool(1)
     );
 
     // When:
@@ -509,7 +513,8 @@ public class StreamedQueryResourceTest {
         denyListPropertyValidator,
         Optional.empty(),
         routingFilterFactory,
-        rateLimiter
+        rateLimiter,
+        Executors.newFixedThreadPool(1)
       );
     final Map<String, Object> props = new HashMap<>(ImmutableMap.of(
         StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"


### PR DESCRIPTION
### Description 
With the pull query physical plan refactoring, a bug was introduced where the executor service was instantiated per pull query request. I fixed that by creating it once in the `KsqlRestApplication`. 

### Testing done 
All tests pass

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

