### PR TITLE
fix: fix error categorization on NPE from streams (#6655)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
@@ -82,8 +82,9 @@ public final class RegexClassifier implements QueryErrorClassifier {
   }
 
   private boolean matches(final Throwable e) {
-    return pattern.matcher(e.getClass().getName()).matches()
-        || pattern.matcher(e.getMessage()).matches();
+    final boolean clsMatches = pattern.matcher(e.getClass().getName()).matches();
+    final boolean msgMatches = e.getMessage() != null && pattern.matcher(e.getMessage()).matches();
+    return clsMatches || msgMatches;
   }
 
 }


### PR DESCRIPTION
Fixes error categorization when streams exits due to an internal NPE
- fixes the regex categorizer to correctly handle NPEs. NPEs have null
  descriptions, so this patch changes the categorizer to ignore the
  description if its null.
- fixes the uncaught handler to categorize errors as UNKNOWN if the
  categorizer throws