### PR TITLE
docs: development in single Slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,7 @@ The following statement will create a Kafka Connect sink connector that continuo
 # Join the Community
 
 For user help, questions or queries about ksqlDB please use our [user Google Group](https://groups.google.com/forum/#!forum/ksql-users)
-or our public Slack channel #ksqldb in [Confluent Community Slack](https://slackpass.io/confluentcommunity)
-
-For discussions about development of ksqlDB please use our [developer Google Group](https://groups.google.com/forum/#!forum/ksql-dev).
-You can also hang out in our developer Slack channel #ksqldb-dev in - [Confluent Community Slack](https://slackpass.io/confluentcommunity) - this is where day to day chat about the development of ksqlDB happens.
-Everyone is welcome!
+or our public Slack channel #ksqldb in [Confluent Community Slack](https://slackpass.io/confluentcommunity). Everyone is welcome!
 
 You can get help, learn how to contribute to ksqlDB, and find the latest news by [connecting with the Confluent community](https://www.confluent.io/contact-us-thank-you/).
 

--- a/design-proposals/README.md
+++ b/design-proposals/README.md
@@ -29,7 +29,7 @@ This is the guts of our improvement proposal process:
 1. Submit a Pull Request from your branch to KSQL:
     1. make sure the title is `docs: klip-<number>: <title>`
     1. update the table entry below from the Proposal Intent step with a link to your KLIP
-1. Share a link to the PR in the `#ksqldb-dev` channel on the [confluent community slack](https://slackpass.io/confluentcommunity).
+1. Share a link to the PR in the `#ksqldb` channel on the [confluent community slack](https://slackpass.io/confluentcommunity).
 1. The design discussion will happen on the pull request
 1. The KLIP is approved and merged if at least two people with write access approve the change
 

--- a/docs/developer-guide/ksqldb-clients/contributing.md
+++ b/docs/developer-guide/ksqldb-clients/contributing.md
@@ -192,6 +192,6 @@ To get started:
 - Testing: Besides unit tests in the relevant language, there should also be integration tests to spin up a ksqlDB server and validate client behavior.
 - Add a new docs page for the client with example usage to the [ksqlDB clients page](index.md).
 
-Don't hesitate to reach out in the #ksqldb-dev channel of our community Slack
+Don't hesitate to reach out in the #ksqldb channel of our community Slack
 (found of the [Confluent Community Slack](https://launchpass.com/confluentcommunity))
 for guidance at any point in the process. Thanks for your contribution!


### PR DESCRIPTION
We've just been using the community channel for all discussion, so let's recommend that one alone.

