### PR TITLE
feat: optional `KAFKA_TOPIC` 

### DIFF
--- a/docs/developer-guide/ksqldb-reference/create-stream.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream.md
@@ -63,7 +63,7 @@ The WITH clause supports the following properties:
 
 |        Property         |                                            Description                                            |
 | ----------------------- | ------------------------------------------------------------------------------------------------- |
-| KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this source. The topic must either already exist in Kafka, or PARTITIONS must be specified to create the topic. Command will fail if the topic exists with different partition/replica counts. |
+| KAFKA_TOPIC             | The name of the Kafka topic that backs this source. The topic must either already exist in Kafka, or PARTITIONS must be specified to create the topic. If neither the topic name or partition count is supplied, ksqlDB will attempt to match the source name to an existing Kafka topic name. The [ksql.persistence.source.topic.naming.strategy](../../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencesourcetopicnamingstrategy) configuration can be used to control this behaviour. |
 | KEY_FORMAT              | Specifies the serialization format of the message key in the topic. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats).<br>If not supplied, the system default, defined by [ksql.persistence.default.format.key](../../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencedefaulformatkey), is used. If the default is also not set the statement will be rejected as invalid. |
 | VALUE_FORMAT            | Specifies the serialization format of the message value in the topic. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats).<br>If not supplied, the system default, defined by [ksql.persistence.default.format.value](../../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencedefaultformatvalue), is used. If the default is also not set the statement will be rejected as invalid. |
 | FORMAT                  | Specifies the serialization format of both the message key and value in the topic. It is not valid to supply this property alongside either `KEY_FORMAT` or `VALUE_FORMAT`. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats). |
@@ -90,6 +90,24 @@ Example
 -------
 
 ```sql
+-- stream, with new topic created:
+CREATE STREAM pageviews (
+    page_id BIGINT,
+    viewtime BIGINT,
+    user_id VARCHAR
+  ) WITH (
+    KAFKA_TOPIC = 'keyless-pageviews-topic',
+    PARTITIONS=12,
+    FORMATS = 'JSON'
+  );
+
+-- stream over existing topic, with declared columns, using default formats and topic naming: 
+CREATE STREAM pageviews (
+    page_id BIGINT,
+    viewtime BIGINT,
+    user_id VARCHAR
+  );
+
 -- stream with a page_id column loaded from the kafka message value:
 CREATE STREAM pageviews (
     page_id BIGINT,

--- a/docs/developer-guide/ksqldb-reference/create-table.md
+++ b/docs/developer-guide/ksqldb-reference/create-table.md
@@ -62,7 +62,7 @@ The WITH clause supports the following properties:
 
 |        Property         |                                            Description                                            |
 | ----------------------- | ------------------------------------------------------------------------------------------------- |
-| KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this source. The topic must either already exist in Kafka, or PARTITIONS must be specified to create the topic. Command will fail if the topic exists with different partition/replica counts. |
+| KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this source. The topic must either already exist in Kafka, or PARTITIONS must be specified to create the topic. If neither the topic name or partition count is supplied, ksqlDB will attempt to match the source name to an existing Kafka topic name. The [ksql.persistence.source.topic.naming.strategy](../../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencesourcetopicnamingstrategy) configuration can be used to control this behaviour. |
 | KEY_FORMAT              | Specifies the serialization format of the message key in the topic. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats).<br>If not supplied, the system default, defined by [ksql.persistence.default.format.key](../../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencedefaultformatkey), is used. If the default is also not set the statement will be rejected as invalid. |
 | VALUE_FORMAT            | Specifies the serialization format of the message value in the topic. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats).<br>If not supplied, the system default, defined by [ksql.persistence.default.format.value](../../operate-and-deploy/installation/server-config/config-reference.md#ksqlpersistencedefaultformatvalue), is used. If the default is also not set the statement will be rejected as invalid. |
 | FORMAT                  | Specifies the serialization format of both the message key and value in the topic. It is not valid to supply this property alongside either `KEY_FORMAT` or `VALUE_FORMAT`. For supported formats, see [Serialization Formats](../serialization.md#serialization-formats). |
@@ -85,7 +85,31 @@ Examples
 --------
 
 ```sql
--- table with declared columns: 
+-- table, with new topic created: 
+CREATE TABLE users (
+     id BIGINT PRIMARY KEY,
+     usertimestamp BIGINT,
+     gender VARCHAR,
+     region_id VARCHAR
+   ) WITH (
+     KAFKA_TOPIC = 'my-users-topic',
+     PARTITIONS = 10, 
+     FORMATS = 'JSON'
+   );
+```
+
+```sql
+-- table over existing topic with declared columns, using default formats and topic naming: 
+CREATE TABLE users (
+     id BIGINT PRIMARY KEY,
+     usertimestamp BIGINT,
+     gender VARCHAR,
+     region_id VARCHAR
+   );
+```
+
+```sql
+-- table with declared columns and explicit value format and topic naming: 
 CREATE TABLE users (
      id BIGINT PRIMARY KEY,
      usertimestamp BIGINT,

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -287,6 +287,25 @@ The corresponding environment variable in the
 [ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_FUNCTIONS_SUBSTRING_LEGACY_ARGS`.
 
+### ksql.persistence.source.topic.naming.strategy
+
+Sets the class that will be instantiated to determine the value of the `KAFKA_TOPIC` property if 
+one is not supplied explicitly in [CREATE TABLE](../../../developer-guide/ksqldb-reference/create-table.md)
+or [CREATE STREAM](../../../developer-guide/ksqldb-reference/create-stream.md)
+statements.
+
+ksqlDB ships with three in-built implementations:
+
+* `io.confluent.ksql.naming.CaseInsensitiveSourceTopicNamingStrategy` (Default): matches any existing
+topic with the same name as the source, ignoring case.
+* `io.confluent.ksql.naming.CaseSensitiveSourceTopicNamingStrategy`: matches any existing
+topic with the exact same name as the source.
+* `io.confluent.ksql.naming.ExplicitSourceTopicNamingStrategy`: forces users to explicitly supply
+the topic name in the `WITH` clause.
+
+Users may also implement their own strategy, if needed. Refer to the JavaDocs of 
+`io.confluent.ksql.naming.SourceTopicNamingStrategy` for more info.
+
 ### ksql.persistence.default.format.key
 
 Sets the default value for the `KEY_FORMAT` property if one is

--- a/ksqldb-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
@@ -101,7 +101,7 @@ public final class ConfigValidators {
       }
 
       final StringBuilder regexBuilder = new StringBuilder();
-      for (Object item : (List)val) {
+      for (Object item : (List<?>)val) {
         if (!(item instanceof String)) {
           throw new IllegalArgumentException("validator should only be used with "
               + "LIST of STRING defs");
@@ -150,6 +150,19 @@ public final class ConfigValidators {
         }
       } else {
         throw new IllegalArgumentException("validator should only be used with int, long");
+      }
+    };
+  }
+
+  public static Validator instanceOf(final Class<?> type) {
+    return (name, val) -> {
+      if (!(val instanceof Class)) {
+        throw new IllegalArgumentException("validator should only be used with CLASS");
+      }
+
+      final Class<?> actual = (Class<?>)val;
+      if (!type.isAssignableFrom(actual)) {
+        throw new ConfigException(name, val, "Not instance of " + type.getCanonicalName());
       }
     };
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/naming/CaseInsensitiveSourceTopicNamingStrategy.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/naming/CaseInsensitiveSourceTopicNamingStrategy.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.naming;
+
+import com.google.common.collect.Iterables;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.util.GrammaticalJoiner;
+import io.confluent.ksql.util.KsqlException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Naming strategy that will match existing topic names case-insensitively.
+ *
+ * <p>Where multiple matches occur, any exact match wins, or else an exception is thrown.
+ *
+ * <p>Set in {@link io.confluent.ksql.util.KsqlConfig#KSQL_SOURCE_TOPIC_NAMING_STRATEGY_CONFIG}.
+ */
+public class CaseInsensitiveSourceTopicNamingStrategy implements SourceTopicNamingStrategy {
+
+  @Override
+  public String resolveExistingTopic(final SourceName sourceName, final Set<String> topicNames) {
+    final List<String> candidates = new ArrayList<>();
+    for (final String topicName : topicNames) {
+      if (!sourceName.text().equalsIgnoreCase(topicName)) {
+        continue;
+      }
+
+      if (sourceName.text().equals(topicName)) {
+        // Exact match!
+        return topicName;
+      }
+
+      candidates.add(topicName);
+    }
+
+    if (candidates.isEmpty()) {
+      throw new KsqlException("No existing topic named " + sourceName + " (case-insensitive)"
+          + System.lineSeparator()
+          + "You can specify an explicit existing topic name by setting '"
+          + CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY + "' in the WITH clause. "
+          + "Alternatively, if you intended to create a new topic, set '"
+          + CommonCreateConfigs.SOURCE_NUMBER_OF_PARTITIONS + "' in the WITH clause."
+      );
+    }
+
+    if (candidates.size() > 1) {
+      throw new KsqlException("Multiple existing topics found that match "
+          + sourceName + " (case-insensitive)."
+          + System.lineSeparator()
+          + "Add an explicit '" + CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY
+          + "' property to the WITH clause to choose either "
+          + GrammaticalJoiner.or().join(candidates)
+      );
+    }
+
+    return Iterables.getOnlyElement(candidates);
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/naming/CaseSensitiveSourceTopicNamingStrategy.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/naming/CaseSensitiveSourceTopicNamingStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.naming;
+
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Set;
+
+/**
+ * Naming strategy that will match existing topic names exactly.
+ *
+ * <p>Set in {@link io.confluent.ksql.util.KsqlConfig#KSQL_SOURCE_TOPIC_NAMING_STRATEGY_CONFIG}.
+ */
+public class CaseSensitiveSourceTopicNamingStrategy implements SourceTopicNamingStrategy {
+
+  @Override
+  public String resolveExistingTopic(final SourceName sourceName, final Set<String> topicNames) {
+    return topicNames.stream()
+        .filter(name -> name.equals(sourceName.text()))
+        .findFirst()
+        .orElseThrow(() -> new KsqlException(
+            "No existing topic named " + sourceName + " (case-sensitive)"
+                + System.lineSeparator()
+                + "You can specify an explicit existing topic name by setting '"
+                + CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY + "' in the WITH clause. "
+                + "Alternatively, if you intended to create a new topic, set '"
+                + CommonCreateConfigs.SOURCE_NUMBER_OF_PARTITIONS + "' in the WITH clause."
+        ));
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/naming/ExplicitSourceTopicNamingStrategy.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/naming/ExplicitSourceTopicNamingStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.naming;
+
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Set;
+
+/**
+ * Naming strategy that requires the user to provide the name of the topic in the WITH clause.
+ *
+ * <p>If the WITH clause is missing the KAFKA_TOPIC, then this strategy will through an exception
+ * informing the user to add it.
+ *
+ * <p>Set in {@link io.confluent.ksql.util.KsqlConfig#KSQL_SOURCE_TOPIC_NAMING_STRATEGY_CONFIG}.
+ */
+@SuppressWarnings("unused") // Invoked via reflection
+public class ExplicitSourceTopicNamingStrategy implements SourceTopicNamingStrategy {
+
+  @Override
+  public String resolveExistingTopic(final SourceName sourceName, final Set<String> topicNames) {
+    throw new KsqlException("Explicit '"
+        + CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY
+        + "' required in the WITH clause");
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/naming/SourceTopicNamingStrategy.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/naming/SourceTopicNamingStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.naming;
+
+import io.confluent.ksql.name.SourceName;
+import java.util.Set;
+
+/**
+ * Interface topic naming strategies must implement
+ */
+public interface SourceTopicNamingStrategy {
+
+  /**
+   * Determine the Kafka topic, if any, that matches the supplied {@code sourceName}.
+   *
+   * @param sourceName the source to find the topic of.
+   * @param topicNames the set of known / accessible topic names.
+   * @return the name of the topic that contains the source's data.
+   * @throws io.confluent.ksql.util.KsqlException if the topic name could not be determined.
+   */
+  String resolveExistingTopic(SourceName sourceName, Set<String> topicNames);
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -46,15 +46,12 @@ public final class CommonCreateConfigs {
 
   public static final String VALUE_DELIMITER_PROPERTY = "VALUE_DELIMITER";
 
-  public static void addToConfigDef(
-      final ConfigDef configDef,
-      final boolean topicNameRequired
-  ) {
+  public static void addToConfigDef(final ConfigDef configDef) {
     configDef
         .define(
             KAFKA_TOPIC_NAME_PROPERTY,
             ConfigDef.Type.STRING,
-            topicNameRequired ? ConfigDef.NO_DEFAULT_VALUE : null,
+            null,
             new NonEmptyString(),
             Importance.HIGH,
             "The topic that stores the data of the source"

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CreateAsConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CreateAsConfigs.java
@@ -25,7 +25,7 @@ public final class CreateAsConfigs {
   private static final ConfigDef CONFIG_DEF = new ConfigDef();
 
   static {
-    CommonCreateConfigs.addToConfigDef(CONFIG_DEF, false);
+    CommonCreateConfigs.addToConfigDef(CONFIG_DEF);
   }
 
   public static final ConfigMetaData CONFIG_METADATA = ConfigMetaData.of(CONFIG_DEF);

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
@@ -78,7 +78,7 @@ public final class CreateConfigs {
       );
 
   static {
-    CommonCreateConfigs.addToConfigDef(CONFIG_DEF, true);
+    CommonCreateConfigs.addToConfigDef(CONFIG_DEF);
   }
 
   public static final ConfigMetaData CONFIG_METADATA = ConfigMetaData.of(CONFIG_DEF);

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -29,6 +29,8 @@ import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.model.SemanticVersion;
+import io.confluent.ksql.naming.CaseInsensitiveSourceTopicNamingStrategy;
+import io.confluent.ksql.naming.SourceTopicNamingStrategy;
 import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.testing.EffectivelyImmutable;
 import java.util.Arrays;
@@ -139,6 +141,11 @@ public class KsqlConfig extends AbstractConfig {
   public static final Boolean KSQL_KEY_FORMAT_ENABLED_DEFAULT = false;
   public static final String KSQL_KEY_FORMAT_ENABLED_DOC =
       "Feature flag for non-Kafka key formats";
+
+  public static final String KSQL_SOURCE_TOPIC_NAMING_STRATEGY_CONFIG =
+      "ksql.persistence.source.topic.naming.strategy";
+  private static final String KSQL_SOURCE_TOPIC_NAMING_STRATEGY_DOC =
+      "Class used to resolve the name of the Kafka topic of a new source";
 
   public static final String KSQL_DEFAULT_KEY_FORMAT_CONFIG = "ksql.persistence.default.format.key";
   private static final String KSQL_DEFAULT_KEY_FORMAT_DEFAULT = "KAFKA";
@@ -613,6 +620,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_KEY_FORMAT_ENABLED_DEFAULT,
             ConfigDef.Importance.LOW,
             KSQL_KEY_FORMAT_ENABLED_DOC
+        ).define(
+            KSQL_SOURCE_TOPIC_NAMING_STRATEGY_CONFIG,
+            Type.CLASS,
+            CaseInsensitiveSourceTopicNamingStrategy.class.getCanonicalName(),
+            ConfigValidators.instanceOf(SourceTopicNamingStrategy.class),
+            ConfigDef.Importance.LOW,
+            KSQL_SOURCE_TOPIC_NAMING_STRATEGY_DOC
         ).define(
             KSQL_DEFAULT_KEY_FORMAT_CONFIG,
             Type.STRING,

--- a/ksqldb-common/src/test/java/io/confluent/ksql/naming/CaseInsensitiveSourceTopicNamingStrategyTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/naming/CaseInsensitiveSourceTopicNamingStrategyTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.naming;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CaseInsensitiveSourceTopicNamingStrategyTest {
+
+  private CaseInsensitiveSourceTopicNamingStrategy strategy;
+
+  @Before
+  public void setUp() {
+    strategy = new CaseInsensitiveSourceTopicNamingStrategy();
+  }
+
+  @Test
+  public void shouldThrowOnNoMatch() {
+    // Given:
+    final SourceName sourceName = SourceName.of("Bob");
+    final Set<String> topicNames = ImmutableSet.of("Not Bob");
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> strategy.resolveExistingTopic(sourceName, topicNames)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("No existing topic named `Bob` (case-insensitive)"
+        + System.lineSeparator()
+        + "You can specify an explicit existing topic name by setting 'KAFKA_TOPIC' in the WITH clause. "
+        + "Alternatively, if you intended to create a new topic, set 'PARTITIONS' in the WITH clause."));
+  }
+
+  @Test
+  public void shouldThrowOnMultipleMatch() {
+    // Given:
+    final SourceName sourceName = SourceName.of("Bob");
+    final Set<String> topicNames = ImmutableSet.of("bob", "BoB", "BOB");
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> strategy.resolveExistingTopic(sourceName, topicNames)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("Multiple existing topics found that match `Bob` (case-insensitive)."
+        + System.lineSeparator()
+        + "Add an explicit 'KAFKA_TOPIC' property to the WITH clause to choose either bob, BoB or BOB"));
+  }
+
+  @Test
+  public void shouldReturnSingleMatch() {
+    // Given:
+    final SourceName sourceName = SourceName.of("Bob");
+    final Set<String> topicNames = ImmutableSet.of("not bob", "bob", "also not bob");
+
+    // When:
+    final String result = strategy.resolveExistingTopic(sourceName, topicNames);
+
+    // Then:
+    assertThat(result, is("bob"));
+  }
+
+  @Test
+  public void shouldNotThrowOnMultipleIfExactMatch() {
+    // Given:
+    final SourceName sourceName = SourceName.of("Bob");
+    final Set<String> topicNames = ImmutableSet.of("bob", "Bob", "BOB");
+
+    // When:
+    final String result = strategy.resolveExistingTopic(sourceName, topicNames);
+
+    // Then:
+    assertThat(result, is("Bob"));
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/naming/CaseSensitiveSourceTopicNamingStrategyTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/naming/CaseSensitiveSourceTopicNamingStrategyTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.naming;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CaseSensitiveSourceTopicNamingStrategyTest {
+
+  private CaseSensitiveSourceTopicNamingStrategy strategy;
+
+  @Before
+  public void setUp() {
+    strategy = new CaseSensitiveSourceTopicNamingStrategy();
+  }
+
+  @Test
+  public void shouldThrowOnNoMatch() {
+    // Given:
+    final SourceName sourceName = SourceName.of("Bob");
+    final Set<String> topicNames = ImmutableSet.of("bob");
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> strategy.resolveExistingTopic(sourceName, topicNames)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("No existing topic named `Bob` (case-sensitive)"
+        + System.lineSeparator()
+        + "You can specify an explicit existing topic name by setting 'KAFKA_TOPIC' in the WITH clause. "
+        + "Alternatively, if you intended to create a new topic, set 'PARTITIONS' in the WITH clause."));
+  }
+
+  @Test
+  public void shouldReturnSingleMatch() {
+    // Given:
+    final SourceName sourceName = SourceName.of("Bob");
+    final Set<String> topicNames = ImmutableSet.of("bob", "Bob", "BOB");
+
+    // When:
+    final String result = strategy.resolveExistingTopic(sourceName, topicNames);
+
+    // Then:
+    assertThat(result, is("Bob"));
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.serde.SerdeFeaturesFactory;
 import io.confluent.ksql.serde.ValueSerdeFactory;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.topic.TopicNaming;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
@@ -104,7 +105,7 @@ public final class CreateSourceFactory {
   ) {
     final SourceName sourceName = statement.getName();
     final CreateSourceProperties props = statement.getProperties();
-    final String topicName = ensureTopicExists(props, serviceContext);
+    final String topicName = resolveSourceTopicName(sourceName, props, ksqlConfig);
     final LogicalSchema schema = buildSchema(statement.getElements());
     final Optional<TimestampColumn> timestampColumn =
         buildTimestampColumn(ksqlConfig, props, schema);
@@ -138,7 +139,7 @@ public final class CreateSourceFactory {
   ) {
     final SourceName sourceName = statement.getName();
     final CreateSourceProperties props = statement.getProperties();
-    final String topicName = ensureTopicExists(props, serviceContext);
+    final String topicName = resolveSourceTopicName(sourceName, props, ksqlConfig);
     final LogicalSchema schema = buildSchema(statement.getElements());
     if (schema.key().isEmpty()) {
       final boolean usingSchemaInference = props.getValueSchemaId().isPresent();
@@ -215,16 +216,19 @@ public final class CreateSourceFactory {
     return props.getWindowType().map(type -> WindowInfo.of(type, props.getWindowSize()));
   }
 
-  private static String ensureTopicExists(
-      final CreateSourceProperties properties,
-      final ServiceContext serviceContext
+  private String resolveSourceTopicName(
+      final SourceName sourceName,
+      final CreateSourceProperties props,
+      final KsqlConfig config
   ) {
-    final String kafkaTopicName = properties.getKafkaTopic();
-    if (!serviceContext.getTopicClient().isTopicExists(kafkaTopicName)) {
-      throw new KsqlException("Kafka topic does not exist: " + kafkaTopicName);
+    final String topicName = TopicNaming
+        .getSourceTopicName(sourceName, props, config, serviceContext.getTopicClient());
+
+    if (!serviceContext.getTopicClient().isTopicExists(topicName)) {
+      throw new KsqlException("Kafka topic does not exist: " + topicName);
     }
 
-    return kafkaTopicName;
+    return topicName;
   }
 
   private static Optional<TimestampColumn> buildTimestampColumn(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -121,7 +121,7 @@ public class DefaultSchemaInjector implements Injector {
     }
 
     return Optional.of(getSchema(
-        props.getKafkaTopic(),
+        props.getKafkaTopic().orElseThrow(IllegalStateException::new),
         props.getKeySchemaId(),
         keyFormat,
         SerdeFeaturesFactory.buildInternal(FormatFactory.of(keyFormat)),
@@ -141,7 +141,7 @@ public class DefaultSchemaInjector implements Injector {
     }
 
     return Optional.of(getSchema(
-        props.getKafkaTopic(),
+        props.getKafkaTopic().orElseThrow(IllegalStateException::new),
         props.getValueSchemaId(),
         valueFormat,
         props.getValueSerdeFeatures(),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -98,7 +98,7 @@ public class SchemaRegisterInjector implements Injector {
 
     registerSchemas(
         schema,
-        statement.getProperties().getKafkaTopic(),
+        statement.getProperties().getKafkaTopic().orElseThrow(IllegalStateException::new),
         keyFormat,
         keyFeatures,
         valueFormat,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImpl.java
@@ -125,11 +125,17 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
       final KsqlSecurityContext securityContext,
       final CreateSource createSource
   ) {
-    final String sourceTopic = createSource.getProperties().getKafkaTopic();
+    final String sourceTopic = createSource.getProperties()
+        .getKafkaTopic()
+        .orElseThrow(IllegalStateException::new);
+
     accessValidator.checkAccess(securityContext, sourceTopic, AclOperation.READ);
   }
 
-  private String getSourceTopicName(final MetaStore metaStore, final SourceName streamOrTable) {
+  private static String getSourceTopicName(
+      final MetaStore metaStore,
+      final SourceName streamOrTable
+  ) {
     final DataSource dataSource = metaStore.getSource(streamOrTable);
     if (dataSource == null) {
       throw new KsqlException("Cannot validate for topic access from an unknown stream/table: "
@@ -139,7 +145,7 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
     return dataSource.getKafkaTopicName();
   }
 
-  private String getCreateAsSelectSinkTopic(
+  private static String getCreateAsSelectSinkTopic(
       final MetaStore metaStore,
       final CreateAsSelect createAsSelect
   ) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedKafkaTopicClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedKafkaTopicClient.java
@@ -16,8 +16,10 @@
 package io.confluent.ksql.services;
 
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
+import static io.confluent.ksql.util.LimitedProxyBuilder.noParams;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.util.LimitedProxyBuilder;
@@ -28,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -58,6 +61,7 @@ final class SandboxedKafkaTopicClient {
         .forward("describeTopic", methodParams(String.class), sandbox)
         .forward("describeTopics", methodParams(Collection.class), sandbox)
         .forward("deleteTopics", methodParams(Collection.class), sandbox)
+        .forward("listTopicNames", noParams(), sandbox)
         .forward("listTopicsStartOffsets", methodParams(Collection.class), sandbox)
         .forward("listTopicsEndOffsets", methodParams(Collection.class), sandbox)
         .build();
@@ -119,6 +123,13 @@ final class SandboxedKafkaTopicClient {
     }
 
     return delegate.isTopicExists(topic);
+  }
+
+  private Set<String> listTopicNames() {
+    return ImmutableSet.<String>builder()
+        .addAll(createdTopics.keySet())
+        .addAll(delegate.listTopicNames())
+        .build();
   }
 
   public TopicDescription describeTopic(final String topicName) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/statement/Injectors.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/statement/Injectors.java
@@ -30,9 +30,9 @@ public enum Injectors implements BiFunction<KsqlExecutionContext, ServiceContext
 
   NO_TOPIC_DELETE((ec, sc) -> InjectorChain.of(
       new DefaultFormatInjector(),
+      new TopicCreateInjector(ec, sc),
       new DefaultSchemaInjector(
           new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient())),
-      new TopicCreateInjector(ec, sc),
       new SchemaRegisterInjector(ec, sc)
   )),
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import org.apache.kafka.common.config.TopicConfig;
 
 /**
@@ -63,7 +62,8 @@ public class TopicCreateInjector implements Injector {
 
   TopicCreateInjector(
       final KafkaTopicClient topicClient,
-      final MetaStore metaStore) {
+      final MetaStore metaStore
+  ) {
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient");
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
   }
@@ -96,14 +96,17 @@ public class TopicCreateInjector implements Injector {
     return statement;
   }
 
-  private ConfiguredStatement<? extends CreateSource> injectForCreateSource(
-      final ConfiguredStatement<? extends CreateSource> statement,
+  @SuppressWarnings("unchecked")
+  private <T extends CreateSource> ConfiguredStatement<T> injectForCreateSource(
+      final ConfiguredStatement<T> statement,
       final TopicProperties.Builder topicPropertiesBuilder
   ) {
     final CreateSource createSource = statement.getStatement();
     final CreateSourceProperties properties = createSource.getProperties();
+    final KsqlConfig config = statement.getSessionConfig().getConfig(true);
 
-    final String topicName = properties.getKafkaTopic();
+    final String topicName = TopicNaming
+        .getSourceTopicName(createSource.getName(), properties, config, topicClient);
 
     if (topicClient.isTopicExists(topicName)) {
       topicPropertiesBuilder.withSource(() -> topicClient.describeTopic(topicName));
@@ -122,16 +125,24 @@ public class TopicCreateInjector implements Injector {
     topicPropertiesBuilder
         .withName(topicName)
         .withWithClause(
-            Optional.of(properties.getKafkaTopic()),
+            properties.getKafkaTopic(),
             properties.getPartitions(),
             properties.getReplicas());
 
     final String topicCleanUpPolicy = createSource instanceof CreateTable
         ? TopicConfig.CLEANUP_POLICY_COMPACT : TopicConfig.CLEANUP_POLICY_DELETE;
 
-    createTopic(topicPropertiesBuilder, topicCleanUpPolicy);
+    final TopicProperties info =
+        createTopic(topicPropertiesBuilder, topicCleanUpPolicy, Collections.emptyMap());
 
-    return statement;
+    final T withTopic = (T) createSource.copyWith(
+        createSource.getElements(),
+        properties.withTopic(info.getTopicName())
+    );
+
+    final String withTopicText = SqlFormatter.formatSql(withTopic);
+
+    return statement.withStatement(withTopicText, withTopic);
   }
 
   @SuppressWarnings("unchecked")
@@ -188,13 +199,6 @@ public class TopicCreateInjector implements Injector {
     final String withTopicText = SqlFormatter.formatSql(withTopic) + ";";
 
     return statement.withStatement(withTopicText, withTopic);
-  }
-
-  private TopicProperties createTopic(
-      final Builder topicPropertiesBuilder,
-      final String topicCleanUpPolicy
-  ) {
-    return createTopic(topicPropertiesBuilder, topicCleanUpPolicy, Collections.emptyMap());
   }
 
   private TopicProperties createTopic(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicNaming.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicNaming.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.topic;
+
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.naming.SourceTopicNamingStrategy;
+import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Set;
+
+/**
+ * Helper methods around topic naming
+ */
+public final class TopicNaming {
+
+  private TopicNaming() {
+  }
+
+  /**
+   * Get the topic name for a source building built.
+   *
+   * <p>Topic name can be explicitly provided by the user in the statement, or can be obtained
+   * from the registered {@link SourceTopicNamingStrategy}.
+   *
+   * @param sourceName the name of the source being created.
+   * @param properties the properties of the source being created.
+   * @param ksqlConfig the system config to use.
+   * @param topicClient the topic client to use.
+   * @return the name of the source's Kafka topic.
+   */
+  public static String getSourceTopicName(
+      final SourceName sourceName,
+      final CreateSourceProperties properties,
+      final KsqlConfig ksqlConfig,
+      final KafkaTopicClient topicClient
+  ) {
+    return properties.getKafkaTopic()
+        .orElseGet(() -> findMatchingTopic(sourceName, ksqlConfig, topicClient));
+  }
+
+  private static String findMatchingTopic(
+      final SourceName sourceName,
+      final KsqlConfig ksqlConfig,
+      final KafkaTopicClient topicClient
+  ) {
+    final SourceTopicNamingStrategy resolver = ksqlConfig.getConfiguredInstance(
+        KsqlConfig.KSQL_SOURCE_TOPIC_NAMING_STRATEGY_CONFIG,
+        SourceTopicNamingStrategy.class
+    );
+
+    final Set<String> topicNames = topicClient.listTopicNames();
+    return resolver.resolveExistingTopic(sourceName, topicNames);
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -90,7 +90,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1442,27 +1441,6 @@ public class KsqlEngineTest {
     assertThat(e, rawMessage(is(
         "Invalid result type. Your SELECT query produces a STREAM. "
             + "Please use CREATE STREAM AS SELECT statement instead.")));
-  }
-
-  @Test
-  public void shouldThrowIfStatementMissingTopicConfig() {
-    final List<ParsedStatement> parsed = parse(
-        "CREATE TABLE FOO (viewtime BIGINT, pageid VARCHAR) WITH (VALUE_FORMAT='AVRO', KEY_FORMAT='KAFKA');"
-            + "CREATE STREAM FOO (viewtime BIGINT, pageid VARCHAR) WITH (VALUE_FORMAT='AVRO', KEY_FORMAT='KAFKA');"
-            + "CREATE TABLE FOO (viewtime BIGINT, pageid VARCHAR) WITH (VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');"
-            + "CREATE STREAM FOO (viewtime BIGINT, pageid VARCHAR) WITH (VALUE_FORMAT='JSON', KEY_FORMAT='KAFKA');"
-    );
-
-    for (final ParsedStatement statement : parsed) {
-
-      try {
-        ksqlEngine.prepare(statement);
-        Assert.fail();
-      } catch (final KsqlStatementException e) {
-        assertThat(e.getMessage(), containsString(
-            "Missing required property \"KAFKA_TOPIC\" which has no default value."));
-      }
-    }
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedKafkaTopicClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedKafkaTopicClientTest.java
@@ -19,6 +19,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
@@ -45,6 +47,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.kafka.clients.admin.TopicDescription;
@@ -80,6 +83,7 @@ public class SandboxedKafkaTopicClientTest {
           .ignore("describeTopic", String.class)
           .ignore("describeTopics", Collection.class)
           .ignore("deleteTopics", Collection.class)
+          .ignore("listTopicNames")
           .ignore("listTopicsStartOffsets", Collection.class)
           .ignore("listTopicsEndOffsets", Collection.class)
           .build();
@@ -346,6 +350,19 @@ public class SandboxedKafkaTopicClientTest {
       assertEquals(2, offsets.keySet().size());
       assertEquals(Long.valueOf(99L), offsets.get(new TopicPartition("some topic", 0)));
       assertEquals(Long.valueOf(100L), offsets.get(new TopicPartition("some topic", 1)));
+    }
+
+    @Test
+    public void shouldListTopicNames() {
+      // Given:
+      when(delegate.listTopicNames()).thenReturn(ImmutableSet.of("topicA", "topicB"));
+      sandboxedClient.createTopic("topicC", 1, (short) 3, configs);
+
+      // When:
+      final Set<String> result = sandboxedClient.listTopicNames();
+
+      // Then:
+      assertThat(result, containsInAnyOrder("topicA", "topicB", "topicC"));
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -40,9 +40,7 @@ import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
-import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
-import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -232,18 +230,14 @@ public class TopicCreateInjectorTest {
     // Given:
     givenStatement("CREATE STREAM x (FOO VARCHAR) WITH(value_format='avro', kafka_topic='topic', partitions=2);");
 
-    final CreateSourceProperties props = ((CreateSource) statement.getStatement())
-        .getProperties();
-
     // When:
     injector.inject(statement, builder);
 
     // Then:
-
     verify(builder).withWithClause(
-        Optional.of(props.getKafkaTopic()),
-        props.getPartitions(),
-        props.getReplicas()
+        Optional.of("topic"),
+        Optional.of(2),
+        Optional.empty()
     );
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -70,7 +70,8 @@ public final class AssertExecutor {
           "type"
       )).add(new SourceProperty(
           DataSource::getKafkaTopicName,
-          (cs, cfg) -> cs.getProperties().getKafkaTopic(),
+          (cs, cfg) -> cs.getProperties().getKafkaTopic()
+              .orElse(cs.getName().toString(FormatOptions.noEscape()).toUpperCase()),
           "kafka topic",
           CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY
       )).add(new SourceProperty(

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/AssertExecutorMetaTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/AssertExecutorMetaTest.java
@@ -31,7 +31,7 @@ public class AssertExecutorMetaTest {
   public void shouldCoverAllWithClauses() {
     // Given:
     final ConfigDef def = new ConfigDef();
-    CommonCreateConfigs.addToConfigDef(def, true);
+    CommonCreateConfigs.addToConfigDef(def);
     final Set<String> allValidProps = def.names();
 
     // When:

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -289,7 +289,8 @@ public class KsqlTesterTest {
     if (engineStatement.getStatement() instanceof CreateSource) {
       final CreateSource statement = (CreateSource) engineStatement.getStatement();
       topicClient.preconditionTopicExists(
-          statement.getProperties().getKafkaTopic(),
+          statement.getProperties().getKafkaTopic()
+              .orElse(statement.getName().toString(FormatOptions.noEscape()).toUpperCase()),
           statement.getProperties().getPartitions().orElse(1),
           statement.getProperties().getReplicas().orElse((short) 1),
           ImmutableMap.of()

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_primitive_-_value/6.2.0_1606402157356/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_primitive_-_value/6.2.0_1606402157356/plan.json
@@ -1,0 +1,146 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, FOO INTEGER) WITH (KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', WRAP_SINGLE_VALUE=false);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `FOO` INTEGER",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        },
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `FOO` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              },
+              "valueFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "sourceSchema" : "`K` STRING KEY, `FOO` INTEGER"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "FOO AS FOO" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.persistence.source.topic.naming.strategy" : "io.confluent.ksql.naming.CaseInsensitiveSourceTopicNamingStrategy",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_primitive_-_value/6.2.0_1606402157356/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_primitive_-_value/6.2.0_1606402157356/spec.json
@@ -1,0 +1,117 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1606402157356,
+  "path" : "query-validation-tests/avro.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `FOO` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO",
+        "features" : [ "UNWRAP_SINGLES" ]
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `FOO` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "deserialize anonymous primitive - value",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : 10
+    }, {
+      "topic" : "input",
+      "key" : null,
+      "value" : null
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "FOO" : 10
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : null
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : "int",
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (WRAP_SINGLE_VALUE=false, value_format='AVRO');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `FOO` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ "UNWRAP_SINGLES" ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `FOO` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "partitions" : 1,
+          "valueSchema" : "int"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "FOO",
+              "type" : [ "null", "int" ],
+              "default" : null
+            } ]
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_primitive_-_value/6.2.0_1606402157356/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_deserialize_anonymous_primitive_-_value/6.2.0_1606402157356/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_quoted_-_match/6.2.0_1606402228919/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_quoted_-_match/6.2.0_1606402228919/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM `InPuT` (VAL STRING) WITH (KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "InPuT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "InPuT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM `InPuT` `InPuT`\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "InPuT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "InPuT",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`VAL` STRING"
+          },
+          "selectExpressions" : [ "VAL AS VAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.persistence.source.topic.naming.strategy" : "io.confluent.ksql.naming.CaseInsensitiveSourceTopicNamingStrategy",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_quoted_-_match/6.2.0_1606402228919/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_quoted_-_match/6.2.0_1606402228919/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1606402228919,
+  "path" : "query-validation-tests/with-topic.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "case-sensitive - quoted - match",
+    "inputs" : [ {
+      "topic" : "InPuT",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "InPuT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM `InPuT` (VAL STRING);", "CREATE STREAM OUTPUT AS SELECT * FROM `InPuT`;" ],
+    "properties" : {
+      "ksql.persistence.default.format.value" : "JSON",
+      "ksql.persistence.source.topic.naming.strategy" : "io.confluent.ksql.naming.CaseSensitiveSourceTopicNamingStrategy"
+    },
+    "post" : {
+      "sources" : [ {
+        "name" : "InPuT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "InPuT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_quoted_-_match/6.2.0_1606402228919/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_quoted_-_match/6.2.0_1606402228919/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [InPuT])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_unquoted_-_match/6.2.0_1606402228902/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_unquoted_-_match/6.2.0_1606402228902/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (VAL STRING) WITH (KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "INPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "INPUT",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`VAL` STRING"
+          },
+          "selectExpressions" : [ "VAL AS VAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.persistence.source.topic.naming.strategy" : "io.confluent.ksql.naming.CaseInsensitiveSourceTopicNamingStrategy",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_unquoted_-_match/6.2.0_1606402228902/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_unquoted_-_match/6.2.0_1606402228902/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1606402228902,
+  "path" : "query-validation-tests/with-topic.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "case-sensitive - unquoted - match",
+    "inputs" : [ {
+      "topic" : "INPUT",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "INPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM InPuT (VAL STRING);", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "properties" : {
+      "ksql.persistence.default.format.value" : "JSON",
+      "ksql.persistence.source.topic.naming.strategy" : "io.confluent.ksql.naming.CaseSensitiveSourceTopicNamingStrategy"
+    },
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "INPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_unquoted_-_match/6.2.0_1606402228902/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_case-sensitive_-_unquoted_-_match/6.2.0_1606402228902/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_quoted_-_match/6.2.0_1606402228887/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_quoted_-_match/6.2.0_1606402228887/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM `InPut` (VAL STRING) WITH (KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "InPut",
+      "schema" : "`VAL` STRING",
+      "topicName" : "Input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM `InPut` `InPut`\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "InPut" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "Input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`VAL` STRING"
+          },
+          "selectExpressions" : [ "VAL AS VAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.persistence.source.topic.naming.strategy" : "io.confluent.ksql.naming.CaseInsensitiveSourceTopicNamingStrategy",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_quoted_-_match/6.2.0_1606402228887/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_quoted_-_match/6.2.0_1606402228887/spec.json
@@ -1,0 +1,99 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1606402228887,
+  "path" : "query-validation-tests/with-topic.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "default (case-insensitive) - quoted - match",
+    "inputs" : [ {
+      "topic" : "Input",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "Input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM `InPut` (VAL STRING);", "CREATE STREAM OUTPUT AS SELECT * FROM `InPut`;" ],
+    "properties" : {
+      "ksql.persistence.default.format.value" : "JSON"
+    },
+    "post" : {
+      "sources" : [ {
+        "name" : "InPut",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "Input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_quoted_-_match/6.2.0_1606402228887/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_quoted_-_match/6.2.0_1606402228887/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [Input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_unquoted_-_match/6.2.0_1606402228871/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_unquoted_-_match/6.2.0_1606402228871/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (VAL STRING) WITH (KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "Input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "Input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`VAL` STRING"
+          },
+          "selectExpressions" : [ "VAL AS VAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.persistence.source.topic.naming.strategy" : "io.confluent.ksql.naming.CaseInsensitiveSourceTopicNamingStrategy",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_unquoted_-_match/6.2.0_1606402228871/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_unquoted_-_match/6.2.0_1606402228871/spec.json
@@ -1,0 +1,99 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1606402228871,
+  "path" : "query-validation-tests/with-topic.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "default (case-insensitive) - unquoted - match",
+    "inputs" : [ {
+      "topic" : "Input",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "Input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (VAL STRING);", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "properties" : {
+      "ksql.persistence.default.format.value" : "JSON"
+    },
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "Input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_unquoted_-_match/6.2.0_1606402228871/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_default_(case-insensitive)_-_unquoted_-_match/6.2.0_1606402228871/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [Input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_explicit_-_provided/6.2.0_1606402228855/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_explicit_-_provided/6.2.0_1606402228855/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (VAL STRING) WITH (KAFKA_TOPIC='INPUT', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "INPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`VAL` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "INPUT",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`VAL` STRING"
+          },
+          "selectExpressions" : [ "VAL AS VAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.persistence.source.topic.naming.strategy" : "io.confluent.ksql.naming.CaseInsensitiveSourceTopicNamingStrategy",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_explicit_-_provided/6.2.0_1606402228855/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_explicit_-_provided/6.2.0_1606402228855/spec.json
@@ -1,0 +1,99 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1606402228855,
+  "path" : "query-validation-tests/with-topic.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`VAL` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "explicit - provided",
+    "inputs" : [ {
+      "topic" : "INPUT",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "VAL" : "v"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "INPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (VAL STRING) WITH (kafka_topic='INPUT');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "properties" : {
+      "ksql.persistence.default.format.value" : "JSON"
+    },
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`VAL` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "INPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_explicit_-_provided/6.2.0_1606402228855/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/with-topic_-_explicit_-_provided/6.2.0_1606402228855/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [INPUT])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -3,18 +3,18 @@
     {
       "name": "deserialize anonymous primitive - value",
       "statements": [
-        "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (WRAP_SINGLE_VALUE=false, kafka_topic='input_topic', value_format='AVRO');",
+        "CREATE STREAM INPUT (K STRING KEY, foo INT) WITH (WRAP_SINGLE_VALUE=false, value_format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
       "topics": [
         {
-          "name": "input_topic",
+          "name": "input",
           "valueSchema": "int"
         }
       ],
       "inputs": [
-        {"topic": "input_topic", "value": 10},
-        {"topic": "input_topic", "value": null}
+        {"topic": "input", "value": 10},
+        {"topic": "input", "value": null}
       ],
       "outputs": [
         {"topic": "OUTPUT", "value": {"FOO": 10}},

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/with-topic.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/with-topic.json
@@ -1,0 +1,163 @@
+{
+  "comments": [
+    "Tests covering the use of KAFKA_TOPIC in the WITH clause."
+  ],
+  "tests": [
+    {
+      "name": "explicit - missing",
+      "statements": [
+        "CREATE STREAM INPUT (VAL STRING);"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON",
+        "ksql.persistence.source.topic.naming.strategy": "io.confluent.ksql.naming.ExplicitSourceTopicNamingStrategy"
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Explicit 'KAFKA_TOPIC' required in the WITH clause"
+      }
+    },
+    {
+      "name": "explicit - provided",
+      "statements": [
+        "CREATE STREAM INPUT (VAL STRING) WITH (kafka_topic='INPUT');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON"
+      },
+      "inputs": [
+        {"topic": "INPUT", "value": {"VAL": "v"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"VAL": "v"}}
+      ]
+    },
+    {
+      "name": "default (case-insensitive) - unquoted - match",
+      "statements": [
+        "CREATE STREAM INPUT (VAL STRING);",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON"
+      },
+      "inputs": [
+        {"topic": "Input", "value": {"VAL": "v"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"VAL": "v"}}
+      ]
+    },
+    {
+      "name": "default (case-insensitive) - unquoted - no match",
+      "statements": [
+        "CREATE STREAM INPUT (VAL STRING);"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON"
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "No existing topic named `INPUT` (case-insensitive)"
+      }
+    },
+    {
+      "name": "default (case-insensitive) - quoted - match",
+      "statements": [
+        "CREATE STREAM `InPut` (VAL STRING);",
+        "CREATE STREAM OUTPUT AS SELECT * FROM `InPut`;"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON"
+      },
+      "inputs": [
+        {"topic": "Input", "value": {"VAL": "v"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"VAL": "v"}}
+      ]
+    },
+    {
+      "name": "default (case-insensitive) - quoted - no match",
+      "statements": [
+        "CREATE STREAM `InPut` (VAL STRING);"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON"
+      },
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "No existing topic named `InPut` (case-insensitive)"
+      }
+    },
+    {
+      "name": "case-sensitive - unquoted - match",
+      "statements": [
+        "CREATE STREAM InPuT (VAL STRING);",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON",
+        "ksql.persistence.source.topic.naming.strategy": "io.confluent.ksql.naming.CaseSensitiveSourceTopicNamingStrategy"
+      },
+      "inputs": [
+        {"topic": "INPUT", "value": {"VAL": "v"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"VAL": "v"}}
+      ]
+    },
+    {
+      "name": "case-sensitive - unquoted- no match",
+      "statements": [
+        "CREATE STREAM InPuT (VAL STRING);"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON",
+        "ksql.persistence.source.topic.naming.strategy": "io.confluent.ksql.naming.CaseSensitiveSourceTopicNamingStrategy"
+      },
+      "topics": [
+        {"name": "InPuT"}
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "No existing topic named `INPUT` (case-sensitive)"
+      }
+    },
+    {
+      "name": "case-sensitive - quoted - match",
+      "statements": [
+        "CREATE STREAM `InPuT` (VAL STRING);",
+        "CREATE STREAM OUTPUT AS SELECT * FROM `InPuT`;"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON",
+        "ksql.persistence.source.topic.naming.strategy": "io.confluent.ksql.naming.CaseSensitiveSourceTopicNamingStrategy"
+      },
+      "inputs": [
+        {"topic": "InPuT", "value": {"VAL": "v"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"VAL": "v"}}
+      ]
+    },
+    {
+      "name": "case-sensitive - quoted- no match",
+      "statements": [
+        "CREATE STREAM `InPuT` (VAL STRING);"
+      ],
+      "properties": {
+        "ksql.persistence.default.format.value": "JSON",
+        "ksql.persistence.source.topic.naming.strategy": "io.confluent.ksql.naming.CaseSensitiveSourceTopicNamingStrategy"
+      },
+      "topics": [
+        {"name": "INPUT"}
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "No existing topic named `InPuT` (case-sensitive)"
+      }
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -6,12 +6,12 @@
     {
       "name": "only key column",
       "statements": [
-        "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM INPUT (K STRING KEY, ID INT) WITH (value_format='JSON');",
         "SELECT K FROM INPUT EMIT CHANGES LIMIT 2;"
       ],
       "inputs": [
-        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {"id": 100}},
-        {"topic": "test_topic", "timestamp": 12365, "key": "12", "value": {"id": 101}}
+        {"topic": "Input", "timestamp": 12345, "key": "11", "value": {"id": 100}},
+        {"topic": "Input", "timestamp": 12365, "key": "12", "value": {"id": 101}}
       ],
       "responses": [
         {"admin": {"@type": "currentStatus"}},

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -76,10 +76,11 @@ public final class CreateSourceProperties {
     CommonCreateConfigs.validateKeyValueFormats(props.originals());
     props.validateDateTimeFormat(CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY);
     validateWindowInfo();
+    validateTopicInfo();
   }
 
-  public String getKafkaTopic() {
-    return props.getString(CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY);
+  public Optional<String> getKafkaTopic() {
+    return Optional.ofNullable(props.getString(CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY));
   }
 
   public Optional<Integer> getPartitions() {
@@ -207,6 +208,12 @@ public final class CreateSourceProperties {
     return props.copyOfOriginalLiterals();
   }
 
+  public CreateSourceProperties withTopic(final String topicName) {
+    final Map<String, Literal> originals = props.copyOfOriginalLiterals();
+    originals.put(CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(topicName));
+    return new CreateSourceProperties(originals, durationParser);
+  }
+
   @Override
   public String toString() {
     return props.toString();
@@ -247,8 +254,16 @@ public final class CreateSourceProperties {
     }
   }
 
+  private void validateTopicInfo() {
+    final boolean creatingNewTopic = getPartitions().isPresent();
+    if (creatingNewTopic && !getKafkaTopic().isPresent()) {
+      throw new KsqlException("'" + CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY
+          + "' must be provided if '" + CommonCreateConfigs.SOURCE_NUMBER_OF_PARTITIONS
+          + "' is provided.");
+    }
+  }
+
   private Optional<String> getFormatName() {
     return Optional.ofNullable(props.getString(CommonCreateConfigs.FORMAT_PROPERTY));
   }
-
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -544,7 +544,7 @@ public class KsqlParserTest {
     assertThat(Iterables.size(result.getElements()), equalTo(7));
     assertThat(Iterables.get(result.getElements(), 0).getName(), equalTo(ColumnName.of("ORDERTIME")));
     assertThat(Iterables.get(result.getElements(), 6).getType().getSqlType().baseType(), equalTo(SqlBaseType.STRUCT));
-    assertThat(result.getProperties().getKafkaTopic(), equalTo("orders_topic"));
+    assertThat(result.getProperties().getKafkaTopic(), equalTo(Optional.of("orders_topic")));
     assertThat(result.getProperties().getValueFormat().map(FormatInfo::getFormat), equalTo(Optional.of("AVRO")));
   }
 
@@ -559,7 +559,7 @@ public class KsqlParserTest {
     assertThat(result.getName(), equalTo(SourceName.of("USERS")));
     assertThat(Iterables.size(result.getElements()), equalTo(4));
     assertThat(Iterables.get(result.getElements(), 0).getName(), equalTo(ColumnName.of("USERTIME")));
-    assertThat(result.getProperties().getKafkaTopic(), equalTo("foo"));
+    assertThat(result.getProperties().getKafkaTopic(), equalTo(Optional.of("foo")));
     assertThat(result.getProperties().getValueFormat().map(FormatInfo::getFormat), equalTo(Optional.of("JSON")));
   }
 
@@ -1167,7 +1167,7 @@ public class KsqlParserTest {
 
     // Then:
     assertThat(result.getName(), equalTo(SourceName.of("ORDERS")));
-    assertThat(result.getProperties().getKafkaTopic(), equalTo("orders_topic"));
+    assertThat(result.getProperties().getKafkaTopic(), equalTo(Optional.of("orders_topic")));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -72,8 +72,8 @@ public class StandaloneExecutorFunctionalTest {
   @ClassRule
   public static final TemporaryFolder TMP = new TemporaryFolder();
 
-  private static final String AVRO_TOPIC = "avro-topic";
-  private static final String JSON_TOPIC = "json-topic";
+  private static final String AVRO_TOPIC = "avro_topic";
+  private static final String JSON_TOPIC = "json_topic";
   private static int DATA_SIZE;
   private static int UNIQUE_DATA_SIZE;
   private static PhysicalSchema DATA_SCHEMA;
@@ -225,9 +225,9 @@ public class StandaloneExecutorFunctionalTest {
     givenScript(""
         + "SET 'auto.offset.reset' = 'earliest';"
         + ""
-        + "CREATE STREAM S (ROWKEY STRING KEY) WITH (kafka_topic='" + AVRO_TOPIC + "', value_format='avro');\n"
+        + "CREATE STREAM " + AVRO_TOPIC + " (ROWKEY STRING KEY) WITH (value_format='avro');\n"
         + ""
-        + "CREATE STREAM " + s1 + " AS SELECT * FROM S;");
+        + "CREATE STREAM " + s1 + " AS SELECT * FROM " + AVRO_TOPIC + ";");
 
     // When:
     standalone.startAsync();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -848,22 +848,6 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldFailIfCreateStatementMissingKafkaTopicName() {
-    // When:
-    final KsqlErrorMessage result = makeFailingRequest(
-        "CREATE STREAM S (foo INT) WITH(KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
-        BAD_REQUEST.code());
-
-    // Then:
-    assertThat(result, is(instanceOf(KsqlStatementErrorMessage.class)));
-    assertThat(result.getErrorCode(), is(Errors.ERROR_CODE_BAD_STATEMENT));
-    assertThat(result.getMessage(),
-        containsString("Missing required property \"KAFKA_TOPIC\" which has no default value."));
-    assertThat(((KsqlStatementErrorMessage) result).getStatementText(),
-        is("CREATE STREAM S (foo INT) WITH(KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');"));
-  }
-
-  @Test
   public void shouldReturnForbiddenKafkaAccessIfKsqlTopicAuthorizationException() {
     // Given:
     final String errorMsg = "some error";


### PR DESCRIPTION
### Description 

implements [KLIP-34]: #6065

This change makes `KAFKA_TOPIC` optional in the `WITH` clause of `CREATE TABLE` and `CREATE STREAM` statements, where the table/stream is being created on top of an existing topic, for example:

```sql
CREATE STREAM pageviews (
    page_id BIGINT,
    viewtime BIGINT,
    user_id VARCHAR
  );
```

The above statement creates a new stream called `PAGEVIEWS`. As no `KAFKA_TOPIC` property is specified, ksqlDB will attempt to find a matching existing and accessible topic in the Kafka cluster. By default, ksqlDB will match any topic with the same name as the source, ignoring case. Where multiple matches are found, any exact match is used or an error is returned.

Users can control this behaviour via the `ksql.persistence.source.topic.naming.strategy` configuration, with three options supplied out of the box:
  * `CaseInsensitiveSourceTopicNamingStrategy` (default): case-insensitive matching
  * `CaseSensitiveSourceTopicNamingStrategy`: exact name matching
  * `ExplicitSourceTopicNamingStrategy`: forces users to explicitly provide `KAFKA_TOPIC` in the statement.

### Testing done 

Usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

