### PR TITLE
feat: added NULLIF function (#6567)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/quick-reference.md
+++ b/docs/developer-guide/ksqldb-reference/quick-reference.md
@@ -656,3 +656,12 @@ SELECT WINDOWSTART, WINDOWEND, aggregate_function
   WINDOW window_expression
   EMIT CHANGES;
 ```
+
+## NULLIF
+Returns NULL if two expressions are equal, otherwise it returns the first expression.
+
+```sql hl_lines="1"
+SELECT NULLIF(col1, col2) 
+    FROM from_stream | from_table
+    EMIT CHANGES;
+```

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -1058,6 +1058,19 @@ If the provided `expression` is NULL, returns `altValue`, otherwise, returns `ex
 Where the parameter type is a complex type, for example `ARRAY` or `STRUCT`, the contents of the
 complex type are not inspected.
 
+### `NULLIF`
+
+Since: -
+
+```sql
+NULLIF(expression1, expression2)
+```
+
+Returns NULL if `expression1` is equal to `expression2`; otherwise, returns `expression1`.
+
+If the parameter type is a complex type, for example, `ARRAY` or `STRUCT`, the contents of the
+complex type are not inspected.
+
 ## Date and time
 
 ### `UNIX_DATE`

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/NullIf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/nulls/NullIf.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.nulls;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+    name = NullIf.NAME_TEXT,
+    category = FunctionCategory.CONDITIONAL,
+    description = "Returns NULL if value1 and value2 are equal. Otherwise it returns value1.",
+    author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public class NullIf {
+
+  public static final String NAME_TEXT = "NULLIF";
+  public static final FunctionName NAME = FunctionName.of(NAME_TEXT);
+
+  @Udf
+  public final <T> T nullIf(
+          @UdfParameter(description = "expression 1") final T expr1,
+          @UdfParameter(description = "expression 2") final T expr2
+  ) {
+    if (expr1 == null) {
+      return null;
+    }
+    if (expr1.equals(expr2)) {
+      return null;
+    } else {
+      return expr1;
+    }
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/nulls/NullIfTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/nulls/NullIfTest.java
@@ -1,0 +1,48 @@
+package io.confluent.ksql.function.udf.nulls;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class NullIfTest {
+
+  private NullIf udf;
+
+  @Before
+  public void setUp() {
+    udf = new NullIf();
+  }
+
+  @Test
+  public void shouldReturnNullIfBothValuesAreNulls() {
+    assertThat(udf.nullIf(null, null), is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullIfValue1IsNull() {
+    assertThat(udf.nullIf(null, "a"), is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullIfBothValuesAreEqual() {
+    assertThat(udf.nullIf("a", "a"), is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnValue1IfBothValuesAreNonEqual() {
+    assertThat(udf.nullIf("a", "b"), is("a"));
+  }
+
+  @Test
+  public void shouldReturnValue1IfValue1IsNotNullAndValue2IsNull(){
+    assertThat(udf.nullIf("a", null), is("a"));
+  }
+
+  @Test
+  public void shouldReturnValue1CaseSensitive(){
+    assertThat(udf.nullIf("a", "A"), is("a"));
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_null_if/6.2.0_1606813248690/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_null_if/6.2.0_1606813248690/plan.json
@@ -1,0 +1,143 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (COL0 INTEGER KEY, COL1 STRING, COL2 ARRAY<INTEGER>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`COL0` INTEGER KEY, `COL1` STRING, `COL2` ARRAY<INTEGER>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.COL0 COL0,\n  NULLIF(INPUT.COL0, 10) A,\n  NULLIF(INPUT.COL1, 'x') B,\n  NULLIF(INPUT.COL2, ARRAY[1, 2, 3]) C\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`COL0` INTEGER KEY, `A` INTEGER, `B` STRING, `C` ARRAY<INTEGER>",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`COL0` INTEGER KEY, `COL1` STRING, `COL2` ARRAY<INTEGER>"
+          },
+          "keyColumnNames" : [ "COL0" ],
+          "selectExpressions" : [ "NULLIF(COL0, 10) AS A", "NULLIF(COL1, 'x') AS B", "NULLIF(COL2, ARRAY[1, 2, 3]) AS C" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_null_if/6.2.0_1606813248690/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_null_if/6.2.0_1606813248690/spec.json
@@ -1,0 +1,224 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1606813248690,
+  "path" : "query-validation-tests/null.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`COL0` INTEGER KEY, `COL1` STRING, `COL2` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`COL0` INTEGER KEY, `A` INTEGER, `B` STRING, `C` ARRAY<INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "null if",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "COL1" : "not null",
+        "COL2" : [ 1, 2, 3 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : { }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : null
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "COL1" : "not null",
+        "COL2" : [ 4, 5, 6 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 3,
+      "value" : {
+        "COL1" : "not null",
+        "COL2" : [ ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 4,
+      "value" : {
+        "COL1" : null,
+        "COL2" : [ 7, 8 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 10,
+      "value" : {
+        "COL1" : "x",
+        "COL2" : [ 7, 8 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "COL1" : "X",
+        "COL2" : [ 7, 8 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "COL1" : "x",
+        "COL2" : [ 7, 8 ]
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "COL1" : null,
+        "COL2" : [ 7, 8 ]
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "A" : 1,
+        "B" : "not null",
+        "C" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "A" : null,
+        "B" : null,
+        "C" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : null
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "A" : 2,
+        "B" : "not null",
+        "C" : [ 4, 5, 6 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "A" : 3,
+        "B" : "not null",
+        "C" : [ ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 4,
+      "value" : {
+        "A" : 4,
+        "B" : null,
+        "C" : [ 7, 8 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 10,
+      "value" : {
+        "A" : null,
+        "B" : null,
+        "C" : [ 7, 8 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "A" : 1,
+        "B" : "X",
+        "C" : [ 7, 8 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "A" : null,
+        "B" : null,
+        "C" : [ 7, 8 ]
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "A" : null,
+        "B" : null,
+        "C" : [ 7, 8 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT COL0, NULLIF(COL0, 10) AS A, NULLIF(COL1, 'x') AS B, NULLIF(COL2, ARRAY[1, 2, 3]) AS C FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`COL0` INTEGER KEY, `COL1` STRING, `COL2` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`COL0` INTEGER KEY, `A` INTEGER, `B` STRING, `C` ARRAY<INTEGER>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_null_if/6.2.0_1606813248690/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_null_if/6.2.0_1606813248690/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
@@ -259,6 +259,37 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Invalid comparison expression 'null' in join '(L.A = null)'. Each side of the join comparision must contain references from exactly one source."
       }
+    },
+    {
+      "name": "null if",
+      "statements": [
+        "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT COL0, NULLIF(COL0, 10) AS A, NULLIF(COL1, 'x') AS B, NULLIF(COL2, ARRAY[1, 2, 3]) AS C FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"COL1": "not null", "COL2": [1, 2, 3]}},
+        {"topic": "test_topic", "key": null, "value": {}},
+        {"topic": "test_topic", "key": null, "value": null},
+        {"topic": "test_topic", "key": 2, "value": {"COL1": "not null", "COL2": [4, 5, 6]}},
+        {"topic": "test_topic", "key": 3, "value": {"COL1": "not null", "COL2": []}},
+        {"topic": "test_topic", "key": 4, "value": {"COL1": null, "COL2": [7,8]}},
+        {"topic": "test_topic", "key": 10, "value": {"COL1": "x", "COL2": [7,8]}},
+        {"topic": "test_topic", "key": 1, "value": {"COL1": "X", "COL2": [7,8]}},
+        {"topic": "test_topic", "key": null, "value": {"COL1": "x", "COL2": [7,8]}},
+        {"topic": "test_topic", "key": null, "value": {"COL1": null, "COL2": [7,8]}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"A": 1, "B": "not null", "C": null}},
+        {"topic": "OUTPUT", "key": null, "value": {"A": null, "B": null, "C": null}},
+        {"topic": "OUTPUT", "key": null, "value": null},
+        {"topic": "OUTPUT", "key": 2, "value": {"A": 2, "B": "not null", "C": [4, 5, 6]}},
+        {"topic": "OUTPUT", "key": 3, "value": {"A": 3, "B": "not null", "C": []}},
+        {"topic": "OUTPUT", "key": 4, "value": {"A": 4, "B": null, "C": [7,8]}},
+        {"topic": "OUTPUT", "key": 10, "value": {"A": null, "B": null, "C": [7,8]}},
+        {"topic": "OUTPUT", "key": 1, "value": {"A": 1, "B": "X", "C": [7,8]}},
+        {"topic": "OUTPUT", "key": null, "value": {"A": null, "B": null, "C": [7,8]}},
+        {"topic": "OUTPUT", "key": null, "value": {"A": null, "B": null, "C": [7,8]}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 
[#6567](https://github.com/confluentinc/ksql/issues/6567)

The `NULLIF` function returns NULL if and only if **value1** and **value2** are equal. Otherwise it returns **value1**.

### Testing done 

- **Engine**. Unit test covering `NULLIF` function.
- **Functional-tests**. Added test case in `null.json` and generated historial plan.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

