### PR TITLE
fix: Refactors rate limiter within LoggingHandler to be singleton

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingHandler.java
@@ -15,11 +15,10 @@
 
 package io.confluent.ksql.api.server;
 
-import static io.confluent.ksql.rest.server.KsqlRestConfig.KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG;
 import static io.confluent.ksql.rest.server.KsqlRestConfig.KSQL_LOGGING_SERVER_SKIPPED_RESPONSE_CODES_CONFIG;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.api.auth.ApiUser;
@@ -31,11 +30,9 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.impl.Utils;
 import java.time.Clock;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,28 +42,27 @@ public class LoggingHandler implements Handler<RoutingContext> {
   static final String HTTP_HEADER_USER_AGENT = "User-Agent";
 
   private final Set<Integer> skipResponseCodes;
-  private final Map<String, Double> rateLimitedPaths;
   private final Logger logger;
   private final Clock clock;
-  private final Function<Double, RateLimiter> rateLimiterFactory;
+  private final LoggingRateLimiter loggingRateLimiter;
 
   private final Map<String, RateLimiter> rateLimiters = new ConcurrentHashMap<>();
 
-  public LoggingHandler(final Server server) {
-    this(server, LOG, Clock.systemUTC(), RateLimiter::create);
+  public LoggingHandler(final Server server, final LoggingRateLimiter loggingRateLimiter) {
+    this(server, loggingRateLimiter, LOG, Clock.systemUTC());
   }
 
   @VisibleForTesting
   LoggingHandler(
       final Server server,
+      final LoggingRateLimiter loggingRateLimiter,
       final Logger logger,
-      final Clock clock,
-      final Function<Double, RateLimiter> rateLimiterFactory) {
+      final Clock clock) {
+    requireNonNull(server);
+    this.loggingRateLimiter = requireNonNull(loggingRateLimiter);
     this.skipResponseCodes = getSkipResponseCodes(server.getConfig());
-    this.rateLimitedPaths = getSkipRequestPaths(server.getConfig());
     this.logger = logger;
     this.clock = clock;
-    this.rateLimiterFactory = rateLimiterFactory;
   }
 
   @Override
@@ -76,13 +72,8 @@ public class LoggingHandler implements Handler<RoutingContext> {
       if (skipResponseCodes.contains(routingContext.response().getStatusCode())) {
         return;
       }
-      if (rateLimitedPaths.containsKey(routingContext.request().path())) {
-        final String path = routingContext.request().path();
-        final double rateLimit = rateLimitedPaths.get(path);
-        rateLimiters.computeIfAbsent(path, (k) -> rateLimiterFactory.apply(rateLimit));
-        if (!rateLimiters.get(path).tryAcquire()) {
-          return;
-        }
+      if (!loggingRateLimiter.shouldLog(routingContext)) {
+        return;
       }
       final long contentLength = routingContext.request().response().bytesWritten();
       final HttpVersion version = routingContext.request().version();
@@ -132,14 +123,6 @@ public class LoggingHandler implements Handler<RoutingContext> {
     return config.getList(KSQL_LOGGING_SERVER_SKIPPED_RESPONSE_CODES_CONFIG)
         .stream()
         .map(Integer::parseInt).collect(ImmutableSet.toImmutableSet());
-  }
-
-  private static Map<String, Double> getSkipRequestPaths(final KsqlRestConfig config) {
-    // Already validated as having double values
-    return config.getStringAsMap(KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG)
-        .entrySet().stream()
-        .collect(ImmutableMap.toImmutableMap(Entry::getKey,
-            entry -> Double.parseDouble(entry.getValue())));
   }
 
   private void doLog(final int status, final String message) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingHandler.java
@@ -72,7 +72,7 @@ public class LoggingHandler implements Handler<RoutingContext> {
       if (skipResponseCodes.contains(routingContext.response().getStatusCode())) {
         return;
       }
-      if (!loggingRateLimiter.shouldLog(routingContext)) {
+      if (!loggingRateLimiter.shouldLog(routingContext.request().path())) {
         return;
       }
       final long contentLength = routingContext.request().response().bytesWritten();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingRateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingRateLimiter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.server;
+
+import static io.confluent.ksql.rest.server.KsqlRestConfig.KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.RateLimiter;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.vertx.ext.web.RoutingContext;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+public class LoggingRateLimiter {
+
+  private final Map<String, Double> rateLimitedPaths;
+  private final Function<Double, RateLimiter> rateLimiterFactory;
+
+  private final Map<String, RateLimiter> rateLimiters = new ConcurrentHashMap<>();
+
+  public LoggingRateLimiter(final KsqlRestConfig ksqlRestConfig) {
+    this(ksqlRestConfig, RateLimiter::create);
+  }
+
+  public LoggingRateLimiter(
+      final KsqlRestConfig ksqlRestConfig,
+      final Function<Double, RateLimiter> rateLimiterFactory) {
+    requireNonNull(ksqlRestConfig);
+    this.rateLimiterFactory = requireNonNull(rateLimiterFactory);
+    this.rateLimitedPaths = getRateLimitedRequestPaths(ksqlRestConfig);
+  }
+
+  public boolean shouldLog(final RoutingContext routingContext) {
+    if (rateLimitedPaths.containsKey(routingContext.request().path())) {
+      final String path = routingContext.request().path();
+      final double rateLimit = rateLimitedPaths.get(path);
+      rateLimiters.computeIfAbsent(path, (k) -> rateLimiterFactory.apply(rateLimit));
+      return rateLimiters.get(path).tryAcquire();
+    }
+    return true;
+  }
+
+  private static Map<String, Double> getRateLimitedRequestPaths(final KsqlRestConfig config) {
+    // Already validated as having double values
+    return config.getStringAsMap(KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG)
+        .entrySet().stream()
+        .collect(ImmutableMap.toImmutableMap(Entry::getKey,
+            entry -> Double.parseDouble(entry.getValue())));
+  }
+
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -110,6 +110,7 @@ public class Server {
     }
     this.workerExecutor = vertx.createSharedWorkerExecutor("ksql-workers",
         config.getInt(KsqlRestConfig.WORKER_POOL_SIZE));
+    final LoggingRateLimiter loggingRateLimiter = new LoggingRateLimiter(config);
     configureTlsCertReload(config);
 
     final List<URI> listenUris = parseListeners(config);
@@ -131,7 +132,7 @@ public class Server {
         final ServerVerticle serverVerticle = new ServerVerticle(endpoints,
             createHttpServerOptions(config, listener.getHost(), listener.getPort(),
                 listener.getScheme().equalsIgnoreCase("https"), isInternalListener.orElse(false)),
-            this, isInternalListener, pullQueryMetrics);
+            this, isInternalListener, pullQueryMetrics, loggingRateLimiter);
         vertx.deployVerticle(serverVerticle, vcf);
         final int index = i;
         final CompletableFuture<String> deployFuture = vcf.thenApply(s -> {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -68,18 +68,21 @@ public class ServerVerticle extends AbstractVerticle {
   private HttpServer httpServer;
   private final Optional<Boolean> isInternalListener;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
+  private final LoggingRateLimiter loggingRateLimiter;
 
   public ServerVerticle(
       final Endpoints endpoints,
       final HttpServerOptions httpServerOptions,
       final Server server,
       final Optional<Boolean> isInternalListener,
-      final Optional<PullQueryExecutorMetrics> pullQueryMetrics) {
+      final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
+      final LoggingRateLimiter loggingRateLimiter) {
     this.endpoints = Objects.requireNonNull(endpoints);
     this.httpServerOptions = Objects.requireNonNull(httpServerOptions);
     this.server = Objects.requireNonNull(server);
     this.isInternalListener = Objects.requireNonNull(isInternalListener);
     this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics);
+    this.loggingRateLimiter = Objects.requireNonNull(loggingRateLimiter);
   }
 
   @Override
@@ -112,7 +115,7 @@ public class ServerVerticle extends AbstractVerticle {
   private Router setupRouter() {
     final Router router = Router.router(vertx);
 
-    router.route().handler(new LoggingHandler(server));
+    router.route().handler(new LoggingHandler(server, loggingRateLimiter));
 
     KsqlCorsHandler.setupCorsHandler(server, router);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingHandlerTest.java
@@ -66,9 +66,10 @@ public class LoggingHandlerTest {
     when(request.response()).thenReturn(response);
     when(request.remoteAddress()).thenReturn(socketAddress);
     when(ksqlRestConfig.getList(any())).thenReturn(ImmutableList.of("401"));
-    when(loggingRateLimiter.shouldLog(any())).thenReturn(true);
+    when(loggingRateLimiter.shouldLog("/query")).thenReturn(true);
     when(clock.millis()).thenReturn(1699813434333L);
     when(response.bytesWritten()).thenReturn(5678L);
+    when(request.path()).thenReturn("/query");
     when(request.uri()).thenReturn("/query");
     when(request.getHeader(HTTP_HEADER_USER_AGENT)).thenReturn("bot");
     when(socketAddress.host()).thenReturn("123.111.222.333");
@@ -132,7 +133,7 @@ public class LoggingHandlerTest {
   public void shouldSkipRateLimited() {
     // Given:
     when(response.getStatusCode()).thenReturn(200);
-    when(loggingRateLimiter.shouldLog(any())).thenReturn(true, true, false, false);
+    when(loggingRateLimiter.shouldLog("/query")).thenReturn(true, true, false, false);
 
     // When:
     loggingHandler.handle(routingContext);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingHandlerTest.java
@@ -10,8 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -37,6 +35,8 @@ public class LoggingHandlerTest {
   @Mock
   private Server server;
   @Mock
+  private LoggingRateLimiter loggingRateLimiter;
+  @Mock
   private Logger logger;
   @Mock
   private RoutingContext routingContext;
@@ -50,8 +50,6 @@ public class LoggingHandlerTest {
   private SocketAddress socketAddress;
   @Mock
   private Clock clock;
-  @Mock
-  private RateLimiter rateLimiter;
   @Captor
   private ArgumentCaptor<String> logStringCaptor;
   @Captor
@@ -68,18 +66,16 @@ public class LoggingHandlerTest {
     when(request.response()).thenReturn(response);
     when(request.remoteAddress()).thenReturn(socketAddress);
     when(ksqlRestConfig.getList(any())).thenReturn(ImmutableList.of("401"));
-    when(ksqlRestConfig.getStringAsMap(any())).thenReturn(ImmutableMap.of("/query", "100"));
-    when(rateLimiter.tryAcquire()).thenReturn(true);
+    when(loggingRateLimiter.shouldLog(any())).thenReturn(true);
     when(clock.millis()).thenReturn(1699813434333L);
     when(response.bytesWritten()).thenReturn(5678L);
     when(request.uri()).thenReturn("/query");
-    when(request.path()).thenReturn("/query");
     when(request.getHeader(HTTP_HEADER_USER_AGENT)).thenReturn("bot");
     when(socketAddress.host()).thenReturn("123.111.222.333");
     when(request.bytesRead()).thenReturn(3456L);
     when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
     when(request.method()).thenReturn(HttpMethod.POST);
-    loggingHandler = new LoggingHandler(server, logger, clock, (rateLimit) -> rateLimiter);
+    loggingHandler = new LoggingHandler(server, loggingRateLimiter, logger, clock);
   }
 
   @Test
@@ -136,7 +132,7 @@ public class LoggingHandlerTest {
   public void shouldSkipRateLimited() {
     // Given:
     when(response.getStatusCode()).thenReturn(200);
-    when(rateLimiter.tryAcquire()).thenReturn(true, true, false, false);
+    when(loggingRateLimiter.shouldLog(any())).thenReturn(true, true, false, false);
 
     // When:
     loggingHandler.handle(routingContext);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingRateLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingRateLimiterTest.java
@@ -12,56 +12,28 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.net.SocketAddress;
-import io.vertx.ext.web.RoutingContext;
-import java.time.Clock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.Logger;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LoggingRateLimiterTest {
 
-  @Mock
-  private Server server;
-  @Mock
-  private Logger logger;
+  private static final String PATH = "/query";
+
   @Mock
   private RateLimiter rateLimiter;
   @Mock
-  private RoutingContext routingContext;
-  @Mock
   private KsqlRestConfig ksqlRestConfig;
-  @Mock
-  private HttpServerRequest request;
-  @Mock
-  private HttpServerResponse response;
-  @Mock
-  private SocketAddress socketAddress;
-  @Mock
-  private Clock clock;
-  @Captor
-  private ArgumentCaptor<String> logStringCaptor;
-  @Captor
-  private ArgumentCaptor<Handler<AsyncResult<Void>>> endCallback;
 
   private LoggingRateLimiter loggingRateLimiter;
 
 
   @Before
   public void setUp() {
-    when(routingContext.request()).thenReturn(request);
-    when(request.path()).thenReturn("/query");
-    when(ksqlRestConfig.getStringAsMap(any())).thenReturn(ImmutableMap.of("/query", "2"));
+    when(ksqlRestConfig.getStringAsMap(any())).thenReturn(ImmutableMap.of(PATH, "2"));
     when(rateLimiter.tryAcquire()).thenReturn(true);
     loggingRateLimiter = new LoggingRateLimiter(ksqlRestConfig, (rateLimit) -> rateLimiter);
   }
@@ -69,7 +41,7 @@ public class LoggingRateLimiterTest {
   @Test
   public void shouldLog() {
     // When:
-    assertThat(loggingRateLimiter.shouldLog(routingContext), is(true));
+    assertThat(loggingRateLimiter.shouldLog(PATH), is(true));
 
     // Then:
     verify(rateLimiter).tryAcquire();
@@ -81,20 +53,19 @@ public class LoggingRateLimiterTest {
     when(rateLimiter.tryAcquire()).thenReturn(true, true, false, false);
 
     // When:
-    assertThat(loggingRateLimiter.shouldLog(routingContext), is(true));
-    assertThat(loggingRateLimiter.shouldLog(routingContext), is(true));
-    assertThat(loggingRateLimiter.shouldLog(routingContext), is(false));
-    assertThat(loggingRateLimiter.shouldLog(routingContext), is(false));
+    assertThat(loggingRateLimiter.shouldLog(PATH), is(true));
+    assertThat(loggingRateLimiter.shouldLog(PATH), is(true));
+    assertThat(loggingRateLimiter.shouldLog(PATH), is(false));
+    assertThat(loggingRateLimiter.shouldLog(PATH), is(false));
 
     // Then:
     verify(rateLimiter, times(4)).tryAcquire();
   }
 
   @Test
-  public void shouldLog_notIncluded() {
+  public void shouldLog_notRateLimited() {
     // When:
-    when(request.path()).thenReturn("/foo");
-    assertThat(loggingRateLimiter.shouldLog(routingContext), is(true));
+    assertThat(loggingRateLimiter.shouldLog("/foo"), is(true));
 
     // Then:
     verify(rateLimiter, never()).tryAcquire();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingRateLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingRateLimiterTest.java
@@ -1,0 +1,102 @@
+package io.confluent.ksql.api.server;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.RateLimiter;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.RoutingContext;
+import java.time.Clock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoggingRateLimiterTest {
+
+  @Mock
+  private Server server;
+  @Mock
+  private Logger logger;
+  @Mock
+  private RateLimiter rateLimiter;
+  @Mock
+  private RoutingContext routingContext;
+  @Mock
+  private KsqlRestConfig ksqlRestConfig;
+  @Mock
+  private HttpServerRequest request;
+  @Mock
+  private HttpServerResponse response;
+  @Mock
+  private SocketAddress socketAddress;
+  @Mock
+  private Clock clock;
+  @Captor
+  private ArgumentCaptor<String> logStringCaptor;
+  @Captor
+  private ArgumentCaptor<Handler<AsyncResult<Void>>> endCallback;
+
+  private LoggingRateLimiter loggingRateLimiter;
+
+
+  @Before
+  public void setUp() {
+    when(routingContext.request()).thenReturn(request);
+    when(request.path()).thenReturn("/query");
+    when(ksqlRestConfig.getStringAsMap(any())).thenReturn(ImmutableMap.of("/query", "2"));
+    when(rateLimiter.tryAcquire()).thenReturn(true);
+    loggingRateLimiter = new LoggingRateLimiter(ksqlRestConfig, (rateLimit) -> rateLimiter);
+  }
+
+  @Test
+  public void shouldLog() {
+    // When:
+    assertThat(loggingRateLimiter.shouldLog(routingContext), is(true));
+
+    // Then:
+    verify(rateLimiter).tryAcquire();
+  }
+
+  @Test
+  public void shouldSkipRateLimited() {
+    // Given:
+    when(rateLimiter.tryAcquire()).thenReturn(true, true, false, false);
+
+    // When:
+    assertThat(loggingRateLimiter.shouldLog(routingContext), is(true));
+    assertThat(loggingRateLimiter.shouldLog(routingContext), is(true));
+    assertThat(loggingRateLimiter.shouldLog(routingContext), is(false));
+    assertThat(loggingRateLimiter.shouldLog(routingContext), is(false));
+
+    // Then:
+    verify(rateLimiter, times(4)).tryAcquire();
+  }
+
+  @Test
+  public void shouldLog_notIncluded() {
+    // When:
+    when(request.path()).thenReturn("/foo");
+    assertThat(loggingRateLimiter.shouldLog(routingContext), is(true));
+
+    // Then:
+    verify(rateLimiter, never()).tryAcquire();
+  }
+}


### PR DESCRIPTION
### Description 
Changes the rate limiting logic within LoggingHandler to be a shared singleton.  Otherwise the limit is multiplied by the number of server verticles.

### Testing done 
Ran unit tests and ran high qps requests manually to verify correct logging.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

