### PR TITLE
chore: split key format feature flag

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -138,7 +138,17 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_KEY_FORMAT_ENABLED = "ksql.key.format.enabled";
   public static final Boolean KSQL_KEY_FORMAT_ENABLED_DEFAULT = false;
   public static final String KSQL_KEY_FORMAT_ENABLED_DOC =
-      "Feature flag for non-Kafka key formats";
+      "Feature flag for key formats under development";
+
+  public static final String KSQL_COMPLEX_KEY_FORMAT_ENABLED = "ksql.complex.key.format.enabled";
+  public static final Boolean KSQL_COMPLEX_KEY_FORMAT_ENABLED_DEFAULT = false;
+  public static final String KSQL_COMPLEX_KEY_FORMAT_ENABLED_DOC =
+      "Feature flag for complex (non-primitive) keys";
+
+  public static final String KSQL_MULTICOL_KEY_FORMAT_ENABLED = "ksql.multicol.key.format.enabled";
+  public static final Boolean KSQL_MULTICOL_KEY_FORMAT_ENABLED_DEFAULT = false;
+  public static final String KSQL_MULTICOL_KEY_FORMAT_ENABLED_DOC =
+      "Feature flag for multi-column keys";
 
   public static final String KSQL_DEFAULT_KEY_FORMAT_CONFIG = "ksql.persistence.default.format.key";
   private static final String KSQL_DEFAULT_KEY_FORMAT_DEFAULT = "KAFKA";
@@ -613,6 +623,18 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_KEY_FORMAT_ENABLED_DEFAULT,
             ConfigDef.Importance.LOW,
             KSQL_KEY_FORMAT_ENABLED_DOC
+        ).define(
+            KSQL_COMPLEX_KEY_FORMAT_ENABLED,
+            Type.BOOLEAN,
+            KSQL_COMPLEX_KEY_FORMAT_ENABLED_DEFAULT,
+            ConfigDef.Importance.LOW,
+            KSQL_COMPLEX_KEY_FORMAT_ENABLED_DOC
+        ).define(
+            KSQL_MULTICOL_KEY_FORMAT_ENABLED,
+            Type.BOOLEAN,
+            KSQL_MULTICOL_KEY_FORMAT_ENABLED_DEFAULT,
+            ConfigDef.Importance.LOW,
+            KSQL_MULTICOL_KEY_FORMAT_ENABLED_DOC
         ).define(
             KSQL_DEFAULT_KEY_FORMAT_CONFIG,
             Type.STRING,

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
@@ -32,6 +32,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public final class PlannedTestUtils {
@@ -48,9 +49,10 @@ public final class PlannedTestUtils {
 
   public static boolean isNotExcluded(final TestCase testCase) {
     // Place temporary logic here to exclude test cases based on feature flags, etc.
-    return !(boolean) testCase
-        .properties()
-        .getOrDefault(KsqlConfig.KSQL_KEY_FORMAT_ENABLED, false);
+    final Map<String, Object> props = testCase.properties();
+    return !(boolean) props.getOrDefault(KsqlConfig.KSQL_KEY_FORMAT_ENABLED, false)
+        && !(boolean) props.getOrDefault(KsqlConfig.KSQL_COMPLEX_KEY_FORMAT_ENABLED, false)
+        && !(boolean) props.getOrDefault(KsqlConfig.KSQL_MULTICOL_KEY_FORMAT_ENABLED, false);
   }
 
   public static boolean isSamePlan(

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/as_value.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/as_value.json
@@ -153,7 +153,7 @@
     {
       "name": "ARRAY",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (ID ARRAY<VARCHAR> KEY, V0 INT, V1 INT) WITH (kafka_topic='input', format='JSON');",
@@ -174,7 +174,7 @@
     {
       "name": "STRUCT",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (ID STRUCT<F1 VARCHAR> KEY, V0 INT, V1 INT) WITH (kafka_topic='input', format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -860,7 +860,7 @@
     {
       "name": "ARRAY - key - no inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
@@ -880,7 +880,7 @@
     {
       "name": "ARRAY - key - inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
@@ -908,7 +908,7 @@
     {
       "name": "MAP - key - C*",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K MAP<INT, DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');"
@@ -921,7 +921,7 @@
     {
       "name": "nested MAP type - key - C*",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<MAP<INT, DOUBLE>> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');"
@@ -934,7 +934,7 @@
     {
       "name": "MAP - key - C*AS",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='AVRO');",
@@ -948,7 +948,7 @@
     {
       "name": "nested MAP type - key - C*AS",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='AVRO');",
@@ -962,7 +962,7 @@
     {
       "name": "STRUCT - key - no inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K STRUCT<F1 VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='AVRO');",
@@ -982,7 +982,7 @@
     {
       "name": "STRUCT - key - inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "topics": [
         {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/delimited.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/delimited.json
@@ -140,7 +140,7 @@
     {
       "name": "ARRAY - C* - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<INT> KEY, foo INT) WITH (kafka_topic='input_topic', format='DELIMITED');"
@@ -153,7 +153,7 @@
     {
       "name": "ARRAY - C*AS - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (v INT) WITH (kafka_topic='input_topic', format='DELIMITED');",
@@ -167,7 +167,7 @@
     {
       "name": "MAP - C* - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K MAP<INT, DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='DELIMITED');"
@@ -180,7 +180,7 @@
     {
       "name": "MAP - C*AS - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='DELIMITED');",
@@ -194,7 +194,7 @@
     {
       "name": "STRUCT - C* - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K STRUCT<F1 DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='DELIMITED');"
@@ -207,7 +207,7 @@
     {
       "name": "STRUCT - C*AS - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (v DOUBLE) WITH (kafka_topic='input_topic', format='DELIMITED');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -2258,7 +2258,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "windowed aggregate with struct key",
       "format": ["JSON", "AVRO"],
@@ -2279,7 +2279,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "windowed aggregate with field within struct key",
       "statements": [
@@ -2358,7 +2358,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "AVRO struct key group by primitive",
       "statements": [
@@ -2403,7 +2403,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "AVRO group by struct",
       "statements": [
@@ -2474,7 +2474,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "JSON group by array",
       "statements": [
@@ -2494,7 +2494,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "JSON group by struct",
       "statements": [
@@ -2514,7 +2514,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "JSON group by struct convert key format",
       "statements": [
@@ -2554,7 +2554,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "JSON group by struct convert to incompatible key format",
       "statements": [
@@ -2568,7 +2568,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "Struct key used in aggregate expression",
       "statements": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/json.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/json.json
@@ -279,7 +279,7 @@
     {
       "name": "ARRAY - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -327,7 +327,7 @@
     {
       "name": "MAP - key - C*",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K MAP<INT, DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='JSON');"
@@ -340,7 +340,7 @@
     {
       "name": "nested MAP type - key - C*",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<MAP<INT, DOUBLE>> KEY, foo INT) WITH (kafka_topic='input_topic', format='JSON');"
@@ -353,7 +353,7 @@
     {
       "name": "MAP - key - C*AS",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='JSON');",
@@ -367,7 +367,7 @@
     {
       "name": "nested MAP type - key - C*AS",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='JSON');",
@@ -411,7 +411,7 @@
     {
       "name": "STRUCT - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K STRUCT<F DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_sr.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_sr.json
@@ -618,7 +618,7 @@
     {
       "name": "ARRAY - key - no inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='JSON_SR');",
@@ -638,7 +638,7 @@
     {
       "name": "ARRAY - key - inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='JSON_SR');",
@@ -678,7 +678,7 @@
     {
       "name": "MAP - key - C*",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K MAP<INT, DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='JSON_SR');"
@@ -691,7 +691,7 @@
     {
       "name": "nested MAP type - key - C*",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<MAP<INT, DOUBLE>> KEY, foo INT) WITH (kafka_topic='input_topic', format='JSON_SR');"
@@ -704,7 +704,7 @@
     {
       "name": "MAP - key - C*AS",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='JSON_SR');",
@@ -718,7 +718,7 @@
     {
       "name": "nested MAP type - key - C*AS",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='JSON_SR');",
@@ -732,7 +732,7 @@
     {
       "name": "STRUCT - key - no inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K STRUCT<F1 VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='JSON_SR');",
@@ -752,7 +752,7 @@
     {
       "name": "STRUCT - key - inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "topics": [
         {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/kafka.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/kafka.json
@@ -131,7 +131,7 @@
     {
       "name": "ARRAY - C* - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<INT> KEY, foo INT) WITH (kafka_topic='input_topic', format='KAFKA');"
@@ -144,7 +144,7 @@
     {
       "name": "ARRAY - C*AS - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (v INT) WITH (kafka_topic='input_topic', format='KAFKA');",
@@ -158,7 +158,7 @@
     {
       "name": "MAP - C* - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K MAP<INT, DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='KAFKA');"
@@ -171,7 +171,7 @@
     {
       "name": "MAP - C*AS - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (k STRING KEY, v STRING) WITH (kafka_topic='input_topic', format='KAFKA');",
@@ -185,7 +185,7 @@
     {
       "name": "STRUCT - C* - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K STRUCT<F1 DOUBLE> KEY, foo INT) WITH (kafka_topic='input_topic', format='KAFKA');"
@@ -198,7 +198,7 @@
     {
       "name": "STRUCT - C*AS - key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (v DOUBLE) WITH (kafka_topic='input_topic', format='KAFKA');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-col-keys.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-col-keys.json
@@ -3,7 +3,7 @@
     {
       "name": "select * from stream",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -28,7 +28,7 @@
     {
       "name": "select * from table",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE TABLE INPUT (K INT PRIMARY KEY, K2 INT PRIMARY KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -49,7 +49,7 @@
     {
       "name": "select * with WHERE on single key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -71,7 +71,7 @@
     {
       "name": "select * with WHERE on both key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -93,7 +93,7 @@
     {
       "name": "select * from stream partition by single key col",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -114,7 +114,8 @@
     {
       "name": "select * from stream partition by struct representing the key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true,
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -135,7 +136,7 @@
     {
       "name": "group by one col",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -156,7 +157,7 @@
     {
       "name": "group by two cols",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -177,7 +178,7 @@
     {
       "name": "group by one col table with tombstones",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE TABLE INPUT (K INT PRIMARY KEY, K2 INT PRIMARY KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -195,7 +196,7 @@
     {
       "name": "group by two cols table with tombstones",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE TABLE INPUT (K INT PRIMARY KEY, K2 INT PRIMARY KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -213,7 +214,7 @@
     {
       "name": "group by two cols with AS_VALUE copies",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -234,7 +235,7 @@
     {
       "name": "windowed group by one col",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -259,7 +260,7 @@
     {
       "name": "join with repartition on single key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM S1 (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='s1', format='JSON');",
@@ -282,7 +283,7 @@
     {
       "name": "join with repartition on single value",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM S1 (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='s1', format='JSON');",
@@ -305,7 +306,8 @@
     {
       "name": "struct as column in multi-column key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true,
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 STRUCT<F1 INT> KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -326,7 +328,7 @@
     {
       "name": "select only single key col",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",
@@ -340,7 +342,7 @@
     {
       "name": "join on multi-column key",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM S1 (K INT KEY, K2 INT KEY, V INT) WITH (kafka_topic='s1', format='JSON');",
@@ -355,7 +357,7 @@
     {
       "name": "join to multi-column table",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM S (K STRING KEY, ID VARCHAR) WITH (kafka_topic='S', format='JSON');",
@@ -370,7 +372,7 @@
     {
       "name": "multi-column partition",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM S (K STRING KEY, ID VARCHAR) WITH (kafka_topic='S', format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
@@ -853,7 +853,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "struct key format",
       "statements": [
@@ -865,7 +865,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "struct key format when original is unwrapped",
       "statements": [
@@ -877,7 +877,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "partition by field within struct key",
       "statements": [
@@ -889,7 +889,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "partition by field within struct key don't select struct key",
       "statements": [
@@ -901,7 +901,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "partition by create struct",
       "statements": [
@@ -913,7 +913,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "partition by struct with different key/value formats",
       "statements": [
@@ -945,7 +945,7 @@
     },
     {
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "name": "partition by struct explicitly change key format",
       "statements": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/project-filter.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/project-filter.json
@@ -467,7 +467,7 @@
     {
       "name": "projection with missing multi-key column",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (ID INT KEY, ID2 INT KEY, NAME STRING) WITH (kafka_topic='test_topic', format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -534,7 +534,8 @@
     {
       "name": "STRUCT ARRAY STRING - key - no inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.key.format.enabled": true,
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (F1 ARRAY<VARCHAR> KEY, foo INT) WITH (kafka_topic='input_topic', format='PROTOBUF');",
@@ -554,7 +555,8 @@
     {
       "name": "STRUCT ARRAY STRING - key - inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.key.format.enabled": true,
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', format='PROTOBUF');",
@@ -581,7 +583,9 @@
     {
       "name": "STRUCT multi field - key - no inference",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.key.format.enabled": true,
+        "ksql.complex.key.format.enabled": true,
+        "ksql.multicol.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (F1 INT KEY, F2 VARCHAR KEY, foo INT) WITH (kafka_topic='input_topic', format='PROTOBUF');",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -415,7 +415,7 @@
         "INSERT INTO TEST (ID, ROWTIME, K) VALUES (10, 1234, STRUCT(f1:='key'));"
       ],
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "inputs": [
       ],

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1946,7 +1946,7 @@
     {
       "name": "non-windowed - array keys",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (ID ARRAY<STRING> KEY, IGNORED INT) WITH (kafka_topic='test_topic', format='JSON');",
@@ -1969,7 +1969,7 @@
     {
       "name": "non-windowed - struct keys",
       "properties": {
-        "ksql.key.format.enabled": true
+        "ksql.complex.key.format.enabled": true
       },
       "statements": [
         "CREATE STREAM INPUT (ID STRUCT<f1 STRING, f2 STRING> KEY, IGNORED INT) WITH (kafka_topic='test_topic', format='JSON');",

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/GenericKeySerDeTest.java
@@ -312,7 +312,7 @@ public class GenericKeySerDeTest {
   @Test
   public void shouldThrowOnMapKeyColumnEvenWithFeatureFlag() {
     // Given:
-    when(config.getBoolean(KsqlConfig.KSQL_KEY_FORMAT_ENABLED)).thenReturn(true);
+    when(config.getBoolean(KsqlConfig.KSQL_COMPLEX_KEY_FORMAT_ENABLED)).thenReturn(true);
     schema = PersistenceSchema.from(
         ImmutableList.of(column(SqlTypes.map(SqlTypes.STRING, SqlTypes.STRING))),
         SerdeFeatures.of()
@@ -336,7 +336,7 @@ public class GenericKeySerDeTest {
   @Test
   public void shouldThrowOnNestedMapKeyColumnEvenWithFeatureFlag() {
     // Given:
-    when(config.getBoolean(KsqlConfig.KSQL_KEY_FORMAT_ENABLED)).thenReturn(true);
+    when(config.getBoolean(KsqlConfig.KSQL_COMPLEX_KEY_FORMAT_ENABLED)).thenReturn(true);
     schema = PersistenceSchema.from(
         ImmutableList.of(column(SqlTypes.struct()
             .field("F", SqlTypes.map(SqlTypes.STRING, SqlTypes.STRING))


### PR DESCRIPTION
### Description 

This PR is stacked on https://github.com/confluentinc/ksql/pull/6694. Only the last commit needs to be reviewed.

This PR separates the current key format feature flag (`ksql.key.format.enabled`) into three:
- `ksql.key.format.enabled` : controls the addition of new key formats. I've kept the old name in order to avoid clashes with https://github.com/confluentinc/ksql/pull/6692
- `ksql.complex.key.format.enabled` : controls support for array and struct keys
- `ksql.multicol.key.format.enabled` : controls support for multi-column keys

### Testing done 

QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

