### PR TITLE
fix: allow the file watcher test to be notified more than once

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.api.server;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -38,6 +39,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.verification.Timeout;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FileWatcherTest {
@@ -72,7 +74,7 @@ public class FileWatcherTest {
     Files.write(filePath, someBytes, StandardOpenOption.CREATE_NEW);
 
     // Then:
-    verify(callback, timeout(TimeUnit.MINUTES.toMillis(1))).run();
+    verify(callback, new Timeout(TimeUnit.MINUTES.toMillis(1), atLeastOnce())).run();
   }
 
   @Test


### PR DESCRIPTION
### Description 
Allows the file watcher creation test to notify the call back more than once. We've seen the build
sometimes fail because it's notified twice. I suspect this can happen if the create and write straddle
a second boundary.