### PR TITLE
fix: fix error categorization on NPE from streams (#6655) (#6668)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/RegexClassifier.java
@@ -82,8 +82,9 @@ public final class RegexClassifier implements QueryErrorClassifier {
   }
 
   private boolean matches(final Throwable e) {
-    return pattern.matcher(e.getClass().getName()).matches()
-        || pattern.matcher(e.getMessage()).matches();
+    final boolean clsMatches = pattern.matcher(e.getClass().getName()).matches();
+    final boolean msgMatches = e.getMessage() != null && pattern.matcher(e.getMessage()).matches();
+    return clsMatches || msgMatches;
   }
 
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -155,16 +155,28 @@ public abstract class QueryMetadata {
   }
 
   protected void uncaughtHandler(final Thread t, final Throwable e) {
-    LOG.error("Unhandled exception caught in streams thread {}.", t.getName(), e);
-    final QueryError queryError =
-        new QueryError(
-            System.currentTimeMillis(),
-            Throwables.getStackTraceAsString(e),
-            errorClassifier.classify(e)
-        );
-
-    queryStateListener.ifPresent(lis -> lis.onError(queryError));
-    queryErrors.add(queryError);
+    QueryError.Type errorType = Type.UNKNOWN;
+    try {
+      errorType = errorClassifier.classify(e);
+    } catch (final Exception classificationException) {
+      LOG.error("Error classifying unhandled exception", classificationException);
+      throw classificationException;
+    } finally {
+      // If error classification throws then we consider the error to be an UNKNOWN error.
+      // We notify listeners and add the error to the errors queue in the finally block to ensure
+      // all listeners and consumers of the error queue (e.g. the API) can see the error. Similarly,
+      // log in finally block to make sure that if there's ever an error in the classification
+      // we still get this in our logs.
+      final QueryError queryError =
+          new QueryError(
+              System.currentTimeMillis(),
+              Throwables.getStackTraceAsString(e),
+              errorType
+          );
+      queryStateListener.ifPresent(lis -> lis.onError(queryError));
+      queryErrors.add(queryError);
+      LOG.error("Unhandled exception caught in streams thread {}. ({})", t.getName(), errorType, e);
+    }
   }
 
   public Map<String, Object> getOverriddenProperties() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -155,7 +155,7 @@ public abstract class QueryMetadata {
   }
 
   protected void uncaughtHandler(final Thread t, final Throwable e) {
-    QueryError.Type errorType = Type.UNKNOWN;
+    QueryError.Type errorType = QueryError.Type.UNKNOWN;
     try {
       errorType = errorClassifier.classify(e);
     } catch (final Exception classificationException) {


### PR DESCRIPTION
* fix: fix error categorization on NPE from streams

Fixes error categorization when streams exits due to an internal NPE
- fixes the regex categorizer to correctly handle NPEs. NPEs have null
  descriptions, so this patch changes the categorizer to ignore the
  description if its null.
- fixes the uncaught handler to categorize errors as UNKNOWN if the
  categorizer throws

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

