### PR TITLE
fix: Fixes bug in latests-by-offset when using nulls and sessions windows

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
@@ -72,19 +72,11 @@ final class KudafByOffsetUtils {
           return -1;
         } else if (struct2.get(VAL_FIELD) == null) {
           return 1;
+        } else if (struct1.get(VAL_FIELD) == null && struct2.get(VAL_FIELD) == null ){
+          return 0;
         }
 
-        // Deal with overflow - we assume if one is positive and the other negative then the
-        // sequence has overflowed - in which case the latest is the one with the smallest sequence
-        final long sequence1 = struct1.getInt64(SEQ_FIELD);
-        final long sequence2 = struct2.getInt64(SEQ_FIELD);
-        if (sequence1 < 0 && sequence2 >= 0) {
-          return 1;
-        } else if (sequence2 < 0 && sequence1 >= 0) {
-          return -1;
-        } else {
-          return Long.compare(sequence1, sequence2);
-        }
+        return INTERMEDIATE_STRUCT_COMPARATOR.compare(struct1, struct2);
       };
 
   static <T> Struct createStruct(final Schema schema, final long sequence, final T val) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
@@ -64,6 +64,28 @@ final class KudafByOffsetUtils {
     }
   };
 
+  static final Comparator<Struct> INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS = (struct1, struct2) -> {
+    // Ignore nulls: If one of the structs has a null value, then return the other irrespective
+    // of sequence.
+    if (struct1.get(VAL_FIELD) == null) {
+      return -1;
+    } else if (struct2.get(VAL_FIELD) == null) {
+      return 1;
+    }
+
+    // Deal with overflow - we assume if one is positive and the other negative then the sequence
+    // has overflowed - in which case the latest is the one with the smallest sequence
+    final long sequence1 = struct1.getInt64(SEQ_FIELD);
+    final long sequence2 = struct2.getInt64(SEQ_FIELD);
+    if (sequence1 < 0 && sequence2 >= 0) {
+      return 1;
+    } else if (sequence2 < 0 && sequence1 >= 0) {
+      return -1;
+    } else {
+      return Long.compare(sequence1, sequence2);
+    }
+  };
+
   static <T> Struct createStruct(final Schema schema, final long sequence, final T val) {
     final Struct struct = new Struct(schema);
     struct.put(SEQ_FIELD, sequence);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
@@ -64,27 +64,28 @@ final class KudafByOffsetUtils {
     }
   };
 
-  static final Comparator<Struct> INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS = (struct1, struct2) -> {
-    // Ignore nulls: If one of the structs has a null value, then return the other irrespective
-    // of sequence.
-    if (struct1.get(VAL_FIELD) == null) {
-      return -1;
-    } else if (struct2.get(VAL_FIELD) == null) {
-      return 1;
-    }
+  static final Comparator<Struct> INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS =
+      (struct1, struct2) -> {
+        // Ignore nulls: If one of the structs has a null value, then return the other irrespective
+        // of sequence.
+        if (struct1.get(VAL_FIELD) == null) {
+          return -1;
+        } else if (struct2.get(VAL_FIELD) == null) {
+          return 1;
+        }
 
-    // Deal with overflow - we assume if one is positive and the other negative then the sequence
-    // has overflowed - in which case the latest is the one with the smallest sequence
-    final long sequence1 = struct1.getInt64(SEQ_FIELD);
-    final long sequence2 = struct2.getInt64(SEQ_FIELD);
-    if (sequence1 < 0 && sequence2 >= 0) {
-      return 1;
-    } else if (sequence2 < 0 && sequence1 >= 0) {
-      return -1;
-    } else {
-      return Long.compare(sequence1, sequence2);
-    }
-  };
+        // Deal with overflow - we assume if one is positive and the other negative then the
+        // sequence has overflowed - in which case the latest is the one with the smallest sequence
+        final long sequence1 = struct1.getInt64(SEQ_FIELD);
+        final long sequence2 = struct2.getInt64(SEQ_FIELD);
+        if (sequence1 < 0 && sequence2 >= 0) {
+          return 1;
+        } else if (sequence2 < 0 && sequence1 >= 0) {
+          return -1;
+        } else {
+          return Long.compare(sequence1, sequence2);
+        }
+      };
 
   static <T> Struct createStruct(final Schema schema, final long sequence, final T val) {
     final Struct struct = new Struct(schema);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
@@ -68,12 +68,12 @@ final class KudafByOffsetUtils {
       (struct1, struct2) -> {
         // Ignore nulls: If one of the structs has a null value, then return the other irrespective
         // of sequence.
-        if (struct1.get(VAL_FIELD) == null) {
+        if (struct1.get(VAL_FIELD) == null && struct2.get(VAL_FIELD) == null) {
+          return 0;
+        } else if (struct1.get(VAL_FIELD) == null) {
           return -1;
         } else if (struct2.get(VAL_FIELD) == null) {
           return 1;
-        } else if (struct1.get(VAL_FIELD) == null && struct2.get(VAL_FIELD) == null) {
-          return 0;
         }
 
         return INTERMEDIATE_STRUCT_COMPARATOR.compare(struct1, struct2);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
@@ -72,7 +72,7 @@ final class KudafByOffsetUtils {
           return -1;
         } else if (struct2.get(VAL_FIELD) == null) {
           return 1;
-        } else if (struct1.get(VAL_FIELD) == null && struct2.get(VAL_FIELD) == null ){
+        } else if (struct1.get(VAL_FIELD) == null && struct2.get(VAL_FIELD) == null) {
           return 0;
         }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
@@ -298,7 +298,7 @@ public final class LatestByOffset {
     };
   }
 
-  private static void setComparator(boolean ignoreNulls) {
+  private static void setComparator(final boolean ignoreNulls) {
     if (ignoreNulls) {
       comparator = INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS;
     } else {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/offset/LatestByOffsetTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/offset/LatestByOffsetTest.java
@@ -242,6 +242,23 @@ public class LatestByOffsetTest {
   }
 
   @Test
+  public void shouldMergeIgnoringNulls() {
+    // Given:
+    final Udaf<Integer, Struct, Integer> udaf = LatestByOffset.latestInteger();
+
+    final Struct agg1 = LatestByOffset.createStruct(STRUCT_INTEGER, 123);
+    final Struct agg2 = LatestByOffset.createStruct(STRUCT_INTEGER, null);
+
+    // When:
+    final Struct merged1 = udaf.merge(agg1, agg2);
+    final Struct merged2 = udaf.merge(agg2, agg1);
+
+    // Then:
+    assertThat(merged1, is(agg1));
+    assertThat(merged2, is(agg1));
+  }
+
+  @Test
   public void shouldComputeLatestLong() {
     // Given:
     final Udaf<Long, Struct, Long> udaf = LatestByOffset.latestLong();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/offset/LatestByOffsetTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/offset/LatestByOffsetTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udaf.offset;
 
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.SEQ_FIELD;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_BOOLEAN;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_DOUBLE;
@@ -44,7 +45,8 @@ public class LatestByOffsetTest {
   @Test
   public void shouldInitialize() {
     // Given:
-    final Udaf<Integer, Struct, Integer> udaf = LatestByOffset.latest(STRUCT_LONG, true);
+    final Udaf<Integer, Struct, Integer> udaf = LatestByOffset.latest(
+        STRUCT_LONG, true, INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS);
 
     // When:
     final Struct init = udaf.initialize();
@@ -57,7 +59,7 @@ public class LatestByOffsetTest {
   public void shouldInitializeLatestN() {
     // Given:
     final Udaf<Integer, List<Struct>, List<Integer>> udaf = LatestByOffset
-        .latestN(STRUCT_LONG, 2, true);
+        .latestN(STRUCT_LONG, 2, true, INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS);
 
     // When:
     final List<Struct> init = udaf.initialize();
@@ -69,7 +71,7 @@ public class LatestByOffsetTest {
   @Test
   public void shouldThrowExceptionForInvalidN() {
     try {
-      LatestByOffset.latestN(STRUCT_LONG, -1, true);
+      LatestByOffset.latestN(STRUCT_LONG, -1, true, INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS);
     } catch (KsqlException e) {
       assertThat(e.getMessage(), is("earliestN must be 1 or greater"));
     }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_when_merging/6.2.0_1607120094381/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_when_merging/6.2.0_1607120094381/plan.json
@@ -1,0 +1,185 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_when_merging/6.2.0_1607120094381/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_when_merging/6.2.0_1607120094381/spec.json
@@ -1,0 +1,168 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1607120094381,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA",
+        "windowInfo" : {
+          "type" : "SESSION"
+        }
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls ignored when merging",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 700,
+      "window" : {
+        "start" : 0,
+        "end" : 700,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_when_merging/6.2.0_1607120094381/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_ignored_when_merging/6.2.0_1607120094381/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_when_merging/6.2.0_1607120094482/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_when_merging/6.2.0_1607120094482/plan.json
@@ -1,0 +1,185 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0, false) L0\nFROM INPUT INPUT\nWINDOW SESSION ( 1 SECONDS ) \nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "windowInfo" : {
+        "type" : "SESSION"
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamWindowedAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "false AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0, false)" ],
+            "windowExpression" : " SESSION ( 1 SECONDS ) "
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.key.format.enabled" : "false",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_when_merging/6.2.0_1607120094482/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_when_merging/6.2.0_1607120094482/spec.json
@@ -1,0 +1,168 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1607120094482,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_INTERNAL_COL_2` BOOLEAN",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA",
+        "windowInfo" : {
+          "type" : "SESSION"
+        }
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "merging session windows - with nulls not ignored when merging",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : null
+      },
+      "timestamp" : 700
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 1
+      },
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 0,
+      "window" : {
+        "start" : 0,
+        "end" : 0,
+        "type" : "SESSION"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : null
+      },
+      "timestamp" : 700,
+      "window" : {
+        "start" : 0,
+        "end" : 700,
+        "type" : "SESSION"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "windowType" : "SESSION"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "windowInfo" : {
+              "type" : "SESSION"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_when_merging/6.2.0_1607120094482/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_merging_session_windows_-_with_nulls_not_ignored_when_merging/6.2.0_1607120094482/topology
@@ -1,0 +1,28 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Aggregate-WindowSelect
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Aggregate-WindowSelect (stores: [])
+      --> Aggregate-Project
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000007
+      <-- Aggregate-Aggregate-WindowSelect
+    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000008 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000007
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
@@ -228,6 +228,22 @@
       ]
     },
     {
+      "name": "merging session windows - with nulls not ignored when merging",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0, false) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": 1}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 700, "key": 0, "window": {"start": 0, "end": 700, "type": "session"}, "value": {"L0": null}}
+      ]
+    },
+    {
       "name": "merging session windows - all nulls",
       "statements": [
         "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
@@ -193,6 +193,22 @@
       ]
     },
     {
+      "name": "merging session windows - with nulls ignored when merging",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0 FROM INPUT WINDOW SESSION (1 SECONDS) GROUP BY ID;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 0, "key": 0, "value": {"F0": 1}},
+        {"topic": "test_topic", "timestamp": 700, "key": 0, "value": {"F0": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": {"L0": 1}},
+        {"topic": "OUTPUT", "timestamp": 0, "key": 0, "window": {"start": 0, "end": 0, "type": "session"}, "value": null},
+        {"topic": "OUTPUT", "timestamp": 700, "key": 0, "window": {"start": 0, "end": 700, "type": "session"}, "value": {"L0": 1}}
+      ]
+    },
+    {
       "name": "merging session windows - with nulls not ignored",
       "statements": [
         "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT) WITH (kafka_topic='test_topic', value_format='JSON');",


### PR DESCRIPTION
### Description 
Fixes: https://github.com/confluentinc/ksql/issues/6557

### Testing done 
Added extra tests for ignoring nulls when merging

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

