### PR TITLE
fix: Makes response codes rate limited as well as prints a message when it is hit

### DIFF
--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -612,11 +612,13 @@ property has the value `KSQL_PROCESSING_LOG`.
 Toggles whether or not the processing log should include rows in log
 messages. By default, this property has the value `false`.
 
-### ksql.logging.server.skipped.response.codes
+### ksql.logging.server.rate.limited.response.codes
 
-A comma-separated list of HTTP response codes to skip during server
-request logging. This is useful for ignoring certain 4XX errors that you
-might not want to show up in the logs.
+A list of `path:rate_limit` pairs, to limit the rate of server request
+logging.  This is useful for limiting certain 4XX errors that you
+might not want to blow up in the logs. 
+This setting enables seeing the logs when the request rate is low 
+and dropping them when they go over the threshold.
 
 ### ksql.logging.server.rate.limited.request.paths
 

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -615,7 +615,7 @@ messages. By default, this property has the value `false`.
 ### ksql.logging.server.rate.limited.response.codes
 
 A list of `path:rate_limit` pairs, to limit the rate of server request
-logging.  This is useful for limiting certain 4XX errors that you
+logging. This is useful for limiting certain 4XX errors that you
 might not want to blow up in the logs. 
 This setting enables seeing the logs when the request rate is low 
 and dropping them when they go over the threshold.

--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -614,18 +614,25 @@ messages. By default, this property has the value `false`.
 
 ### ksql.logging.server.rate.limited.response.codes
 
-A list of `path:rate_limit` pairs, to limit the rate of server request
-logging. This is useful for limiting certain 4XX errors that you
-might not want to blow up in the logs. 
+A list of `code:qps` pairs, to limit the rate of server request
+logging.  An example would be "400:10" which would limit 400 error
+logs to 10 per second.  This is useful for limiting certain 4XX errors that you
+might not want to blow up in the logs.
 This setting enables seeing the logs when the request rate is low 
 and dropping them when they go over the threshold.
+A message will be logged every 5 seconds indicating if the rate limit
+is being hit, so an absence of this message means a complete set of logs.
 
 ### ksql.logging.server.rate.limited.request.paths
 
-A list of `path:rate_limit` pairs, to limit the rate of server request
-logging.  This is useful for requests that are coming in at a high rate,
-such as for pull queries. This setting enables seeing the logs when the request rate is low
+A list of `path:qps` pairs, to limit the rate of server request
+logging.  An example would be "/query:10" which would limit pull query
+logs to 10 per second. This is useful for requests that are coming in
+at a high rate, such as for pull queries.
+This setting enables seeing the logs when the request rate is low
 and dropping them when they go over the threshold.
+A message will be logged every 5 seconds indicating if the rate limit
+is being hit, so an absence of this message means a complete set of logs.
 
 ksqlDB-Connect Settings
 -----------------------

--- a/ksqldb-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
@@ -173,6 +173,29 @@ public final class ConfigValidators {
     };
   }
 
+  public static Validator mapWithIntKeyDoubleValue() {
+    return (name, val) -> {
+      if (!(val instanceof String)) {
+        throw new ConfigException(name, val, "Must be a string");
+      }
+
+      final String str = (String) val;
+      final Map<String, String> map = KsqlConfig.parseStringAsMap(name, str);
+      map.forEach((keyStr, valueStr) -> {
+        try {
+          Integer.parseInt(keyStr);
+        } catch (NumberFormatException e) {
+          throw new ConfigException(name, keyStr, "Not an int");
+        }
+        try {
+          Double.parseDouble(valueStr);
+        } catch (NumberFormatException e) {
+          throw new ConfigException(name, valueStr, "Not a double");
+        }
+      });
+    };
+  }
+
   public static Validator mapWithDoubleValue() {
     return (name, val) -> {
       if (!(val instanceof String)) {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
@@ -274,14 +274,14 @@ public class ConfigValidatorsTest {
   public void shouldParseDoubleValueInMap() {
     // Given:
     final Validator validator = ConfigValidators.mapWithDoubleValue();
-    validator.ensureValid("propName", "foo:1.2");
+    validator.ensureValid("propName", "foo:1.2,bar:3");
   }
 
   @Test
   public void shouldParseIntKeyDoubleValueInMap() {
     // Given:
     final Validator validator = ConfigValidators.mapWithIntKeyDoubleValue();
-    validator.ensureValid("propName", "123:1.2");
+    validator.ensureValid("propName", "123:1.2,345:9.0");
   }
 
   @Test

--- a/ksqldb-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
@@ -271,14 +271,14 @@ public class ConfigValidatorsTest {
   }
 
   @Test
-  public void shouldParseDoubleValueInMap_v1() {
+  public void shouldParseDoubleValueInMap() {
     // Given:
     final Validator validator = ConfigValidators.mapWithDoubleValue();
     validator.ensureValid("propName", "foo:1.2");
   }
 
   @Test
-  public void shouldParseIntKeyDoubleValueInMap_v1() {
+  public void shouldParseIntKeyDoubleValueInMap() {
     // Given:
     final Validator validator = ConfigValidators.mapWithIntKeyDoubleValue();
     validator.ensureValid("propName", "123:1.2");

--- a/ksqldb-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
@@ -270,6 +270,58 @@ public class ConfigValidatorsTest {
     assertThat(e.getMessage(), containsString("validator should only be used with LIST of STRING defs"));
   }
 
+  @Test
+  public void shouldParseDoubleValueInMap_v1() {
+    // Given:
+    final Validator validator = ConfigValidators.mapWithDoubleValue();
+    validator.ensureValid("propName", "foo:1.2");
+  }
+
+  @Test
+  public void shouldParseIntKeyDoubleValueInMap_v1() {
+    // Given:
+    final Validator validator = ConfigValidators.mapWithIntKeyDoubleValue();
+    validator.ensureValid("propName", "123:1.2");
+  }
+
+  @Test
+  public void shouldThrowOnBadDoubleValueInMap() {
+    // Given:
+    final Validator validator = ConfigValidators.mapWithDoubleValue();
+
+    // When:
+    final Exception e = assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid("propName", "foo:abc")
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Invalid value abc for configuration propName: Not a double"));
+  }
+
+  @Test
+  public void shouldThrowOnBadIntDoubleValueInMap() {
+    // Given:
+    final Validator validator = ConfigValidators.mapWithIntKeyDoubleValue();
+
+    // When:
+    final Exception e = assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid("propName", "1:abc")
+    );
+    final Exception e2 = assertThrows(
+        ConfigException.class,
+        () -> validator.ensureValid("propName", "abc:1.2")
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Invalid value abc for configuration propName: Not a double"));
+    assertThat(e2.getMessage(),
+        containsString("Invalid value abc for configuration propName: Not an int"));
+  }
+
   private enum TestEnum {
     FOO, BAR
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingRateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/LoggingRateLimiter.java
@@ -25,8 +25,6 @@ import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.Pair;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.slf4j.Logger;
 
@@ -90,7 +88,7 @@ class LoggingRateLimiter {
     return config.getStringAsMap(KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG)
         .entrySet().stream()
         .map(entry -> {
-          double rateLimit = Double.parseDouble(entry.getValue());
+          final double rateLimit = Double.parseDouble(entry.getValue());
           return Pair.of(entry.getKey(), rateLimiterFactory.apply(rateLimit));
         })
         .collect(ImmutableMap.toImmutableMap(Pair::getLeft, Pair::getRight));
@@ -104,8 +102,8 @@ class LoggingRateLimiter {
     return config.getStringAsMap(KSQL_LOGGING_SERVER_RATE_LIMITED_RESPONSE_CODES_CONFIG)
         .entrySet().stream()
         .map(entry -> {
-          int statusCode = Integer.parseInt(entry.getKey());
-          double rateLimit = Double.parseDouble(entry.getValue());
+          final int statusCode = Integer.parseInt(entry.getKey());
+          final double rateLimit = Double.parseDouble(entry.getValue());
           return Pair.of(statusCode, rateLimiterFactory.apply(rateLimit));
         })
         .collect(ImmutableMap.toImmutableMap(Pair::getLeft, Pair::getRight));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.rest.server;
 
-import static io.confluent.ksql.configdef.ConfigValidators.intList;
 import static io.confluent.ksql.configdef.ConfigValidators.mapWithDoubleValue;
+import static io.confluent.ksql.configdef.ConfigValidators.mapWithIntKeyDoubleValue;
 import static io.confluent.ksql.configdef.ConfigValidators.oneOrMore;
 import static io.confluent.ksql.configdef.ConfigValidators.zeroOrPositive;
 
@@ -333,10 +333,10 @@ public class KsqlRestConfig extends AbstractConfig {
       "The key store certificate alias to be used for internal client requests. If not set, "
           + "the system will fall back on the Vert.x default choice";
 
-  public static final String KSQL_LOGGING_SERVER_SKIPPED_RESPONSE_CODES_CONFIG =
-      KSQL_CONFIG_PREFIX + "logging.server.skipped.response.codes";
-  private static final String KSQL_LOGGING_SERVER_SKIPPED_RESPONSE_CODES_DOC =
-      "A list of HTTP response codes to skip during server request logging";
+  public static final String KSQL_LOGGING_SERVER_RATE_LIMITED_RESPONSE_CODES_CONFIG =
+      KSQL_CONFIG_PREFIX + "logging.server.rate.limited.response.codes";
+  private static final String KSQL_LOGGING_SERVER_RATE_LIMITED_RESPONSE_CODES_DOC =
+      "A list of code:rate_limit pairs, to rate limit the server request logging";
 
   public static final String KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG =
       KSQL_CONFIG_PREFIX + "logging.server.rate.limited.request.paths";
@@ -640,12 +640,12 @@ public class KsqlRestConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             KSQL_AUTHENTICATION_PLUGIN_DOC
         ).define(
-            KSQL_LOGGING_SERVER_SKIPPED_RESPONSE_CODES_CONFIG,
-            Type.LIST,
+            KSQL_LOGGING_SERVER_RATE_LIMITED_RESPONSE_CODES_CONFIG,
+            Type.STRING,
             "",
-            intList(),
+            mapWithIntKeyDoubleValue(),
             ConfigDef.Importance.LOW,
-            KSQL_LOGGING_SERVER_SKIPPED_RESPONSE_CODES_DOC
+            KSQL_LOGGING_SERVER_RATE_LIMITED_RESPONSE_CODES_DOC
         ).define(
             KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG,
             Type.STRING,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingHandlerTest.java
@@ -66,7 +66,8 @@ public class LoggingHandlerTest {
     when(request.response()).thenReturn(response);
     when(request.remoteAddress()).thenReturn(socketAddress);
     when(ksqlRestConfig.getList(any())).thenReturn(ImmutableList.of("401"));
-    when(loggingRateLimiter.shouldLog("/query")).thenReturn(true);
+    when(loggingRateLimiter.shouldLog(logger, "/query", 200)).thenReturn(true);
+    when(loggingRateLimiter.shouldLog(logger, "/query", 405)).thenReturn(true);
     when(clock.millis()).thenReturn(1699813434333L);
     when(response.bytesWritten()).thenReturn(5678L);
     when(request.path()).thenReturn("/query");
@@ -117,6 +118,7 @@ public class LoggingHandlerTest {
   public void shouldSkipLog() {
     // Given:
     when(response.getStatusCode()).thenReturn(401);
+    when(loggingRateLimiter.shouldLog(logger, "/query", 401)).thenReturn(false);
 
     // When:
     loggingHandler.handle(routingContext);
@@ -133,7 +135,7 @@ public class LoggingHandlerTest {
   public void shouldSkipRateLimited() {
     // Given:
     when(response.getStatusCode()).thenReturn(200);
-    when(loggingRateLimiter.shouldLog("/query")).thenReturn(true, true, false, false);
+    when(loggingRateLimiter.shouldLog(logger, "/query", 200)).thenReturn(true, true, false, false);
 
     // When:
     loggingHandler.handle(routingContext);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingRateLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingRateLimiterTest.java
@@ -1,6 +1,8 @@
 package io.confluent.ksql.api.server;
 
 
+import static io.confluent.ksql.rest.server.KsqlRestConfig.KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG;
+import static io.confluent.ksql.rest.server.KsqlRestConfig.KSQL_LOGGING_SERVER_RATE_LIMITED_RESPONSE_CODES_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,62 +14,98 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
+import java.util.function.Function;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LoggingRateLimiterTest {
 
   private static final String PATH = "/query";
+  private static final int RESPONSE_CODE = 401;
 
   @Mock
   private RateLimiter rateLimiter;
   @Mock
+  private RateLimiter pathLimiter;
+  @Mock
+  private RateLimiter responseCodeLimiter;
+  @Mock
   private KsqlRestConfig ksqlRestConfig;
+  @Mock
+  private Logger logger;
+  @Mock
+  Function<Double, RateLimiter> factory;
 
   private LoggingRateLimiter loggingRateLimiter;
 
 
   @Before
   public void setUp() {
-    when(ksqlRestConfig.getStringAsMap(any())).thenReturn(ImmutableMap.of(PATH, "2"));
+    when(ksqlRestConfig.getStringAsMap(KSQL_LOGGING_SERVER_RATE_LIMITED_REQUEST_PATHS_CONFIG))
+        .thenReturn(ImmutableMap.of(PATH, "2"));
+    when(ksqlRestConfig.getStringAsMap(KSQL_LOGGING_SERVER_RATE_LIMITED_RESPONSE_CODES_CONFIG))
+        .thenReturn(ImmutableMap.of(Integer.toString(RESPONSE_CODE), "1"));
     when(rateLimiter.tryAcquire()).thenReturn(true);
-    loggingRateLimiter = new LoggingRateLimiter(ksqlRestConfig, (rateLimit) -> rateLimiter);
+    when(factory.apply(any())).thenReturn(pathLimiter, responseCodeLimiter, rateLimiter);
+    when(pathLimiter.tryAcquire()).thenReturn(true);
+    when(responseCodeLimiter.tryAcquire()).thenReturn(true);
+    loggingRateLimiter = new LoggingRateLimiter(ksqlRestConfig, factory);
   }
 
   @Test
   public void shouldLog() {
     // When:
-    assertThat(loggingRateLimiter.shouldLog(PATH), is(true));
+    assertThat(loggingRateLimiter.shouldLog(logger, PATH, 200), is(true));
 
     // Then:
     verify(rateLimiter).tryAcquire();
+    verify(logger, never()).info(any());
   }
 
   @Test
-  public void shouldSkipRateLimited() {
+  public void shouldSkipRateLimited_path() {
     // Given:
     when(rateLimiter.tryAcquire()).thenReturn(true, true, false, false);
 
     // When:
-    assertThat(loggingRateLimiter.shouldLog(PATH), is(true));
-    assertThat(loggingRateLimiter.shouldLog(PATH), is(true));
-    assertThat(loggingRateLimiter.shouldLog(PATH), is(false));
-    assertThat(loggingRateLimiter.shouldLog(PATH), is(false));
+    assertThat(loggingRateLimiter.shouldLog(logger, PATH, 200), is(true));
+    assertThat(loggingRateLimiter.shouldLog(logger, PATH, 200), is(true));
+    assertThat(loggingRateLimiter.shouldLog(logger, PATH, 200), is(false));
+    assertThat(loggingRateLimiter.shouldLog(logger, PATH, 200), is(false));
 
     // Then:
     verify(rateLimiter, times(4)).tryAcquire();
+    verify(logger, times(2)).info("Hit rate limit for path /query with limit 2.0");
+  }
+
+  @Test
+  public void shouldSkipRateLimited_responseCode() {
+    // Given:
+    when(rateLimiter.tryAcquire()).thenReturn(true, false, false, false);
+
+    // When:
+    assertThat(loggingRateLimiter.shouldLog(logger, "/foo", RESPONSE_CODE), is(true));
+    assertThat(loggingRateLimiter.shouldLog(logger, "/foo", RESPONSE_CODE), is(false));
+    assertThat(loggingRateLimiter.shouldLog(logger, "/foo", RESPONSE_CODE), is(false));
+    assertThat(loggingRateLimiter.shouldLog(logger, "/foo", RESPONSE_CODE), is(false));
+
+    // Then:
+    verify(rateLimiter, times(4)).tryAcquire();
+    verify(logger, times(3)).info("Hit rate limit for response code 401 with limit 1.0");
   }
 
   @Test
   public void shouldLog_notRateLimited() {
     // When:
-    assertThat(loggingRateLimiter.shouldLog("/foo"), is(true));
+    assertThat(loggingRateLimiter.shouldLog(logger, "/foo", 200), is(true));
 
     // Then:
     verify(rateLimiter, never()).tryAcquire();
+    verify(logger, never()).info(any());
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingRateLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingRateLimiterTest.java
@@ -71,6 +71,7 @@ public class LoggingRateLimiterTest {
   public void shouldSkipRateLimited_path() {
     // Given:
     when(rateLimiter.tryAcquire()).thenReturn(true, true, false, false);
+    when(rateLimiter.getRate()).thenReturn(2d);
 
     // When:
     assertThat(loggingRateLimiter.shouldLog(logger, PATH, 200), is(true));
@@ -87,6 +88,7 @@ public class LoggingRateLimiterTest {
   public void shouldSkipRateLimited_responseCode() {
     // Given:
     when(rateLimiter.tryAcquire()).thenReturn(true, false, false, false);
+    when(rateLimiter.getRate()).thenReturn(1d);
 
     // When:
     assertThat(loggingRateLimiter.shouldLog(logger, "/foo", RESPONSE_CODE), is(true));


### PR DESCRIPTION
### Description 
Makes response codes logging rate limited too.  Also prints a message when rate limit is hit.

### Testing done 
Unit tests and manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

