### PR TITLE
fix: use Java's Base64 instead of jersey's

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
@@ -34,8 +34,10 @@ import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.rest.RestConfig;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -53,7 +55,6 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.glassfish.jersey.internal.util.Base64;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -203,7 +204,8 @@ public class BasicAuthFunctionalTest {
   }
 
   private static String buildBasicAuthHeader(final String userName, final String password) {
-    return Base64.encodeAsString(userName + ":" + password);
+    final String creds = userName + ":" + password;
+    return Base64.getEncoder().encodeToString(creds.getBytes(Charset.defaultCharset()));
   }
 
   private static String createJaasConfigContent() {

--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -168,6 +168,16 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Transitive dependency of wiremock-jre8 that's excluded in ksql-parent pom.xml
+             because it brings an older version of jetty than we'd like -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <!-- jetty.version definition comes from rest-utils -->
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -37,6 +37,8 @@ import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.test.util.secure.Credentials;
 import io.confluent.rest.validation.JacksonMessageBodyProvider;
 import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -49,7 +51,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.glassfish.jersey.internal.util.Base64;
 
 final class RestIntegrationTestUtil {
 
@@ -232,7 +233,8 @@ final class RestIntegrationTestUtil {
   }
 
   private static String buildBasicAuthHeader(final Credentials credentials) {
-    return Base64.encodeAsString(credentials.username + ":" + credentials.password);
+    final String creds = credentials.username + ":" + credentials.password;
+    return Base64.getEncoder().encodeToString(creds.getBytes(Charset.defaultCharset()));
   }
 
   private static String buildStreamingRequest(final String sql) {

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,13 @@
                 <artifactId>wiremock-jre8</artifactId>
                 <version>${wiremock.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <!-- To avoid multiple versions of jetty -->
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-webapp</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
### Description 
Using Jersey's private utility function prevent Jersey upgrades in upstream rest-utils. This pull request replaces jersey's Base64 utility with Java's built-in Base64 in two tests.

### Testing done 
Tests run by CI

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

