### PR TITLE
fix: change locate() error message for a more user-friendly message

### DIFF
--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -89,10 +89,11 @@ public final class KsLocator implements Locator {
 
       // Fail fast if Streams not ready. Let client handle it
       if (metadata == KeyQueryMetadata.NOT_AVAILABLE) {
-        LOG.debug("KeyQueryMetadata not available for state store {} and key {}",
+        LOG.debug("KeyQueryMetadata not available for state store '{}' and key {}",
             stateStoreName, key);
         throw new MaterializationException(String.format(
-            "KeyQueryMetadata not available for state store %s and key %s", stateStoreName, key));
+            "Materialized data for key %s is not available yet. "
+                + "Please try again later.", key));
       }
 
       LOG.debug("Handling pull query for key {} in partition {} of state store {}.",

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -164,7 +164,7 @@ public class KsLocatorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "KeyQueryMetadata not available for state store someStoreName and key [1]"));
+        "Materialized data for key [1] is not available yet. Please try again later."));
   }
 
   @Test


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
Fixes https://github.com/confluentinc/ksql/issues/6249

Add a better error message when the issue in https://github.com/confluentinc/ksql/issues/6249 is thrown. 
```
ksql> CREATE TABLE MSG_COUNT WITH (KAFKA_TOPIC='MSG_COUNT', PARTITIONS=1, REPLICAS=1) AS SELECT
  'X' X,
  COUNT(*) MSG_CT
FROM PAGEVIEWS PAGEVIEWS
GROUP BY 'X'
EMIT CHANGES;

ksql> SELECT * FROM MSG_COUNT WHERE X='X';
Materialized data for key ['X'] is not available yet. Please try again later.
```

There was another fix that retry the failing request here (https://github.com/confluentinc/ksql/pull/6633), but seems pull queries must fail fast. Instead, the user should be warned about the issue and let them know they need to retry.

### Testing done 
Uni tests
Manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

