### PR TITLE
test: attempt to make CliTest more robust

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -1343,12 +1343,6 @@ public class CliTest {
     return Matchers.contains(expected);
   }
 
-  private static Matcher<Iterable<? extends Iterable<? extends String>>> isRow(
-      final String... expected
-  ) {
-    return Matchers.contains(row(expected));
-  }
-
   @SafeVarargs
   @SuppressWarnings("varargs")
   private static Matcher<Iterable<? extends Iterable<? extends String>>> isRow(

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -86,6 +86,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -202,9 +203,6 @@ public class CliTest {
 
   @Before
   public void setUp() {
-    REST_APP.closePersistentQueries();
-    REST_APP.dropSourcesExcept(ORDER_DATA_PROVIDER.sourceName());
-
     streamName = KsqlIdentifierTestUtil.uniqueIdentifierName();
     tableName = KsqlIdentifierTestUtil.uniqueIdentifierName();
     terminal = new TestTerminal(lineSupplier);
@@ -391,11 +389,14 @@ public class CliTest {
 
     assertRunListCommand(
         "streams",
-        isRow(ORDER_DATA_PROVIDER.sourceName(), ORDER_DATA_PROVIDER.topicName(), "KAFKA", "JSON", "false")
+        hasRow(
+            equalTo(ORDER_DATA_PROVIDER.sourceName()),
+            equalTo(ORDER_DATA_PROVIDER.topicName()),
+            equalTo("KAFKA"),
+            equalTo("JSON"),
+            equalTo("false")
+        )
     );
-
-    assertRunListCommand("tables", is(EMPTY_RESULT));
-    assertRunListCommand("queries", is(EMPTY_RESULT));
   }
 
   @Test
@@ -793,6 +794,25 @@ public class CliTest {
             isRow(containsString("Created query with ID CTAS_" + tableName.toUpperCase())),
             isRow(is("Parsing statement")),
             isRow(is("Executing statement"))));
+    assertRunListCommand("tables",
+        hasRow(
+            equalTo(tableName),
+            equalTo(tableName.toUpperCase(Locale.ROOT)),
+            equalTo("KAFKA"),
+            equalTo("JSON"),
+            equalTo("false")
+    ));
+
+    assertRunListCommand("queries",
+        hasRow(
+            containsString("CTAS_" + tableName),
+            equalTo("PERSISTENT"),
+            equalTo("RUNNING:1"),
+            equalTo(tableName),
+            equalTo(tableName),
+            containsString("CREATE TABLE " + tableName)
+        )
+    );
 
     dropTable(tableName);
   }
@@ -1071,7 +1091,7 @@ public class CliTest {
     // Given:
     final File scriptFile = TMP.newFile("script.sql");
     Files.write(scriptFile.toPath(), (""
-        + "CREATE STREAM shouldRunScript AS SELECT * FROM " + ORDER_DATA_PROVIDER.sourceName() + ";"
+        + "CREATE STREAM " + streamName + " AS SELECT * FROM " + ORDER_DATA_PROVIDER.sourceName() + ";"
         + "").getBytes(StandardCharsets.UTF_8));
 
     when(lineSupplier.get())
@@ -1083,7 +1103,7 @@ public class CliTest {
 
     // Then:
     assertThat(terminal.getOutputString(),
-        containsString("Created query with ID CSAS_SHOULDRUNSCRIPT"));
+        containsString("Created query with ID CSAS_" + streamName));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -231,10 +231,10 @@ public class TestKsqlRestApp extends ExternalResource {
     }
   }
 
-  public void dropSourcesExcept(final String... blackList) {
+  public void dropSourcesExcept(final String... exceptSources) {
     try (final KsqlRestClient client = buildKsqlClient()) {
 
-      final Set<String> except = Arrays.stream(blackList)
+      final Set<String> except = Arrays.stream(exceptSources)
           .map(String::toUpperCase)
           .collect(Collectors.toSet());
 


### PR DESCRIPTION
### Description 

We were getting failures like:
```
java.lang.UnsupportedOperationException: 
error msg: Could not write the statement 'TERMINATE CTAS_ID_15_9;' into the command topic.
Caused by: Timeout while waiting for command topic consumer to process command
	topic
	at io.confluent.ksql.cli.CliTest.setUp(CliTest.java:205)
```

I have no idea why those are happening, but I hope that this change (which just removes the parts which terminate queries) will make this better. Note that all queries are terminated after the class is done because `KSQL_REST_APP` is an `ExternalResource` which gets cleaned up by JUnit.

### Testing done 

test only change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

