### PR TITLE
chore: update processing log exists msg from info to warn (MINOR)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/TopicValidationUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/TopicValidationUtil.java
@@ -61,7 +61,7 @@ final class TopicValidationUtil {
           actualNumPartitions,
           requiredNumReplicas,
           actualNumReplicas
-      ));
+      ), true);
     }
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/exception/KafkaTopicExistsException.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/exception/KafkaTopicExistsException.java
@@ -17,6 +17,10 @@ package io.confluent.ksql.exception;
 
 public class KafkaTopicExistsException extends KafkaTopicClientException {
 
+  /**
+   * Whether the Kafka topic exists with an unexpected number of either
+   * partitions or replicas.
+   */
   private final boolean partitionOrReplicaMismatch;
 
   public KafkaTopicExistsException(

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/exception/KafkaTopicExistsException.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/exception/KafkaTopicExistsException.java
@@ -17,8 +17,19 @@ package io.confluent.ksql.exception;
 
 public class KafkaTopicExistsException extends KafkaTopicClientException {
 
-  public KafkaTopicExistsException(final String message) {
+  private final boolean partitionOrReplicaMismatch;
+
+  public KafkaTopicExistsException(
+      final String message,
+      final boolean partitionOrReplicaMismatch
+  ) {
     super(message);
+
+    this.partitionOrReplicaMismatch = partitionOrReplicaMismatch;
+  }
+
+  public boolean getPartitionOrReplicaMismatch() {
+    return partitionOrReplicaMismatch;
   }
 
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaTopicClient.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/stubs/StubKafkaTopicClient.java
@@ -219,7 +219,7 @@ public class StubKafkaTopicClient implements KafkaTopicClient {
           existing.numPartitions,
           requiredNumReplicas,
           existing.replicationFactor
-      ));
+      ), true);
     }
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogServerUtils.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogServerUtils.java
@@ -67,7 +67,11 @@ public final class ProcessingLogServerUtils {
     try {
       topicClient.createTopic(topicName, nPartitions, nReplicas);
     } catch (final KafkaTopicExistsException e) {
-      LOGGER.info(String.format("Log topic %s already exists", topicName), e);
+      if (e.getPartitionOrReplicaMismatch()) {
+        LOGGER.warn(String.format("Log topic %s already exists", topicName), e);
+      } else {
+        LOGGER.info(String.format("Log topic %s already exists", topicName), e);
+      }
     }
     return Optional.of(topicName);
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
@@ -140,7 +140,7 @@ public class KsqlInternalTopicUtilsTest {
   @Test
   public void shouldFailIfTopicExistsOnCreationWithDifferentConfigs() {
     // Given:
-    doThrow(new KafkaTopicExistsException("exists"))
+    doThrow(new KafkaTopicExistsException("exists", true))
         .when(topicClient)
         .createTopic(any(), anyInt(), anyShort(), anyMap());
 


### PR DESCRIPTION
### Description 

The number of partitions for the processing log topic is configurable via the `ksql.logging.processing.topic.partitions` config. However, if the processing log topic already exists with a different number of partitions, the existing topic is left untouched and the ksqlDB server continues to start up after logging a message indicating that topic exists and the number of partitions was not as expected. (The same behavior is true as well for number of replicas.) This log message is currently logged at level INFO. This PR changes the log message to level WARN instead.

### Testing done 

Manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

