### PR TITLE
fix: (minor) don't use deprecated jersey calls

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/filters/KsqlAuthorizationFilterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/filters/KsqlAuthorizationFilterTest.java
@@ -138,7 +138,8 @@ public class KsqlAuthorizationFilterTest {
         URI.create(path),
         method,
         securityContext,
-        mock(PropertiesDelegate.class)
+        mock(PropertiesDelegate.class),
+        null
     );
 
     return requestContext;


### PR DESCRIPTION
### Description 

This pull request updates the call signature for jersey's `ContainerRequest(...)` to a non-deprecated one in a test. Jersey 2.30 and above add a new `Configuration` parameter (see [here](https://javadoc.io/static/org.glassfish.jersey.bundles/jaxrs-ri/2.30/org/glassfish/jersey/server/ContainerRequest.html#constructor.summary)). 

The context for this pull request is that I am trying to update Jersey to 2.31 in upstream rest-utils (https://github.com/confluentinc/rest-utils/pull/210). Ksql treats warnings as errors, and the deprecation warning causes the upstream pull request from building correctly. Once that pull request actually upgrades the jetty version, ksql builds would fail without this current PR specifically because of treating deprecation warnings as errors. 

Merging this pull request will cause the immediate builds to break, but the current ksql build is already broken as of now. The reason for the current broken build is multiple jetty versions, which the upstream PR attempts to fix.

### Testing done 
None

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

