### PR TITLE
docs: clarify that all data types except maps are supported as keys

### DIFF
--- a/docs/concepts/schemas.md
+++ b/docs/concepts/schemas.md
@@ -400,6 +400,11 @@ ARRAY[2, 4, 6]
 The `MAP` type defines a variable-length collection of key-value pairs. All keys in the map must be
 of the same type. All values in the map must be of the same type.
 
+!!! note
+    The `MAP` type is only supported for value columns, not key columns, as map keys
+    may lead to unexpected behavior due to inconsistent serialization.
+    This restriction includes nested types containing maps as well.
+
 To declare a `MAP` use the syntax:
 
 ```

--- a/docs/concepts/schemas.md
+++ b/docs/concepts/schemas.md
@@ -398,7 +398,8 @@ ARRAY[2, 4, 6]
 ### Map type
 
 The `MAP` type defines a variable-length collection of key-value pairs. All keys in the map must be
-of the same type. All values in the map must be of the same type.
+of the same type. All values in the map must be of the same type. Currently only `STRING` keys are
+supported. The value type can be any valid SQL type.
 
 !!! note
     The `MAP` type is only supported for value columns, not key columns, as map keys

--- a/docs/developer-guide/syntax-reference.md
+++ b/docs/developer-guide/syntax-reference.md
@@ -264,7 +264,8 @@ MAP<KeyType, ValueType>
 
 ksqlDB supports fields that are maps. A map has a key and value type. All
 of the keys must be of the same type, and all of the values must be also
-be of the same type.
+be of the same type. Currently only `STRING` keys are supported. The
+value type can be any valid SQL type.
 
 Access the values of a map by using the `[]` operator and passing in the
 key. For example, `SOME_MAP['cost']` retrieves the value for the entry

--- a/docs/developer-guide/syntax-reference.md
+++ b/docs/developer-guide/syntax-reference.md
@@ -255,12 +255,16 @@ MAP<KeyType, ValueType>
 ```
 
 !!! note
+    The `MAP` type is only supported for value columns, not key columns, as map keys
+    may lead to unexpected behavior due to inconsistent serialization.
+    This restriction includes nested types containing maps as well.
+
+!!! note
 		The `DELIMITED` format doesn't support maps.
 
 ksqlDB supports fields that are maps. A map has a key and value type. All
 of the keys must be of the same type, and all of the values must be also
-be of the same type. Currently only `STRING` keys are supported. The
-value type can be any valid SQL type.
+be of the same type.
 
 Access the values of a map by using the `[]` operator and passing in the
 key. For example, `SOME_MAP['cost']` retrieves the value for the entry


### PR DESCRIPTION
### Description 

Docs for https://github.com/confluentinc/ksql/pull/6722. I don't see anywhere in the docs today where we say only primitive types are supported as keys. With 0.15, all non-map types will be supported, which this PR explicitly clarifies.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

