### PR TITLE
chore: remove usage of SRClient#getAllSubjects

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.SimpleColumn;
+import io.confluent.ksql.schema.registry.SchemaRegistryUtil;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
@@ -198,7 +199,7 @@ public class SchemaRegisterInjector implements Injector {
     try {
       final SchemaRegistryClient srClient = serviceContext.getSchemaRegistryClient();
 
-      if (registerIfSchemaExists || !srClient.getAllSubjects().contains(subject)) {
+      if (registerIfSchemaExists || !SchemaRegistryUtil.subjectExists(srClient, subject)) {
         final SchemaTranslator translator = format.getSchemaTranslator(formatInfo.getProperties());
 
         final ParsedSchema parsedSchema = translator.toParsedSchema(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -22,7 +22,6 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
-import java.io.IOException;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -76,6 +75,15 @@ public final class SchemaRegistryUtil {
     );
   }
 
+
+  public static boolean subjectExists(
+      final SchemaRegistryClient srClient,
+      final String subject
+  ) {
+    return getLatestSchema(srClient, subject).isPresent();
+  }
+
+
   public static Optional<SchemaMetadata> getLatestSchema(
       final SchemaRegistryClient srClient,
       final String topic,
@@ -83,13 +91,6 @@ public final class SchemaRegistryUtil {
   ) {
     final String subject = KsqlConstants.getSRSubject(topic, getKeySchema);
     return getLatestSchema(srClient, subject);
-  }
-
-  public static boolean subjectExists(
-      final SchemaRegistryClient srClient,
-      final String subject
-  ) {
-    return getLatestSchema(srClient, subject).isPresent();
   }
 
   private static Optional<SchemaMetadata> getLatestSchema(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -82,6 +82,20 @@ public final class SchemaRegistryUtil {
       final boolean getKeySchema
   ) {
     final String subject = KsqlConstants.getSRSubject(topic, getKeySchema);
+    return getLatestSchema(srClient, subject);
+  }
+
+  public static boolean subjectExists(
+      final SchemaRegistryClient srClient,
+      final String subject
+  ) {
+    return getLatestSchema(srClient, subject).isPresent();
+  }
+
+  private static Optional<SchemaMetadata> getLatestSchema(
+      final SchemaRegistryClient srClient,
+      final String subject
+  ) {
     try {
       final SchemaMetadata schemaMetadata = srClient.getLatestSchemaMetadata(subject);
       return Optional.ofNullable(schemaMetadata);
@@ -89,22 +103,7 @@ public final class SchemaRegistryUtil {
       if (isSubjectNotFoundErrorCode(e)) {
         return Optional.empty();
       }
-      throw new KsqlException("Could not get latest schema for subject " + topic, e);
-    }
-  }
-
-  public static boolean subjectExists(
-      final SchemaRegistryClient srClient,
-      final String subject
-  ) {
-    try {
-      srClient.getLatestSchemaMetadata(subject);
-      return true;
-    } catch (RestClientException | IOException e) {
-      if (isSubjectNotFoundErrorCode(e)) {
-        return false;
-      }
-      throw new KsqlException("Could not check if subject exists: \"" + subject + '"', e);
+      throw new KsqlException("Could not get latest schema for subject " + subject, e);
     }
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.KsqlExecutionContext;
@@ -100,6 +101,8 @@ public class SchemaRegisterInjectorTest {
   private ServiceContext serviceContext;
   @Mock
   private SchemaRegistryClient schemaRegistryClient;
+  @Mock
+  private SchemaMetadata schemaMetadata;
   @Mock
   private KafkaTopicClient topicClient;
   @Mock
@@ -235,8 +238,8 @@ public class SchemaRegisterInjectorTest {
       throws Exception {
     // Given:
     givenStatement("CREATE STREAM sink (f1 VARCHAR) WITH (kafka_topic='expectedName', key_format='AVRO', value_format='AVRO', partitions=1);");
-    doReturn(null).when(schemaRegistryClient).getLatestSchemaMetadata("expectedName-value");
-    doReturn(null).when(schemaRegistryClient).getLatestSchemaMetadata("expectedName-key");
+    doReturn(schemaMetadata).when(schemaRegistryClient).getLatestSchemaMetadata("expectedName-value");
+    doReturn(schemaMetadata).when(schemaRegistryClient).getLatestSchemaMetadata("expectedName-key");
 
     // When:
     injector.inject(statement);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjectorTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,10 +31,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.engine.KsqlPlan;
@@ -51,6 +52,7 @@ import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.schema.registry.SchemaRegistryUtil;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -69,6 +71,7 @@ import java.io.IOException;
 import java.util.Optional;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -124,7 +127,7 @@ public class SchemaRegisterInjectorTest {
   private ConfiguredStatement<?> statement;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException, RestClientException {
     metaStore = new MetaStoreImpl(new InternalFunctionRegistry());
     config = new KsqlConfig(ImmutableMap.of(
         KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "foo:8081"
@@ -148,6 +151,9 @@ public class SchemaRegisterInjectorTest {
     when(formats.getValueFormat()).thenReturn(FormatInfo.of(FormatFactory.AVRO.name()));
     when(formats.getValueFeatures()).thenReturn(valFeatures);
 
+    when(schemaRegistryClient.getLatestSchemaMetadata(any())).thenThrow(
+        new RestClientException("foo", 404, SchemaRegistryUtil.SUBJECT_NOT_FOUND_ERROR_CODE));
+
     final KsqlTopic sourceTopic = new KsqlTopic(
         "source",
         KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()), SerdeFeatures.of()),
@@ -162,6 +168,14 @@ public class SchemaRegisterInjectorTest {
         sourceTopic
     );
     metaStore.putSource(source, false);
+  }
+
+  @After
+  public void after() throws IOException, RestClientException {
+    // we should never call getAllSubjects() because this has stricter
+    // privilege requirements (i.e. I may have permission to see subject
+    // X but not all subjects)
+    verify(schemaRegistryClient, never()).getAllSubjects();
   }
 
   @Test
@@ -221,7 +235,8 @@ public class SchemaRegisterInjectorTest {
       throws Exception {
     // Given:
     givenStatement("CREATE STREAM sink (f1 VARCHAR) WITH (kafka_topic='expectedName', key_format='AVRO', value_format='AVRO', partitions=1);");
-    when(schemaRegistryClient.getAllSubjects()).thenReturn(ImmutableSet.of("expectedName-value", "expectedName-key"));
+    doReturn(null).when(schemaRegistryClient).getLatestSchemaMetadata("expectedName-value");
+    doReturn(null).when(schemaRegistryClient).getLatestSchemaMetadata("expectedName-key");
 
     // When:
     injector.inject(statement);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
@@ -15,7 +15,10 @@
 
 package io.confluent.ksql.schema.registry;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -166,5 +169,31 @@ public class SchemaRegistryUtilTest {
     // Then not exception (only tried once):
     verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "SOME-changelog-key");
     verify(schemaRegistryClient, times(1)).deleteSubject(APP_ID + "SOME-changelog-value");
+  }
+
+  @Test
+  public void shouldReturnTrueOnIsSubjectExists() throws Exception {
+    // Given:
+    when(schemaRegistryClient.getLatestSchemaMetadata("foo-value")).thenReturn(null);
+
+    // When:
+    final boolean subjectExists = SchemaRegistryUtil.subjectExists(schemaRegistryClient, "foo-value");
+
+    // Then:
+    assertTrue("Expected subject to exist", subjectExists);
+  }
+
+  @Test
+  public void shouldReturnFalseOnSubjectMissing() throws Exception {
+    // Given:
+    when(schemaRegistryClient.getLatestSchemaMetadata("bar-value")).thenThrow(
+        new RestClientException("foo", 404, SchemaRegistryUtil.SUBJECT_NOT_FOUND_ERROR_CODE)
+    );
+
+    // When:
+    final boolean subjectExists = SchemaRegistryUtil.subjectExists(schemaRegistryClient, "bar-value");
+
+    // Then:
+    assertFalse("Expected subject to not exist", subjectExists);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.junit.Test;
@@ -41,6 +42,8 @@ public class SchemaRegistryUtilTest {
 
   @Mock
   private SchemaRegistryClient schemaRegistryClient;
+  @Mock
+  private SchemaMetadata schemaMetadata;
 
   @Test
   public void shouldDeleteChangeLogTopicSchema() throws Exception {
@@ -174,7 +177,7 @@ public class SchemaRegistryUtilTest {
   @Test
   public void shouldReturnTrueOnIsSubjectExists() throws Exception {
     // Given:
-    when(schemaRegistryClient.getLatestSchemaMetadata("foo-value")).thenReturn(null);
+    when(schemaRegistryClient.getLatestSchemaMetadata("foo-value")).thenReturn(schemaMetadata);
 
     // When:
     final boolean subjectExists = SchemaRegistryUtil.subjectExists(schemaRegistryClient, "foo-value");


### PR DESCRIPTION
Fixes #6729 

### Description 
Don't use `getAllSubjects` when we can get look up just a single subject.

### Testing done 
- unit testing
- e2e testing to make sure the right exception is thrown with real SRClient

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

