### PR TITLE
chore: support KEY_DELIMITER and tests for multi-col

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -143,7 +143,7 @@ public final class CommonCreateConfigs {
             "The delimiter to use when VALUE_FORMAT='DELIMITED'. Supports single "
               + "character to be a delimiter, defaults to ','. For space and tab delimited values "
               + "you must use the special values 'SPACE' or 'TAB', not an actual space or tab "
-              + "character.")
+              + "character. Also see " + KEY_DELIMITER_PROPERTY)
         .define(
             KEY_FORMAT_PROPERTY,
             ConfigDef.Type.STRING,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -45,6 +45,7 @@ public final class CommonCreateConfigs {
   public static final String WRAP_SINGLE_VALUE = "WRAP_SINGLE_VALUE";
 
   public static final String VALUE_DELIMITER_PROPERTY = "VALUE_DELIMITER";
+  public static final String KEY_DELIMITER_PROPERTY = "KEY_DELIMITER";
 
   public static void addToConfigDef(
       final ConfigDef configDef,
@@ -123,6 +124,16 @@ public final class CommonCreateConfigs {
             Importance.LOW,
             "The fully qualified name of the Avro schema to use"
         )
+        .define(
+            KEY_DELIMITER_PROPERTY,
+            ConfigDef.Type.STRING,
+            null,
+            ConfigValidators.nullsAllowed(ConfigValidators.parses(Delimiter::parse)),
+            Importance.LOW,
+            "The delimiter to use when KEY_FORMAT='DELIMITED'. Supports single "
+              + "character to be a delimiter, defaults to ','. For space and tab delimited values "
+              + "you must use the special values 'SPACE' or 'TAB', not an actual space or tab "
+              + "character. Also see " + VALUE_DELIMITER_PROPERTY)
         .define(
             VALUE_DELIMITER_PROPERTY,
             ConfigDef.Type.STRING,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -81,6 +81,12 @@ public final class AssertExecutor {
           CommonCreateConfigs.KEY_FORMAT_PROPERTY,
           CommonCreateConfigs.FORMAT_PROPERTY
       )).add(new SourceProperty(
+          ds -> ds.getKsqlTopic().getKeyFormat().getFormatInfo().getFormat(),
+          (cs, cfg) -> cs.getProperties().getKeyFormat(cs.getName()).map(FormatInfo::getFormat)
+              .orElse(cfg.getString(KsqlConfig.KSQL_DEFAULT_KEY_FORMAT_CONFIG)),
+          "key format properties",
+          CommonCreateConfigs.KEY_DELIMITER_PROPERTY
+      )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getFormat(),
           (cs, cfg) -> cs.getProperties().getValueFormat().map(FormatInfo::getFormat)
               .orElse(cfg.getString(KsqlConfig.KSQL_DEFAULT_VALUE_FORMAT_CONFIG)),
@@ -90,7 +96,7 @@ public final class AssertExecutor {
       )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getProperties(),
           (cs, cfg) -> cs.getProperties().getValueFormatProperties(),
-          "delimiter",
+          "value format properties",
           CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME,
           CommonCreateConfigs.VALUE_DELIMITER_PROPERTY
       )).add(new SourceProperty(

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/delimited.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/delimited.json
@@ -108,6 +108,42 @@
       ]
     },
     {
+      "name": "multi-column key",
+      "properties": {
+        "ksql.multicol.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K1 STRING KEY, K2 STRING KEY, V INT) WITH (kafka_topic='input_topic', format='DELIMITED');",
+        "CREATE STREAM OUTPUT WITH (key_format='JSON') AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "foo,bar", "value": "0"},
+        {"topic": "input_topic", "key": "\"foo\",\"bar\"", "value": "0"},
+        {"topic": "input_topic", "key": null, "value": "0"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"K1": "foo", "K2": "bar"}, "value": "0"},
+        {"topic": "OUTPUT", "key": {"K1": "foo", "K2": "bar"}, "value": "0"},
+        {"topic": "OUTPUT", "key": null, "value": "0"}
+      ]
+    },
+    {
+      "name": "multi-column key with different kv delimiters",
+      "properties": {
+        "ksql.multicol.key.format.enabled": true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (K1 STRING KEY, K2 STRING KEY, V INT, V2 INT) WITH (kafka_topic='input_topic', format='DELIMITED', key_delimiter=';', value_delimiter='-');",
+        "CREATE STREAM OUTPUT WITH (key_format='JSON') AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "foo,bar;baz", "value": "0-1"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"K1": "foo,bar", "K2": "baz"}, "value": "0-1"}
+      ]
+    },
+    {
       "name": "ARRAY - key",
       "statements": [
         "CREATE STREAM INPUT (K ARRAY<DOUBLE> KEY, V INT) WITH (kafka_topic='input_topic', format='DELIMITED');"

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.parser.properties.with;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
@@ -116,14 +117,20 @@ public final class CreateSourceAsProperties {
       final String name,
       final String keyFormat
   ) {
-    if (AvroFormat.NAME.equals(keyFormat)) {
+    final Builder<String, String> builder = ImmutableMap.builder();
+    if (AvroFormat.NAME.equalsIgnoreCase(keyFormat)) {
       // ensure that the schema name for the key is unique to the sink - this allows
       // users to always generate valid, non-conflicting avro record definitions in
       // generated Java classes (https://github.com/confluentinc/ksql/issues/6465)
-      return ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, AvroFormat.getKeySchemaName(name));
+      builder.put(AvroFormat.FULL_SCHEMA_NAME, AvroFormat.getKeySchemaName(name));
     }
 
-    return ImmutableMap.of();
+    final String delimiter = props.getString(CommonCreateConfigs.KEY_DELIMITER_PROPERTY);
+    if (delimiter != null) {
+      builder.put(DelimitedFormat.DELIMITER, delimiter);
+    }
+
+    return builder.build();
   }
 
   public Map<String, String> getValueFormatProperties() {

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.parser.properties.with;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
@@ -140,14 +141,20 @@ public final class CreateSourceProperties {
   }
 
   private Map<String, String> getKeyFormatProperties(final String keyFormat, final String name) {
+    final Builder<String, String> builder = ImmutableMap.builder();
     if (AvroFormat.NAME.equalsIgnoreCase(keyFormat)) {
-      // ensure that the schema name for the key is unique to the source - this allows
+      // ensure that the schema name for the key is unique to the sink - this allows
       // users to always generate valid, non-conflicting avro record definitions in
       // generated Java classes (https://github.com/confluentinc/ksql/issues/6465)
-      return ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, AvroFormat.getKeySchemaName(name));
+      builder.put(AvroFormat.FULL_SCHEMA_NAME, AvroFormat.getKeySchemaName(name));
     }
 
-    return ImmutableMap.of();
+    final String delimiter = props.getString(CommonCreateConfigs.KEY_DELIMITER_PROPERTY);
+    if (delimiter != null) {
+      builder.put(DelimitedFormat.DELIMITER, delimiter);
+    }
+
+    return builder.build();
   }
 
   public Optional<FormatInfo> getValueFormat() {


### PR DESCRIPTION
### Description 

Partial work toward #824 by supporting `KEY_DELIMITER` for delimited and adding some multi-col tests for delimited format.

### Testing done 

Added QTT tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

