### PR TITLE
test: improve error message for unknown output topic in QTT (MINOR)

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -157,7 +157,8 @@ public class TopicInfoCache {
           .collect(Collectors.toSet());
 
       if (keyTypes.isEmpty()) {
-        throw new TestFrameworkException("no source found for topic");
+        throw new TestFrameworkException("No information found for topic '"
+            + topicName + "'. Available topics: " + cache.asMap().keySet());
       }
 
       return Iterables.get(keyTypes, 0);


### PR DESCRIPTION
### Description 

Previous message was confusing:
```
>>>>> Test failed: Topic output: Failed to read record 0. io.confluent.ksql.test.TestFrameworkException: Failed to determine key type for
topic: output
reason: no source found for topic
```

New one gives more information on which topics are available. This is especially important because of case sensitivity.

### Testing done 

Test only change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

