### PR TITLE
fix: include 'ksql.streams.topic.*' prefix properties on LIST PROPERTIES output

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/config/KsqlConfigResolver.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/config/KsqlConfigResolver.java
@@ -87,6 +87,13 @@ public class KsqlConfigResolver implements ConfigResolver {
       return Optional.empty();  // Unknown streams config
     }
 
+    if (key.startsWith(StreamsConfig.TOPIC_PREFIX)) {
+      final String topicKey = stripPrefix(key, StreamsConfig.TOPIC_PREFIX);
+      if (KsqlConfig.STREAM_TOPIC_CONFIG_NAMES.contains(topicKey)) {
+        return Optional.of(ConfigItem.unresolved(key));
+      }
+    }
+
     // Unknown config (which could be used):
     return strict ? Optional.empty() : Optional.of(ConfigItem.unresolved(key));
   }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/config/KsqlConfigResolverTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/config/KsqlConfigResolverTest.java
@@ -91,7 +91,7 @@ public class KsqlConfigResolverTest {
   public void shouldReturnUnresolvedForTopicPrefixedStreamsConfig() {
     final String prop = StreamsConfig.TOPIC_PREFIX + TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG;
     assertThat(resolver.resolve(
-        KsqlConfig.KSQL_STREAMS_PREFIX + prop, false), is(unresolvedItem(prop)));
+        KsqlConfig.KSQL_STREAMS_PREFIX + prop, true), is(unresolvedItem(prop)));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -101,4 +101,22 @@ public class ListPropertiesExecutorTest {
         toMap(properties),
         not(hasKey(isIn(KsqlConfig.SSL_CONFIG_NAMES))));
   }
+
+  @Test
+  public void shouldListUnresolvedStreamsTopicProperties() {
+    // When:
+    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
+        engine.configure("LIST PROPERTIES;")
+            .withConfig(new KsqlConfig(ImmutableMap.of(
+                "ksql.streams.topic.min.insync.replicas", "2"))),
+        mock(SessionProperties.class),
+        engine.getEngine(),
+        engine.getServiceContext()
+    ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(
+        properties.getProperties(),
+        hasItem(new Property("ksql.streams.topic.min.insync.replicas", "KSQL", "2")));
+  }
 }


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/6734

Includes `ksql.streams.topic.*` prefixed properties into the `LIST PROPERTIES` output.
```
ksql> list properties;
...        
ksql.streams.topic.min.insync.replicas                 | KSQL  | SERVER           | 1        
...
```

It also allows users to set the `ksql.streams.topic.*` properties from the CLI.

### Testing done 
Added unit tests
Verified manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

