### PR TITLE
fix: closing a rebalancing transient query may leak the state store directory

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -83,7 +83,7 @@ public final class QueryExecutor {
 
   // Each stream thread has two internal consumer threads running. When closing those consumer
   // threads, the close has a hard-coded 30 seconds timeout per thread.
-  private static long INTERNAL_CONSUMER_THREADS_TIMEOUT = 2 * 30000;
+  private static long INTERNAL_CONSUMER_THREADS_TIMEOUT_MS = 2 * 30_000;
 
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
   private final SessionConfig config;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.query;
 
 import static io.confluent.ksql.util.KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG;
+import static io.confluent.ksql.util.KsqlConstants.defaultNumberOfStreamsThreads;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -79,6 +80,10 @@ public final class QueryExecutor {
 
   private static final String KSQL_THREAD_EXCEPTION_UNCAUGHT_LOGGER
       = "ksql.logger.thread.exception.uncaught";
+
+  // Each stream thread has two internal consumer threads running. When closing those consumer
+  // threads, the close has a hard-coded 30 seconds timeout per thread.
+  private static long INTERNAL_CONSUMER_THREADS_TIMEOUT = 2 * 30000;
 
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
   private final SessionConfig config;
@@ -170,6 +175,8 @@ public final class QueryExecutor {
         ? windowInfo.isPresent() ? ResultType.WINDOWED_TABLE : ResultType.TABLE
         : ResultType.STREAM;
 
+    final long queryTimeout = getTransientQueryCloseTimeout(streamsProperties);
+
     return new TransientQueryMetadata(
         statementText,
         schema,
@@ -182,10 +189,22 @@ public final class QueryExecutor {
         streamsProperties,
         config.getOverrides(),
         queryCloseCallback,
-        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG),
+        queryTimeout,
         ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_ERROR_MAX_QUEUE_SIZE),
         resultType
     );
+  }
+
+  private long getTransientQueryCloseTimeout(final Map<String, Object> streamsProperties) {
+    final int numThreads = (int)streamsProperties.getOrDefault(
+        StreamsConfig.NUM_STREAM_THREADS_CONFIG, defaultNumberOfStreamsThreads);
+
+    // Each streams thread has internal threads that are closed one at a time (one after the other).
+    // Each close operation has a timeout that is used in this formula to derive the query timeout.
+    // For transient queries, we only use the total consumer timeouts because are the only ones
+    // that may affect the query closing time and that may re-create the state directory if a
+    // smaller query timeout is set and consumers were still rebalancing during that time.
+    return numThreads * INTERNAL_CONSUMER_THREADS_TIMEOUT;
   }
 
   private static Optional<MaterializationInfo> getMaterializationInfo(final Object result) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -265,6 +265,10 @@ public abstract class QueryMetadata {
     return ImmutableList.copyOf(queryErrors);
   }
 
+  public long getCloseTimeout() {
+    return closeTimeout.toMillis();
+  }
+
   public long uptime() {
     return queryStateListener.map(QueryStateListener::uptime).orElse(0L);
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -55,6 +55,8 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
+
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -229,6 +231,8 @@ public class QueryExecutorTest {
 
   @Test
   public void shouldBuildTransientQueryCorrectly() {
+    final int defaultNumOfThreads = 4;
+
     // Given:
     givenTransientQuery();
 
@@ -251,8 +255,52 @@ public class QueryExecutorTest {
     assertThat(queryMetadata.getExecutionPlan(), equalTo(SUMMARY));
     assertThat(queryMetadata.getTopology(), is(topology));
     assertThat(queryMetadata.getOverriddenProperties(), equalTo(OVERRIDES));
+    assertThat(queryMetadata.getCloseTimeout(), is(defaultNumOfThreads * 60000L));
     verify(kafkaStreamsBuilder).build(any(), propertyCaptor.capture());
     assertThat(queryMetadata.getStreamsProperties(), equalTo(propertyCaptor.getValue()));
+  }
+
+  @Test
+  public void shouldBuildTransientQueryCorrectlyWithDerivedClosingTimeout() {
+    final int numOfThreads = 2;
+
+    // Given:
+    when(ksqlConfig.getKsqlStreamConfigProps(anyString())).thenReturn(ImmutableMap.of(
+        StreamsConfig.NUM_STREAM_THREADS_CONFIG, numOfThreads
+    ));
+
+    queryBuilder = new QueryExecutor(
+        config,
+        processingLogContext,
+        serviceContext,
+        functionRegistry,
+        closeCallback,
+        kafkaStreamsBuilder,
+        streamsBuilder,
+        new MaterializationProviderBuilderFactory(
+            ksqlConfig,
+            serviceContext,
+            ksMaterializationFactory,
+            ksqlMaterializationFactory
+        ));
+
+    givenTransientQuery();
+
+    // When:
+    final TransientQueryMetadata queryMetadata = queryBuilder.buildTransientQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        SOURCES,
+        physicalPlan,
+        SUMMARY,
+        TRANSIENT_SINK_SCHEMA,
+        LIMIT,
+        Optional.empty(),
+        false
+    );
+
+    // Then:
+    assertThat(queryMetadata.getCloseTimeout(), is(numOfThreads * 60000L));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/6360

If a small timeout is set during the transient query close and the query is still rebalancing after the timeout expires, then the stream thread re-creates the internal topics and state stores causing the leak.

This PR derives the query timeout from the internal stream threads timeouts instead of using a configured timeout.

### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

