### PR TITLE
docs: make Java client method usage docs more prominent (MINOR)

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -152,11 +152,24 @@ Receive query results one row at a time (streamQuery())<a name="stream-query"></
 The `streamQuery()` method enables client apps to receive query results one row at a time,
 either asynchronously via a Reactive Streams subscriber or synchronously in a polling fashion.
 
+You can use this method to issue both push and pull queries, but the usage pattern is better for push queries.
+For pull queries, consider using the [`executeQuery()`](#execute-query)
+method instead.
+
+Query properties can be passed as an optional second argument. For more information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map)).
+
+By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
+set the `auto.offset.reset` property to `earliest`.
+
 ```java
 public interface Client {
 
   /**
    * Executes a query (push or pull) and returns the results one row at a time.
+   * 
+   * <p>This method may be used to issue both push and pull queries, but the usage 
+   * pattern is better for push queries. For pull queries, consider using the 
+   * {@link Client#executeQuery(String)} method instead.
    *
    * <p>If a non-200 response is received from the server, the {@code CompletableFuture} will be
    * failed.
@@ -171,15 +184,6 @@ public interface Client {
   
 }
 ```
-
-You can use this method to issue both push and pull queries, but the usage pattern is better for push queries.
-For pull queries, consider using the [`executeQuery()`](#execute-query)
-method instead.
-
-Query properties can be passed as an optional second argument. For more information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#streamQuery(java.lang.String,java.util.Map)).
-
-By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
-set the `auto.offset.reset` property to `earliest`.
 
 ### Asynchronous Usage ###
 
@@ -270,12 +274,26 @@ Receive query results in a single batch (executeQuery())<a name="execute-query">
 The `executeQuery()` method enables client apps to receive query results as a single batch
 that's returned when the query completes.
 
+This method is suitable for both pull queries and for terminating push queries,
+for example, queries that have a `LIMIT` clause. For non-terminating push queries,
+use the [`streamQuery()`](#stream-query) method instead.
+
+Query properties can be passed as an optional second argument. For more
+information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String,java.util.Map)).
+
+By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
+set the `auto.offset.reset` property to `earliest`.
+
 ```java
 public interface Client {
 
   /**
    * Executes a query (push or pull) and returns all result rows in a single batch, once the query
    * has completed.
+   * 
+   * <p>This method is suitable for both pull queries and for terminating push queries,
+   * for example, queries that have a {@code LIMIT} clause. For non-terminating push queries,
+   * use the {@link Client#streamQuery(String)} method instead.
    *
    * @param sql statement of query to execute
    * @return query result
@@ -286,17 +304,6 @@ public interface Client {
   
 }
 ```
-
-This method is suitable for both pull queries and for terminating push queries,
-for example, queries that have a `LIMIT` clause). For non-terminating push queries,
-use the [`streamQuery()`](#stream-query)
-method instead.
-
-Query properties can be passed as an optional second argument. For more
-information, see the [client API reference](api/io/confluent/ksql/api/client/Client.html#executeQuery(java.lang.String,java.util.Map)).
-
-By default, push queries return only newly arriving rows. To start from the beginning of the stream or table,
-set the `auto.offset.reset` property to `earliest`.
 
 ### Example Usage ###
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -30,6 +30,10 @@ public interface Client {
   /**
    * Executes a query (push or pull) and returns the results one row at a time.
    *
+   * <p>This method may be used to issue both push and pull queries, but the usage
+   * pattern is better for push queries. For pull queries, consider using the
+   * {@link Client#executeQuery(String)} method instead.
+   *
    * <p>If a non-200 response is received from the server, the {@code CompletableFuture} will be
    * failed.
    *
@@ -41,6 +45,10 @@ public interface Client {
 
   /**
    * Executes a query (push or pull) and returns the results one row at a time.
+   *
+   * <p>This method may be used to issue both push and pull queries, but the usage
+   * pattern is better for push queries. For pull queries, consider using the
+   * {@link Client#executeQuery(String, Map)} method instead.
    *
    * <p>If a non-200 response is received from the server, the {@code CompletableFuture} will be
    * failed.
@@ -56,6 +64,10 @@ public interface Client {
    * Executes a query (push or pull) and returns all result rows in a single batch, once the query
    * has completed.
    *
+   * <p>This method is suitable for both pull queries and for terminating push queries,
+   * for example, queries that have a {@code LIMIT} clause. For non-terminating push queries,
+   * use the {@link Client#streamQuery(String)} method instead.
+   *
    * @param sql statement of query to execute
    * @return query result
    */
@@ -64,6 +76,10 @@ public interface Client {
   /**
    * Executes a query (push or pull) and returns all result rows in a single batch, once the query
    * has completed.
+   *
+   * <p>This method is suitable for both pull queries and for terminating push queries,
+   * for example, queries that have a {@code LIMIT} clause. For non-terminating push queries,
+   * use the {@link Client#streamQuery(String, Map)} method instead.
    *
    * @param sql statement of query to execute
    * @param properties query properties


### PR DESCRIPTION
### Description 

The sentences that clarify when it is appropriate to use each of the `streamQuery()` and `executeQuery()` Java client methods are currently underneath the Javadoc excerpts in the docs, which makes them easy to miss. This PR pulls the information above the Javadoc excerpts, and also adds the information into the Javadocs themselves so it will appear in the API docs.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

