### PR TITLE
docs: Update ksqlDB Stream Processing Cookbook links to point to Kafka Tutorials

### DIFF
--- a/docs/concepts/schemas.md
+++ b/docs/concepts/schemas.md
@@ -264,8 +264,8 @@ CREATE STREAM pageviews_avro
     `PAGEVIEWS_AVRO-value`.
 
 For more information, see
-[Changing Data Serialization Format from JSON to Avro](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/changing-data-serialization-format-json-avro)
-in the [Stream Processing Cookbook](https://www.confluent.io/product/ksql/stream-processing-cookbook).
+[How to convert a stream's serialization format](https://kafka-tutorials.confluent.io/changing-serialization-format/ksql.html)
+in [Kafka Tutorials](https://kafka-tutorials.confluent.io/).
 
 ## Valid Identifiers
 

--- a/docs/developer-guide/aggregate-streaming-data.md
+++ b/docs/developer-guide/aggregate-streaming-data.md
@@ -127,6 +127,6 @@ Next Steps
 ----------
 
 -   Watch the screencast of [Aggregations](https://www.youtube.com/embed/db5SsmNvej4).
--   [Aggregating Data](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/aggregating-data)
--   [Detecting Abnormal Transactions](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/detecting-abnormal-transactions)
--   [Inline Streaming Aggregation](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/inline-streaming-aggregation)
+-   [Aggregating Data](https://kafka-tutorials.confluent.io/create-tumbling-windows/ksql.html)
+-   [Anomaly detection](https://kafka-tutorials.confluent.io/anomaly-detection/ksql.html)
+-   [How to find the min/max in a stream of events](https://kafka-tutorials.confluent.io/create-stateful-aggregation-minmax/ksql.html)

--- a/docs/developer-guide/joins/partition-data.md
+++ b/docs/developer-guide/joins/partition-data.md
@@ -186,8 +186,8 @@ CREATE STREAM products_rekeyed
 ```
 
 For more information, see
-[Inspecting and Changing Topic Keys](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/inspecting-changing-topic-keys)
-in the [Stream Processing Cookbook](https://www.confluent.io/product/ksql/stream-processing-cookbook).
+[How to rekey a stream with a value](https://kafka-tutorials.confluent.io/rekey-a-stream/ksql.html)
+in [Kafka Tutorials](https://kafka-tutorials.confluent.io/).
 
 ### Records Have the Same Number of Partitions
 

--- a/docs/developer-guide/transform-a-stream-with-ksqldb.md
+++ b/docs/developer-guide/transform-a-stream-with-ksqldb.md
@@ -107,11 +107,10 @@ CREATE STREAM pageviews_for_other_users AS
 Next Steps
 ----------
 
-Here are some examples of useful streaming transformations in the
-[Stream Processing Cookbook](https://www.confluent.io/stream-processing-cookbook):
+Here are some examples of useful streaming transformations in
+[Kafka Tutorials](https://kafka-tutorials.confluent.io/):
 
--   [Data Routing](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/data-routing)
--   [Changing Data Serialization Format from Avro to CSV](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/changing-data-serialization-format-avro-csv)
--   [Changing Data Serialization Format from JSON to Avro](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/changing-data-serialization-format-json-avro)
--   [Changing Data Serialization Format from Delimited (CSV) to Avro](https://www.confluent.io/stream-processing-cookbook/ksql-recipes/changing-data-serialization-format-delimited-csv-avro)
+-   [How to transform a stream of events](https://kafka-tutorials.confluent.io/transform-a-stream-of-events/ksql.html)
+-   [How to convert a stream's serialization format](https://kafka-tutorials.confluent.io/changing-serialization-format/ksql.html)
+
 

--- a/docs/tutorials/examples.md
+++ b/docs/tutorials/examples.md
@@ -9,7 +9,7 @@ keywords: ksqldb
 These examples use a `pageviews` stream and a `users` table.
 
 !!! tip
-      The [Stream Processing Cookbook](https://www.confluent.io/product/ksql/stream-processing-cookbook)
+      [Kafka Tutorials](https://kafka-tutorials.confluent.io/)
       contains ksqlDB recipes that provide in-depth tutorials and recommended
       deployment scenarios.
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -14,9 +14,9 @@ keywords: ksqldb, query, application, quickstart, tutorial, walkthrough, how to
 - [ksqlDB with Embedded Connect](embedded-connect.md)
 - [Integrating with PostgreSQL](connect-integration.md)
 
-### Stream Processing Cookbook
+### Kafka Tutorials
 
-The [Stream Processing Cookbook](https://www.confluent.io/product/ksql/stream-processing-cookbook)
+[Kafka Tutorials](https://kafka-tutorials.confluent.io/)
 contains ksqlDB recipes that provide in-depth tutorials and recommended
 deployment scenarios.
 


### PR DESCRIPTION
### Description 
Stream Processing Cookbook is out of date and being decommissioned.  This PR replaces links to the Cookbook with links to Kafka Tutorials (https://kafka-tutorials.confluent.io).  

### Testing done 
Rendered the docs locally per docs/README.md instructions and validated all changes.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

