### PR TITLE
fix: LDAP Authentication

### DIFF
--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -139,6 +139,12 @@
             <version>${reactive-streams.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jaas</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
         <!-- Required for running tests -->
 
         <dependency>
@@ -169,20 +175,6 @@
             <artifactId>mbknor-jackson-jsonschema_${kafka.scala.version}</artifactId>
             <version>1.0.39</version>
             <scope>test</scope>
-        </dependency>
-
-        <!-- Only required to provide LoginModule implementation in tests -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jaas</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jaas</artifactId>
-            <version>${jetty.version}</version>
-            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -181,13 +181,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-jaas</artifactId>
-            <version>9.4.28.v20200408</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-jaas</artifactId>
-            <version>9.4.28.v20200408</version>
+            <version>${jetty.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -178,6 +178,18 @@
             <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jaas</artifactId>
+            <version>9.4.28.v20200408</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jaas</artifactId>
+            <version>9.4.28.v20200408</version>
+            <scope>compile</scope>
+        </dependency>
 
     </dependencies>
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/BasicCallbackHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/BasicCallbackHandler.java
@@ -15,18 +15,17 @@
 
 package io.confluent.ksql.api.auth;
 
-import org.eclipse.jetty.jaas.callback.ObjectCallback;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.io.IOException;
+import java.util.Objects;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.TextOutputCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import java.io.IOException;
-import java.util.Objects;
+import org.eclipse.jetty.jaas.callback.ObjectCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class BasicCallbackHandler implements CallbackHandler {
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/BasicCallbackHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/BasicCallbackHandler.java
@@ -15,16 +15,13 @@
 
 package io.confluent.ksql.api.auth;
 
-import java.io.IOException;
-import java.util.Objects;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.TextOutputCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
+import org.eclipse.jetty.jaas.callback.ObjectCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.security.auth.callback.*;
+import java.io.IOException;
+import java.util.Objects;
 
 class BasicCallbackHandler implements CallbackHandler {
 
@@ -45,6 +42,9 @@ class BasicCallbackHandler implements CallbackHandler {
       if (callback instanceof NameCallback) {
         final NameCallback nc = (NameCallback) callback;
         nc.setName(username);
+      } else if (callback instanceof ObjectCallback) {
+        final ObjectCallback oc = (ObjectCallback)callback;
+        oc.setObject(password);
       } else if (callback instanceof PasswordCallback) {
         final PasswordCallback pc = (PasswordCallback) callback;
         pc.setPassword(password.toCharArray());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/BasicCallbackHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/BasicCallbackHandler.java
@@ -19,7 +19,12 @@ import org.eclipse.jetty.jaas.callback.ObjectCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.security.auth.callback.*;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.TextOutputCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
 import java.io.IOException;
 import java.util.Objects;
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/BasicCallbackHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/BasicCallbackHandlerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
+import org.eclipse.jetty.jaas.callback.ObjectCallback;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +36,8 @@ public class BasicCallbackHandlerTest {
   @Mock
   private NameCallback nameCallback;
   @Mock
+  private ObjectCallback objectCallback;
+  @Mock
   private PasswordCallback passwordCallback;
   @Mock
   private Callback unknownCallback;
@@ -47,13 +50,23 @@ public class BasicCallbackHandlerTest {
   }
 
   @Test
-  public void shouldHandleCallbacks() throws Exception {
+  public void shouldHandlePasswordCallback() throws Exception {
     // When:
     callbackHandler.handle(new Callback[]{nameCallback, passwordCallback});
 
     // Then:
     verify(nameCallback).setName(USERNAME);
     verify(passwordCallback).setPassword(PASSWORD.toCharArray());
+  }
+
+  @Test
+  public void shouldHandleObjectCallback() throws Exception {
+    // When:
+    callbackHandler.handle(new Callback[]{nameCallback, objectCallback});
+
+    // Then:
+    verify(nameCallback).setName(USERNAME);
+    verify(objectCallback).setObject(PASSWORD.toCharArray());
   }
 
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/BasicCallbackHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/BasicCallbackHandlerTest.java
@@ -66,7 +66,7 @@ public class BasicCallbackHandlerTest {
 
     // Then:
     verify(nameCallback).setName(USERNAME);
-    verify(objectCallback).setObject(PASSWORD.toCharArray());
+    verify(objectCallback).setObject(PASSWORD);
   }
 
 }


### PR DESCRIPTION
### Description 
fixes #6730 

### Testing done 
Manual testing by adding the following configs to `ksql-server.properties`:
```
authentication.method=BASIC
authentication.realm=KsqlServer-Props
authentication.roles=Developers
```

`docker-compose.yml`:
```
version: '2'
services:
  ldap:
    image: osixia/openldap:1.4.0
    hostname: ldap
    container_name: ldap
    environment:
      LDAP_ORGANISATION: "Confluent"
      LDAP_DOMAIN: "confluent.io"
    ports:
      - "389:389"
    volumes:
      - "$PWD/ldap:/container/service/slapd/assets/config/bootstrap/ldif/custom"
    command: "--copy-service"

  zookeeper:
    image: confluentinc/cp-zookeeper:${CP_VERSION}
    environment:
      ZOOKEEPER_CLIENT_PORT: 32181
      ZOOKEEPER_TICK_TIME: 2000

  kafka:
    image: confluentinc/cp-enterprise-kafka:${CP_VERSION}
    ports:
      - "29092:29092"
    depends_on:
      - zookeeper
    environment:
      KAFKA_BROKER_ID: 1
      KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 100

  schema-registry:
    image: confluentinc/cp-schema-registry:${CP_VERSION}
    depends_on:
      - zookeeper
      - kafka
    environment:
      SCHEMA_REGISTRY_HOST_NAME: schema-registry
      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181

  primary-ksqldb-server:
    image: ${KSQL_IMAGE_BASE}confluentinc/ksqldb-server:${KSQL_VERSION}
    hostname: primary-ksqldb-server
    container_name: primary-ksqldb-server
    depends_on:
      - kafka
      - schema-registry
    ports:
      - "8088:8088"
    volumes:
      - ./secrets/:/home/appuser/
    environment:
      KSQL_LISTENERS: http://0.0.0.0:8088
      KSQL_BOOTSTRAP_SERVERS: kafka:9092
      KSQL_KSQL_SCHEMA_REGISTRY_URL: http://schema-registry:8081
      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
      KSQL_AUTHENTICATION_METHOD: BASIC
      KSQL_AUTHENTICATION_ROLES: Developers
      KSQL_AUTHENTICATION_REALM: KsqlServer-Props
      KSQL_CLASSPATH: /home/appuser/jetty-jaas-9.4.24.v20191120.jar:/usr/share/java/ksqldb-server/*
      KSQL_OPTS: "-Djava.security.auth.login.config=/home/appuser/jaas_config.file"
```
then running `<ksql-install>bin/ksql --user fred --password letmein http://localhost:8088` should work

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

