### PR TITLE
chore: improve error messages on invalid GROUP BYs

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
@@ -28,7 +28,7 @@ public interface FunctionRegistry {
   SqlType DEFAULT_FUNCTION_ARG_SCHEMA = SqlTypes.BIGINT;
 
   /**
-   * Test if the supplied {@code functionName} is an aggregate function.
+   * Test if there is an aggregate function with the supplied {@code functionName}.
    *
    * <p>Note: unknown functions result in {@code false} return value.
    *
@@ -38,7 +38,7 @@ public interface FunctionRegistry {
   boolean isAggregate(FunctionName functionName);
 
   /**
-   * Test if the supplied {@code functionName} is a table function.
+   * Test if there is a table function with the supplied {@code functionName}.
    *
    * <p>Note: unknown functions result in {@code false} return value.
    *
@@ -46,6 +46,14 @@ public interface FunctionRegistry {
    * @return {@code true} if it is a table function, {@code false} otherwise.
    */
   boolean isTableFunction(FunctionName functionName);
+
+  /**
+   * Test whether this is a function with the supplied {@code functionName}.
+   *
+   * @param functionName the name of the function to test
+   * @return {@code true} if the function exists, {@code false} otherwise.
+   */
+  boolean isPresent(FunctionName functionName);
 
   /**
    * Get the factory for a UDF.

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
@@ -48,7 +48,7 @@ public interface FunctionRegistry {
   boolean isTableFunction(FunctionName functionName);
 
   /**
-   * Test whether this is a function with the supplied {@code functionName}.
+   * Test whether there is a function with the supplied {@code functionName}.
    *
    * @param functionName the name of the function to test
    * @return {@code true} if the function exists, {@code false} otherwise.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
@@ -329,6 +329,11 @@ public class AggregateAnalyzer {
     @Override
     public Void visitFunctionCall(final FunctionCall node, final Void context) {
       final FunctionName functionName = node.getName();
+
+      if (!functionRegistry.isPresent(functionName)) {
+        throw new KsqlException("Can't find any functions with the name '"
+            + functionName.text() + "'");
+      }
       final boolean aggregateFunc = functionRegistry.isAggregate(functionName);
 
       final FunctionCall functionCall = aggregateFunc && node.getArguments().isEmpty()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -98,6 +98,20 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
   }
 
   @Override
+  public boolean isPresent(final FunctionName functionName) {
+    if (udfs.containsKey(functionName.text().toUpperCase())) {
+      return true;
+    }
+    if (udafs.containsKey(functionName.text().toUpperCase())) {
+      return true;
+    }
+    if (udtfs.containsKey(functionName.text().toUpperCase())) {
+      return true;
+    }
+    return false;
+  }
+
+  @Override
   public synchronized KsqlAggregateFunction getAggregateFunction(
       final FunctionName functionName,
       final SqlType argumentType,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -291,13 +291,13 @@ public class LogicalPlanner {
         getTargetSchema()
     );
 
-    final LogicalSchema schema =
-        buildAggregateSchema(sourcePlanNode, groupBy, projectionExpressions);
-
     final RewrittenAggregateAnalysis aggregateAnalysis = new RewrittenAggregateAnalysis(
         aggregateAnalyzer.analyze(analysis, projectionExpressions),
         refRewriter::process
     );
+
+    final LogicalSchema schema =
+        buildAggregateSchema(sourcePlanNode, groupBy, projectionExpressions);
 
     if (analysis.getHavingExpression().isPresent()) {
       final FilterTypeValidator validator = new FilterTypeValidator(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -367,6 +367,18 @@ public class InternalFunctionRegistryTest {
     assertThat(functionRegistry.listFunctions(), hasItem(sameInstance(udfFactory)));
   }
 
+  @Test
+  public void shouldKnowIfFunctionIsPresent() {
+    // Given:
+    when(udafFactory.getName()).thenReturn(UDF_NAME);
+    functionRegistry.addAggregateFunctionFactory(udafFactory);
+
+    // When / Then:
+    assertThat(functionRegistry.isPresent(FunctionName.of("count")), is(true));
+    assertThat(functionRegistry.isPresent(FunctionName.of(UDF_NAME)), is(true));
+    assertThat(functionRegistry.isPresent(FunctionName.of("not_found")), is(false));
+  }
+
   private void givenUdfFactoryRegistered() {
     functionRegistry.ensureFunctionFactory(UdfLoaderUtil.createTestUdfFactory(func));
   }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -459,6 +459,17 @@
       }
     },
     {
+      "name": "unknown function - multi group by",
+      "statements": [
+        "CREATE STREAM TEST (ID INT KEY, data STRING, other STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT DATA, OTHER, WONT_FIND_ME(ID) FROM TEST GROUP BY DATA, OTHER;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Can't find any functions with the name 'WONT_FIND_ME'"
+      }
+    },
+    {
       "name": "non-table udaf on table",
       "statements": [
         "CREATE TABLE INPUT (ID BIGINT PRIMARY KEY, F0 INT, F1 BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/window-bounds.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/window-bounds.json
@@ -192,6 +192,18 @@
       }
     },
     {
+      "name": "windowed group by -  only window bounds in GROUP BY only column",
+      "comment": "In the future this can be supported, but isn't as yet",
+      "statements": [
+        "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE S2 as SELECT ROWKEY, count(1) as count FROM test WINDOW TUMBLING (SIZE 1 SECOND) group by WINDOWSTART;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Window bounds column WINDOWSTART can only be used in the SELECT clause of windowed aggregations"
+      }
+    },
+    {
       "name": "windowed group by - window bounds in expression in GROUP BY",
       "statements": [
         "CREATE STREAM TEST (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -219,6 +219,10 @@ public final class MetaStoreImpl implements MutableMetaStore {
     return functionRegistry.isTableFunction(functionName);
   }
 
+  public boolean isPresent(final FunctionName functionName) {
+    return functionRegistry.isPresent(functionName);
+  }
+
   public KsqlAggregateFunction<?, ?, ?> getAggregateFunction(
       final FunctionName functionName,
       final SqlType argumentType,


### PR DESCRIPTION
### Description 

tl;dr this PR improves error messages on invalid statements involving GROUP BYs.

The long version: Currently, in the logical planner when we build aggregate nodes, validation is split across the logic for building the aggregate schema (`LogicalPlanner#buildAggregateSchema()`) and for performing the aggregate analysis (`AggregateAnalyzer#analyze()`). The former throws a nice error message if the statement contains a function call that doesn’t exist. The latter throws a nice error message if the GROUP BY expressions contain window bounds (since doesn't support that today). However, the two pieces of logic throw unhelpful errors in the reverse scenarios: if the schema building logic encounters window bounds, it throws an error saying the column doesn’t exist. If the aggregate analyzer encounters an unknown function, it ignores it and returns an error about not finding any aggregate functions in the select expressions. In order to get helpful error messages in both scenarios, this PR updates `AggregateAnazlyer` to throw a helpful error message if a nonexistent function call is encountered, and moves the AggregateAnalyzer code above the schema building code in order to fail early (with helpful error messages).

### Testing done 

Unit + QTT.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

