### PR TITLE
chore: fix bad error message on insert into

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SelectionUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SelectionUtil.java
@@ -96,7 +96,13 @@ public final class SelectionUtil {
 
     if (selectItem instanceof SingleColumn) {
       final SingleColumn column = (SingleColumn) selectItem;
-      final Optional<Column> targetColumn = targetSchema.map(schema -> schema.columns().get(idx));
+      // if the column we are trying to coerce into a target schema is beyond
+      // the target schema's max columns ignore it. this will generate a failure
+      // down the line when we check that the result schema is identical to
+      // the schema of the source we are attempting to fit
+      final Optional<Column> targetColumn = targetSchema
+          .filter(schema -> schema.columns().size() > idx)
+          .map(schema -> schema.columns().get(idx));
 
       return resolveSingleColumn(idx, parentNode, column, targetColumn);
     }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
@@ -183,6 +183,32 @@
       "outputs": [
         {"topic": "target", "value": {"C1": 1.00, "C2": 2.00}}
       ]
+    },
+    {
+      "name": "join mismatch (fewer columns than expected)",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data VARCHAR) WITH (kafka_topic='stream-source', value_format='DELIMITED');",
+        "CREATE STREAM SOURCE2 (K STRING KEY, data VARCHAR) WITH (kafka_topic='insert-source', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT K, DATA AS DATA_1, DATA AS DATA_2 FROM SOURCE1;",
+        "INSERT INTO OUTPUT SELECT S1.K AS K, S1.DATA AS DATA_1 FROM SOURCE1 S1 JOIN SOURCE2 S2 WITHIN 1 SECOND ON S1.K = S2.K;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Result schema is `K` STRING KEY, `DATA_1` STRING\nSink schema is `K` STRING KEY, `DATA_1` STRING, `DATA_2` STRING"
+      }
+    },
+    {
+      "name": "join mismatch (more columns than expected)",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data VARCHAR) WITH (kafka_topic='stream-source', value_format='DELIMITED');",
+        "CREATE STREAM SOURCE2 (K STRING KEY, data VARCHAR) WITH (kafka_topic='insert-source', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT K, DATA AS DATA_1, DATA AS DATA_2 FROM SOURCE1;",
+        "INSERT INTO OUTPUT SELECT S1.K AS K, S1.DATA AS DATA_1, S2.DATA AS DATA_2, S2.DATA AS DATA_3 FROM SOURCE1 S1 JOIN SOURCE2 S2 WITHIN 1 SECOND ON S1.K = S2.K;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Result schema is `K` STRING KEY, `DATA_1` STRING, `DATA_2` STRING, `DATA_3` STRING\nSink schema is `K` STRING KEY, `DATA_1` STRING, `DATA_2` STRING"
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 
fixes #6760 by ensuring that the old error message is thrown when we try to insert into a source with more columns than it has. before this patch, the code would fail with IndexOutOfBounds exception when trying to get the column at an index greater than the number of columns. this fixes it by "ignoring" that column and just letting it throw later down the line.

### Testing done 
QTT testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

