### PR TITLE
chore: clarify single key unwrapping during schema inference (MINOR)

### DIFF
--- a/docs/concepts/schemas.md
+++ b/docs/concepts/schemas.md
@@ -104,13 +104,21 @@ don't supply one the stream is created without a key column.
 
 The following example statements show how to create streams and tables that have 
 Avro-formatted data. If you want to use Protobuf- or JSON-formatted data,
-substitute `PROTOBUF`, `JSON` or `JSON_SR` for `AVRO` in each statement.
+substitute `PROTOBUF` or `JSON_SR` for `AVRO` in each statement.
 
 !!! note
     ksqlDB handles the `JSON` and `JSON_SR` formats differently. `JSON_SR` reads and 
     registers new schemas with {{ site.sr }} as necessary, while `JSON` requires you
     to specify the schema. Data formatted with `JSON_SR` is not binary compatible with
     the `JSON` format.
+    
+!!! note
+    When performing schema inference to infer value schemas, ksqlDB takes user-specified
+    [single field (un)wrapping](../developer-guide/serialization.md#single-field-unwrapping) 
+    into account. When performing schema inference on key schemas, the resulting key schema
+    will always be unwrapped. If your key is contained in an outer record or object, the
+    inferred key will be represented as a `STRUCT`. You can access individual fields within
+    the `STRUCT` via [STRUCT dereference](../developer-guide/ksqldb-reference/operators.md#struct-dereference).
 
 ### Create a new stream
 

--- a/docs/concepts/schemas.md
+++ b/docs/concepts/schemas.md
@@ -116,9 +116,11 @@ substitute `PROTOBUF` or `JSON_SR` for `AVRO` in each statement.
     When performing schema inference to infer value schemas, ksqlDB takes user-specified
     [single field (un)wrapping](../developer-guide/serialization.md#single-field-unwrapping) 
     into account. When performing schema inference on key schemas, the resulting key schema
-    will always be unwrapped. If your key is contained in an outer record or object, the
-    inferred key will be represented as a `STRUCT`. You can access individual fields within
-    the `STRUCT` via [STRUCT dereference](../developer-guide/ksqldb-reference/operators.md#struct-dereference).
+    is always unwrapped. If your key is contained in an outer record or object, the
+    inferred key is represented as a `STRUCT`. You can access individual fields within
+    the `STRUCT` by using [STRUCT dereference](../developer-guide/ksqldb-reference/operators.md#struct-dereference).
+    Alternatively, you can specify the individual fields as key columns explicitly and
+    avoid schema inference altogether.
 
 ### Create a new stream
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -125,7 +125,9 @@ public class DefaultSchemaInjector implements Injector {
         props.getKafkaTopic(),
         props.getKeySchemaId(),
         keyFormat,
-        SerdeFeaturesFactory.buildInternal(FormatFactory.of(keyFormat)),
+        // until we support user-configuration of single key wrapping/unwrapping, we choose
+        // to have key schema inference always result in an unwrapped key
+        SerdeFeaturesFactory.buildKeyFeatures(FormatFactory.of(keyFormat), true),
         statement.getStatementText(),
         true
     ));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/serde/SerdeFeaturesFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/serde/SerdeFeaturesFactory.java
@@ -63,9 +63,16 @@ public final class SerdeFeaturesFactory {
       final LogicalSchema schema,
       final Format keyFormat
   ) {
+    return buildKeyFeatures(keyFormat, schema.key().size() == 1);
+  }
+
+  public static SerdeFeatures buildKeyFeatures(
+    final Format keyFormat,
+    final boolean isSingleKey
+  ) {
     final ImmutableSet.Builder<SerdeFeature> builder = ImmutableSet.builder();
 
-    getKeyWrapping(schema.key().size() == 1, keyFormat)
+    getKeyWrapping(isSingleKey, keyFormat)
         .ifPresent(builder::add);
 
     return SerdeFeatures.from(builder.build());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/serde/SerdeFeaturesFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/serde/SerdeFeaturesFactory.java
@@ -67,8 +67,8 @@ public final class SerdeFeaturesFactory {
   }
 
   public static SerdeFeatures buildKeyFeatures(
-    final Format keyFormat,
-    final boolean isSingleKey
+      final Format keyFormat,
+      final boolean isSingleKey
   ) {
     final ImmutableSet.Builder<SerdeFeature> builder = ImmutableSet.builder();
 

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-col-keys_-_select___from_stream_-_with_key_inference/6.2.0_1608161572199/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-col-keys_-_select___from_stream_-_with_key_inference/6.2.0_1608161572199/plan.json
@@ -1,0 +1,159 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ROWKEY STRUCT<K INTEGER, K2 INTEGER> KEY, V INTEGER) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='AVRO', KEY_SCHEMA_ID=1, VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ROWKEY` STRUCT<`K` INTEGER, `K2` INTEGER> KEY, `V` INTEGER",
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "AVRO",
+          "properties" : {
+            "fullSchemaName" : "io.confluent.ksql.avro_schemas.InputKey"
+          }
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ROWKEY` STRUCT<`K` INTEGER, `K2` INTEGER> KEY, `V` INTEGER",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "AVRO",
+          "properties" : {
+            "fullSchemaName" : "io.confluent.ksql.avro_schemas.OutputKey"
+          }
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "AVRO",
+                "properties" : {
+                  "fullSchemaName" : "io.confluent.ksql.avro_schemas.InputKey"
+                }
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              },
+              "keyFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "sourceSchema" : "`ROWKEY` STRUCT<`K` INTEGER, `K2` INTEGER> KEY, `V` INTEGER"
+          },
+          "keyColumnNames" : [ "ROWKEY" ],
+          "selectExpressions" : [ "V AS V" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "io.confluent.ksql.avro_schemas.OutputKey"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "keyFeatures" : [ "UNWRAP_SINGLES" ]
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.multicol.key.format.enabled" : "false",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-col-keys_-_select___from_stream_-_with_key_inference/6.2.0_1608161572199/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-col-keys_-_select___from_stream_-_with_key_inference/6.2.0_1608161572199/spec.json
@@ -1,0 +1,188 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1608161572199,
+  "path" : "query-validation-tests/multi-col-keys.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ROWKEY` STRUCT<`K` INTEGER, `K2` INTEGER> KEY, `V` INTEGER",
+      "keyFormat" : {
+        "format" : "AVRO",
+        "properties" : {
+          "fullSchemaName" : "io.confluent.ksql.avro_schemas.InputKey"
+        },
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ROWKEY` STRUCT<`K` INTEGER, `K2` INTEGER> KEY, `V` INTEGER",
+      "keyFormat" : {
+        "format" : "AVRO",
+        "properties" : {
+          "fullSchemaName" : "io.confluent.ksql.avro_schemas.OutputKey"
+        },
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "select * from stream - with key inference",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : {
+        "K" : 1,
+        "K2" : 2
+      },
+      "value" : {
+        "V" : 0
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : {
+        "K" : null,
+        "K2" : 2
+      },
+      "value" : {
+        "V" : 0
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : null,
+      "value" : {
+        "V" : 0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K" : 1,
+        "K2" : 2
+      },
+      "value" : {
+        "V" : 0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K" : null,
+        "K2" : 2
+      },
+      "value" : {
+        "V" : 0
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "V" : 0
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "keySchema" : {
+        "type" : "record",
+        "name" : "most_recent_key_schema_at_SR",
+        "fields" : [ {
+          "name" : "K",
+          "type" : [ "null", "int" ]
+        }, {
+          "name" : "K2",
+          "type" : [ "null", "int" ]
+        } ]
+      },
+      "keyFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (V INT) WITH (kafka_topic='input_topic', key_format='AVRO', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ROWKEY` STRUCT<`K` INTEGER, `K2` INTEGER> KEY, `V` INTEGER",
+        "keyFormat" : {
+          "format" : "AVRO"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ROWKEY` STRUCT<`K` INTEGER, `K2` INTEGER> KEY, `V` INTEGER",
+        "keyFormat" : {
+          "format" : "AVRO"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "io.confluent.ksql.avro_schemas.InputKey"
+            },
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 1,
+          "keySchema" : {
+            "type" : "record",
+            "name" : "most_recent_key_schema_at_SR",
+            "fields" : [ {
+              "name" : "K",
+              "type" : [ "null", "int" ],
+              "default" : null
+            }, {
+              "name" : "K2",
+              "type" : [ "null", "int" ],
+              "default" : null
+            } ],
+            "connect.name" : "most_recent_key_schema_at_SR"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "io.confluent.ksql.avro_schemas.OutputKey"
+            },
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4,
+          "keySchema" : {
+            "type" : "record",
+            "name" : "OutputKey",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "K",
+              "type" : [ "null", "int" ],
+              "default" : null
+            }, {
+              "name" : "K2",
+              "type" : [ "null", "int" ],
+              "default" : null
+            } ]
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-col-keys_-_select___from_stream_-_with_key_inference/6.2.0_1608161572199/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-col-keys_-_select___from_stream_-_with_key_inference/6.2.0_1608161572199/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-col-keys.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-col-keys.json
@@ -23,6 +23,34 @@
       }
     },
     {
+      "name": "select * from stream - with key inference",
+      "statements": [
+        "CREATE STREAM INPUT (V INT) WITH (kafka_topic='input_topic', key_format='AVRO', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "keySchema": {"type": "record", "name": "most_recent_key_schema_at_SR", "fields": [{"name": "K", "type": ["null", "int"]}, {"name": "K2", "type": ["null", "int"]}]}
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": {"K": 1, "K2": 2}, "value": {"V": 0}},
+        {"topic": "input_topic", "key": {"K": null, "K2": 2}, "value": {"V": 0}},
+        {"topic": "input_topic", "key": null, "value": {"V": 0}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"K": 1, "K2": 2}, "value": {"V": 0}},
+        {"topic": "OUTPUT", "key": {"K": null, "K2": 2}, "value": {"V": 0}},
+        {"topic": "OUTPUT", "key": null, "value": {"V": 0}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY STRUCT<K INT, K2 INT> KEY, V INT"}
+        ]
+      }
+    },
+    {
       "name": "select * from table",
       "statements": [
         "CREATE TABLE INPUT (K INT PRIMARY KEY, K2 INT PRIMARY KEY, V INT) WITH (kafka_topic='input_topic', format='JSON');",


### PR DESCRIPTION
### Description 

Docs changes and a minor refactor to clarify that key schema inference always results in an unwrapped key today. Also adds a QTT for multi-column key schema inference to confirm.

### Testing done 

New QTT passes.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

