### PR TITLE
chore: support multi-col pull queries

### DIFF
--- a/docs/concepts/queries/pull.md
+++ b/docs/concepts/queries/pull.md
@@ -36,7 +36,7 @@ Pull query features and limitations
   with a GROUP BY clause.
 - For non-windowed aggregations, pull queries only support looking up events
   by key.
-- WHERE clauses can only have constraints on the key column(s) for non-windowed tables.
+- WHERE clauses must have constraints that encompass all key column(s) for non-windowed tables.
 
 - In addition, windowed tables support bounds on `WINDOWSTART` and `WINDOWEND` using operators
   `<=`, `<`, `=`, `>`, `>=`.

--- a/docs/concepts/queries/pull.md
+++ b/docs/concepts/queries/pull.md
@@ -36,7 +36,7 @@ Pull query features and limitations
   with a GROUP BY clause.
 - For non-windowed aggregations, pull queries only support looking up events
   by key.
-- WHERE clauses can only have constraints on the key column for non-windowed tables.
+- WHERE clauses can only have constraints on the key column(s) for non-windowed tables.
 
 - In addition, windowed tables support bounds on `WINDOWSTART` and `WINDOWEND` using operators
   `<=`, `<`, `=`, `>`, `>=`.

--- a/docs/developer-guide/ksqldb-reference/select-pull-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-pull-query.md
@@ -15,7 +15,7 @@ Synopsis
 ```sql
 SELECT select_expr [, ...]
   FROM aggregate_table
-  WHERE key_column=key [, ...]
+  WHERE key_column=key [AND ...]
   [AND window_bounds];
 ```
 
@@ -49,8 +49,9 @@ SELECT * FROM pageviews_by_region
     AND 1570051876000 <= WINDOWSTART AND WINDOWEND <= 1570138276000;
 ```
 
-If the `pageviews_by_region` was created as an aggregation of multiple columns (e.g. `countryId`
-and `regionId`) then each key column must be present in the WHERE clause:
+If the `pageviews_by_region` table was created as an aggregation of multiple columns,
+then each key column must be present in the WHERE clause. The following example shows how to 
+query the table if `countryId` and `regionId` where both key columns:
 
 ```sql
 SELECT * FROM pageviews_by_region

--- a/docs/developer-guide/ksqldb-reference/select-pull-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-pull-query.md
@@ -15,7 +15,7 @@ Synopsis
 ```sql
 SELECT select_expr [, ...]
   FROM aggregate_table
-  WHERE key_column=key
+  WHERE key_column=key [, ...]
   [AND window_bounds];
 ```
 
@@ -35,7 +35,7 @@ request/response flows. For asynchronous application flows, see
 Execute a pull query by sending an HTTP request to the ksqlDB REST API, and
 the API responds with a single response.  
 
-The WHERE clause must contain a single primary-key to retrieve and may
+The WHERE clause must contain a value for each primary-key column to retrieve and may
 optionally include bounds on `WINDOWSTART` and `WINDOWEND` if the materialized table is windowed.
 For more information, see 
 [Time and Windows in ksqlDB](../../concepts/time-and-windows-in-ksqldb-queries.md).
@@ -46,6 +46,15 @@ Example
 ```sql
 SELECT * FROM pageviews_by_region
   WHERE regionId = 'Region_1'
+    AND 1570051876000 <= WINDOWSTART AND WINDOWEND <= 1570138276000;
+```
+
+If the `pageviews_by_region` was created as an aggregation of multiple columns (e.g. `countryId`
+and `regionId`) then each key column must be present in the WHERE clause:
+
+```sql
+SELECT * FROM pageviews_by_region
+  WHERE countryId = 'USA' AND regionId = 'Region_1'
     AND 1570051876000 <= WINDOWSTART AND WINDOWEND <= 1570138276000;
 ```
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.physical.pull;
 
-import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.analyzer.PullQueryValidator;
@@ -198,10 +197,7 @@ public class PullPhysicalPlanBuilder {
     if (whereInfo == null) {
       throw new KsqlException("Pull queries must have a WHERE clause");
     }
-    keys = whereInfo.getKeysBound().stream()
-        .map(GenericKey::genericKey)
-        .collect(ImmutableList.toImmutableList());
-
+    keys = whereInfo.getKeysBound();
     if (!whereInfo.isWindowed()) {
       return new KeyedTableLookupOperator(mat, logicalNode);
     } else {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
@@ -193,11 +193,6 @@ public final class WhereInfo {
       final MetaStore metaStore,
       final KsqlConfig config
   ) {
-    if (schema.key().size() > 1) {
-      throw invalidWhereClauseException("Schemas with multiple "
-          + "KEY columns are not supported", false);
-    }
-
     final InPredicate inPredicate = Iterables.getLast(inPredicates);
     final Column keyColumn = Iterables.getOnlyElement(schema.key());
     return inPredicate.getValueList()
@@ -418,6 +413,11 @@ public final class WhereInfo {
       final InPredicate inPredicate,
       final LogicalSchema schema
   ) {
+    if (schema.key().size() > 1) {
+      throw invalidWhereClauseException("Schemas with multiple "
+          + "KEY columns are not supported for IN predicates", false);
+    }
+
     final UnqualifiedColumnReferenceExp column
         = (UnqualifiedColumnReferenceExp) inPredicate.getValue();
     final ColumnName keyColumn = Iterables.getOnlyElement(schema.key()).name();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/WhereInfoTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/WhereInfoTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
+import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression.Sign;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
@@ -59,6 +60,12 @@ public class WhereInfoTest {
       .valueColumn(ColumnName.of("C1"), SqlTypes.INTEGER)
       .build();
 
+  private static final LogicalSchema MULTI_KEY_SCHEMA = LogicalSchema.builder()
+      .keyColumn(ColumnName.of("K1"), SqlTypes.INTEGER)
+      .keyColumn(ColumnName.of("K2"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("C1"), SqlTypes.INTEGER)
+      .build();
+
   @Test
   public void shouldExtractFromLiteralEquals() {
     // Given:
@@ -72,7 +79,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, false, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(false));
     assertThat(where.getWindowBounds(), is(Optional.empty()));
   }
@@ -90,7 +97,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, false, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(-1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(-1))));
     assertThat(where.isWindowed(), is(false));
     assertThat(where.getWindowBounds(), is(Optional.empty()));
   }
@@ -109,7 +116,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, false, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1, 2)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1), GenericKey.genericKey(2))));
     assertThat(where.isWindowed(), is(false));
     assertThat(where.getWindowBounds(), is(Optional.empty()));
   }
@@ -129,7 +136,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -162,7 +169,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -195,7 +202,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -228,7 +235,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -261,7 +268,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -294,7 +301,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -327,7 +334,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -360,7 +367,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -393,7 +400,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -426,7 +433,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -470,7 +477,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -503,7 +510,7 @@ public class WhereInfoTest {
     final WhereInfo where = WhereInfo.extractWhereInfo(expression, SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(where.getKeysBound(), is(ImmutableList.of(1)));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1))));
     assertThat(where.isWindowed(), is(true));
     assertThat(where.getWindowBounds(), is(Optional.of(
         new WindowBounds(
@@ -659,39 +666,16 @@ public class WhereInfoTest {
   }
 
   @Test
-  public void shouldThrowOnMultiColKeySchema() {
-    // Given:
-    final LogicalSchema multiSchema = LogicalSchema.builder()
-        .keyColumn(ColumnName.of("K"), SqlTypes.INTEGER)
-        .keyColumn(ColumnName.of("K2"), SqlTypes.INTEGER)
-        .valueColumn(ColumnName.of("C1"), SqlTypes.INTEGER)
-        .build();
-    final Expression expression = new ComparisonExpression(
-        Type.EQUAL,
-        new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
-        new ArithmeticUnaryExpression(Optional.empty(), Sign.MINUS, new IntegerLiteral(1))
-    );
-
-    // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
-        () -> WhereInfo.extractWhereInfo(expression, multiSchema, false, METASTORE, CONFIG));
-
-    // Then:
-    assertThat(e.getMessage(), containsString("Schemas with multiple KEY columns are not supported"));
-  }
-
-  @Test
-  public void shouldThrowOnMultiKeyExpressions() {
+  public void shouldSupportMultiKeyExpressions() {
     // Given:
     final Expression expression1 = new ComparisonExpression(
         Type.EQUAL,
-        new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
+        new UnqualifiedColumnReferenceExp(ColumnName.of("K1")),
         new IntegerLiteral(1)
     );
     final Expression expression2 = new ComparisonExpression(
         Type.EQUAL,
-        new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
+        new UnqualifiedColumnReferenceExp(ColumnName.of("K2")),
         new IntegerLiteral(2)
     );
     final Expression expression  = new LogicalBinaryExpression(
@@ -701,12 +685,31 @@ public class WhereInfoTest {
     );
 
     // When:
-    final KsqlException e = assertThrows(
-        KsqlException.class,
-        () -> WhereInfo.extractWhereInfo(expression, SCHEMA, false, METASTORE, CONFIG));
+    final WhereInfo where = WhereInfo.extractWhereInfo(expression, MULTI_KEY_SCHEMA, true, METASTORE, CONFIG);
 
     // Then:
-    assertThat(e.getMessage(), containsString("Multiple bounds on key column."));
+    assertThat(where.getKeysBound(), is(ImmutableList.of(GenericKey.genericKey(1, 2))));
+  }
+
+
+  @Test
+  public void shouldSupportMultiKeyExpressionsThatDontCoverAllKeys() {
+    // Given:
+    final Expression expression = new ComparisonExpression(
+        Type.EQUAL,
+        new UnqualifiedColumnReferenceExp(ColumnName.of("K1")),
+        new IntegerLiteral(1)
+    );
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> WhereInfo.extractWhereInfo(expression, MULTI_KEY_SCHEMA, false, METASTORE, CONFIG));
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Multi-column sources must specify every key in the WHERE clause. "
+            + "Specified: [`K1`] Expected: [`K1` INTEGER KEY, `K2` INTEGER KEY]"));
   }
 
   @Test
@@ -767,7 +770,7 @@ public class WhereInfoTest {
         () -> WhereInfo.extractWhereInfo(expression, SCHEMA, false, METASTORE, CONFIG));
 
     // Then:
-    assertThat(e.getMessage(), containsString("WHERE clause on unsupported column: C1"));
+    assertThat(e.getMessage(), containsString("WHERE clause on non-key column: C1"));
   }
 
   @Test
@@ -785,7 +788,7 @@ public class WhereInfoTest {
         () -> WhereInfo.extractWhereInfo(expression, SCHEMA, false, METASTORE, CONFIG));
 
     // Then:
-    assertThat(e.getMessage(), containsString("Bound on 'K' must currently be '='."));
+    assertThat(e.getMessage(), containsString("Bound on key columns '[`K` INTEGER KEY]' must currently be '='"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/WhereInfoTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/WhereInfoTest.java
@@ -693,7 +693,7 @@ public class WhereInfoTest {
 
 
   @Test
-  public void shouldSupportMultiKeyExpressionsThatDontCoverAllKeys() {
+  public void shouldNotSupportMultiKeyExpressionsThatDontCoverAllKeys() {
     // Given:
     final Expression expression = new ComparisonExpression(
         Type.EQUAL,
@@ -909,6 +909,25 @@ public class WhereInfoTest {
 
     // Then:
     assertThat(e.getMessage(), containsString("Primary key columns can not be NULL: (K = null)"));
+  }
+
+  @Test
+  public void shouldThrowOnInExpressionWithMultiColKeySchema() {
+    // Given:
+    final Expression expression = new InPredicate(
+        new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
+        new InListExpression(
+            ImmutableList.of(new IntegerLiteral(1), new IntegerLiteral(2))
+        )
+    );
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> WhereInfo.extractWhereInfo(expression, MULTI_KEY_SCHEMA, false, METASTORE, CONFIG));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Schemas with multiple KEY columns are not supported for IN predicates"));
   }
 
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2002,6 +2002,28 @@
           {"row":{"columns":[10, 1]}}
         ]}
       ]
+    },
+    {
+      "name": "multi-column aggregation",
+      "properties": {
+        "ksql.multicol.key.format.enabled" : true
+      },
+      "statements": [
+        "CREATE STREAM INPUT (ID1 STRING KEY, ID2 INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID1, ID2, COUNT(1) AS COUNT FROM INPUT GROUP BY ID1, ID2;",
+        "SELECT * FROM AGGREGATE WHERE ID1='11' AND ID2=10;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {"id2": 10}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID1` STRING KEY, `ID2` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["11", 10, 1]}}
+        ]}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2024,6 +2024,33 @@
           {"row":{"columns":["11", 10, 1]}}
         ]}
       ]
+    },
+    {
+      "name": "multi-column windowed aggregation",
+      "statements": [
+        "CREATE STREAM INPUT (ID1 STRING KEY, ID2 INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID1, ID2, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID1, ID2;",
+        "SELECT * FROM AGGREGATE WHERE ID1='11' AND ID2=10 AND WindowStart <= 13000 AND WindowEnd < 17000;",
+        "SELECT * FROM AGGREGATE WHERE ID1='11' AND ID2=10 AND WindowStart >= 13000 AND WindowEnd < 17000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12000, "key": "11", "value": {"id2": 10}},
+        {"topic": "test_topic", "timestamp": 12000, "key": "11", "value": {"id2": 10}},
+        {"topic": "test_topic", "timestamp": 14000, "key": "11", "value": {"id2": 10}},
+        {"topic": "test_topic", "timestamp": 14000, "key": "11", "value": {"id2": 10}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID1` STRING KEY, `ID2` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["11", 10, 12000, 13000, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID1` STRING KEY, `ID2` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["11", 10, 14000, 15000, 2]}}
+        ]}
+      ]
     }
   ]
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -328,7 +328,7 @@ public class ApiIntegrationTest {
     String sql = "SELECT * from " + AGG_TABLE + " WHERE LONG=12345;";
 
     // Then:
-    shouldFailToExecuteQuery(sql, "WHERE clause on unsupported column: LONG.");
+    shouldFailToExecuteQuery(sql, "WHERE clause on non-key column: LONG");
   }
 
   @Test


### PR DESCRIPTION
### Description 

Support pull queries on aggregations that aggregate over multiple key columns by requiring that all keys that make up the primary key are selected in the `WHERE` clause as a conjunction of equality expressions (e.g. `WHERE K1=1 AND K2=2`). 

"In" queries are not yet supported, there's some thinking to be done about how we can support that (cc @AlanConfluent perhaps we could do something like `WHERE K1 IN (1, 2) AND K2 in (3,4)` and this would find keys that make up the cross-product of those fields `{1,3}, {1, 4}, {2, 3}, {2, 4}`)

Alternatively, we could consider supporting `OR` in order to get multiple keys (e.g. `WHERE (K1 = 1 AND K2 =2) OR (K1 = 3 AND K2 = 4`)

### Testing done 

- Unit testing
- QTT testing
- e2e testing (in progress)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

