### PR TITLE
feat: bound the size of the shared buffer cache used by queries

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -359,6 +359,17 @@ public class KsqlConfig extends AbstractConfig {
   private static final String KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC = "Comma-separated list of "
       + "properties that KSQL users cannot override.";
 
+  public static final String KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING =
+      "ksql.cache.max.bytes.buffering.total";
+  public static final long KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_DEFAULT = -1;
+  public static final String KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_DOC = "Limit on the total bytes "
+      + "used by Kafka Streams cache across all persistent queries";
+  public static final String KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT =
+      "ksql.transient.cache.max.bytes.buffering.total";
+  public static final long KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT_DEFAULT = -1;
+  public static final String KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT_DOC = "Limit on the "
+      + "total bytes used by Kafka Streams cache across all transient queries";
+
   public static final String KSQL_VARIABLE_SUBSTITUTION_ENABLE
       = "ksql.variable.substitution.enable";
   public static final boolean KSQL_VARIABLE_SUBSTITUTION_ENABLE_DEFAULT = true;
@@ -835,6 +846,20 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_VARIABLE_SUBSTITUTION_ENABLE_DEFAULT,
             Importance.LOW,
             KSQL_VARIABLE_SUBSTITUTION_ENABLE_DOC
+        )
+        .define(
+            KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING,
+            Type.LONG,
+            KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_DEFAULT,
+            Importance.LOW,
+            KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_DOC
+        )
+        .define(
+            KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT,
+            Type.LONG,
+            KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT_DEFAULT,
+            Importance.LOW,
+            KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -360,12 +360,12 @@ public class KsqlConfig extends AbstractConfig {
       + "properties that KSQL users cannot override.";
 
   public static final String KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING =
-      "ksql.cache.max.bytes.buffering.total";
+      "ksql.query.persistent.max.bytes.buffering.total";
   public static final long KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_DEFAULT = -1;
   public static final String KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_DOC = "Limit on the total bytes "
       + "used by Kafka Streams cache across all persistent queries";
   public static final String KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT =
-      "ksql.transient.cache.max.bytes.buffering.total";
+      "ksql.query.transient.max.bytes.buffering.total";
   public static final long KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT_DEFAULT = -1;
   public static final String KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT_DOC = "Limit on the "
       + "total bytes used by Kafka Streams cache across all transient queries";

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -38,8 +38,10 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.VariableSubstitutor;
 import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
 import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
+import io.confluent.ksql.query.KafkaStreamsQueryValidator;
 import io.confluent.ksql.query.QueryExecutor;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.query.QueryValidator;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
@@ -219,6 +221,10 @@ final class EngineContext {
         serviceContext,
         processingLogContext
     );
+  }
+
+  QueryValidator createQueryValidator() {
+    return new KafkaStreamsQueryValidator();
   }
 
   QueryExecutor createQueryExecutor(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -192,6 +192,12 @@ final class EngineExecutor {
     final KsqlBareOutputNode outputNode = (KsqlBareOutputNode) plans.logicalPlan.getNode().get();
     final QueryExecutor executor = engineContext.createQueryExecutor(config, serviceContext);
 
+    engineContext.createQueryValidator().validateQuery(
+        config,
+        plans.physicalPlan,
+        engineContext.getAllLiveQueries()
+    );
+
     return executor.buildTransientQuery(
         statement.getStatementText(),
         plans.physicalPlan.getQueryId(),
@@ -246,6 +252,12 @@ final class EngineExecutor {
           outputNode.getIntoSourceName(),
           plans.physicalPlan.getPhysicalPlan(),
           plans.physicalPlan.getQueryId()
+      );
+
+      engineContext.createQueryValidator().validateQuery(
+          config,
+          plans.physicalPlan,
+          engineContext.getAllLiveQueries()
       );
 
       return KsqlPlan.queryPlanCurrent(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.physical.PhysicalPlan;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.TransientQueryMetadata;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.StreamsConfig;
+
+public class KafkaStreamsQueryValidator implements QueryValidator {
+  @Override
+  public void validateQuery(
+      final SessionConfig config,
+      final PhysicalPlan physicalPlan,
+      final Collection<QueryMetadata> runningQueries
+  ) {
+    validateCacheBytesUsage(
+        runningQueries.stream()
+            .filter(q -> q instanceof PersistentQueryMetadata)
+            .collect(Collectors.toList()),
+        config,
+        config.getConfig(false)
+            .getLong(KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING)
+    );
+  }
+
+  @Override
+  public void validateTransientQuery(
+      final SessionConfig config,
+      final PhysicalPlan physicalPlan,
+      final Collection<QueryMetadata> runningQueries
+  ) {
+    validateCacheBytesUsage(
+        runningQueries.stream()
+            .filter(q -> q instanceof TransientQueryMetadata)
+            .collect(Collectors.toList()),
+        config,
+        config.getConfig(false)
+            .getLong(KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT)
+    );
+  }
+
+  private void validateCacheBytesUsage(
+      final Collection<QueryMetadata> running,
+      final SessionConfig config,
+      final long limit
+  ) {
+    if (limit < 0) {
+      return;
+    }
+    final long configured = getCacheMaxBytesBuffering(config);
+    final long usedByRunning = running.stream()
+        .mapToLong(r -> new StreamsConfig(r.getStreamsProperties())
+                .getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG))
+        .sum();
+    if (configured + usedByRunning > limit) {
+      throw new KsqlException(String.format(
+          "Configured cache usage (cache.max.bytes.buffering=%d) would put usage over the "
+              + "configured limit (%d). Current usage is %d",
+          configured, usedByRunning, limit
+      ));
+    }
+  }
+
+  private long getCacheMaxBytesBuffering(final SessionConfig config) {
+    return getDummyStreamsConfig(config).getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG);
+  }
+
+  private StreamsConfig getDummyStreamsConfig(final SessionConfig config) {
+    // hack to get at default config value
+    return new StreamsConfig(
+        ImmutableMap.<String, Object>builder()
+            .put(StreamsConfig.APPLICATION_ID_CONFIG, "dummy.app.id")
+            .put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy.bootstrap")
+            .putAll(config.getConfig(true).getKsqlStreamConfigProps())
+            .build()
+    );
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -57,6 +57,7 @@ import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata.ResultType;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -57,7 +57,6 @@ import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata.ResultType;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.physical.PhysicalPlan;
+import io.confluent.ksql.util.QueryMetadata;
+import java.util.Collection;
+
+/**
+ * Validate that a given physical plan can be executed by the underlying runtime.
+ *
+ * <p>Ensures that a given physical plan can be executed by the underlying runtime. It's important
+ * to decouple this from query execution, so that a query can be planned and validated, then
+ * committed (e.g. to a log of queries to be executed) with the expectation that it should always
+ * be able to execute.
+ */
+public interface QueryValidator {
+  void validateTransientQuery(
+      SessionConfig config,
+      PhysicalPlan physicalPlan,
+      Collection<QueryMetadata> runningQueries
+  );
+
+  void validateQuery(
+      SessionConfig config,
+      PhysicalPlan physicalPlan,
+      Collection<QueryMetadata> runningQueries
+  );
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.physical.PhysicalPlan;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.TransientQueryMetadata;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.OptionalLong;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KafkaStreamsQueryValidatorTest {
+  @Mock
+  private TransientQueryMetadata transientQueryMetadata1;
+  @Mock
+  private TransientQueryMetadata transientQueryMetadata2;
+  @Mock
+  private PersistentQueryMetadata persistentQueryMetadata1;
+  @Mock
+  private  PersistentQueryMetadata persistentQueryMetadata2;
+  @Mock
+  private PhysicalPlan plan;
+
+  private Collection<QueryMetadata> queries;
+
+  private final QueryValidator queryValidator = new KafkaStreamsQueryValidator();
+
+  @Before
+  public void setup() {
+    when(transientQueryMetadata1.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(10));
+    when(transientQueryMetadata2.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(20));
+    when(persistentQueryMetadata1.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(10));
+    when(persistentQueryMetadata2.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(20));
+    queries = ImmutableList.of(
+        transientQueryMetadata1,
+        transientQueryMetadata2,
+        persistentQueryMetadata1,
+        persistentQueryMetadata2
+    );
+  }
+
+  @Test
+  public void shouldLimitBufferCacheUsage() {
+    // Given:
+    final SessionConfig config = configWithLimits(5, OptionalLong.of(30));
+
+    // When/Then:
+    assertThrows(KsqlException.class, () -> queryValidator.validateQuery(config, plan, queries));
+  }
+
+  @Test
+  public void shouldNotThrowIfUnderLimit() {
+    // Given:
+    final SessionConfig config = configWithLimits(5, OptionalLong.of(40));
+
+    // When/Then (no throw)
+    queryValidator.validateQuery(config, plan, queries);
+  }
+
+  @Test
+  public void shouldIgnoreBufferCacheLimitIfNotSet() {
+    // Given:
+    final SessionConfig config = configWithLimits(100000000000L, OptionalLong.empty());
+
+    // When/Then (no throw)
+    queryValidator.validateQuery(config, plan, queries);
+  }
+
+  @Test
+  public void shouldLimitBufferCacheLimitForTransientQueries() {
+    // Given:
+    final SessionConfig config = configWithLimitsTransient(5, OptionalLong.of(30));
+
+    // When/Then:
+    assertThrows(
+        KsqlException.class,
+        () -> queryValidator.validateTransientQuery(config, plan, queries)
+    );
+  }
+
+  @Test
+  public void shouldIgnoreBufferCacheLimitIfNotSetForTransientQueries() {
+    // Given:
+    final SessionConfig config = configWithLimits(100000000000L, OptionalLong.empty());
+
+    // When/Then (no throw)
+    queryValidator.validateTransientQuery(config, plan, queries);
+  }
+
+  @Test
+  public void shouldIgnoreGlobalLimitSetInOverrides() {
+    // Given:
+    final SessionConfig config = SessionConfig.of(
+        new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 30)),
+        ImmutableMap.of(
+            StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 50,
+            KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 500
+        )
+    );
+
+    // When/Then:
+    assertThrows(
+        KsqlException.class,
+        () -> queryValidator.validateQuery(config, plan, queries)
+    );
+  }
+
+  private SessionConfig configWithLimits(
+      final long queryLimit,
+      final OptionalLong globalLimit
+  ) {
+    return configWithLimits(
+        KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, queryLimit, globalLimit);
+  }
+
+  private SessionConfig configWithLimitsTransient(
+      final long queryLimit,
+      final OptionalLong globalLimit
+  ) {
+    return configWithLimits(
+        KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT, queryLimit, globalLimit);
+  }
+
+  private SessionConfig configWithLimits(
+      final String config,
+      final long queryLimit,
+      final OptionalLong globalLimit
+  ) {
+    final Map<String, Object> ksqlProperties = globalLimit.isPresent()
+        ? ImmutableMap.of(config, globalLimit.getAsLong()) : Collections.emptyMap();
+    return SessionConfig.of(
+        new KsqlConfig(ksqlProperties),
+        ImmutableMap.of(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, queryLimit)
+    );
+  }
+
+  private Map<String, Object> streamPropsWithCacheLimit(long limit) {
+    return ImmutableMap.of(
+        StreamsConfig.APPLICATION_ID_CONFIG, "fake-app-id",
+        StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "fake-bootstrap",
+        StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, limit
+    );
+  }
+}


### PR DESCRIPTION
bound the total size of the shared buffer cache used by queries. The
bound is controlled by 2 configs, one for controlling the limit for
persistent queries, the other for transient queries. Today, this limit
is implemented by accounting the full limit for each query against the
total bound. In the future we may implement by using a shared cache.