### PR TITLE
test: additional test coverage for multi-column key null-handling (MINOR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ logs/
 .settings
 .tern-port
 ui/
-/ksql-functional-tests/src/test/resources/**/scratch.json
+/ksqldb-functional-tests/src/test/resources/**/scratch.json

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -486,6 +486,9 @@
       "inputs": [
         {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
         {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 1, "value": {"f2": null}},
+        {"topic": "test_topic", "key": 1, "value": null},
+        {"topic": "test_topic", "key": null, "value": {"f2": "1"}},
         {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
         {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
         {"topic": "test_topic", "key": 2, "value": {"f2": "1"}}
@@ -575,12 +578,17 @@
       "inputs": [
         {"topic": "test_topic", "key": 10, "value": {"VALUE": 0}},
         {"topic": "test_topic", "key": 1666, "value": {"VALUE": 0}},
-        {"topic": "test_topic", "key": 98, "value": {"VALUE": 0}}
+        {"topic": "test_topic", "key": 98, "value": {"VALUE": 0}},
+        {"topic": "test_topic", "key": 98, "value": {"VALUE": 1}},
+        {"topic": "test_topic", "key": 2, "value": {"VALUE": null}},
+        {"topic": "test_topic", "key": 2, "value": null}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": {"VALUE": 0, "K": 1}, "value": {"ID": 1}},
         {"topic": "OUTPUT", "key": {"VALUE": 0, "K": 1}, "value": {"ID": 2}},
-        {"topic": "OUTPUT", "key": {"VALUE": 0, "K": 1}, "value": {"ID": 3}}
+        {"topic": "OUTPUT", "key": {"VALUE": 0, "K": 1}, "value": {"ID": 3}},
+        {"topic": "OUTPUT", "key": {"VALUE": 0, "K": 1}, "value": {"ID": 2}},
+        {"topic": "OUTPUT", "key": {"VALUE": 1, "K": 1}, "value": {"ID": 1}}
       ],
       "post": {
         "sources": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-col-keys.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-col-keys.json
@@ -57,10 +57,15 @@
         "CREATE TABLE OUTPUT AS SELECT * FROM INPUT;"
       ],
       "inputs": [
-        {"topic": "input_topic", "key": {"K": 1, "K2": 2}, "value": {"V": 0}}
+        {"topic": "input_topic", "key": {"K": 1, "K2": 2}, "value": {"V": 0}},
+        {"topic": "input_topic", "key": {"K": null, "K2": 2}, "value": {"V": 0}},
+        {"topic": "input_topic", "key": {"K": null, "K2": 2}, "value": null},
+        {"topic": "input_topic", "key": null, "value": {"V": 0}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": {"K": 1, "K2": 2}, "value": {"V": 0}}
+        {"topic": "OUTPUT", "key": {"K": 1, "K2": 2}, "value": {"V": 0}},
+        {"topic": "OUTPUT", "key": {"K": null, "K2": 2}, "value": {"V": 0}},
+        {"topic": "OUTPUT", "key": {"K": null, "K2": 2}, "value": null}
       ],
       "post": {
         "sources": [


### PR DESCRIPTION
### Description 

Adds some additional  QTT coverage for null-handling in the context of multi-column keys:
- GROUP BY drops records if any key column evaluates to null
- Table sources do not drop records with null primary key columns, unless the entire key is null

### Testing done 

Test-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

