### PR TITLE
chore: add mention of IN clause to pull query error msg (MINOR)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
@@ -179,8 +179,8 @@ public final class WhereInfo {
             + System.lineSeparator()
             + " - either:"
             + System.lineSeparator()
-            + "   \t - specifies an equality condition that is a conjunction of equality expressions "
-            + "that cover all keys."
+            + "   \t - specifies an equality condition that is a conjunction of equality "
+            + "expressions that cover all keys."
             + System.lineSeparator()
             + "   \t - specifies a list of literal values for the key column of interest, e.g. "
             + "`SELECT * FROM X WHERE <key-column> IN ('value_1', 'value_2');`"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WhereInfo.java
@@ -177,8 +177,13 @@ public final class WhereInfo {
             + System.lineSeparator()
             + " - limits the query to keys only, e.g. `SELECT * FROM X WHERE <key-column>=Y;`."
             + System.lineSeparator()
-            + " - specifies an equality condition that is a conjunction of equality expressions "
+            + " - either:"
+            + System.lineSeparator()
+            + "   \t - specifies an equality condition that is a conjunction of equality expressions "
             + "that cover all keys."
+            + System.lineSeparator()
+            + "   \t - specifies a list of literal values for the key column of interest, e.g. "
+            + "`SELECT * FROM X WHERE <key-column> IN ('value_1', 'value_2');`"
             + additional
     );
   }


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/6802

Previously:
```
ksql> select * from foo where v in ('val1', 'val2');

IN expression on unsupported column: V.  See https://cnfl.io/queries for more info.
Add EMIT CHANGES if you intended to issue a push query.
Pull queries require a WHERE clause that:
 - limits the query to keys only, e.g. `SELECT * FROM X WHERE <key-column>=Y;`.
 - specifies an equality condition that is a conjunction of equality expressions that cover all keys.
```
Now:
```
ksql> select * from foo where v in ('val1', 'val2');

IN expression on unsupported column: V.  See https://cnfl.io/queries for more info.
Add EMIT CHANGES if you intended to issue a push query.
Pull queries require a WHERE clause that:
 - limits the query to keys only, e.g. `SELECT * FROM X WHERE <key-column>=Y;`.
 - either:
   	 - specifies an equality condition that is a conjunction of equality expressions that cover all keys.
   	 - specifies a list of literal values for the key column of interest, e.g. `SELECT * FROM X WHERE <key-column> IN ('value_1', 'value_2');`
```

### Testing done 

The only change in this PR is an update to an error message.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

