### PR TITLE
chore: Update VERSION_PATTERN to accomodate Prereleased versioned artifacts

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/KsqlVersion.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/KsqlVersion.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 public final class KsqlVersion implements Comparable<KsqlVersion> {
 
   private static final Pattern VERSION_PATTERN = Pattern
-      .compile("(?<major>\\d+)\\.(?<minor>\\d+)(?<patch>.\\d+)?(?:-(SNAPSHOT|\\d+))?");
+      .compile("(?<major>\\d+)\\.(?<minor>\\d+)(?<patch>.\\d+)?(?:-([A-Za-z0-9]+|\\d+))?");
 
   @EffectivelyImmutable
   private static final Comparator<KsqlVersion> COMPARATOR =
@@ -53,7 +53,7 @@ public final class KsqlVersion implements Comparable<KsqlVersion> {
     if (!matcher.matches()) {
       throw new IllegalArgumentException(
           "Failed to parse version: '" + version + "'. "
-              + "Version must be in format <major>.<minor>[.<patch>][-SNAPSHOT]"
+              + "Version must be in format '" + VERSION_PATTERN.pattern() + "'. "
       );
     }
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
@@ -75,6 +75,36 @@ public class KsqlVersionTest {
   }
 
   @Test
+  public void shouldParsePrerelease() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("6.2.0-foo123456");
+
+    // Then:
+    assertThat(result.getName(), is("6.2.0-foo123456"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(6, 2, 0)));
+  }
+
+  @Test
+  public void shouldParsePrereleaseAlpha() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("6.2.0-alpha1");
+
+    // Then:
+    assertThat(result.getName(), is("6.2.0-alpha1"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(6, 2, 0)));
+  }
+
+  @Test
+  public void shouldParsePrereleaseBeta() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("6.2.0-beta1234568");
+
+    // Then:
+    assertThat(result.getName(), is("6.2.0-beta1234568"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(6, 2, 0)));
+  }
+
+  @Test
   public void shouldCompareUsingTimestamps() {
     // Given:
     final KsqlVersion v1 = KsqlVersion.parse("5.4.1").withTimestamp(123);


### PR DESCRIPTION
- Add support for Prereleased values. Eg: -alpha1, -beta1234.
- Add unit tests for supported versions.
- Updated exception message to include used pattern for matching.

### Description 
The `6.2.x-alpha1` branch was failing to build in Jenkins due to a failure in some tests. They surfaced as `NoClassDefFound` exceptions, but if you watched the logs, there was actually an earlier `IllegalArgumentException` being thrown about the version not being in a format, so I tracked that down to here, made the regex a little more tolerant of this valid semver format, made the Exception message slightly more helpfull and added some Unit tests to support.

### Testing done 
This is a meta change. Check the `6.2.x-alpha1` branch job in Jenkins and you can see after these changes it passes.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

