### PR TITLE
fix: use the right name for fallback subject for transient queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -15,11 +15,11 @@
 
 package io.confluent.ksql.physical;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.planner.LogicalPlanNode;
 import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.planner.plan.PlanBuildContext;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.ServiceContext;
@@ -59,16 +59,13 @@ public class PhysicalPlanBuilder {
     final OutputNode outputNode = logicalPlanNode.getNode()
         .orElseThrow(() -> new IllegalArgumentException("Need an output node to build a plan"));
 
-    final KsqlQueryBuilder ksqlQueryBuilder = KsqlQueryBuilder.of(
-        builder,
+    final PlanBuildContext ksqlQueryExecuteContext = PlanBuildContext.of(
         ksqlConfig,
         serviceContext,
-        processingLogContext,
-        functionRegistry,
-        queryId
+        functionRegistry
     );
 
-    final SchemaKStream<?> resultStream = outputNode.buildStream(ksqlQueryBuilder);
+    final SchemaKStream<?> resultStream = outputNode.buildStream(ksqlQueryExecuteContext);
 
     final LogicalSchema logicalSchema = outputNode.getSchema();
     final LogicalSchema physicalSchema = resultStream.getSchema();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -59,13 +59,13 @@ public class PhysicalPlanBuilder {
     final OutputNode outputNode = logicalPlanNode.getNode()
         .orElseThrow(() -> new IllegalArgumentException("Need an output node to build a plan"));
 
-    final PlanBuildContext ksqlQueryExecuteContext = PlanBuildContext.of(
+    final PlanBuildContext buildContext = PlanBuildContext.of(
         ksqlConfig,
         serviceContext,
         functionRegistry
     );
 
-    final SchemaKStream<?> resultStream = outputNode.buildStream(ksqlQueryExecuteContext);
+    final SchemaKStream<?> resultStream = outputNode.buildStream(buildContext);
 
     final LogicalSchema logicalSchema = outputNode.getSchema();
     final LogicalSchema physicalSchema = resultStream.getSchema();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -111,10 +111,10 @@ public class DataSourceNode extends PlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builder) {
-    final Stacker contextStacker = builder.buildNodeContext(getId().toString());
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
+    final Stacker contextStacker = buildContext.buildNodeContext(getId().toString());
     return schemaKStreamFactory.create(
-        builder,
+        buildContext,
         dataSource,
         contextStacker.push(SOURCE_OP_NAME)
     );
@@ -200,7 +200,7 @@ public class DataSourceNode extends PlanNode {
   interface SchemaKStreamFactory {
 
     SchemaKStream<?> create(
-        PlanBuildContext builder,
+        PlanBuildContext buildContext,
         DataSource dataSource,
         QueryContext.Stacker contextStacker
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
@@ -112,7 +111,7 @@ public class DataSourceNode extends PlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext builder) {
     final Stacker contextStacker = builder.buildNodeContext(getId().toString());
     return schemaKStreamFactory.create(
         builder,
@@ -201,7 +200,7 @@ public class DataSourceNode extends PlanNode {
   interface SchemaKStreamFactory {
 
     SchemaKStream<?> create(
-        KsqlQueryBuilder builder,
+        PlanBuildContext builder,
         DataSource dataSource,
         QueryContext.Stacker contextStacker
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -46,7 +45,7 @@ public class FilterNode extends SingleSourcePlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext builder) {
     final Stacker contextStacker = builder.buildNodeContext(getId().toString());
 
     return getSource().buildStream(builder)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -45,10 +45,10 @@ public class FilterNode extends SingleSourcePlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builder) {
-    final Stacker contextStacker = builder.buildNodeContext(getId().toString());
+  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+    final Stacker contextStacker = builderContext.buildNodeContext(getId().toString());
 
-    return getSource().buildStream(builder)
+    return getSource().buildStream(builderContext)
         .filter(
             getPredicate(),
             contextStacker

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter;
 import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter.Context;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
@@ -79,11 +78,11 @@ public class FlatMapNode extends SingleSourcePlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
 
-    final QueryContext.Stacker contextStacker = builder.buildNodeContext(getId().toString());
+    final QueryContext.Stacker contextStacker = builderContext.buildNodeContext(getId().toString());
 
-    return getSource().buildStream(builder).flatMap(
+    return getSource().buildStream(builderContext).flatMap(
         tableFunctions,
         contextStacker
     );
@@ -96,7 +95,7 @@ public class FlatMapNode extends SingleSourcePlanNode {
     final TableFunctionExpressionRewriter tableFunctionExpressionRewriter =
         new TableFunctionExpressionRewriter(functionRegistry);
 
-    final ImmutableMap.Builder<Integer, Expression> builder = ImmutableMap
+    final ImmutableMap.Builder<Integer, Expression> builderContext = ImmutableMap
         .builder();
 
     for (int idx = 0; idx < analysis.getSelectItems().size(); idx++) {
@@ -110,11 +109,11 @@ public class FlatMapNode extends SingleSourcePlanNode {
           tableFunctionExpressionRewriter::process, singleColumn.getExpression());
 
       if (!rewritten.equals(singleColumn.getExpression())) {
-        builder.put(idx, rewritten);
+        builderContext.put(idx, rewritten);
       }
     }
 
-    return builder.build();
+    return builderContext.build();
   }
 
   private static class TableFunctionExpressionRewriter

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
@@ -78,11 +78,11 @@ public class FlatMapNode extends SingleSourcePlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
 
-    final QueryContext.Stacker contextStacker = builderContext.buildNodeContext(getId().toString());
+    final QueryContext.Stacker contextStacker = buildContext.buildNodeContext(getId().toString());
 
-    return getSource().buildStream(builderContext).flatMap(
+    return getSource().buildStream(buildContext).flatMap(
         tableFunctions,
         contextStacker
     );
@@ -95,7 +95,7 @@ public class FlatMapNode extends SingleSourcePlanNode {
     final TableFunctionExpressionRewriter tableFunctionExpressionRewriter =
         new TableFunctionExpressionRewriter(functionRegistry);
 
-    final ImmutableMap.Builder<Integer, Expression> builderContext = ImmutableMap
+    final ImmutableMap.Builder<Integer, Expression> buildContext = ImmutableMap
         .builder();
 
     for (int idx = 0; idx < analysis.getSelectItems().size(); idx++) {
@@ -109,11 +109,11 @@ public class FlatMapNode extends SingleSourcePlanNode {
           tableFunctionExpressionRewriter::process, singleColumn.getExpression());
 
       if (!rewritten.equals(singleColumn.getExpression())) {
-        builderContext.put(idx, rewritten);
+        buildContext.put(idx, rewritten);
       }
     }
 
-    return builderContext.build();
+    return buildContext.build();
   }
 
   private static class TableFunctionExpressionRewriter

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -48,8 +48,8 @@ public class KsqlBareOutputNode extends OutputNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
-    return getSource().buildStream(builderContext);
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
+    return getSource().buildStream(buildContext);
   }
 
   public Optional<WindowInfo> getWindowInfo() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -49,8 +48,8 @@ public class KsqlBareOutputNode extends OutputNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
-    return getSource().buildStream(builder);
+  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+    return getSource().buildStream(builderContext);
   }
 
   public Optional<WindowInfo> getWindowInfo() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -81,11 +81,11 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
     final PlanNode source = getSource();
-    final SchemaKStream<?> schemaKStream = source.buildStream(builderContext);
+    final SchemaKStream<?> schemaKStream = source.buildStream(buildContext);
 
-    final QueryContext.Stacker contextStacker = builderContext.buildNodeContext(getId().toString());
+    final QueryContext.Stacker contextStacker = buildContext.buildNodeContext(getId().toString());
 
     return schemaKStream.into(
         ksqlTopic,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
@@ -82,11 +81,11 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
     final PlanNode source = getSource();
-    final SchemaKStream<?> schemaKStream = source.buildStream(builder);
+    final SchemaKStream<?> schemaKStream = source.buildStream(builderContext);
 
-    final QueryContext.Stacker contextStacker = builder.buildNodeContext(getId().toString());
+    final QueryContext.Stacker contextStacker = builderContext.buildNodeContext(getId().toString());
 
     return schemaKStream.into(
         ksqlTopic,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanBuildContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanBuildContext.java
@@ -22,6 +22,9 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 
+/**
+ * Contains all the context required to build an execution plan from a logical plan.
+ */
 public final class PlanBuildContext {
   private final KsqlConfig ksqlConfig;
   private final ServiceContext serviceContext;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanBuildContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanBuildContext.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+
+public final class PlanBuildContext {
+  private final KsqlConfig ksqlConfig;
+  private final ServiceContext serviceContext;
+  private final FunctionRegistry functionRegistry;
+
+  public static PlanBuildContext of(
+      final KsqlConfig ksqlConfig,
+      final ServiceContext serviceContext,
+      final FunctionRegistry functionRegistry
+  ) {
+    return new PlanBuildContext(
+        ksqlConfig,
+        serviceContext,
+        functionRegistry
+    );
+  }
+
+  private PlanBuildContext(
+      final KsqlConfig ksqlConfig,
+      final ServiceContext serviceContext,
+      final FunctionRegistry functionRegistry
+  ) {
+    this.ksqlConfig = requireNonNull(ksqlConfig, "ksqlConfig");
+    this.serviceContext = requireNonNull(serviceContext, "serviceContext");
+    this.functionRegistry = requireNonNull(functionRegistry, "functionRegistry");
+  }
+
+  public ServiceContext getServiceContext() {
+    return serviceContext;
+  }
+
+  public KsqlConfig getKsqlConfig() {
+    return ksqlConfig;
+  }
+
+  public FunctionRegistry getFunctionRegistry() {
+    return functionRegistry;
+  }
+
+  public PlanBuildContext withKsqlConfig(final KsqlConfig newConfig) {
+    return of(
+        newConfig,
+        serviceContext,
+        functionRegistry
+    );
+  }
+
+  @SuppressWarnings("MethodMayBeStatic") // Non-static to allow DI/mocking
+  public QueryContext.Stacker buildNodeContext(final String context) {
+    return new QueryContext.Stacker()
+        .push(context);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -83,7 +83,7 @@ public abstract class PlanNode {
 
   protected abstract int getPartitions(KafkaTopicClient kafkaTopicClient);
 
-  public abstract SchemaKStream<?> buildStream(PlanBuildContext builderContext);
+  public abstract SchemaKStream<?> buildStream(PlanBuildContext buildContext);
 
   Optional<SourceName> getSourceName() {
     return sourceName;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.links.DocumentationLinks;
@@ -84,7 +83,7 @@ public abstract class PlanNode {
 
   protected abstract int getPartitions(KafkaTopicClient kafkaTopicClient);
 
-  public abstract SchemaKStream<?> buildStream(KsqlQueryBuilder builder);
+  public abstract SchemaKStream<?> buildStream(PlanBuildContext builderContext);
 
   Optional<SourceName> getSourceName() {
     return sourceName;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PreJoinRepartitionNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PreJoinRepartitionNode.java
@@ -102,17 +102,17 @@ public class PreJoinRepartitionNode extends SingleSourcePlanNode implements Join
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
     if (!keyFormatSet) {
       throw new IllegalStateException("PreJoinRepartitionNode must set key format");
     }
 
-    return getSource().buildStream(builderContext)
+    return getSource().buildStream(buildContext)
         .selectKey(
             valueFormat.getFormatInfo(),
             ImmutableList.of(partitionBy),
             forcedInternalKeyFormat,
-            builderContext.buildNodeContext(getId().toString()),
+            buildContext.buildNodeContext(getId().toString()),
             forceRepartition
         );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PreJoinRepartitionNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PreJoinRepartitionNode.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.FormatFactory;
@@ -103,17 +102,17 @@ public class PreJoinRepartitionNode extends SingleSourcePlanNode implements Join
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
     if (!keyFormatSet) {
       throw new IllegalStateException("PreJoinRepartitionNode must set key format");
     }
 
-    return getSource().buildStream(builder)
+    return getSource().buildStream(builderContext)
         .selectKey(
             valueFormat.getFormatInfo(),
             ImmutableList.of(partitionBy),
             forcedInternalKeyFormat,
-            builder.buildNodeContext(getId().toString()),
+            builderContext.buildNodeContext(getId().toString()),
             forceRepartition
         );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -34,8 +34,8 @@ public abstract class ProjectNode extends SingleSourcePlanNode {
   public abstract List<SelectExpression> getSelectExpressions();
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
-    final SchemaKStream<?> stream = getSource().buildStream(builderContext);
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
+    final SchemaKStream<?> stream = getSource().buildStream(buildContext);
 
     final List<ColumnName> keyColumnNames = getSchema().key().stream()
         .map(Column::name)
@@ -44,8 +44,8 @@ public abstract class ProjectNode extends SingleSourcePlanNode {
     return stream.select(
         keyColumnNames,
         getSelectExpressions(),
-        builderContext.buildNodeContext(getId().toString()),
-        builderContext
+        buildContext.buildNodeContext(getId().toString()),
+        buildContext
     );
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
@@ -35,8 +34,8 @@ public abstract class ProjectNode extends SingleSourcePlanNode {
   public abstract List<SelectExpression> getSelectExpressions();
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
-    final SchemaKStream<?> stream = getSource().buildStream(builder);
+  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+    final SchemaKStream<?> stream = getSource().buildStream(builderContext);
 
     final List<ColumnName> keyColumnNames = getSchema().key().stream()
         .map(Column::name)
@@ -45,8 +44,8 @@ public abstract class ProjectNode extends SingleSourcePlanNode {
     return stream.select(
         keyColumnNames,
         getSelectExpressions(),
-        builder.buildNodeContext(getId().toString()),
-        builder
+        builderContext.buildNodeContext(getId().toString()),
+        builderContext
     );
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.analyzer.PullQueryValidator;
 import io.confluent.ksql.engine.generic.GenericExpressionResolver;
 import io.confluent.ksql.engine.rewrite.StatementRewriteForMagicPseudoTimestamp;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
@@ -136,7 +135,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildCtx) {
     throw new UnsupportedOperationException();
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SuppressNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SuppressNode.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -67,9 +66,9 @@ public class SuppressNode extends SingleSourcePlanNode implements VerifiableNode
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
-    final QueryContext.Stacker contextStacker = builder.buildNodeContext(getId().toString());
-    final SchemaKStream<?> schemaKStream = getSource().buildStream(builder);
+  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+    final QueryContext.Stacker contextStacker = builderContext.buildNodeContext(getId().toString());
+    final SchemaKStream<?> schemaKStream = getSource().buildStream(builderContext);
 
     if (!(schemaKStream instanceof SchemaKTable)) {
       throw new KsqlException("Failed in suppress node. Expected to find a Table, but "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SuppressNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SuppressNode.java
@@ -66,9 +66,9 @@ public class SuppressNode extends SingleSourcePlanNode implements VerifiableNode
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
-    final QueryContext.Stacker contextStacker = builderContext.buildNodeContext(getId().toString());
-    final SchemaKStream<?> schemaKStream = getSource().buildStream(builderContext);
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
+    final QueryContext.Stacker contextStacker = buildContext.buildNodeContext(getId().toString());
+    final SchemaKStream<?> schemaKStream = getSource().buildStream(buildContext);
 
     if (!(schemaKStream instanceof SchemaKTable)) {
       throw new KsqlException("Failed in suppress node. Expected to find a Table, but "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/UserRepartitionNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/UserRepartitionNode.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.planner.plan;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.streams.PartitionByParamsFactory;
@@ -62,13 +61,13 @@ public class UserRepartitionNode extends SingleSourcePlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
-    return getSource().buildStream(builder)
+  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+    return getSource().buildStream(builderContext)
         .selectKey(
             valueFormat.getFormatInfo(),
             partitionBys,
             Optional.empty(),
-            builder.buildNodeContext(getId().toString()),
+            builderContext.buildNodeContext(getId().toString()),
             false
         );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/UserRepartitionNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/UserRepartitionNode.java
@@ -61,13 +61,13 @@ public class UserRepartitionNode extends SingleSourcePlanNode {
   }
 
   @Override
-  public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
-    return getSource().buildStream(builderContext)
+  public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
+    return getSource().buildStream(buildContext)
         .selectKey(
             valueFormat.getFormatInfo(),
             partitionBys,
             Optional.empty(),
-            builderContext.buildNodeContext(getId().toString()),
+            buildContext.buildNodeContext(getId().toString()),
             false
         );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -156,7 +156,7 @@ public final class QueryExecutor {
   ) {
     final KsqlConfig ksqlConfig = config.getConfig(true);
     final String applicationId = QueryApplicationId.build(ksqlConfig, false, queryId);
-    final RuntimeBuildContext runtimeBuildContext = queryBuilder(applicationId, queryId);
+    final RuntimeBuildContext runtimeBuildContext = buildContext(applicationId, queryId);
     final Object buildResult = buildQueryImplementation(physicalPlan, runtimeBuildContext);
 
     final BlockingRowQueue queue = buildTransientQueryQueue(buildResult, limit, excludeTombstones);
@@ -213,7 +213,7 @@ public final class QueryExecutor {
         sinkDataSource.getKsqlTopic().getValueFormat().getFeatures()
     );
 
-    final RuntimeBuildContext runtimeBuildContext = queryBuilder(applicationId, queryId);
+    final RuntimeBuildContext runtimeBuildContext = buildContext(applicationId, queryId);
     final Object result = buildQueryImplementation(physicalPlan, runtimeBuildContext);
 
     final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
@@ -301,7 +301,7 @@ public final class QueryExecutor {
     return physicalPlan.build(planBuilder);
   }
 
-  private RuntimeBuildContext queryBuilder(final String applicationId, final QueryId queryId) {
+  private RuntimeBuildContext buildContext(final String applicationId, final QueryId queryId) {
     return RuntimeBuildContext.of(
         streamsBuilder,
         config.getConfig(true),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -160,8 +160,8 @@ public final class QueryExecutor {
 
     final Map<String, Object> streamsProperties = buildStreamsProperties(applicationId, queryId);
     final Object buildResult = buildQueryImplementation(physicalPlan, runtimeBuildContext);
-    final Topology topology = streamsBuilder.build(PropertiesUtil.asProperties(streamsProperties));
     final BlockingRowQueue queue = buildTransientQueryQueue(buildResult, limit, excludeTombstones);
+    final Topology topology = streamsBuilder.build(PropertiesUtil.asProperties(streamsProperties));
 
     final TransientQueryMetadata.ResultType resultType = buildResult instanceof KTableHolder
         ? windowInfo.isPresent() ? ResultType.WINDOWED_TABLE : ResultType.TABLE

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -157,12 +157,11 @@ public final class QueryExecutor {
     final KsqlConfig ksqlConfig = config.getConfig(true);
     final String applicationId = QueryApplicationId.build(ksqlConfig, false, queryId);
     final RuntimeBuildContext runtimeBuildContext = buildContext(applicationId, queryId);
-    final Object buildResult = buildQueryImplementation(physicalPlan, runtimeBuildContext);
-
-    final BlockingRowQueue queue = buildTransientQueryQueue(buildResult, limit, excludeTombstones);
 
     final Map<String, Object> streamsProperties = buildStreamsProperties(applicationId, queryId);
+    final Object buildResult = buildQueryImplementation(physicalPlan, runtimeBuildContext);
     final Topology topology = streamsBuilder.build(PropertiesUtil.asProperties(streamsProperties));
+    final BlockingRowQueue queue = buildTransientQueryQueue(buildResult, limit, excludeTombstones);
 
     final TransientQueryMetadata.ResultType resultType = buildResult instanceof KTableHolder
         ? windowInfo.isPresent() ? ResultType.WINDOWED_TABLE : ResultType.TABLE
@@ -205,7 +204,6 @@ public final class QueryExecutor {
 
     final String applicationId = QueryApplicationId.build(ksqlConfig, true, queryId);
     final Map<String, Object> streamsProperties = buildStreamsProperties(applicationId, queryId);
-    final Topology topology = streamsBuilder.build(PropertiesUtil.asProperties(streamsProperties));
 
     final PhysicalSchema querySchema = PhysicalSchema.from(
         sinkDataSource.getSchema(),
@@ -215,6 +213,7 @@ public final class QueryExecutor {
 
     final RuntimeBuildContext runtimeBuildContext = buildContext(applicationId, queryId);
     final Object result = buildQueryImplementation(physicalPlan, runtimeBuildContext);
+    final Topology topology = streamsBuilder.build(PropertiesUtil.asProperties(streamsProperties));
 
     final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
         materializationProviderBuilder = getMaterializationInfo(result).map(info ->

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
@@ -43,7 +43,7 @@ public final class SchemaKSourceFactory {
   }
 
   public static SchemaKStream<?> buildSource(
-      final PlanBuildContext builder,
+      final PlanBuildContext buildContext,
       final DataSource dataSource,
       final QueryContext.Stacker contextStacker
   ) {
@@ -52,11 +52,11 @@ public final class SchemaKSourceFactory {
       case KSTREAM:
         return windowed
             ? buildWindowedStream(
-            builder,
+            buildContext,
             dataSource,
             contextStacker
         ) : buildStream(
-            builder,
+            buildContext,
             dataSource,
             contextStacker
         );
@@ -64,11 +64,11 @@ public final class SchemaKSourceFactory {
       case KTABLE:
         return windowed
             ? buildWindowedTable(
-            builder,
+            buildContext,
             dataSource,
             contextStacker
         ) : buildTable(
-            builder,
+            buildContext,
             dataSource,
             contextStacker
         );
@@ -79,7 +79,7 @@ public final class SchemaKSourceFactory {
   }
 
   private static SchemaKStream<?> buildWindowedStream(
-      final PlanBuildContext builder,
+      final PlanBuildContext buildContext,
       final DataSource dataSource,
       final Stacker contextStacker
   ) {
@@ -96,15 +96,15 @@ public final class SchemaKSourceFactory {
     );
 
     return schemaKStream(
-        builder,
-        resolveSchema(builder, step, dataSource),
+        buildContext,
+        resolveSchema(buildContext, step, dataSource),
         dataSource.getKsqlTopic().getKeyFormat(),
         step
     );
   }
 
   private static SchemaKStream<?> buildStream(
-      final PlanBuildContext builder,
+      final PlanBuildContext buildContext,
       final DataSource dataSource,
       final Stacker contextStacker
   ) {
@@ -121,15 +121,15 @@ public final class SchemaKSourceFactory {
     );
 
     return schemaKStream(
-        builder,
-        resolveSchema(builder, step, dataSource),
+        buildContext,
+        resolveSchema(buildContext, step, dataSource),
         dataSource.getKsqlTopic().getKeyFormat(),
         step
     );
   }
 
   private static SchemaKTable<?> buildWindowedTable(
-      final PlanBuildContext builder,
+      final PlanBuildContext buildContext,
       final DataSource dataSource,
       final Stacker contextStacker
   ) {
@@ -146,15 +146,15 @@ public final class SchemaKSourceFactory {
     );
 
     return schemaKTable(
-        builder,
-        resolveSchema(builder, step, dataSource),
+        buildContext,
+        resolveSchema(buildContext, step, dataSource),
         dataSource.getKsqlTopic().getKeyFormat(),
         step
     );
   }
 
   private static SchemaKTable<?> buildTable(
-      final PlanBuildContext builder,
+      final PlanBuildContext buildContext,
       final DataSource dataSource,
       final Stacker contextStacker
   ) {
@@ -171,15 +171,15 @@ public final class SchemaKSourceFactory {
     );
 
     return schemaKTable(
-        builder,
-        resolveSchema(builder, step, dataSource),
+        buildContext,
+        resolveSchema(buildContext, step, dataSource),
         dataSource.getKsqlTopic().getKeyFormat(),
         step
     );
   }
 
   private static <K> SchemaKStream<K> schemaKStream(
-      final PlanBuildContext builder,
+      final PlanBuildContext buildContext,
       final LogicalSchema schema,
       final KeyFormat keyFormat,
       final SourceStep<KStreamHolder<K>> streamSource
@@ -188,13 +188,13 @@ public final class SchemaKSourceFactory {
         streamSource,
         schema,
         keyFormat,
-        builder.getKsqlConfig(),
-        builder.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     );
   }
 
   private static <K> SchemaKTable<K> schemaKTable(
-      final PlanBuildContext builder,
+      final PlanBuildContext buildContext,
       final LogicalSchema schema,
       final KeyFormat keyFormat,
       final SourceStep<KTableHolder<K>> tableSource
@@ -203,18 +203,18 @@ public final class SchemaKSourceFactory {
         tableSource,
         schema,
         keyFormat,
-        builder.getKsqlConfig(),
-        builder.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     );
   }
 
   private static LogicalSchema resolveSchema(
-      final PlanBuildContext builderContext,
+      final PlanBuildContext buildContext,
       final ExecutionStep<?> step,
       final DataSource dataSource) {
     return new StepSchemaResolver(
-        builderContext.getKsqlConfig(),
-        builderContext.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     ).resolve(step, dataSource.getSchema());
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.structured;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.plan.ExecutionStep;
@@ -30,6 +29,7 @@ import io.confluent.ksql.execution.plan.WindowedTableSource;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.streams.StepSchemaResolver;
 import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.planner.plan.PlanBuildContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.WindowInfo;
@@ -43,7 +43,7 @@ public final class SchemaKSourceFactory {
   }
 
   public static SchemaKStream<?> buildSource(
-      final KsqlQueryBuilder builder,
+      final PlanBuildContext builder,
       final DataSource dataSource,
       final QueryContext.Stacker contextStacker
   ) {
@@ -79,7 +79,7 @@ public final class SchemaKSourceFactory {
   }
 
   private static SchemaKStream<?> buildWindowedStream(
-      final KsqlQueryBuilder builder,
+      final PlanBuildContext builder,
       final DataSource dataSource,
       final Stacker contextStacker
   ) {
@@ -104,7 +104,7 @@ public final class SchemaKSourceFactory {
   }
 
   private static SchemaKStream<?> buildStream(
-      final KsqlQueryBuilder builder,
+      final PlanBuildContext builder,
       final DataSource dataSource,
       final Stacker contextStacker
   ) {
@@ -129,7 +129,7 @@ public final class SchemaKSourceFactory {
   }
 
   private static SchemaKTable<?> buildWindowedTable(
-      final KsqlQueryBuilder builder,
+      final PlanBuildContext builder,
       final DataSource dataSource,
       final Stacker contextStacker
   ) {
@@ -154,7 +154,7 @@ public final class SchemaKSourceFactory {
   }
 
   private static SchemaKTable<?> buildTable(
-      final KsqlQueryBuilder builder,
+      final PlanBuildContext builder,
       final DataSource dataSource,
       final Stacker contextStacker
   ) {
@@ -179,7 +179,7 @@ public final class SchemaKSourceFactory {
   }
 
   private static <K> SchemaKStream<K> schemaKStream(
-      final KsqlQueryBuilder builder,
+      final PlanBuildContext builder,
       final LogicalSchema schema,
       final KeyFormat keyFormat,
       final SourceStep<KStreamHolder<K>> streamSource
@@ -194,7 +194,7 @@ public final class SchemaKSourceFactory {
   }
 
   private static <K> SchemaKTable<K> schemaKTable(
-      final KsqlQueryBuilder builder,
+      final PlanBuildContext builder,
       final LogicalSchema schema,
       final KeyFormat keyFormat,
       final SourceStep<KTableHolder<K>> tableSource
@@ -209,10 +209,12 @@ public final class SchemaKSourceFactory {
   }
 
   private static LogicalSchema resolveSchema(
-      final KsqlQueryBuilder queryBuilder,
+      final PlanBuildContext builderContext,
       final ExecutionStep<?> step,
       final DataSource dataSource) {
-    return new StepSchemaResolver(queryBuilder.getKsqlConfig(), queryBuilder.getFunctionRegistry())
-        .resolve(step, dataSource.getSchema());
+    return new StepSchemaResolver(
+        builderContext.getKsqlConfig(),
+        builderContext.getFunctionRegistry()
+    ).resolve(step, dataSource.getSchema());
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.structured;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.engine.rewrite.StatementRewriteForMagicPseudoTimestamp;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -43,6 +42,7 @@ import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.planner.plan.PlanBuildContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.InternalFormats;
@@ -139,7 +139,7 @@ public class SchemaKStream<K> {
       final List<ColumnName> keyColumnNames,
       final List<SelectExpression> selectExpressions,
       final Stacker contextStacker,
-      final KsqlQueryBuilder ksqlQueryBuilder
+      final PlanBuildContext builderContext
   ) {
     final StreamSelect<K> step = ExecutionStepFactory.streamSelect(
         contextStacker,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -139,7 +139,7 @@ public class SchemaKStream<K> {
       final List<ColumnName> keyColumnNames,
       final List<SelectExpression> selectExpressions,
       final Stacker contextStacker,
-      final PlanBuildContext builderContext
+      final PlanBuildContext buildContext
   ) {
     final StreamSelect<K> step = ExecutionStepFactory.streamSelect(
         contextStacker,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -121,7 +121,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
       final List<ColumnName> keyColumnNames,
       final List<SelectExpression> selectExpressions,
       final Stacker contextStacker,
-      final PlanBuildContext builderContext
+      final PlanBuildContext buildContext
   ) {
     final TableSelect<K> step = ExecutionStepFactory.tableMapValues(
         contextStacker,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.structured;
 
 import com.google.common.collect.Iterables;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -36,6 +35,7 @@ import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.planner.plan.PlanBuildContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.InternalFormats;
@@ -121,7 +121,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
       final List<ColumnName> keyColumnNames,
       final List<SelectExpression> selectExpressions,
       final Stacker contextStacker,
-      final KsqlQueryBuilder ksqlQueryBuilder
+      final PlanBuildContext builderContext
   ) {
     final TableSelect<K> step = ExecutionStepFactory.tableMapValues(
         contextStacker,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -97,7 +97,7 @@ public class AggregateNodeTest {
   private static final KsqlConfig KSQL_CONFIG = new KsqlConfig(new HashMap<>());
 
   @Mock
-  private PlanBuildContext builderContext;
+  private PlanBuildContext buildContext;
   @Mock
   private RuntimeBuildContext runtimeBuildContext;
   @Mock
@@ -319,9 +319,9 @@ public class AggregateNodeTest {
   }
 
   private SchemaKStream buildQuery(final AggregateNode aggregateNode, final KsqlConfig ksqlConfig) {
-    when(builderContext.getKsqlConfig()).thenReturn(ksqlConfig);
-    when(builderContext.getFunctionRegistry()).thenReturn(FUNCTION_REGISTRY);
-    when(builderContext.buildNodeContext(any())).thenAnswer(inv ->
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(FUNCTION_REGISTRY);
+    when(buildContext.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
     when(runtimeBuildContext.getKsqlConfig()).thenReturn(ksqlConfig);
@@ -330,7 +330,7 @@ public class AggregateNodeTest {
     when(runtimeBuildContext.getProcessingLogger(any())).thenReturn(processLogger);
     when(runtimeBuildContext.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
 
-    final SchemaKTable schemaKTable = (SchemaKTable) aggregateNode.buildStream(builderContext);
+    final SchemaKTable schemaKTable = (SchemaKTable) aggregateNode.buildStream(buildContext);
     schemaKTable.getSourceTableStep().build(new KSPlanBuilder(runtimeBuildContext));
     return schemaKTable;
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -137,7 +137,7 @@ public class DataSourceNodeTest {
   @Mock
   private Serde<String> keySerde;
   @Mock
-  private PlanBuildContext builderContext;
+  private PlanBuildContext buildContext;
   @Mock
   private RuntimeBuildContext executeContext;
   @Mock
@@ -164,9 +164,9 @@ public class DataSourceNodeTest {
   public void before() {
     realBuilder = new StreamsBuilder();
 
-    when(builderContext.getKsqlConfig()).thenReturn(realConfig);
-    when(builderContext.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(builderContext.buildNodeContext(any())).thenAnswer(inv ->
+    when(buildContext.getKsqlConfig()).thenReturn(realConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
 
@@ -289,7 +289,7 @@ public class DataSourceNodeTest {
     givenNodeWithMockSource();
 
     // When:
-    node.buildStream(builderContext);
+    node.buildStream(buildContext);
 
     // Then:
     verify(schemaKStreamFactory).create(any(), any(), any());
@@ -303,7 +303,7 @@ public class DataSourceNodeTest {
     givenNodeWithMockSource();
 
     // When:
-    node.buildStream(builderContext);
+    node.buildStream(buildContext);
 
     // Then:
     verify(schemaKStreamFactory).create(any(), any(), any());
@@ -316,12 +316,12 @@ public class DataSourceNodeTest {
     givenNodeWithMockSource();
 
     // When:
-    final SchemaKStream<?> returned = node.buildStream(builderContext);
+    final SchemaKStream<?> returned = node.buildStream(buildContext);
 
     // Then:
     assertThat(returned, is(stream));
     verify(schemaKStreamFactory).create(
-        same(builderContext),
+        same(buildContext),
         same(dataSource),
         stackerCaptor.capture()
     );
@@ -337,11 +337,11 @@ public class DataSourceNodeTest {
     givenNodeWithMockSource();
 
     // When:
-    node.buildStream(builderContext);
+    node.buildStream(buildContext);
 
     // Then:
     verify(schemaKStreamFactory).create(
-        same(builderContext),
+        same(buildContext),
         same(dataSource),
         stackerCaptor.capture()
     );
@@ -357,7 +357,7 @@ public class DataSourceNodeTest {
     givenNodeWithMockSource();
 
     // When:
-    final SchemaKStream<?> returned = node.buildStream(builderContext);
+    final SchemaKStream<?> returned = node.buildStream(buildContext);
 
     // Then:
     assertThat(returned, is(table));
@@ -458,7 +458,7 @@ public class DataSourceNodeTest {
   }
 
   private SchemaKStream<?> buildStream(final DataSourceNode node) {
-    final SchemaKStream<?> stream = node.buildStream(builderContext);
+    final SchemaKStream<?> stream = node.buildStream(buildContext);
     if (stream instanceof SchemaKTable) {
       final SchemaKTable<?> table = (SchemaKTable<?>) stream;
       table.getSourceTableStep().build(new KSPlanBuilder(executeContext));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/FilterNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/FilterNodeTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
-import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -46,7 +44,7 @@ public class FilterNodeTest {
   @Mock
   private SchemaKStream schemaKStream;
   @Mock
-  private KsqlQueryBuilder ksqlStreamBuilder;
+  private PlanBuildContext planBuildContext;
   @Mock
   private Stacker stacker;
 
@@ -65,7 +63,7 @@ public class FilterNodeTest {
     when(schemaKStream.filter(any(), any()))
         .thenReturn(schemaKStream);
 
-    when(ksqlStreamBuilder.buildNodeContext(NODE_ID.toString())).thenReturn(stacker);
+    when(planBuildContext.buildNodeContext(NODE_ID.toString())).thenReturn(stacker);
 
     node = new FilterNode(NODE_ID, sourceNode, predicate);
   }
@@ -73,10 +71,10 @@ public class FilterNodeTest {
   @Test
   public void shouldApplyFilterCorrectly() {
     // When:
-    node.buildStream(ksqlStreamBuilder);
+    node.buildStream(planBuildContext);
 
     // Then:
-    verify(sourceNode).buildStream(ksqlStreamBuilder);
+    verify(sourceNode).buildStream(planBuildContext);
     verify(schemaKStream).filter(predicate, stacker);
   }
 
@@ -84,7 +82,7 @@ public class FilterNodeTest {
   @Test
   public void shouldUseRightOpName() {
     // When:
-    node.buildStream(ksqlStreamBuilder);
+    node.buildStream(planBuildContext);
 
     // Then:
     verifyNoMoreInteractions(stacker);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.GenericKey;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -69,7 +69,9 @@ public class KsqlBareOutputNodeTest {
   private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
 
   @Mock
-  private KsqlQueryBuilder ksqlStreamBuilder;
+  private PlanBuildContext planBuildContext;
+  @Mock
+  private RuntimeBuildContext executeContext;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock
@@ -81,20 +83,22 @@ public class KsqlBareOutputNodeTest {
   public void before() {
     builder = new StreamsBuilder();
 
-    when(ksqlStreamBuilder.getKsqlConfig()).thenReturn(new KsqlConfig(Collections.emptyMap()));
-    when(ksqlStreamBuilder.getStreamsBuilder()).thenReturn(builder);
-    when(ksqlStreamBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
-    when(ksqlStreamBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
+    when(planBuildContext.getKsqlConfig()).thenReturn(new KsqlConfig(Collections.emptyMap()));
+    when(planBuildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(planBuildContext.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
-    when(ksqlStreamBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(executeContext.getKsqlConfig()).thenReturn(new KsqlConfig(Collections.emptyMap()));
+    when(executeContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(executeContext.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(executeContext.getStreamsBuilder()).thenReturn(builder);
+    when(executeContext.getProcessingLogger(any())).thenReturn(processingLogger);
 
     final KsqlBareOutputNode planNode = (KsqlBareOutputNode) AnalysisTestUtil
         .buildLogicalPlan(ksqlConfig, SIMPLE_SELECT_WITH_FILTER, metaStore);
 
-    stream = planNode.buildStream(ksqlStreamBuilder);
-    stream.getSourceStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+    stream = planNode.buildStream(planBuildContext);
+    stream.getSourceStep().build(new KSPlanBuilder(executeContext));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
@@ -72,7 +71,7 @@ public class KsqlStructuredDataOutputNodeTest {
       .of(FormatInfo.of(FormatFactory.JSON.name()), SerdeFeatures.of());
 
   @Mock
-  private KsqlQueryBuilder ksqlStreamBuilder;
+  private PlanBuildContext planBuildContext;
   @Mock
   private FinalProjectNode sourceNode;
   @Mock
@@ -94,12 +93,12 @@ public class KsqlStructuredDataOutputNodeTest {
 
     when(sourceNode.getSchema()).thenReturn(LogicalSchema.builder().build());
     when(sourceNode.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
-    when(sourceNode.buildStream(ksqlStreamBuilder)).thenReturn((SchemaKStream) sourceStream);
+    when(sourceNode.buildStream(planBuildContext)).thenReturn((SchemaKStream) sourceStream);
 
     when(sourceStream.into(any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStream);
 
-    when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
+    when(planBuildContext.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
 
@@ -131,10 +130,10 @@ public class KsqlStructuredDataOutputNodeTest {
   @Test
   public void shouldBuildSourceNode() {
     // When:
-    outputNode.buildStream(ksqlStreamBuilder);
+    outputNode.buildStream(planBuildContext);
 
     // Then:
-    verify(sourceNode).buildStream(ksqlStreamBuilder);
+    verify(sourceNode).buildStream(planBuildContext);
   }
 
   @Test
@@ -159,7 +158,7 @@ public class KsqlStructuredDataOutputNodeTest {
     );
 
     // When:
-    outputNode.buildStream(ksqlStreamBuilder);
+    outputNode.buildStream(planBuildContext);
 
     // Then:
     verify(sourceStream).into(eq(ksqlTopic), any(), any());
@@ -168,7 +167,7 @@ public class KsqlStructuredDataOutputNodeTest {
   @Test
   public void shouldCallInto() {
     // When:
-    final SchemaKStream<?> result = outputNode.buildStream(ksqlStreamBuilder);
+    final SchemaKStream<?> result = outputNode.buildStream(planBuildContext);
 
     // Then:
     verify(sourceStream).into(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PlanBuildContextTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PlanBuildContextTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.confluent.ksql.execution.context.QueryContext.Stacker;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class PlanBuildContextTest {
+  @Mock
+  private KsqlConfig ksqlConfig;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private FunctionRegistry functionRegistry;
+
+  private PlanBuildContext runtimeBuildContext;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  public void setup() {
+    runtimeBuildContext = PlanBuildContext.of(
+        ksqlConfig,
+        serviceContext,
+        functionRegistry
+    );
+  }
+
+  @Test
+  public void shouldBuildNodeContext() {
+    // When:
+    final Stacker result = runtimeBuildContext.buildNodeContext("some-id");
+
+    // Then:
+    assertThat(result, is(new Stacker().push("some-id")));
+  }
+
+  @Test
+  public void shouldSwapInKsqlConfig() {
+    // Given:
+    final KsqlConfig other = mock(KsqlConfig.class);
+
+    // When:
+    final PlanBuildContext result = runtimeBuildContext.withKsqlConfig(other);
+
+    // Then:
+    assertThat(runtimeBuildContext.getKsqlConfig(), is(ksqlConfig));
+    assertThat(result.getKsqlConfig(), is(other));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PlanNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PlanNodeTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
@@ -151,7 +150,7 @@ public class PlanNodeTest {
     }
 
     @Override
-    public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
+    public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
       return null;
     }
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PlanNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PlanNodeTest.java
@@ -150,7 +150,7 @@ public class PlanNodeTest {
     }
 
     @Override
-    public SchemaKStream<?> buildStream(final PlanBuildContext builderContext) {
+    public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
       return null;
     }
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -74,7 +73,7 @@ public class ProjectNodeTest {
   @Mock
   private SchemaKStream<?> stream;
   @Mock
-  private KsqlQueryBuilder ksqlStreamBuilder;
+  private PlanBuildContext planBuildContext;
   @Mock
   private Stacker stacker;
 
@@ -85,7 +84,7 @@ public class ProjectNodeTest {
   public void init() {
     when(source.buildStream(any())).thenReturn((SchemaKStream) stream);
     when(source.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
-    when(ksqlStreamBuilder.buildNodeContext(NODE_ID.toString())).thenReturn(stacker);
+    when(planBuildContext.buildNodeContext(NODE_ID.toString())).thenReturn(stacker);
     when(stream.select(any(), any(), any(), any())).thenReturn((SchemaKStream) stream);
 
     projectNode = new TestProjectNode(
@@ -99,23 +98,23 @@ public class ProjectNodeTest {
   @Test
   public void shouldBuildSourceOnceWhenBeingBuilt() {
     // When:
-    projectNode.buildStream(ksqlStreamBuilder);
+    projectNode.buildStream(planBuildContext);
 
     // Then:
-    verify(source, times(1)).buildStream(ksqlStreamBuilder);
+    verify(source, times(1)).buildStream(planBuildContext);
   }
 
   @Test
   public void shouldSelectProjection() {
     // When:
-    projectNode.buildStream(ksqlStreamBuilder);
+    projectNode.buildStream(planBuildContext);
 
     // Then:
     verify(stream).select(
         ImmutableList.of(K),
         SELECTS,
         stacker,
-        ksqlStreamBuilder
+        planBuildContext
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/SuppressNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/SuppressNodeTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
@@ -50,7 +49,7 @@ public class SuppressNodeTest {
   @Mock
   private SchemaKTable schemaKTable;
   @Mock
-  private KsqlQueryBuilder ksqlStreamBuilder;
+  private PlanBuildContext planBuildContext;
   @Mock
   private Stacker stacker;
   @Mock
@@ -71,7 +70,7 @@ public class SuppressNodeTest {
 
   @Before
   public void setUp() {
-    when(ksqlStreamBuilder.buildNodeContext(NODE_ID.toString())).thenReturn(stacker);
+    when(planBuildContext.buildNodeContext(NODE_ID.toString())).thenReturn(stacker);
     when(sourceNode.getLeftmostSourceNode()).thenReturn(dataSourceNode);
     when(dataSourceNode.getDataSource()).thenReturn(dataSource);
     when(dataSource.getKsqlTopic()).thenReturn(ksqlTopic);
@@ -90,7 +89,7 @@ public class SuppressNodeTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> node.buildStream(ksqlStreamBuilder)
+        () -> node.buildStream(planBuildContext)
     );
 
     // Then
@@ -107,7 +106,7 @@ public class SuppressNodeTest {
     node = new SuppressNode(NODE_ID, sourceNode, refinementInfo);
 
     // When:
-    node.buildStream(ksqlStreamBuilder);
+    node.buildStream(planBuildContext);
 
     // Then
     verify(schemaKTable).suppress(refinementInfo, valueFormat.getFormatInfo(), stacker);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
@@ -66,7 +66,7 @@ public class SchemaKSourceFactoryTest {
   private static final KsqlConfig CONFIG = new KsqlConfig(ImmutableMap.of());
 
   @Mock
-  private PlanBuildContext builderContext;
+  private PlanBuildContext buildContext;
   @Mock
   private DataSource dataSource;
   @Mock
@@ -99,8 +99,8 @@ public class SchemaKSourceFactoryTest {
 
     when(contextStacker.getQueryContext()).thenReturn(queryContext);
 
-    when(builderContext.getKsqlConfig()).thenReturn(CONFIG);
-    when(builderContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.getKsqlConfig()).thenReturn(CONFIG);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
 
     when(keyFormat.getFormatInfo()).thenReturn(keyFormatInfo);
     when(keyFormat.getFeatures()).thenReturn(SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
@@ -117,7 +117,7 @@ public class SchemaKSourceFactoryTest {
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
-        builderContext,
+        buildContext,
         dataSource,
         contextStacker
     );
@@ -139,7 +139,7 @@ public class SchemaKSourceFactoryTest {
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
-        builderContext,
+        buildContext,
         dataSource,
         contextStacker
     );
@@ -161,7 +161,7 @@ public class SchemaKSourceFactoryTest {
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
-        builderContext,
+        buildContext,
         dataSource,
         contextStacker
     );
@@ -183,7 +183,7 @@ public class SchemaKSourceFactoryTest {
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
-        builderContext,
+        buildContext,
         dataSource,
         contextStacker
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.planner.plan.PlanBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
@@ -66,7 +66,7 @@ public class SchemaKSourceFactoryTest {
   private static final KsqlConfig CONFIG = new KsqlConfig(ImmutableMap.of());
 
   @Mock
-  private KsqlQueryBuilder builder;
+  private PlanBuildContext builderContext;
   @Mock
   private DataSource dataSource;
   @Mock
@@ -99,8 +99,8 @@ public class SchemaKSourceFactoryTest {
 
     when(contextStacker.getQueryContext()).thenReturn(queryContext);
 
-    when(builder.getKsqlConfig()).thenReturn(CONFIG);
-    when(builder.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(builderContext.getKsqlConfig()).thenReturn(CONFIG);
+    when(builderContext.getFunctionRegistry()).thenReturn(functionRegistry);
 
     when(keyFormat.getFormatInfo()).thenReturn(keyFormatInfo);
     when(keyFormat.getFeatures()).thenReturn(SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
@@ -117,7 +117,7 @@ public class SchemaKSourceFactoryTest {
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
-        builder,
+        builderContext,
         dataSource,
         contextStacker
     );
@@ -139,7 +139,7 @@ public class SchemaKSourceFactoryTest {
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
-        builder,
+        builderContext,
         dataSource,
         contextStacker
     );
@@ -161,7 +161,7 @@ public class SchemaKSourceFactoryTest {
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
-        builder,
+        builderContext,
         dataSource,
         contextStacker
     );
@@ -183,7 +183,7 @@ public class SchemaKSourceFactoryTest {
 
     // When:
     final SchemaKStream<?> result = SchemaKSourceFactory.buildSource(
-        builder,
+        builderContext,
         dataSource,
         contextStacker
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -102,7 +102,7 @@ public class SchemaKStreamTest {
   @Mock
   private ExecutionStep sourceStep;
   @Mock
-  private PlanBuildContext builderContext;
+  private PlanBuildContext buildContext;
   @Mock
   private KsqlTopic topic;
 
@@ -133,7 +133,7 @@ public class SchemaKStreamTest {
         ImmutableList.of(ColumnName.of("K")),
         selectExpressions,
         childContextStacker,
-        builderContext);
+        buildContext);
 
     // Then:
     assertThat(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.planner.plan.PlanBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
@@ -102,7 +102,7 @@ public class SchemaKStreamTest {
   @Mock
   private ExecutionStep sourceStep;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private PlanBuildContext builderContext;
   @Mock
   private KsqlTopic topic;
 
@@ -133,7 +133,7 @@ public class SchemaKStreamTest {
         ImmutableList.of(ColumnName.of("K")),
         selectExpressions,
         childContextStacker,
-        queryBuilder);
+        builderContext);
 
     // Then:
     assertThat(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -148,7 +148,7 @@ public class SchemaKTableTest {
   private PlanBuilder planBuilder;
 
   @Mock
-  private PlanBuildContext builderContext;
+  private PlanBuildContext buildContext;
   @Mock
   private RuntimeBuildContext executeContext;
   @Mock
@@ -280,7 +280,7 @@ public class SchemaKTableTest {
         ImmutableList.of(ColumnName.of("K")),
         projectNode.getSelectExpressions(),
         childContextStacker,
-        builderContext
+        buildContext
     );
 
     // Then:
@@ -403,7 +403,7 @@ public class SchemaKTableTest {
 
     // When:
     final SchemaKTable<?> projectedSchemaKStream = initialSchemaKTable.select(ImmutableList.of(),
-        projectNode.getSelectExpressions(), childContextStacker, builderContext);
+        projectNode.getSelectExpressions(), childContextStacker, buildContext);
 
     // Then:
     assertThat(projectedSchemaKStream.getSchema(),
@@ -426,7 +426,7 @@ public class SchemaKTableTest {
         ImmutableList.of(),
         projectNode.getSelectExpressions(),
         childContextStacker,
-        builderContext
+        buildContext
     );
 
     // Then:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -32,7 +32,8 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
+import io.confluent.ksql.planner.plan.PlanBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
@@ -147,7 +148,9 @@ public class SchemaKTableTest {
   private PlanBuilder planBuilder;
 
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private PlanBuildContext builderContext;
+  @Mock
+  private RuntimeBuildContext executeContext;
   @Mock
   private ExecutionKeyFactory<Struct> executionKeyFactory;
   @Mock
@@ -182,12 +185,12 @@ public class SchemaKTableTest {
     firstSchemaKTable = buildSchemaKTableForJoin(ksqlTable, mockKTable);
     secondSchemaKTable = buildSchemaKTableForJoin(secondKsqlTable, secondKTable);
 
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(executeContext.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(executeContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(executeContext.getProcessingLogger(any())).thenReturn(processingLogger);
 
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        executeContext,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),
         new StreamsFactories(
@@ -277,7 +280,7 @@ public class SchemaKTableTest {
         ImmutableList.of(ColumnName.of("K")),
         projectNode.getSelectExpressions(),
         childContextStacker,
-        queryBuilder
+        builderContext
     );
 
     // Then:
@@ -400,7 +403,7 @@ public class SchemaKTableTest {
 
     // When:
     final SchemaKTable<?> projectedSchemaKStream = initialSchemaKTable.select(ImmutableList.of(),
-        projectNode.getSelectExpressions(), childContextStacker, queryBuilder);
+        projectNode.getSelectExpressions(), childContextStacker, builderContext);
 
     // Then:
     assertThat(projectedSchemaKStream.getSchema(),
@@ -423,7 +426,7 @@ public class SchemaKTableTest {
         ImmutableList.of(),
         projectNode.getSelectExpressions(),
         childContextStacker,
-        queryBuilder
+        builderContext
     );
 
     // Then:
@@ -634,7 +637,7 @@ public class SchemaKTableTest {
     // Given:
     final Serde<GenericRow> valSerde =
         getRowSerde(ksqlTable.getKsqlTopic(), ksqlTable.getSchema());
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valSerde);
+    when(executeContext.buildValueSerde(any(), any(), any())).thenReturn(valSerde);
     final Grouped<Object, GenericRow> grouped = mock(Grouped.class);
     when(
         groupedFactory.create(

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionKeyFactory.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionKeyFactory.java
@@ -44,7 +44,7 @@ public interface ExecutionKeyFactory<K> {
   /**
    * @return a new {@code ExecutionKeyFactory}
    */
-  ExecutionKeyFactory<K> withQueryBuilder(RuntimeBuildContext builder);
+  ExecutionKeyFactory<K> withQueryBuilder(RuntimeBuildContext buildContext);
 
   /**
    * This method can construct a new key given the old key and the
@@ -56,23 +56,23 @@ public interface ExecutionKeyFactory<K> {
    */
   K constructNewKey(K oldKey, GenericKey newKey);
 
-  static ExecutionKeyFactory<GenericKey> unwindowed(final RuntimeBuildContext queryBuilder) {
-    return new UnwindowedFactory(queryBuilder);
+  static ExecutionKeyFactory<GenericKey> unwindowed(final RuntimeBuildContext buildContext) {
+    return new UnwindowedFactory(buildContext);
   }
 
   static ExecutionKeyFactory<Windowed<GenericKey>> windowed(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final WindowInfo windowInfo
   ) {
-    return new WindowedFactory(windowInfo, queryBuilder);
+    return new WindowedFactory(windowInfo, buildContext);
   }
 
   class UnwindowedFactory implements ExecutionKeyFactory<GenericKey> {
 
-    private final RuntimeBuildContext queryBuilder;
+    private final RuntimeBuildContext buildContext;
 
-    public UnwindowedFactory(final RuntimeBuildContext queryBuilder) {
-      this.queryBuilder = Objects.requireNonNull(queryBuilder, "queryBuilder");
+    public UnwindowedFactory(final RuntimeBuildContext buildContext) {
+      this.buildContext = Objects.requireNonNull(buildContext, "buildContext");
     }
 
     @Override
@@ -81,12 +81,14 @@ public interface ExecutionKeyFactory<K> {
         final PhysicalSchema physicalSchema,
         final QueryContext queryContext
     ) {
-      return queryBuilder.buildKeySerde(format, physicalSchema, queryContext);
+      return buildContext.buildKeySerde(format, physicalSchema, queryContext);
     }
 
     @Override
-    public ExecutionKeyFactory<GenericKey> withQueryBuilder(final RuntimeBuildContext builder) {
-      return new UnwindowedFactory(builder);
+    public ExecutionKeyFactory<GenericKey> withQueryBuilder(
+        final RuntimeBuildContext buildContext
+    ) {
+      return new UnwindowedFactory(buildContext);
     }
 
     @Override
@@ -98,14 +100,14 @@ public interface ExecutionKeyFactory<K> {
   class WindowedFactory implements ExecutionKeyFactory<Windowed<GenericKey>> {
 
     private final WindowInfo windowInfo;
-    private final RuntimeBuildContext queryBuilder;
+    private final RuntimeBuildContext buildContext;
 
     public WindowedFactory(
         final WindowInfo windowInfo,
-        final RuntimeBuildContext queryBuilder
+        final RuntimeBuildContext buildContext
     ) {
       this.windowInfo = Objects.requireNonNull(windowInfo, "windowInfo");
-      this.queryBuilder = Objects.requireNonNull(queryBuilder, "queryBuilder");
+      this.buildContext = Objects.requireNonNull(buildContext, "buildContext");
     }
 
     @Override
@@ -113,14 +115,14 @@ public interface ExecutionKeyFactory<K> {
         final FormatInfo format,
         final PhysicalSchema physicalSchema,
         final QueryContext queryContext) {
-      return queryBuilder.buildKeySerde(format, windowInfo, physicalSchema, queryContext);
+      return buildContext.buildKeySerde(format, windowInfo, physicalSchema, queryContext);
     }
 
     @Override
     public ExecutionKeyFactory<Windowed<GenericKey>> withQueryBuilder(
-        final RuntimeBuildContext builder
+        final RuntimeBuildContext buildContext
     ) {
-      return new WindowedFactory(windowInfo, builder);
+      return new WindowedFactory(windowInfo, buildContext);
     }
 
     @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionKeyFactory.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionKeyFactory.java
@@ -15,8 +15,8 @@
 package io.confluent.ksql.execution.plan;
 
 import io.confluent.ksql.GenericKey;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.WindowInfo;
@@ -44,7 +44,7 @@ public interface ExecutionKeyFactory<K> {
   /**
    * @return a new {@code ExecutionKeyFactory}
    */
-  ExecutionKeyFactory<K> withQueryBuilder(KsqlQueryBuilder builder);
+  ExecutionKeyFactory<K> withQueryBuilder(RuntimeBuildContext builder);
 
   /**
    * This method can construct a new key given the old key and the
@@ -56,12 +56,12 @@ public interface ExecutionKeyFactory<K> {
    */
   K constructNewKey(K oldKey, GenericKey newKey);
 
-  static ExecutionKeyFactory<GenericKey> unwindowed(final KsqlQueryBuilder queryBuilder) {
+  static ExecutionKeyFactory<GenericKey> unwindowed(final RuntimeBuildContext queryBuilder) {
     return new UnwindowedFactory(queryBuilder);
   }
 
   static ExecutionKeyFactory<Windowed<GenericKey>> windowed(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final WindowInfo windowInfo
   ) {
     return new WindowedFactory(windowInfo, queryBuilder);
@@ -69,9 +69,9 @@ public interface ExecutionKeyFactory<K> {
 
   class UnwindowedFactory implements ExecutionKeyFactory<GenericKey> {
 
-    private final KsqlQueryBuilder queryBuilder;
+    private final RuntimeBuildContext queryBuilder;
 
-    public UnwindowedFactory(final KsqlQueryBuilder queryBuilder) {
+    public UnwindowedFactory(final RuntimeBuildContext queryBuilder) {
       this.queryBuilder = Objects.requireNonNull(queryBuilder, "queryBuilder");
     }
 
@@ -85,7 +85,7 @@ public interface ExecutionKeyFactory<K> {
     }
 
     @Override
-    public ExecutionKeyFactory<GenericKey> withQueryBuilder(final KsqlQueryBuilder builder) {
+    public ExecutionKeyFactory<GenericKey> withQueryBuilder(final RuntimeBuildContext builder) {
       return new UnwindowedFactory(builder);
     }
 
@@ -98,9 +98,12 @@ public interface ExecutionKeyFactory<K> {
   class WindowedFactory implements ExecutionKeyFactory<Windowed<GenericKey>> {
 
     private final WindowInfo windowInfo;
-    private final KsqlQueryBuilder queryBuilder;
+    private final RuntimeBuildContext queryBuilder;
 
-    public WindowedFactory(final WindowInfo windowInfo, final KsqlQueryBuilder queryBuilder) {
+    public WindowedFactory(
+        final WindowInfo windowInfo,
+        final RuntimeBuildContext queryBuilder
+    ) {
       this.windowInfo = Objects.requireNonNull(windowInfo, "windowInfo");
       this.queryBuilder = Objects.requireNonNull(queryBuilder, "queryBuilder");
     }
@@ -115,7 +118,7 @@ public interface ExecutionKeyFactory<K> {
 
     @Override
     public ExecutionKeyFactory<Windowed<GenericKey>> withQueryBuilder(
-        final KsqlQueryBuilder builder
+        final RuntimeBuildContext builder
     ) {
       return new WindowedFactory(windowInfo, builder);
     }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/runtime/RuntimeBuildContext.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/runtime/RuntimeBuildContext.java
@@ -44,6 +44,11 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Windowed;
 
+/**
+ * Contains all the context required to build the final runtime topology fom an execution plan.
+ * Ultimately we should make this more abstract to support different runtimes, but for now the
+ * assumed runtime is Kafka Streams.
+ */
 public final class RuntimeBuildContext {
 
   /**

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/schema/query/QuerySchemas.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/schema/query/QuerySchemas.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
@@ -38,7 +39,7 @@ import java.util.Set;
  *
  * <p>Contains an map of 'logger name prefix' to the schema and formats used when creating a serde.
  *
- * <p>If {@link io.confluent.ksql.execution.builder.KsqlQueryBuilder#KSQL_TEST_TRACK_SERDE_TOPICS}
+ * <p>If {@link RuntimeBuildContext#KSQL_TEST_TRACK_SERDE_TOPICS}
  * system property set the class will also track the 'logger name prefix' used when creating a serde
  * to the topic name the serde is asked to handle data for.
  *

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -34,7 +34,7 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.engine.KsqlEngine;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
@@ -161,7 +161,7 @@ public class TestExecutor implements Closeable {
     final KsqlConfig ksqlConfig = testCase.applyPersistedProperties(new KsqlConfig(config));
 
     try {
-      System.setProperty(KsqlQueryBuilder.KSQL_TEST_TRACK_SERDE_TOPICS, "true");
+      System.setProperty(RuntimeBuildContext.KSQL_TEST_TRACK_SERDE_TOPICS, "true");
 
       final List<TopologyTestDriverContainer> topologyTestDrivers = topologyBuilder
           .buildStreamsTopologyTestDrivers(
@@ -259,7 +259,7 @@ public class TestExecutor implements Closeable {
 
       assertThat(e, isThrowable(expectedExceptionMatcher.get()));
     } finally {
-      System.clearProperty(KsqlQueryBuilder.KSQL_TEST_TRACK_SERDE_TOPICS);
+      System.clearProperty(RuntimeBuildContext.KSQL_TEST_TRACK_SERDE_TOPICS);
     }
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericKey;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
 import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.KStreamHolder;
@@ -49,6 +48,7 @@ import io.confluent.ksql.execution.plan.TableSuppress;
 import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.execution.plan.WindowedStreamSource;
 import io.confluent.ksql.execution.plan.WindowedTableSource;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.transform.sqlpredicate.SqlPredicate;
 import java.util.Objects;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -58,12 +58,12 @@ import org.apache.kafka.streams.kstream.Windowed;
  * Kafka Streams app
  */
 public final class KSPlanBuilder implements PlanBuilder {
-  private final KsqlQueryBuilder queryBuilder;
+  private final RuntimeBuildContext queryBuilder;
   private final SqlPredicateFactory sqlPredicateFactory;
   private final AggregateParamsFactory aggregateParamFactory;
   private final StreamsFactories streamsFactories;
 
-  public KSPlanBuilder(final KsqlQueryBuilder queryBuilder) {
+  public KSPlanBuilder(final RuntimeBuildContext queryBuilder) {
     this(
         queryBuilder,
         SqlPredicate::new,
@@ -73,7 +73,7 @@ public final class KSPlanBuilder implements PlanBuilder {
   }
 
   public KSPlanBuilder(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final SqlPredicateFactory sqlPredicateFactory,
       final AggregateParamsFactory aggregateParamFactory,
       final StreamsFactories streamsFactories) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/MaterializationUtil.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/MaterializationUtil.java
@@ -50,7 +50,7 @@ final class MaterializationUtil {
       final ExecutionStep<?> step,
       final LogicalSchema aggregateSchema,
       final Formats formats,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final MaterializedFactory materializedFactory,
       final ExecutionKeyFactory<K> executionKeyFactory
   ) {
@@ -66,7 +66,7 @@ final class MaterializationUtil {
         buildKeySerde(formats, physicalAggregationSchema, queryContext, executionKeyFactory);
 
     final Serde<GenericRow> valueSerde =
-        buildValueSerde(formats, queryBuilder, physicalAggregationSchema, queryContext);
+        buildValueSerde(formats, buildContext, physicalAggregationSchema, queryContext);
 
     return materializedFactory
         .create(keySerde, valueSerde, StreamsUtil.buildOpName(queryContext));
@@ -91,12 +91,12 @@ final class MaterializationUtil {
 
   private static Serde<GenericRow> buildValueSerde(
       final Formats formats,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final PhysicalSchema physicalAggregationSchema,
       final QueryContext queryContext
   ) {
     try {
-      return queryBuilder.buildValueSerde(
+      return buildContext.buildValueSerde(
           formats.getValueFormat(),
           physicalAggregationSchema,
           queryContext

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/MaterializationUtil.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/MaterializationUtil.java
@@ -17,11 +17,11 @@ package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.SchemaNotSupportedException;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import org.apache.kafka.common.serialization.Serde;
@@ -50,7 +50,7 @@ final class MaterializationUtil {
       final ExecutionStep<?> step,
       final LogicalSchema aggregateSchema,
       final Formats formats,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory,
       final ExecutionKeyFactory<K> executionKeyFactory
   ) {
@@ -91,7 +91,7 @@ final class MaterializationUtil {
 
   private static Serde<GenericRow> buildValueSerde(
       final Formats formats,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final PhysicalSchema physicalAggregationSchema,
       final QueryContext queryContext
   ) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SinkBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SinkBuilder.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.execution.streams;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.timestamp.KsqlTimestampExtractor;
 import io.confluent.ksql.execution.streams.timestamp.TimestampExtractionPolicy;
 import io.confluent.ksql.execution.streams.timestamp.TimestampExtractionPolicyFactory;
@@ -54,7 +54,7 @@ public final class SinkBuilder {
       final KStream<K, GenericRow> stream,
       final ExecutionKeyFactory<K> executionKeyFactory,
       final QueryContext queryContext,
-      final KsqlQueryBuilder queryBuilder
+      final RuntimeBuildContext queryBuilder
   ) {
     final PhysicalSchema physicalSchema = PhysicalSchema.from(
         schema,
@@ -90,7 +90,7 @@ public final class SinkBuilder {
   }
 
   private static  <K> Optional<TransformTimestamp<K>> timestampTransformer(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final QueryContext queryContext,
       final LogicalSchema sourceSchema,
       final Optional<TimestampColumn> timestampColumn

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.function.udaf.KudafAggregator;
 import io.confluent.ksql.execution.materialization.MaterializationInfo;
@@ -27,6 +26,7 @@ import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.StreamAggregate;
 import io.confluent.ksql.execution.plan.StreamWindowedAggregate;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
 import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
@@ -60,7 +60,7 @@ public final class StreamAggregateBuilder {
   public static KTableHolder<GenericKey> build(
       final KGroupedStreamHolder groupedStream,
       final StreamAggregate aggregate,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory) {
     return build(
         groupedStream,
@@ -74,7 +74,7 @@ public final class StreamAggregateBuilder {
   static KTableHolder<GenericKey> build(
       final KGroupedStreamHolder groupedStream,
       final StreamAggregate aggregate,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory,
       final AggregateParamsFactory aggregateParamsFactory) {
     final LogicalSchema sourceSchema = groupedStream.getSchema();
@@ -132,7 +132,7 @@ public final class StreamAggregateBuilder {
   public static KTableHolder<Windowed<GenericKey>> build(
       final KGroupedStreamHolder groupedStream,
       final StreamWindowedAggregate aggregate,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory
   ) {
     return build(
@@ -148,7 +148,7 @@ public final class StreamAggregateBuilder {
   static KTableHolder<Windowed<GenericKey>> build(
       final KGroupedStreamHolder groupedStream,
       final StreamWindowedAggregate aggregate,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory,
       final AggregateParamsFactory aggregateParamsFactory
   ) {
@@ -217,7 +217,7 @@ public final class StreamAggregateBuilder {
     final QueryContext queryContext;
     final Formats formats;
     final KGroupedStream<GenericKey, GenericRow> groupedStream;
-    final KsqlQueryBuilder queryBuilder;
+    final RuntimeBuildContext queryBuilder;
     final MaterializedFactory materializedFactory;
     final Serde<GenericKey> keySerde;
     final Serde<GenericRow> valueSerde;
@@ -227,7 +227,7 @@ public final class StreamAggregateBuilder {
         final KGroupedStream<GenericKey, GenericRow> groupedStream,
         final StreamWindowedAggregate aggregate,
         final LogicalSchema aggregateSchema,
-        final KsqlQueryBuilder queryBuilder,
+        final RuntimeBuildContext queryBuilder,
         final MaterializedFactory materializedFactory,
         final AggregateParams aggregateParams) {
       Objects.requireNonNull(aggregate, "aggregate");

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
@@ -16,9 +16,9 @@
 package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamFilter;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.transform.sqlpredicate.SqlPredicate;
@@ -37,14 +37,14 @@ public final class StreamFilterBuilder {
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamFilter<K> step,
-      final KsqlQueryBuilder queryBuilder) {
+      final RuntimeBuildContext queryBuilder) {
     return build(stream, step, queryBuilder, SqlPredicate::new);
   }
 
   static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamFilter<K> step,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final SqlPredicateFactory predicateFactory
   ) {
     final SqlPredicate predicate = predicateFactory.create(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
@@ -37,24 +37,24 @@ public final class StreamFilterBuilder {
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamFilter<K> step,
-      final RuntimeBuildContext queryBuilder) {
-    return build(stream, step, queryBuilder, SqlPredicate::new);
+      final RuntimeBuildContext buildContext) {
+    return build(stream, step, buildContext, SqlPredicate::new);
   }
 
   static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamFilter<K> step,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final SqlPredicateFactory predicateFactory
   ) {
     final SqlPredicate predicate = predicateFactory.create(
         step.getFilterExpression(),
         stream.getSchema(),
-        queryBuilder.getKsqlConfig(),
-        queryBuilder.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     );
 
-    final ProcessingLogger processingLogger = queryBuilder
+    final ProcessingLogger processingLogger = buildContext
         .getProcessingLogger(step.getProperties().getQueryContext());
 
     final KStream<K, GenericRow> filtered = stream.getStream()

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.execution.streams;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.context.QueryContext;
@@ -29,6 +28,7 @@ import io.confluent.ksql.execution.function.udtf.KudtfFlatMapper;
 import io.confluent.ksql.execution.function.udtf.TableFunctionApplier;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamFlatMap;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
 import io.confluent.ksql.execution.util.ExpressionTypeManager;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -52,7 +52,7 @@ public final class StreamFlatMapBuilder {
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamFlatMap<K> step,
-      final KsqlQueryBuilder queryBuilder
+      final RuntimeBuildContext queryBuilder
   ) {
     final List<FunctionCall> tableFunctions = step.getTableFunctions();
     final LogicalSchema schema = stream.getSchema();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -52,13 +52,13 @@ public final class StreamFlatMapBuilder {
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamFlatMap<K> step,
-      final RuntimeBuildContext queryBuilder
+      final RuntimeBuildContext buildContext
   ) {
     final List<FunctionCall> tableFunctions = step.getTableFunctions();
     final LogicalSchema schema = stream.getSchema();
     final Builder<TableFunctionApplier> tableFunctionAppliersBuilder = ImmutableList.builder();
     final CodeGenRunner codeGenRunner =
-        new CodeGenRunner(schema, queryBuilder.getKsqlConfig(), queryBuilder.getFunctionRegistry());
+        new CodeGenRunner(schema, buildContext.getKsqlConfig(), buildContext.getFunctionRegistry());
 
     for (final FunctionCall functionCall: tableFunctions) {
       final List<ExpressionMetadata> expressionMetadataList = new ArrayList<>(
@@ -69,7 +69,7 @@ public final class StreamFlatMapBuilder {
         expressionMetadataList.add(expressionMetadata);
       }
       final KsqlTableFunction tableFunction = UdtfUtil.resolveTableFunction(
-          queryBuilder.getFunctionRegistry(),
+          buildContext.getFunctionRegistry(),
           functionCall,
           schema
       );
@@ -80,7 +80,7 @@ public final class StreamFlatMapBuilder {
 
     final QueryContext queryContext = step.getProperties().getQueryContext();
 
-    final ProcessingLogger processingLogger = queryBuilder.getProcessingLogger(queryContext);
+    final ProcessingLogger processingLogger = buildContext.getProcessingLogger(queryContext);
 
     final ImmutableList<TableFunctionApplier> tableFunctionAppliers = tableFunctionAppliersBuilder
         .build();
@@ -95,7 +95,7 @@ public final class StreamFlatMapBuilder {
         buildSchema(
             stream.getSchema(),
             step.getTableFunctions(),
-            queryBuilder.getFunctionRegistry()
+            buildContext.getFunctionRegistry()
         )
     );
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilder.java
@@ -16,12 +16,12 @@
 package io.confluent.ksql.execution.streams;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 
 public final class StreamGroupByBuilder extends StreamGroupByBuilderBase {
 
   public StreamGroupByBuilder(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory
   ) {
     this(queryBuilder, groupedFactory, GroupByParamsFactory::build);
@@ -29,7 +29,7 @@ public final class StreamGroupByBuilder extends StreamGroupByBuilderBase {
 
   @VisibleForTesting
   StreamGroupByBuilder(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilder.java
@@ -21,18 +21,18 @@ import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 public final class StreamGroupByBuilder extends StreamGroupByBuilderBase {
 
   public StreamGroupByBuilder(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory
   ) {
-    this(queryBuilder, groupedFactory, GroupByParamsFactory::build);
+    this(buildContext, groupedFactory, GroupByParamsFactory::build);
   }
 
   @VisibleForTesting
   StreamGroupByBuilder(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {
-    super(queryBuilder, groupedFactory, paramsFactory);
+    super(buildContext, groupedFactory, paramsFactory);
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderBase.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderBase.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.context.QueryContext;
@@ -28,6 +27,7 @@ import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamGroupByKey;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -38,12 +38,12 @@ import org.apache.kafka.streams.kstream.KGroupedStream;
 
 class StreamGroupByBuilderBase {
 
-  private final KsqlQueryBuilder queryBuilder;
+  private final RuntimeBuildContext queryBuilder;
   private final GroupedFactory groupedFactory;
   private final ParamsFactory paramsFactory;
 
   StreamGroupByBuilderBase(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {
@@ -109,7 +109,7 @@ class StreamGroupByBuilderBase {
       final Formats formats,
       final LogicalSchema schema,
       final QueryContext queryContext,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory
   ) {
     final PhysicalSchema physicalSchema = PhysicalSchema.from(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderBase.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderBase.java
@@ -38,16 +38,16 @@ import org.apache.kafka.streams.kstream.KGroupedStream;
 
 class StreamGroupByBuilderBase {
 
-  private final RuntimeBuildContext queryBuilder;
+  private final RuntimeBuildContext buildContext;
   private final GroupedFactory groupedFactory;
   private final ParamsFactory paramsFactory;
 
   StreamGroupByBuilderBase(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {
-    this.queryBuilder = requireNonNull(queryBuilder, "queryBuilder");
+    this.buildContext = requireNonNull(buildContext, "buildContext");
     this.groupedFactory = requireNonNull(groupedFactory, "groupedFactory");
     this.paramsFactory = requireNonNull(paramsFactory, "paramsFactory");
   }
@@ -63,7 +63,7 @@ class StreamGroupByBuilderBase {
         formats,
         sourceSchema,
         queryContext,
-        queryBuilder,
+        buildContext,
         groupedFactory
     );
     return KGroupedStreamHolder.of(stream.getStream().groupByKey(grouped), stream.getSchema());
@@ -81,11 +81,11 @@ class StreamGroupByBuilderBase {
         groupByExpressions.stream(),
         "Group By",
         sourceSchema,
-        queryBuilder.getKsqlConfig(),
-        queryBuilder.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     );
 
-    final ProcessingLogger logger = queryBuilder.getProcessingLogger(queryContext);
+    final ProcessingLogger logger = buildContext.getProcessingLogger(queryContext);
 
     final GroupByParams params = paramsFactory
         .build(sourceSchema, groupBy, logger);
@@ -94,7 +94,7 @@ class StreamGroupByBuilderBase {
         formats,
         params.getSchema(),
         queryContext,
-        queryBuilder,
+        buildContext,
         groupedFactory
     );
 
@@ -109,7 +109,7 @@ class StreamGroupByBuilderBase {
       final Formats formats,
       final LogicalSchema schema,
       final QueryContext queryContext,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory
   ) {
     final PhysicalSchema physicalSchema = PhysicalSchema.from(
@@ -118,12 +118,12 @@ class StreamGroupByBuilderBase {
         formats.getValueFeatures()
     );
 
-    final Serde<GenericKey> keySerde = queryBuilder.buildKeySerde(
+    final Serde<GenericKey> keySerde = buildContext.buildKeySerde(
         formats.getKeyFormat(),
         physicalSchema,
         queryContext
     );
-    final Serde<GenericRow> valSerde = queryBuilder.buildValueSerde(
+    final Serde<GenericRow> valSerde = buildContext.buildValueSerde(
         formats.getValueFormat(),
         physicalSchema,
         queryContext

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderV1.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderV1.java
@@ -21,18 +21,18 @@ import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 public final class StreamGroupByBuilderV1 extends StreamGroupByBuilderBase {
 
   public StreamGroupByBuilderV1(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory
   ) {
-    this(queryBuilder, groupedFactory, GroupByParamsV1Factory::build);
+    this(buildContext, groupedFactory, GroupByParamsV1Factory::build);
   }
 
   @VisibleForTesting
   StreamGroupByBuilderV1(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {
-    super(queryBuilder, groupedFactory, paramsFactory);
+    super(buildContext, groupedFactory, paramsFactory);
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderV1.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderV1.java
@@ -16,12 +16,12 @@
 package io.confluent.ksql.execution.streams;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 
 public final class StreamGroupByBuilderV1 extends StreamGroupByBuilderBase {
 
   public StreamGroupByBuilderV1(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory
   ) {
     this(queryBuilder, groupedFactory, GroupByParamsV1Factory::build);
@@ -29,7 +29,7 @@ public final class StreamGroupByBuilderV1 extends StreamGroupByBuilderBase {
 
   @VisibleForTesting
   StreamGroupByBuilderV1(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectBuilder.java
@@ -33,7 +33,7 @@ public final class StreamSelectBuilder {
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamSelect<K> step,
-      final RuntimeBuildContext queryBuilder
+      final RuntimeBuildContext buildContext
   ) {
     final QueryContext queryContext = step.getProperties().getQueryContext();
 
@@ -43,13 +43,13 @@ public final class StreamSelectBuilder {
         sourceSchema,
         step.getKeyColumnNames(),
         step.getSelectExpressions(),
-        queryBuilder.getKsqlConfig(),
-        queryBuilder.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     );
 
     final SelectValueMapper<K> selectMapper = selection.getMapper();
 
-    final ProcessingLogger logger = queryBuilder.getProcessingLogger(queryContext);
+    final ProcessingLogger logger = buildContext.getProcessingLogger(queryContext);
 
     final Named selectName =
         Named.as(StreamsUtil.buildOpName(queryContext));

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectBuilder.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamSelect;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
 import io.confluent.ksql.execution.transform.select.SelectValueMapper;
 import io.confluent.ksql.execution.transform.select.Selection;
@@ -33,7 +33,7 @@ public final class StreamSelectBuilder {
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamSelect<K> step,
-      final KsqlQueryBuilder queryBuilder
+      final RuntimeBuildContext queryBuilder
   ) {
     final QueryContext queryContext = step.getProperties().getQueryContext();
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
@@ -17,12 +17,12 @@ package io.confluent.ksql.execution.streams;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamSelectKey;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.PartitionByParams.Mapper;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
@@ -40,7 +40,7 @@ public final class StreamSelectKeyBuilder {
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamSelectKey<K> selectKey,
-      final KsqlQueryBuilder queryBuilder
+      final RuntimeBuildContext queryBuilder
   ) {
     return build(stream, selectKey, queryBuilder, PartitionByParamsFactory::build);
   }
@@ -49,7 +49,7 @@ public final class StreamSelectKeyBuilder {
   static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamSelectKey<K> selectKey,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final PartitionByParamsBuilder paramsBuilder
   ) {
     final LogicalSchema sourceSchema = stream.getSchema();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
@@ -40,29 +40,29 @@ public final class StreamSelectKeyBuilder {
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamSelectKey<K> selectKey,
-      final RuntimeBuildContext queryBuilder
+      final RuntimeBuildContext buildContext
   ) {
-    return build(stream, selectKey, queryBuilder, PartitionByParamsFactory::build);
+    return build(stream, selectKey, buildContext, PartitionByParamsFactory::build);
   }
 
   @VisibleForTesting
   static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
       final StreamSelectKey<K> selectKey,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final PartitionByParamsBuilder paramsBuilder
   ) {
     final LogicalSchema sourceSchema = stream.getSchema();
     final QueryContext queryContext = selectKey.getProperties().getQueryContext();
 
-    final ProcessingLogger logger = queryBuilder.getProcessingLogger(queryContext);
+    final ProcessingLogger logger = buildContext.getProcessingLogger(queryContext);
 
     final PartitionByParams<K> params = paramsBuilder.build(
         sourceSchema,
         stream.getExecutionKeyFactory(),
         selectKey.getKeyExpressions(),
-        queryBuilder.getKsqlConfig(),
-        queryBuilder.getFunctionRegistry(),
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry(),
         logger
     );
 
@@ -76,7 +76,7 @@ public final class StreamSelectKeyBuilder {
     return new KStreamHolder<>(
         reKeyed,
         params.getSchema(),
-        stream.getExecutionKeyFactory().withQueryBuilder(queryBuilder)
+        stream.getExecutionKeyFactory().withQueryBuilder(buildContext)
     );
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1.java
@@ -17,12 +17,12 @@ package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamSelectKeyV1;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.function.Function;
@@ -38,7 +38,7 @@ public final class StreamSelectKeyBuilderV1 {
   public static KStreamHolder<GenericKey> build(
       final KStreamHolder<?> stream,
       final StreamSelectKeyV1 selectKey,
-      final KsqlQueryBuilder queryBuilder
+      final RuntimeBuildContext queryBuilder
   ) {
     final LogicalSchema sourceSchema = stream.getSchema();
 
@@ -74,7 +74,7 @@ public final class StreamSelectKeyBuilderV1 {
 
   private static ExpressionMetadata buildExpressionEvaluator(
       final StreamSelectKeyV1 selectKey,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final LogicalSchema sourceSchema
   ) {
     final CodeGenRunner codeGen = new CodeGenRunner(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSinkBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSinkBuilder.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamSink;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 
 public final class StreamSinkBuilder {
   private StreamSinkBuilder() {
@@ -26,7 +26,7 @@ public final class StreamSinkBuilder {
   public static <K> void build(
       final KStreamHolder<K> stream,
       final StreamSink<K> streamSink,
-      final KsqlQueryBuilder queryBuilder) {
+      final RuntimeBuildContext queryBuilder) {
     SinkBuilder.build(
         stream.getSchema(),
         streamSink.getFormats(),

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSinkBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSinkBuilder.java
@@ -26,7 +26,7 @@ public final class StreamSinkBuilder {
   public static <K> void build(
       final KStreamHolder<K> stream,
       final StreamSink<K> streamSink,
-      final RuntimeBuildContext queryBuilder) {
+      final RuntimeBuildContext buildContext) {
     SinkBuilder.build(
         stream.getSchema(),
         streamSink.getFormats(),
@@ -35,7 +35,7 @@ public final class StreamSinkBuilder {
         stream.getStream(),
         stream.getExecutionKeyFactory(),
         streamSink.getProperties().getQueryContext(),
-        queryBuilder
+        buildContext
     );
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
@@ -16,11 +16,11 @@
 package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamStreamJoin;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import org.apache.kafka.common.serialization.Serde;
@@ -39,7 +39,7 @@ public final class StreamStreamJoinBuilder {
       final KStreamHolder<K> left,
       final KStreamHolder<K> right,
       final StreamStreamJoin<K> join,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final StreamJoinedFactory streamJoinedFactory) {
     final Formats leftFormats = join.getLeftInternalFormats();
     final QueryContext queryContext = join.getProperties().getQueryContext();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
@@ -39,7 +39,7 @@ public final class StreamStreamJoinBuilder {
       final KStreamHolder<K> left,
       final KStreamHolder<K> right,
       final StreamStreamJoin<K> join,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final StreamJoinedFactory streamJoinedFactory) {
     final Formats leftFormats = join.getLeftInternalFormats();
     final QueryContext queryContext = join.getProperties().getQueryContext();
@@ -51,7 +51,7 @@ public final class StreamStreamJoinBuilder {
         leftFormats.getValueFeatures()
     );
 
-    final Serde<GenericRow> leftSerde = queryBuilder.buildValueSerde(
+    final Serde<GenericRow> leftSerde = buildContext.buildValueSerde(
         leftFormats.getValueFormat(),
         leftPhysicalSchema,
         stacker.push(LEFT_SERDE_CTX).getQueryContext()
@@ -64,7 +64,7 @@ public final class StreamStreamJoinBuilder {
         rightFormats.getValueFeatures()
     );
 
-    final Serde<GenericRow> rightSerde = queryBuilder.buildValueSerde(
+    final Serde<GenericRow> rightSerde = buildContext.buildValueSerde(
         rightFormats.getValueFormat(),
         rightPhysicalSchema,
         stacker.push(RIGHT_SERDE_CTX).getQueryContext()

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilder.java
@@ -16,12 +16,12 @@
 package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.StreamTableJoin;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import org.apache.kafka.common.serialization.Serde;
@@ -39,7 +39,7 @@ public final class StreamTableJoinBuilder {
       final KStreamHolder<K> left,
       final KTableHolder<K> right,
       final StreamTableJoin<K> join,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final JoinedFactory joinedFactory
   ) {
     final Formats leftFormats = join.getInternalFormats();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilder.java
@@ -39,7 +39,7 @@ public final class StreamTableJoinBuilder {
       final KStreamHolder<K> left,
       final KTableHolder<K> right,
       final StreamTableJoin<K> join,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final JoinedFactory joinedFactory
   ) {
     final Formats leftFormats = join.getInternalFormats();
@@ -52,7 +52,7 @@ public final class StreamTableJoinBuilder {
         leftFormats.getValueFeatures()
     );
 
-    final Serde<GenericRow> leftSerde = queryBuilder.buildValueSerde(
+    final Serde<GenericRow> leftSerde = buildContext.buildValueSerde(
         leftFormats.getValueFormat(),
         leftPhysicalSchema,
         stacker.push(SERDE_CTX).getQueryContext()

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
@@ -40,12 +40,12 @@ public final class TableAggregateBuilder {
   public static KTableHolder<GenericKey> build(
       final KGroupedTableHolder groupedTable,
       final TableAggregate aggregate,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final MaterializedFactory materializedFactory) {
     return build(
         groupedTable,
         aggregate,
-        queryBuilder,
+        buildContext,
         materializedFactory,
         new AggregateParamsFactory()
     );
@@ -54,7 +54,7 @@ public final class TableAggregateBuilder {
   public static KTableHolder<GenericKey> build(
       final KGroupedTableHolder groupedTable,
       final TableAggregate aggregate,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final MaterializedFactory materializedFactory,
       final AggregateParamsFactory aggregateParamsFactory
   ) {
@@ -63,7 +63,7 @@ public final class TableAggregateBuilder {
     final AggregateParams aggregateParams = aggregateParamsFactory.createUndoable(
         sourceSchema,
         nonFuncColumns,
-        queryBuilder.getFunctionRegistry(),
+        buildContext.getFunctionRegistry(),
         aggregate.getAggregationFunctions()
     );
     final LogicalSchema aggregateSchema = aggregateParams.getAggregateSchema();
@@ -73,9 +73,9 @@ public final class TableAggregateBuilder {
             aggregate,
             aggregateSchema,
             aggregate.getInternalFormats(),
-            queryBuilder,
+            buildContext,
             materializedFactory,
-            ExecutionKeyFactory.unwindowed(queryBuilder)
+            ExecutionKeyFactory.unwindowed(buildContext)
         );
     final KTable<GenericKey, GenericRow> aggregated = groupedTable.getGroupedTable().aggregate(
         aggregateParams.getInitializer(),
@@ -98,7 +98,7 @@ public final class TableAggregateBuilder {
     return KTableHolder.materialized(
         aggregated,
         resultSchema,
-        ExecutionKeyFactory.unwindowed(queryBuilder),
+        ExecutionKeyFactory.unwindowed(buildContext),
         materializationBuilder
     );
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
@@ -17,12 +17,12 @@ package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableAggregate;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -40,7 +40,7 @@ public final class TableAggregateBuilder {
   public static KTableHolder<GenericKey> build(
       final KGroupedTableHolder groupedTable,
       final TableAggregate aggregate,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory) {
     return build(
         groupedTable,
@@ -54,7 +54,7 @@ public final class TableAggregateBuilder {
   public static KTableHolder<GenericKey> build(
       final KGroupedTableHolder groupedTable,
       final TableAggregate aggregate,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory,
       final AggregateParamsFactory aggregateParamsFactory
   ) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
@@ -39,24 +39,24 @@ public final class TableFilterBuilder {
   public static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableFilter<K> step,
-      final RuntimeBuildContext queryBuilder) {
-    return build(table, step, queryBuilder, SqlPredicate::new);
+      final RuntimeBuildContext buildContext) {
+    return build(table, step, buildContext, SqlPredicate::new);
   }
 
   static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableFilter<K> step,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final SqlPredicateFactory sqlPredicateFactory
   ) {
     final SqlPredicate predicate = sqlPredicateFactory.create(
         step.getFilterExpression(),
         table.getSchema(),
-        queryBuilder.getKsqlConfig(),
-        queryBuilder.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     );
 
-    final ProcessingLogger processingLogger = queryBuilder
+    final ProcessingLogger processingLogger = buildContext
         .getProcessingLogger(step.getProperties().getQueryContext());
 
     final Stacker stacker = Stacker.of(step.getProperties().getQueryContext());

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
@@ -16,10 +16,10 @@
 package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableFilter;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
 import io.confluent.ksql.execution.transform.sqlpredicate.SqlPredicate;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
@@ -39,14 +39,14 @@ public final class TableFilterBuilder {
   public static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableFilter<K> step,
-      final KsqlQueryBuilder queryBuilder) {
+      final RuntimeBuildContext queryBuilder) {
     return build(table, step, queryBuilder, SqlPredicate::new);
   }
 
   static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableFilter<K> step,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final SqlPredicateFactory sqlPredicateFactory
   ) {
     final SqlPredicate predicate = sqlPredicateFactory.create(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
@@ -16,12 +16,12 @@
 package io.confluent.ksql.execution.streams;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 
 public final class TableGroupByBuilder extends TableGroupByBuilderBase {
 
   public TableGroupByBuilder(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory
   ) {
     this(queryBuilder, groupedFactory, GroupByParamsFactory::build);
@@ -29,7 +29,7 @@ public final class TableGroupByBuilder extends TableGroupByBuilderBase {
 
   @VisibleForTesting
   TableGroupByBuilder(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
@@ -21,18 +21,18 @@ import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 public final class TableGroupByBuilder extends TableGroupByBuilderBase {
 
   public TableGroupByBuilder(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory
   ) {
-    this(queryBuilder, groupedFactory, GroupByParamsFactory::build);
+    this(buildContext, groupedFactory, GroupByParamsFactory::build);
   }
 
   @VisibleForTesting
   TableGroupByBuilder(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {
-    super(queryBuilder, groupedFactory, paramsFactory);
+    super(buildContext, groupedFactory, paramsFactory);
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilderBase.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilderBase.java
@@ -40,16 +40,16 @@ import org.apache.kafka.streams.kstream.KeyValueMapper;
 
 class TableGroupByBuilderBase {
 
-  private final RuntimeBuildContext queryBuilder;
+  private final RuntimeBuildContext buildContext;
   private final GroupedFactory groupedFactory;
   private final ParamsFactory paramsFactory;
 
   TableGroupByBuilderBase(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {
-    this.queryBuilder = requireNonNull(queryBuilder, "queryBuilder");
+    this.buildContext = requireNonNull(buildContext, "buildContext");
     this.groupedFactory = requireNonNull(groupedFactory, "groupedFactory");
     this.paramsFactory = requireNonNull(paramsFactory, "paramsFactory");
   }
@@ -66,11 +66,11 @@ class TableGroupByBuilderBase {
         groupByExpressions.stream(),
         "Group By",
         sourceSchema,
-        queryBuilder.getKsqlConfig(),
-        queryBuilder.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     );
 
-    final ProcessingLogger logger = queryBuilder.getProcessingLogger(queryContext);
+    final ProcessingLogger logger = buildContext.getProcessingLogger(queryContext);
 
     final GroupByParams params = paramsFactory
         .build(sourceSchema, groupBy, logger);
@@ -81,12 +81,12 @@ class TableGroupByBuilderBase {
         formats.getValueFeatures()
     );
 
-    final Serde<GenericKey> keySerde = queryBuilder.buildKeySerde(
+    final Serde<GenericKey> keySerde = buildContext.buildKeySerde(
         formats.getKeyFormat(),
         physicalSchema,
         queryContext
     );
-    final Serde<GenericRow> valSerde = queryBuilder.buildValueSerde(
+    final Serde<GenericRow> valSerde = buildContext.buildValueSerde(
         formats.getValueFormat(),
         physicalSchema,
         queryContext

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilderBase.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilderBase.java
@@ -19,7 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.context.QueryContext;
@@ -27,6 +26,7 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -40,12 +40,12 @@ import org.apache.kafka.streams.kstream.KeyValueMapper;
 
 class TableGroupByBuilderBase {
 
-  private final KsqlQueryBuilder queryBuilder;
+  private final RuntimeBuildContext queryBuilder;
   private final GroupedFactory groupedFactory;
   private final ParamsFactory paramsFactory;
 
   TableGroupByBuilderBase(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilderV1.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilderV1.java
@@ -16,12 +16,12 @@
 package io.confluent.ksql.execution.streams;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 
 public final class TableGroupByBuilderV1 extends TableGroupByBuilderBase {
 
   public TableGroupByBuilderV1(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory
   ) {
     this(queryBuilder, groupedFactory, GroupByParamsV1Factory::build);
@@ -29,7 +29,7 @@ public final class TableGroupByBuilderV1 extends TableGroupByBuilderBase {
 
   @VisibleForTesting
   TableGroupByBuilderV1(
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilderV1.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilderV1.java
@@ -21,18 +21,18 @@ import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 public final class TableGroupByBuilderV1 extends TableGroupByBuilderBase {
 
   public TableGroupByBuilderV1(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory
   ) {
-    this(queryBuilder, groupedFactory, GroupByParamsV1Factory::build);
+    this(buildContext, groupedFactory, GroupByParamsV1Factory::build);
   }
 
   @VisibleForTesting
   TableGroupByBuilderV1(
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final GroupedFactory groupedFactory,
       final ParamsFactory paramsFactory
   ) {
-    super(queryBuilder, groupedFactory, paramsFactory);
+    super(buildContext, groupedFactory, paramsFactory);
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
@@ -37,7 +37,7 @@ public final class TableSelectBuilder {
   public static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSelect<K> step,
-      final RuntimeBuildContext queryBuilder
+      final RuntimeBuildContext buildContext
   ) {
     final LogicalSchema sourceSchema = table.getSchema();
     final QueryContext queryContext = step.getProperties().getQueryContext();
@@ -46,13 +46,13 @@ public final class TableSelectBuilder {
         sourceSchema,
         step.getKeyColumnNames(),
         step.getSelectExpressions(),
-        queryBuilder.getKsqlConfig(),
-        queryBuilder.getFunctionRegistry()
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry()
     );
 
     final SelectValueMapper<K> selectMapper = selection.getMapper();
 
-    final ProcessingLogger logger = queryBuilder.getProcessingLogger(queryContext);
+    final ProcessingLogger logger = buildContext.getProcessingLogger(queryContext);
 
     final Named selectName = Named.as(StreamsUtil.buildOpName(queryContext));
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
@@ -16,10 +16,10 @@
 package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableSelect;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.transform.select.SelectValueMapper;
@@ -37,7 +37,7 @@ public final class TableSelectBuilder {
   public static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSelect<K> step,
-      final KsqlQueryBuilder queryBuilder
+      final RuntimeBuildContext queryBuilder
   ) {
     final LogicalSchema sourceSchema = table.getSchema();
     final QueryContext queryContext = step.getProperties().getQueryContext();

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectKeyBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectKeyBuilder.java
@@ -44,13 +44,13 @@ public final class TableSelectKeyBuilder {
   public static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSelectKey<K> selectKey,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final MaterializedFactory materializedFactory
   ) {
     return build(
         table,
         selectKey,
-        queryBuilder,
+        buildContext,
         materializedFactory,
         PartitionByParamsFactory::build
     );
@@ -60,21 +60,21 @@ public final class TableSelectKeyBuilder {
   static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSelectKey<K> selectKey,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final MaterializedFactory materializedFactory,
       final PartitionByParamsBuilder paramsBuilder
   ) {
     final LogicalSchema sourceSchema = table.getSchema();
     final QueryContext queryContext = selectKey.getProperties().getQueryContext();
 
-    final ProcessingLogger logger = queryBuilder.getProcessingLogger(queryContext);
+    final ProcessingLogger logger = buildContext.getProcessingLogger(queryContext);
 
     final PartitionByParams<K> params = paramsBuilder.build(
         sourceSchema,
         table.getExecutionKeyFactory(),
         selectKey.getKeyExpressions(),
-        queryBuilder.getKsqlConfig(),
-        queryBuilder.getFunctionRegistry(),
+        buildContext.getKsqlConfig(),
+        buildContext.getFunctionRegistry(),
         logger
     );
 
@@ -87,7 +87,7 @@ public final class TableSelectKeyBuilder {
             selectKey,
             params.getSchema(),
             selectKey.getInternalFormats(),
-            queryBuilder,
+            buildContext,
             materializedFactory,
             table.getExecutionKeyFactory()
         );
@@ -104,7 +104,7 @@ public final class TableSelectKeyBuilder {
     return KTableHolder.materialized(
         reKeyed,
         params.getSchema(),
-        table.getExecutionKeyFactory().withQueryBuilder(queryBuilder),
+        table.getExecutionKeyFactory().withQueryBuilder(buildContext),
         materializationBuilder
     );
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectKeyBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectKeyBuilder.java
@@ -17,13 +17,13 @@ package io.confluent.ksql.execution.streams;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableSelectKey;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.PartitionByParams.Mapper;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
@@ -44,7 +44,7 @@ public final class TableSelectKeyBuilder {
   public static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSelectKey<K> selectKey,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory
   ) {
     return build(
@@ -60,7 +60,7 @@ public final class TableSelectKeyBuilder {
   static <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSelectKey<K> selectKey,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final MaterializedFactory materializedFactory,
       final PartitionByParamsBuilder paramsBuilder
   ) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
@@ -26,7 +26,7 @@ public final class TableSinkBuilder {
   public static <K> void build(
       final KTableHolder<K> table,
       final TableSink<K> tableSink,
-      final RuntimeBuildContext queryBuilder) {
+      final RuntimeBuildContext buildContext) {
     SinkBuilder.build(
         table.getSchema(),
         tableSink.getFormats(),
@@ -35,7 +35,7 @@ public final class TableSinkBuilder {
         table.getTable().toStream(),
         table.getExecutionKeyFactory(),
         tableSink.getProperties().getQueryContext(),
-        queryBuilder
+        buildContext
     );
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableSink;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 
 public final class TableSinkBuilder {
   private TableSinkBuilder() {
@@ -26,7 +26,7 @@ public final class TableSinkBuilder {
   public static <K> void build(
       final KTableHolder<K> table,
       final TableSink<K> tableSink,
-      final KsqlQueryBuilder queryBuilder) {
+      final RuntimeBuildContext queryBuilder) {
     SinkBuilder.build(
         table.getSchema(),
         tableSink.getFormats(),

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
@@ -46,13 +46,13 @@ public final class TableSuppressBuilder {
   public <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSuppress<K> step,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final ExecutionKeyFactory<K> executionKeyFactory
   ) {
     return build(
         table,
         step,
-        queryBuilder,
+        buildContext,
         executionKeyFactory,
         PhysicalSchema::from,
         Materialized::with
@@ -64,7 +64,7 @@ public final class TableSuppressBuilder {
   <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSuppress<K> step,
-      final RuntimeBuildContext queryBuilder,
+      final RuntimeBuildContext buildContext,
       final ExecutionKeyFactory<K> executionKeyFactory,
       final PhysicalSchemaFactory physicalSchemaFactory,
       final BiFunction<Serde<K>, Serde<GenericRow>, Materialized> materializedFactory
@@ -83,7 +83,7 @@ public final class TableSuppressBuilder {
         physicalSchema,
         queryContext
     );
-    final Serde<GenericRow> valueSerde = queryBuilder.buildValueSerde(
+    final Serde<GenericRow> valueSerde = buildContext.buildValueSerde(
         step.getInternalFormats().getValueFormat(),
         physicalSchema,
         queryContext
@@ -95,7 +95,7 @@ public final class TableSuppressBuilder {
         );
 
     final Suppressed.StrictBufferConfig strictBufferConfig;
-    final long maxBytes = queryBuilder.getKsqlConfig().getLong(
+    final long maxBytes = buildContext.getKsqlConfig().getLong(
         KsqlConfig.KSQL_SUPPRESS_BUFFER_SIZE_BYTES);
 
     if (maxBytes < 0) {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
@@ -17,11 +17,11 @@ package io.confluent.ksql.execution.streams;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableSuppress;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -46,7 +46,7 @@ public final class TableSuppressBuilder {
   public <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSuppress<K> step,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final ExecutionKeyFactory<K> executionKeyFactory
   ) {
     return build(
@@ -64,7 +64,7 @@ public final class TableSuppressBuilder {
   <K> KTableHolder<K> build(
       final KTableHolder<K> table,
       final TableSuppress<K> step,
-      final KsqlQueryBuilder queryBuilder,
+      final RuntimeBuildContext queryBuilder,
       final ExecutionKeyFactory<K> executionKeyFactory,
       final PhysicalSchemaFactory physicalSchemaFactory,
       final BiFunction<Serde<K>, Serde<GenericRow>, Materialized> materializedFactory

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
@@ -120,7 +120,7 @@ public class PartitionByParamsFactoryTest {
   @Mock
   private UdfFactory constantUdfFactory;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
 
   private final GenericKey key = genericKey(OLD_KEY);
   private final GenericRow value = new GenericRow();
@@ -496,7 +496,7 @@ public class PartitionByParamsFactoryTest {
   }
 
   private PartitionByParams<GenericKey> partitionBy(final List<Expression> expression) {
-    final ExecutionKeyFactory<GenericKey> factory = ExecutionKeyFactory.unwindowed(queryBuilder);
+    final ExecutionKeyFactory<GenericKey> factory = ExecutionKeyFactory.unwindowed(buildContext);
 
     return PartitionByParamsFactory
         .build(

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/PartitionByParamsFactoryTest.java
@@ -29,7 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression.Sign;
@@ -120,7 +120,7 @@ public class PartitionByParamsFactoryTest {
   @Mock
   private UdfFactory constantUdfFactory;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
 
   private final GenericKey key = genericKey(OLD_KEY);
   private final GenericRow value = new GenericRow();

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SinkBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SinkBuilderTest.java
@@ -79,7 +79,7 @@ public class SinkBuilderTest {
       .from(SCHEMA.withoutPseudoAndKeyColsInValue(), SerdeFeatures.of(), SerdeFeatures.of());
 
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private ExecutionKeyFactory<Struct> executionKeyFactory;
   @Mock
@@ -105,8 +105,8 @@ public class SinkBuilderTest {
   public void setup() {
     when(executionKeyFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
 
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valSerde);
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.buildValueSerde(any(), any(), any())).thenReturn(valSerde);
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
     when(queryContext.getContext()).thenReturn(ImmutableList.of(QUERY_CONTEXT_NAME));
   }
 
@@ -125,7 +125,7 @@ public class SinkBuilderTest {
     buildDefaultSinkBuilder();
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         VALUE_FORMAT,
         PHYSICAL_SCHEMA,
         queryContext
@@ -161,7 +161,7 @@ public class SinkBuilderTest {
         kStream,
         executionKeyFactory,
         queryContext,
-        queryBuilder
+        buildContext
     );
 
     // Then
@@ -285,7 +285,7 @@ public class SinkBuilderTest {
         kStream,
         executionKeyFactory,
         queryContext,
-        queryBuilder
+        buildContext
     );
   }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SinkBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SinkBuilderTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
@@ -79,7 +79,7 @@ public class SinkBuilderTest {
       .from(SCHEMA.withoutPseudoAndKeyColsInValue(), SerdeFeatures.of(), SerdeFeatures.of());
 
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private ExecutionKeyFactory<Struct> executionKeyFactory;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.plan.ExecutionStep;
@@ -143,7 +143,7 @@ public class SourceBuilderTest {
 
   private final QueryContext ctx = new Stacker().push("base").push("source").getQueryContext();
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private StreamsBuilder streamsBuilder;
   @Mock
@@ -204,6 +204,7 @@ public class SourceBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void setup() {
+    when(queryBuilder.getApplicationId()).thenReturn("appid");
     when(queryBuilder.getStreamsBuilder()).thenReturn(streamsBuilder);
     when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
     when(streamsBuilder.stream(anyString(), any(Consumed.class))).thenReturn(kStream);
@@ -216,7 +217,6 @@ public class SourceBuilderTest {
     when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
     when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
     when(queryBuilder.getServiceContext()).thenReturn(serviceContext);
-    when(queryBuilder.getQueryId()).thenReturn(new QueryId("id"));
     when(queryBuilder.getKsqlConfig()).thenReturn(KSQL_CONFIG);
     when(processorCtx.timestamp()).thenReturn(A_ROWTIME);
     when(serviceContext.getSchemaRegistryClient()).thenReturn(srClient);
@@ -353,7 +353,7 @@ public class SourceBuilderTest {
 
     verify(consumed).withValueSerde(serdeCaptor.capture());
     final StaticTopicSerde<GenericRow> value = serdeCaptor.getValue();
-    assertThat(value.getTopic(), is("_confluent-ksql-default_query_id-base-Reduce-changelog"));
+    assertThat(value.getTopic(), is("appid-base-Reduce-changelog"));
   }
 
   @Test

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -160,7 +160,7 @@ public class StreamAggregateBuilderTest {
   @Mock
   private KTable<Windowed<GenericKey>, GenericRow> windowedWithWindowBounds;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -160,7 +160,7 @@ public class StreamAggregateBuilderTest {
   @Mock
   private KTable<Windowed<GenericKey>, GenericRow> windowedWithWindowBounds;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock
@@ -206,9 +206,9 @@ public class StreamAggregateBuilderTest {
   @Before
   public void init() {
     when(sourceStep.build(any(), eq(planInfo))).thenReturn(KGroupedStreamHolder.of(groupedStream, INPUT_SCHEMA));
-    when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(buildContext.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
     when(aggregateParamsFactory.create(any(), any(), any(), any(), anyBoolean()))
         .thenReturn(aggregateParams);
     when(aggregateParams.getAggregator()).thenReturn((KudafAggregator) aggregator);
@@ -219,7 +219,7 @@ public class StreamAggregateBuilderTest {
     when(aggregateParams.getInitializer()).thenReturn(initializer);
 
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        buildContext,
         mock(SqlPredicateFactory.class),
         aggregateParamsFactory,
         new StreamsFactories(
@@ -396,7 +396,7 @@ public class StreamAggregateBuilderTest {
     aggregate.build(planBuilder, planInfo);
 
     // Then:
-    verify(queryBuilder).buildKeySerde(KEY_FORMAT, PHYSICAL_AGGREGATE_SCHEMA, MATERIALIZE_CTX);
+    verify(buildContext).buildKeySerde(KEY_FORMAT, PHYSICAL_AGGREGATE_SCHEMA, MATERIALIZE_CTX);
   }
 
   @Test
@@ -408,7 +408,7 @@ public class StreamAggregateBuilderTest {
     aggregate.build(planBuilder, planInfo);
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         VALUE_FORMAT,
         PHYSICAL_AGGREGATE_SCHEMA,
         MATERIALIZE_CTX
@@ -595,14 +595,14 @@ public class StreamAggregateBuilderTest {
   public void shouldBuildKeySerdeCorrectlyForWindowedAggregate() {
     for (final Runnable given : given()) {
       // Given:
-      clearInvocations(groupedStream, timeWindowedStream, sessionWindowedStream, aggregated, queryBuilder);
+      clearInvocations(groupedStream, timeWindowedStream, sessionWindowedStream, aggregated, buildContext);
       given.run();
 
       // When:
       windowedAggregate.build(planBuilder, planInfo);
 
       // Then:
-      verify(queryBuilder)
+      verify(buildContext)
           .buildKeySerde(KEY_FORMAT, PHYSICAL_AGGREGATE_SCHEMA, MATERIALIZE_CTX);
     }
   }
@@ -611,7 +611,7 @@ public class StreamAggregateBuilderTest {
   public void shouldReturnCorrectSerdeForWindowedAggregate() {
     for (final Runnable given : given()) {
       // Given:
-      clearInvocations(groupedStream, timeWindowedStream, sessionWindowedStream, aggregated, queryBuilder);
+      clearInvocations(groupedStream, timeWindowedStream, sessionWindowedStream, aggregated, buildContext);
       given.run();
 
       // When:
@@ -623,7 +623,7 @@ public class StreamAggregateBuilderTest {
       final PhysicalSchema mockSchema = mock(PhysicalSchema.class);
       final QueryContext mockCtx = mock(QueryContext.class);
       serdeFactory.buildKeySerde(mockFormat, mockSchema, mockCtx);
-      verify(queryBuilder).buildKeySerde(
+      verify(buildContext).buildKeySerde(
           same(mockFormat),
           eq(windowedAggregate.getWindowExpression().getWindowInfo()),
           same(mockSchema),
@@ -636,14 +636,14 @@ public class StreamAggregateBuilderTest {
   public void shouldBuildValueSerdeCorrectlyForWindowedAggregate() {
     for (final Runnable given : given()) {
       // Given:
-      clearInvocations(groupedStream, timeWindowedStream, sessionWindowedStream, aggregated, queryBuilder);
+      clearInvocations(groupedStream, timeWindowedStream, sessionWindowedStream, aggregated, buildContext);
       given.run();
 
       // When:
       windowedAggregate.build(planBuilder, planInfo);
 
       // Then:
-      verify(queryBuilder)
+      verify(buildContext)
           .buildValueSerde(VALUE_FORMAT, PHYSICAL_AGGREGATE_SCHEMA, MATERIALIZE_CTX);
     }
   }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
@@ -46,7 +46,7 @@ public class StreamFilterBuilderTest {
   @Mock
   private KsqlTransformer<GenericKey, Optional<GenericRow>> predicate;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private ProcessingLogger processingLogger;
   @Mock
@@ -83,7 +83,6 @@ public class StreamFilterBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(queryBuilder.getQueryId()).thenReturn(new QueryId("foo"));
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
@@ -46,7 +46,7 @@ public class StreamFilterBuilderTest {
   @Mock
   private KsqlTransformer<GenericKey, Optional<GenericRow>> predicate;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private ProcessingLogger processingLogger;
   @Mock
@@ -83,9 +83,9 @@ public class StreamFilterBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
     when(sourceStep.getProperties()).thenReturn(sourceProperties);
     when(sourceKStream
         .flatTransformValues(any(ValueTransformerWithKeySupplier.class), any(Named.class)))
@@ -99,7 +99,7 @@ public class StreamFilterBuilderTest {
     ));
     final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(queryContext);
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        buildContext,
         predicateFactory,
         mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
@@ -146,6 +146,6 @@ public class StreamFilterBuilderTest {
     step.build(planBuilder, planInfo);
 
     // Then:
-    verify(queryBuilder).getProcessingLogger(queryContext);
+    verify(buildContext).getProcessingLogger(queryContext);
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -93,7 +93,7 @@ public class StreamGroupByBuilderTest {
   );
 
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -145,11 +145,11 @@ public class StreamGroupByBuilderTest {
     when(groupByParams.getSchema()).thenReturn(REKEYED_SCHEMA);
     when(groupByParams.getMapper()).thenReturn(mapper);
 
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(buildContext.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
     when(groupedFactory.create(any(), any(Serde.class), any())).thenReturn(grouped);
     when(sourceStream.groupByKey(any(Grouped.class))).thenReturn(groupedStream);
     when(sourceStream.filter(any())).thenReturn(filteredStream);
@@ -165,7 +165,7 @@ public class StreamGroupByBuilderTest {
 
     groupByKey = new StreamGroupByKey(PROPERTIES, sourceStep, FORMATS);
 
-    builder = new StreamGroupByBuilder(queryBuilder, groupedFactory, paramsFactory);
+    builder = new StreamGroupByBuilder(buildContext, groupedFactory, paramsFactory);
   }
 
   @Test
@@ -229,7 +229,7 @@ public class StreamGroupByBuilderTest {
     buildGroupBy(builder, streamHolder, groupBy);
 
     // Then:
-    verify(queryBuilder).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         FORMATS.getKeyFormat(),
         REKEYED_PHYSICAL_SCHEMA,
         STEP_CTX
@@ -242,7 +242,7 @@ public class StreamGroupByBuilderTest {
     buildGroupBy(builder, streamHolder, groupBy);
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         FORMATS.getValueFormat(),
         REKEYED_PHYSICAL_SCHEMA,
         STEP_CTX
@@ -293,7 +293,7 @@ public class StreamGroupByBuilderTest {
     builder.build(streamHolder, groupByKey);
 
     // Then:
-    verify(queryBuilder).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         FORMATS.getKeyFormat(),
         PHYSICAL_SCHEMA,
         STEP_CTX);
@@ -305,7 +305,7 @@ public class StreamGroupByBuilderTest {
     builder.build(streamHolder, groupByKey);
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         FORMATS.getValueFormat(),
         PHYSICAL_SCHEMA,
         STEP_CTX

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -93,7 +93,7 @@ public class StreamGroupByBuilderTest {
   );
 
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderV1Test.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -93,7 +93,7 @@ public class StreamGroupByBuilderV1Test {
   );
 
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderV1Test.java
@@ -93,7 +93,7 @@ public class StreamGroupByBuilderV1Test {
   );
 
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -145,11 +145,11 @@ public class StreamGroupByBuilderV1Test {
     when(groupByParams.getSchema()).thenReturn(REKEYED_SCHEMA);
     when(groupByParams.getMapper()).thenReturn(mapper);
 
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(buildContext.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
     when(groupedFactory.create(any(), any(Serde.class), any())).thenReturn(grouped);
     when(sourceStream.groupByKey(any(Grouped.class))).thenReturn(groupedStream);
     when(sourceStream.filter(any())).thenReturn(filteredStream);
@@ -165,7 +165,7 @@ public class StreamGroupByBuilderV1Test {
 
     groupByKey = new StreamGroupByKey(PROPERTIES, sourceStep, FORMATS);
 
-    builder = new StreamGroupByBuilderV1(queryBuilder, groupedFactory, paramsFactory);
+    builder = new StreamGroupByBuilderV1(buildContext, groupedFactory, paramsFactory);
   }
 
   @Test
@@ -229,7 +229,7 @@ public class StreamGroupByBuilderV1Test {
     buildGroupBy(builder, streamHolder, groupBy);
 
     // Then:
-    verify(queryBuilder).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         FORMATS.getKeyFormat(),
         REKEYED_PHYSICAL_SCHEMA,
         STEP_CTX
@@ -242,7 +242,7 @@ public class StreamGroupByBuilderV1Test {
     buildGroupBy(builder, streamHolder, groupBy);
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         FORMATS.getValueFormat(),
         REKEYED_PHYSICAL_SCHEMA,
         STEP_CTX
@@ -293,7 +293,7 @@ public class StreamGroupByBuilderV1Test {
     builder.build(streamHolder, groupByKey);
 
     // Then:
-    verify(queryBuilder).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         FORMATS.getKeyFormat(),
         PHYSICAL_SCHEMA,
         STEP_CTX);
@@ -305,7 +305,7 @@ public class StreamGroupByBuilderV1Test {
     builder.build(streamHolder, groupByKey);
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         FORMATS.getValueFormat(),
         PHYSICAL_SCHEMA,
         STEP_CTX

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
@@ -89,7 +89,7 @@ public class StreamSelectBuilderTest {
   @Mock
   private KStream<Struct, GenericRow> resultKStream;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -113,9 +113,9 @@ public class StreamSelectBuilderTest {
   @Before
   public void setup() {
     when(properties.getQueryContext()).thenReturn(context);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(mock(FunctionRegistry.class));
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(mock(FunctionRegistry.class));
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
     when(sourceKStream
         .transformValues(any(ValueTransformerWithKeySupplier.class), any(Named.class)))
         .thenReturn(resultKStream);
@@ -129,7 +129,7 @@ public class StreamSelectBuilderTest {
         SELECT_EXPRESSIONS
     );
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        buildContext,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
@@ -206,6 +206,6 @@ public class StreamSelectBuilderTest {
     step.build(planBuilder, planInfo);
 
     // Then:
-    verify(queryBuilder).getProcessingLogger(context);
+    verify(buildContext).getProcessingLogger(context);
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
@@ -89,7 +89,7 @@ public class StreamSelectBuilderTest {
   @Mock
   private KStream<Struct, GenericRow> resultKStream;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -92,7 +92,7 @@ public class StreamSelectKeyBuilderTest {
   @Mock
   private ExecutionStep<KStreamHolder<GenericKey>> sourceStep;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock
@@ -124,9 +124,9 @@ public class StreamSelectKeyBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.getKsqlConfig()).thenReturn(CONFIG);
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.getKsqlConfig()).thenReturn(CONFIG);
 
     when(paramBuilder.build(any(), eq(keyFactory), any(), any(), any(), any())).thenReturn(params);
 
@@ -139,7 +139,7 @@ public class StreamSelectKeyBuilderTest {
     when(stream.getExecutionKeyFactory()).thenReturn(keyFactory);
     when(keyFactory.withQueryBuilder(any())).thenReturn(keyFactory);
     when(keyFactory.buildKeySerde(any(), any(), any()))
-        .thenAnswer(inv -> queryBuilder.buildKeySerde(
+        .thenAnswer(inv -> buildContext.buildKeySerde(
             inv.getArgument(0), inv.getArgument(1), inv.getArgument(2)));
 
     when(kstream.map(any(KeyValueMapper.class), any(Named.class))).thenReturn(rekeyedKstream);
@@ -155,7 +155,7 @@ public class StreamSelectKeyBuilderTest {
   public void shouldPassCorrectArgsToParamBuilder() {
     // When:
     StreamSelectKeyBuilder
-        .build(stream, selectKey, queryBuilder, paramBuilder);
+        .build(stream, selectKey, buildContext, paramBuilder);
 
     // Then:
     verify(paramBuilder).build(
@@ -172,7 +172,7 @@ public class StreamSelectKeyBuilderTest {
   public void shouldUserMapperInMapCall() {
     // When:
     StreamSelectKeyBuilder
-        .build(stream, selectKey, queryBuilder, paramBuilder);
+        .build(stream, selectKey, buildContext, paramBuilder);
 
     // Then:
     verify(kstream).map(mapperCaptor.capture(), any());
@@ -191,7 +191,7 @@ public class StreamSelectKeyBuilderTest {
   public void shouldUseCorrectNameInMapCall() {
     // When:
     StreamSelectKeyBuilder
-        .build(stream, selectKey, queryBuilder, paramBuilder);
+        .build(stream, selectKey, buildContext, paramBuilder);
 
     // Then:
     verify(kstream).map(any(), nameCaptor.capture());
@@ -203,7 +203,7 @@ public class StreamSelectKeyBuilderTest {
   public void shouldOnlyMap() {
     // When:
     StreamSelectKeyBuilder
-        .build(stream, selectKey, queryBuilder, paramBuilder);
+        .build(stream, selectKey, buildContext, paramBuilder);
 
     // Then:
     verify(kstream).map(any(), any());
@@ -214,7 +214,7 @@ public class StreamSelectKeyBuilderTest {
   public void shouldReturnRekeyedStream() {
     // When:
     final KStreamHolder<GenericKey> result = StreamSelectKeyBuilder
-        .build(stream, selectKey, queryBuilder, paramBuilder);
+        .build(stream, selectKey, buildContext, paramBuilder);
 
     // Then:
     assertThat(result.getStream(), is(rekeyedKstream));
@@ -224,7 +224,7 @@ public class StreamSelectKeyBuilderTest {
   public void shouldReturnCorrectSchema() {
     // When:
     final KStreamHolder<GenericKey> result = StreamSelectKeyBuilder
-        .build(stream, selectKey, queryBuilder, paramBuilder);
+        .build(stream, selectKey, buildContext, paramBuilder);
 
     // Then:
     assertThat(result.getSchema(), is(RESULT_SCHEMA));
@@ -234,7 +234,7 @@ public class StreamSelectKeyBuilderTest {
   public void shouldReturnCorrectSerdeFactory() {
     // When:
     final KStreamHolder<GenericKey> result = StreamSelectKeyBuilder
-        .build(stream, selectKey, queryBuilder, paramBuilder);
+        .build(stream, selectKey, buildContext, paramBuilder);
 
     // Then:
     result.getExecutionKeyFactory().buildKeySerde(
@@ -243,7 +243,7 @@ public class StreamSelectKeyBuilderTest {
         queryContext
     );
 
-    verify(queryBuilder).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         FormatInfo.of(FormatFactory.JSON.name()),
         PhysicalSchema.from(SOURCE_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of()),
         queryContext);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -92,7 +92,7 @@ public class StreamSelectKeyBuilderTest {
   @Mock
   private ExecutionStep<KStreamHolder<GenericKey>> sourceStep;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
@@ -94,7 +94,7 @@ public class StreamSelectKeyBuilderV1Test {
   @Mock
   private ExecutionStep<KStreamHolder<GenericKey>> sourceStep;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderV1Test.java
@@ -94,7 +94,7 @@ public class StreamSelectKeyBuilderV1Test {
   @Mock
   private ExecutionStep<KStreamHolder<GenericKey>> sourceStep;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock
@@ -113,14 +113,14 @@ public class StreamSelectKeyBuilderV1Test {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of()));
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.getKsqlConfig()).thenReturn(new KsqlConfig(ImmutableMap.of()));
     when(kstream.filter(any())).thenReturn(filteredKStream);
     when(filteredKStream.selectKey(any(KeyValueMapper.class))).thenReturn(rekeyedKstream);
     when(sourceStep.build(any(), eq(planInfo))).thenReturn(
         new KStreamHolder<>(kstream, SOURCE_SCHEMA, mock(ExecutionKeyFactory.class)));
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        buildContext,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
@@ -156,7 +156,7 @@ public class StreamSelectKeyBuilderV1Test {
         PhysicalSchema.from(SOURCE_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of()),
         queryContext
     );
-    verify(queryBuilder).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         FormatInfo.of(FormatFactory.JSON.name()),
         PhysicalSchema.from(SOURCE_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of()),
         queryContext);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -122,7 +122,7 @@ public class StreamStreamJoinBuilderTest {
   @Mock
   private StreamJoinedFactory streamJoinedFactory;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private ExecutionKeyFactory<Struct> executionKeyFactory;
   @Mock
@@ -141,9 +141,9 @@ public class StreamStreamJoinBuilderTest {
   @SuppressWarnings("unchecked")
   public void init() {
     when(executionKeyFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(FormatFactory.JSON.name())), any(), any()))
+    when(buildContext.buildValueSerde(eq(FormatInfo.of(FormatFactory.JSON.name())), any(), any()))
         .thenReturn(leftSerde);
-    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(FormatFactory.AVRO.name())), any(), any()))
+    when(buildContext.buildValueSerde(eq(FormatInfo.of(FormatFactory.AVRO.name())), any(), any()))
         .thenReturn(rightSerde);
     when(streamJoinedFactory.create(any(Serde.class), any(Serde.class), any(Serde.class), anyString(), anyString())).thenReturn(joined);
     when(left.build(any(), eq(planInfo))).thenReturn(
@@ -156,7 +156,7 @@ public class StreamStreamJoinBuilderTest {
     when(leftKStream.join(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
 
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        buildContext,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),
         new StreamsFactories(
@@ -346,7 +346,7 @@ public class StreamStreamJoinBuilderTest {
 
     // Then:
     final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("Left").getQueryContext();
-    verify(queryBuilder).buildValueSerde(FormatInfo.of(FormatFactory.JSON.name()), LEFT_PHYSICAL, leftCtx);
+    verify(buildContext).buildValueSerde(FormatInfo.of(FormatFactory.JSON.name()), LEFT_PHYSICAL, leftCtx);
   }
 
   @Test
@@ -359,7 +359,7 @@ public class StreamStreamJoinBuilderTest {
 
     // Then:
     final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("Right").getQueryContext();
-    verify(queryBuilder).buildValueSerde(FormatInfo.of(FormatFactory.AVRO.name()), RIGHT_PHYSICAL, leftCtx);
+    verify(buildContext).buildValueSerde(FormatInfo.of(FormatFactory.AVRO.name()), RIGHT_PHYSICAL, leftCtx);
   }
 
   private void givenLeftJoin(final ColumnName keyName) {

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
@@ -122,7 +122,7 @@ public class StreamStreamJoinBuilderTest {
   @Mock
   private StreamJoinedFactory streamJoinedFactory;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private ExecutionKeyFactory<Struct> executionKeyFactory;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
@@ -93,7 +93,7 @@ public class StreamTableJoinBuilderTest {
   @Mock
   private JoinedFactory joinedFactory;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private ExecutionKeyFactory<Struct> executionKeyFactory;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -93,7 +93,7 @@ public class StreamTableJoinBuilderTest {
   @Mock
   private JoinedFactory joinedFactory;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private ExecutionKeyFactory<Struct> executionKeyFactory;
   @Mock
@@ -110,7 +110,7 @@ public class StreamTableJoinBuilderTest {
   @SuppressWarnings("unchecked")
   public void init() {
     when(executionKeyFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(FormatFactory.JSON.name())), any(), any()))
+    when(buildContext.buildValueSerde(eq(FormatInfo.of(FormatFactory.JSON.name())), any(), any()))
         .thenReturn(leftSerde);
     when(joinedFactory.create(any(Serde.class), any(), any(), any())).thenReturn(joined);
     when(left.build(any(), eq(planInfo))).thenReturn(
@@ -122,7 +122,7 @@ public class StreamTableJoinBuilderTest {
     when(leftKStream.join(any(KTable.class), any(), any())).thenReturn(resultStream);
 
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        buildContext,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),
         new StreamsFactories(
@@ -294,7 +294,7 @@ public class StreamTableJoinBuilderTest {
 
     // Then:
     final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("Left").getQueryContext();
-    verify(queryBuilder).buildValueSerde(FormatInfo.of(FormatFactory.JSON.name()), LEFT_PHYSICAL, leftCtx);
+    verify(buildContext).buildValueSerde(FormatInfo.of(FormatFactory.JSON.name()), LEFT_PHYSICAL, leftCtx);
   }
 
   private void givenLeftJoin(final ColumnName keyName) {

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -120,7 +120,7 @@ public class TableAggregateBuilderTest {
   @Mock
   private KTable<GenericKey, GenericRow> aggregatedWithResults;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -120,7 +120,7 @@ public class TableAggregateBuilderTest {
   @Mock
   private KTable<GenericKey, GenericRow> aggregatedWithResults;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private FunctionRegistry functionRegistry;
   @Mock
@@ -156,9 +156,9 @@ public class TableAggregateBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(buildContext.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
     when(aggregateParamsFactory.createUndoable(any(), any(), any(), any()))
         .thenReturn(aggregateParams);
     when(aggregateParams.getAggregator()).thenReturn((KudafAggregator)aggregator);
@@ -182,7 +182,7 @@ public class TableAggregateBuilderTest {
     );
     when(sourceStep.build(any(), eq(planInfo))).thenReturn(KGroupedTableHolder.of(groupedTable, INPUT_SCHEMA));
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        buildContext,
         mock(SqlPredicateFactory.class),
         aggregateParamsFactory,
         new StreamsFactories(
@@ -241,7 +241,7 @@ public class TableAggregateBuilderTest {
     aggregate.build(planBuilder, planInfo);
 
     // Then:
-    verify(queryBuilder).buildKeySerde(KEY_FORMAT, PHYSICAL_AGGREGATE_SCHEMA, MATERIALIZE_CTX);
+    verify(buildContext).buildKeySerde(KEY_FORMAT, PHYSICAL_AGGREGATE_SCHEMA, MATERIALIZE_CTX);
   }
 
   @Test
@@ -250,7 +250,7 @@ public class TableAggregateBuilderTest {
     aggregate.build(planBuilder, planInfo);
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         VALUE_FORMAT,
         PHYSICAL_AGGREGATE_SCHEMA,
         MATERIALIZE_CTX

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
@@ -52,7 +52,7 @@ public class TableFilterBuilderTest {
   @Mock
   private KsqlTransformer<Struct, Optional<GenericRow>> preTransformer;
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private ProcessingLogger processingLogger;
   @Mock
@@ -104,9 +104,9 @@ public class TableFilterBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
     when(sourceStep.getProperties()).thenReturn(sourceProperties);
     when(sourceKTable.transformValues(any(), any(Named.class))).thenReturn((KTable)preKTable);
     when(preKTable.filter(any(), any(Named.class))).thenReturn((KTable)filteredKTable);
@@ -121,7 +121,7 @@ public class TableFilterBuilderTest {
     ;
     when(preTransformer.transform(any(), any(), any())).thenReturn(Optional.empty());
     planBuilder = new KSPlanBuilder(
-        queryBuilder,
+        buildContext,
         predicateFactory,
         mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
@@ -167,7 +167,7 @@ public class TableFilterBuilderTest {
     step.build(planBuilder, planInfo);
 
     // Then:
-    verify(queryBuilder).getProcessingLogger(queryContext);
+    verify(buildContext).getProcessingLogger(queryContext);
   }
 
   @Test

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
@@ -9,7 +9,7 @@
  import static org.mockito.Mockito.when;
 
  import io.confluent.ksql.GenericRow;
- import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+ import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
  import io.confluent.ksql.execution.context.QueryContext;
  import io.confluent.ksql.execution.expression.tree.Expression;
  import io.confluent.ksql.execution.materialization.MaterializationInfo;
@@ -52,7 +52,7 @@ public class TableFilterBuilderTest {
   @Mock
   private KsqlTransformer<Struct, Optional<GenericRow>> preTransformer;
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private ProcessingLogger processingLogger;
   @Mock
@@ -104,7 +104,6 @@ public class TableFilterBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(queryBuilder.getQueryId()).thenReturn(new QueryId("foo"));
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -105,7 +105,7 @@ public class TableGroupByBuilderTest {
   private static final GenericKey KEY = GenericKey.genericKey("key");
 
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -105,7 +105,7 @@ public class TableGroupByBuilderTest {
   private static final GenericKey KEY = GenericKey.genericKey("key");
 
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -156,11 +156,11 @@ public class TableGroupByBuilderTest {
     when(groupByParams.getSchema()).thenReturn(REKEYED_SCHEMA);
     when(groupByParams.getMapper()).thenReturn(mapper);
 
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(buildContext.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
     when(groupedFactory.create(any(), any(Serde.class), any())).thenReturn(grouped);
     when(sourceTable.filter(any())).thenReturn(filteredTable);
     when(filteredTable.groupBy(any(KeyValueMapper.class), any(Grouped.class)))
@@ -173,7 +173,7 @@ public class TableGroupByBuilderTest {
         GROUPBY_EXPRESSIONS
     );
 
-    builder = new TableGroupByBuilder(queryBuilder, groupedFactory, paramsFactory);
+    builder = new TableGroupByBuilder(buildContext, groupedFactory, paramsFactory);
   }
 
   @Test
@@ -237,7 +237,7 @@ public class TableGroupByBuilderTest {
     build(builder, tableHolder, groupBy);
 
     // Then:
-    verify(queryBuilder).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         FORMATS.getKeyFormat(),
         REKEYED_PHYSICAL_SCHEMA,
         STEP_CONTEXT
@@ -250,7 +250,7 @@ public class TableGroupByBuilderTest {
     build(builder, tableHolder, groupBy);
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         FORMATS.getValueFormat(),
         REKEYED_PHYSICAL_SCHEMA,
         STEP_CONTEXT

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderV1Test.java
@@ -105,7 +105,7 @@ public class TableGroupByBuilderV1Test {
   private static final GenericKey KEY = GenericKey.genericKey("key");
 
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -156,11 +156,11 @@ public class TableGroupByBuilderV1Test {
     when(groupByParams.getSchema()).thenReturn(REKEYED_SCHEMA);
     when(groupByParams.getMapper()).thenReturn(mapper);
 
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
-    when(queryBuilder.getProcessingLogger(any())).thenReturn(processingLogger);
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(buildContext.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(buildContext.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(buildContext.getProcessingLogger(any())).thenReturn(processingLogger);
     when(groupedFactory.create(any(), any(Serde.class), any())).thenReturn(grouped);
     when(sourceTable.filter(any())).thenReturn(filteredTable);
     when(filteredTable.groupBy(any(KeyValueMapper.class), any(Grouped.class)))
@@ -173,7 +173,7 @@ public class TableGroupByBuilderV1Test {
         GROUPBY_EXPRESSIONS
     );
 
-    builder = new TableGroupByBuilderV1(queryBuilder, groupedFactory, paramsFactory);
+    builder = new TableGroupByBuilderV1(buildContext, groupedFactory, paramsFactory);
   }
 
   @Test
@@ -237,7 +237,7 @@ public class TableGroupByBuilderV1Test {
     build(builder, tableHolder, groupBy);
 
     // Then:
-    verify(queryBuilder).buildKeySerde(
+    verify(buildContext).buildKeySerde(
         FORMATS.getKeyFormat(),
         REKEYED_PHYSICAL_SCHEMA,
         STEP_CONTEXT
@@ -250,7 +250,7 @@ public class TableGroupByBuilderV1Test {
     build(builder, tableHolder, groupBy);
 
     // Then:
-    verify(queryBuilder).buildValueSerde(
+    verify(buildContext).buildValueSerde(
         FORMATS.getValueFormat(),
         REKEYED_PHYSICAL_SCHEMA,
         STEP_CONTEXT

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderV1Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderV1Test.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -105,7 +105,7 @@ public class TableGroupByBuilderV1Test {
   private static final GenericKey KEY = GenericKey.genericKey("key");
 
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableSuppressBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableSuppressBuilderTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
@@ -54,7 +54,7 @@ import org.mockito.junit.MockitoRule;
 public class TableSuppressBuilderTest {
 
   @Mock
-  private KsqlQueryBuilder queryBuilder;
+  private RuntimeBuildContext queryBuilder;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableSuppressBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableSuppressBuilderTest.java
@@ -54,7 +54,7 @@ import org.mockito.junit.MockitoRule;
 public class TableSuppressBuilderTest {
 
   @Mock
-  private RuntimeBuildContext queryBuilder;
+  private RuntimeBuildContext buildContext;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -108,9 +108,9 @@ public class TableSuppressBuilderTest {
     when(physicalSchemaFactory.create(any(), any(), any())).thenReturn(physicalSchema);
     materializedFactory = (a,b) -> materialized;
 
-    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(buildContext.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
     when(executionKeyFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(buildContext.getKsqlConfig()).thenReturn(ksqlConfig);
     when(ksqlConfig.getLong(any())).thenReturn(maxBytes);
 
     when(tableHolder.getTable()).thenReturn(sourceKTable);
@@ -126,7 +126,7 @@ public class TableSuppressBuilderTest {
   @SuppressWarnings("unchecked")
   public void shouldSuppressSourceTable() {
     // When:
-    final KTableHolder<Struct> result = builder.build(tableHolder, tableSuppress, queryBuilder, executionKeyFactory, physicalSchemaFactory, materializedFactory);
+    final KTableHolder<Struct> result = builder.build(tableHolder, tableSuppress, buildContext, executionKeyFactory, physicalSchemaFactory, materializedFactory);
 
     // Then:
     assertThat(result, is(suppressedtable));

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
@@ -88,7 +88,7 @@ public class TableTableJoinBuilderTest {
     when(leftKTable.join(any(KTable.class), any())).thenReturn(resultKTable);
 
     planBuilder = new KSPlanBuilder(
-        mock(KsqlQueryBuilder.class),
+        mock(RuntimeBuildContext.class),
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)


### PR DESCRIPTION
### Description 
Fixes #6817 plus a small refactor (most of the diff is the refactor):
- Split up KsqlQueryBuilder into PlanBuildContext and RuntimeBuildContext. PlanBuildContext
  contains all the context required to build an execution plan from a logical plan.
  RuntimeBuildContext contains all the context required to build the final runtime topology
  from an execution plan. Ultimately we should make this more abstract to support different
  runtimes, but for now the assumed runtime is Kafka Streams.
- Add the application id to RuntimeBuildContext
- Use the application id to construct the fallback subject name.

### Testing done 
updated unit tests according to the above
