### PR TITLE
refactor: wrap Vert.x SSL configurations inside a VertxSslOptionsFactory class

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/WebsocketUtils.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/WebsocketUtils.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.cli;
 
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.util.VertxSslOptionsFactory;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientOptions;
@@ -25,11 +26,11 @@ import io.vertx.core.net.JksOptions;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
-import org.apache.kafka.common.config.SslConfigs;
 
 public class WebsocketUtils {
 
@@ -49,26 +50,13 @@ public class WebsocketUtils {
       if (tls) {
         httpClientOptions.setSsl(true).setVerifyHost(false);
 
-        String trustStorePath = clientProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
-        String trustStorePassword = clientProps.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
-        String keyStorePath = clientProps.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
-        String keyStorePassword = clientProps.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+        final Optional<JksOptions> trustStoreOptions =
+            VertxSslOptionsFactory.getJksTrustStoreOptions(clientProps);
+        final Optional<JksOptions> keyStoreOptions =
+            VertxSslOptionsFactory.buildJksKeyStoreOptions(clientProps, Optional.empty());
 
-        if (trustStorePath != null) {
-          JksOptions trustStoreOptions = new JksOptions().setPath(trustStorePath);
-          if (trustStorePassword != null) {
-            trustStoreOptions.setPassword(trustStorePassword);
-          }
-          httpClientOptions.setTrustStoreOptions(trustStoreOptions);
-        }
-
-        if (keyStorePath != null) {
-          JksOptions keyStoreOptions = new JksOptions().setPath(keyStorePath);
-          if (keyStorePassword != null) {
-            keyStoreOptions.setPassword(keyStorePassword);
-          }
-          httpClientOptions.setKeyStoreOptions(keyStoreOptions);
-        }
+        trustStoreOptions.ifPresent(options -> httpClientOptions.setTrustStoreOptions(options));
+        keyStoreOptions.ifPresent(options -> httpClientOptions.setKeyStoreOptions(options));
       }
 
       httpClient = vertx.createHttpClient(httpClientOptions);

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertiesUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertiesUtil.java
@@ -78,6 +78,20 @@ public final class PropertiesUtil {
   }
 
   /**
+   * Convert object properties values to its string form.
+   *
+   * @param props The map that contains values of different type.
+   * @return A map with all values converted to strings.
+   */
+  public static Map<String, String> toMapStrings(final Map<String, Object> props) {
+    final Map<String, String> stringsProps = new HashMap<>();
+    for (Map.Entry<String, Object> entry : props.entrySet()) {
+      stringsProps.put(entry.getKey(), entry.getValue().toString());
+    }
+    return stringsProps;
+  }
+
+  /**
    * Apply non-blacklisted entries in the suplied {@code overrides} to the supplied {@code props}.
    *
    * @param props the props to overwrite with sys props.

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertiesUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/PropertiesUtil.java
@@ -86,7 +86,7 @@ public final class PropertiesUtil {
   public static Map<String, String> toMapStrings(final Map<String, Object> props) {
     final Map<String, String> stringsProps = new HashMap<>();
     for (Map.Entry<String, Object> entry : props.entrySet()) {
-      stringsProps.put(entry.getKey(), entry.getValue().toString());
+      stringsProps.put(entry.getKey(), String.valueOf(entry.getValue()));
     }
     return stringsProps;
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KeystoreUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KeystoreUtil.java
@@ -13,9 +13,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.rest.util;
+package io.confluent.ksql.util;
 
-import io.confluent.ksql.util.KsqlException;
 import io.vertx.core.buffer.Buffer;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/VertxSslOptionsFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/VertxSslOptionsFactory.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.base.Strings;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.PfxOptions;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.config.SslConfigs;
+
+public final class VertxSslOptionsFactory {
+  private static final String SSL_STORE_TYPE_JKS = "JKS";
+
+  private VertxSslOptionsFactory() {
+  }
+
+  private static String getTrustStoreLocation(final Map<String, String> props) {
+    return props.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+  }
+
+  private static String getTrustStorePassword(final Map<String, String> props) {
+    return props.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+  }
+
+  private static String getKeyStoreLocation(final Map<String, String> props) {
+    return props.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+  }
+
+  private static String getKeyStorePassword(final Map<String, String> props) {
+    return props.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+  }
+
+  private static JksOptions buildJksOptions(final String path, final String password) {
+    return new JksOptions().setPath(path).setPassword(Strings.nullToEmpty(password));
+  }
+
+  private static JksOptions buildJksOptions(final Buffer buffer, final String password) {
+    return new JksOptions().setValue(buffer).setPassword(Strings.nullToEmpty(password));
+  }
+
+  private static Buffer loadJksKeyStore(
+      final String path,
+      final String keyStorePassword,
+      final String keyPassword,
+      final String alias
+  ) {
+    return KeystoreUtil.getKeyStore(
+        SSL_STORE_TYPE_JKS,
+        path,
+        Optional.ofNullable(Strings.emptyToNull(keyStorePassword)),
+        Optional.ofNullable(Strings.emptyToNull(keyPassword)),
+        alias
+    );
+  }
+
+  private static PfxOptions buildPfxOptions(final String path, final String password) {
+    return new PfxOptions().setPath(path).setPassword(Strings.nullToEmpty(password));
+  }
+
+  /**
+   * Returns a {@code JksOptions} object using the truststore following SSL configurations:
+   * <ul>
+   *  <li>Required: {@value SslConfigs#SSL_TRUSTSTORE_LOCATION_CONFIG}</li>
+   *  <li>Optional: {@value SslConfigs#SSL_TRUSTSTORE_PASSWORD_CONFIG}</li>
+   * </ul>
+   *
+   * @param props A Map with the truststore location and password configs.
+   * @return The {@code JksOptions} configured with the above SSL settings.
+   *         Optional.empty() if the truststore location is null or empty.
+   */
+  public static Optional<JksOptions> getJksTrustStoreOptions(final Map<String, String> props) {
+    final String location = getTrustStoreLocation(props);
+    final String password = getTrustStorePassword(props);
+
+    if (!Strings.isNullOrEmpty(location)) {
+      return Optional.of(buildJksOptions(location, password));
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Returns a {@code PfxOptions} object using the following truststore SSL configurations:
+   * <ul>
+   *  <li>Required: {@value SslConfigs#SSL_TRUSTSTORE_LOCATION_CONFIG}</li>
+   *  <li>Optional: {@value SslConfigs#SSL_TRUSTSTORE_PASSWORD_CONFIG}</li>
+   * </ul>
+   *
+   * @param props A Map with the truststore location and password configs.
+   * @return The {@code PfxOptions} configured with the above SSL settings.
+   *         Optional.empty() if the truststore location is null or empty.
+   */
+  public static Optional<PfxOptions> getPfxTrustStoreOptions(final Map<String, String> props) {
+    final String location = getTrustStoreLocation(props);
+    final String password = getTrustStorePassword(props);
+
+    if (!Strings.isNullOrEmpty(location)) {
+      return Optional.of(buildPfxOptions(location, password));
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Returns a {@code JksOptions} object using the keystore SSL configurations:
+   * <ul>
+   *  <li>Required: {@value SslConfigs#SSL_KEYSTORE_LOCATION_CONFIG}</li>
+   *  <li>Optional: {@value SslConfigs#SSL_KEYSTORE_PASSWORD_CONFIG}</li>
+   * </ul>
+   *
+   * <p>If an {@code alias} is used, then it builds the {@code JksOptions} with the internal
+   * private key referenced with the alias. The internal private key will be decrypted using
+   * the same keystore password.
+   *
+   * @param props A Map with the keystore location and password configs.
+   * @return The {@code JksOptions} configured with the above SSL settings.
+   *         Optional.empty() if the truststore location is null or empty.
+   */
+  public static Optional<JksOptions> buildJksKeyStoreOptions(
+      final Map<String, String> props,
+      final Optional<String> alias
+  ) {
+    final String location = getKeyStoreLocation(props);
+    final String keyStorePassword = getKeyStorePassword(props);
+
+    if (!Strings.isNullOrEmpty(location)) {
+      final JksOptions jksOptions;
+
+      if (alias.isPresent() && !alias.get().isEmpty()) {
+        jksOptions = buildJksOptions(
+            loadJksKeyStore(location, keyStorePassword, keyStorePassword, alias.get()),
+            keyStorePassword
+        );
+      } else {
+        jksOptions = buildJksOptions(location, keyStorePassword);
+      }
+
+      return Optional.of(jksOptions);
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Returns a {@code PfxOptions} object using the keystore SSL configurations:
+   * <ul>
+   *  <li>Required: {@value SslConfigs#SSL_KEYSTORE_LOCATION_CONFIG}</li>
+   *  <li>Optional: {@value SslConfigs#SSL_KEYSTORE_PASSWORD_CONFIG}</li>
+   * </ul>
+   *
+   * @param props A Map with the keystore location and password configs.
+   * @return The {@code PfxOptions} configured with the above SSL settings.
+   *         Optional.empty() if the truststore location is null or empty.
+   */
+  public static Optional<PfxOptions> getPfxKeyStoreOptions(final Map<String, String> props) {
+    // PFX key stores do not have a Private key password
+    final String location = getKeyStoreLocation(props);
+    final String password = getKeyStorePassword(props);
+
+    if (!Strings.isNullOrEmpty(location)) {
+      return Optional.of(buildPfxOptions(location, password));
+    }
+
+    return Optional.empty();
+  }
+}

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/VertxSslOptionsFactoryTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/VertxSslOptionsFactoryTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.test.util.secure.ServerKeyStore;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.PfxOptions;
+import org.apache.kafka.common.config.SslConfigs;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VertxSslOptionsFactoryTest {
+  private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
+
+  @ClassRule
+  public static final TemporaryFolder TMP = new TemporaryFolder();
+
+  @Test
+  public void shouldBuildTrustStoreJksOptionsWithPathAndPassword() {
+    // When
+    final Optional<JksOptions> jksOptions = VertxSslOptionsFactory.getJksTrustStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+            "path",
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+            "password"
+        )
+    );
+
+    // Then
+    assertThat(jksOptions.get().getPath(), is("path"));
+    assertThat(jksOptions.get().getPassword(), is("password"));
+  }
+
+  @Test
+  public void shouldReturnEmptyTrustStoreJksOptionsIfLocationIsEmpty() {
+    // When
+    final Optional<JksOptions> jksOptions = VertxSslOptionsFactory.getJksTrustStoreOptions(
+        ImmutableMap.of()
+    );
+
+    // Then
+    assertThat(jksOptions, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldBuildTrustStoreJksOptionsWithPathOnly() {
+    // When
+    final Optional<JksOptions> jksOptions = VertxSslOptionsFactory.getJksTrustStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+            "path"
+        )
+    );
+
+    // Then
+    assertThat(jksOptions.get().getPath(), is("path"));
+    assertThat(jksOptions.get().getPassword(), is(""));
+  }
+
+  @Test
+  public void shouldBuildTrustStorePfxOptionsWithPathAndPassword() {
+    // When
+    final Optional<PfxOptions> pfxOptions = VertxSslOptionsFactory.getPfxTrustStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+            "path",
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+            "password"
+        )
+    );
+
+    // Then
+    assertThat(pfxOptions.get().getPath(), is("path"));
+    assertThat(pfxOptions.get().getPassword(), is("password"));
+  }
+
+  @Test
+  public void shouldReturnEmptyTrustStorePfxOptionsIfLocationIsEmpty() {
+    // When
+    final Optional<PfxOptions> pfxOptions = VertxSslOptionsFactory.getPfxTrustStoreOptions(
+        ImmutableMap.of()
+    );
+
+    // Then
+    assertThat(pfxOptions, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldBuildTrustStorePfxOptionsWithPathOnly() {
+    // When
+    final Optional<PfxOptions> pfxOptions = VertxSslOptionsFactory.getPfxTrustStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+            "path"
+        )
+    );
+
+    // Then
+    assertThat(pfxOptions.get().getPath(), is("path"));
+    assertThat(pfxOptions.get().getPassword(), is(""));
+  }
+
+  @Test
+  public void shouldBuildKeyStoreJksOptionsWithPathAndPassword() {
+    // When
+    final Optional<JksOptions> jksOptions = VertxSslOptionsFactory.buildJksKeyStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+            "path",
+            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+            "password"
+        ),
+        Optional.empty()
+    );
+
+    // Then
+    assertThat(jksOptions.get().getPath(), is("path"));
+    assertThat(jksOptions.get().getPassword(), is("password"));
+  }
+
+  @Test
+  public void shouldReturnEmptyKeyStoreJksOptionsIfLocationIsEmpty() {
+    // When
+    final Optional<JksOptions> jksOptions = VertxSslOptionsFactory.buildJksKeyStoreOptions(
+        ImmutableMap.of(),
+        Optional.empty()
+    );
+
+    // Then
+    assertThat(jksOptions, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldBuildKeyStoreJksOptionsWithPathOnly() {
+    // When
+    final Optional<JksOptions> jksOptions = VertxSslOptionsFactory.buildJksKeyStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+            "path"
+        ),
+        Optional.empty()
+    );
+
+    // Then
+    assertThat(jksOptions.get().getPath(), is("path"));
+    assertThat(jksOptions.get().getPassword(), is(""));
+  }
+
+  @Test
+  public void shouldBuildKeyStoreJksOptionsWithKeyPasswordWhenAliasIsPassed() {
+    // When
+    final Optional<JksOptions> jksOptions = VertxSslOptionsFactory.buildJksKeyStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+            SERVER_KEY_STORE.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
+            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+            SERVER_KEY_STORE.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
+            SslConfigs.SSL_KEY_PASSWORD_CONFIG,
+            SERVER_KEY_STORE.keyStoreProps().get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)
+        ),
+        Optional.of("localhost")
+    );
+
+    // Then
+    assertThat(jksOptions.get().getValue(), not(nullValue()));
+    assertThat(jksOptions.get().getPassword(),
+        is(SERVER_KEY_STORE.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)));
+
+    // When a key password is set, the Vert.x options are built without a keyStore location
+    assertThat(jksOptions.get().getPath(), is(nullValue()));
+  }
+
+  @Test
+  public void shouldBuildKeyStorePfxOptionsWithPathAndPassword() {
+    // When
+    final Optional<PfxOptions> pfxOptions = VertxSslOptionsFactory.getPfxKeyStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+            "path",
+            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+            "password"
+        )
+    );
+
+    // Then
+    assertThat(pfxOptions.get().getPath(), is("path"));
+    assertThat(pfxOptions.get().getPassword(), is("password"));
+  }
+
+  @Test
+  public void shouldReturnEmptyKeyStorePfxOptionsIfLocationIsEmpty() {
+    // When
+    final Optional<PfxOptions> pfxOptions = VertxSslOptionsFactory.getPfxKeyStoreOptions(
+        ImmutableMap.of()
+    );
+
+    // Then
+    assertThat(pfxOptions, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldBuildKeyStorePfxOptionsWithPathOnly() {
+    // When
+    final Optional<PfxOptions> pfxOptions = VertxSslOptionsFactory.getPfxKeyStoreOptions(
+        ImmutableMap.of(
+            SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+            "path"
+        )
+    );
+
+    // Then
+    assertThat(pfxOptions.get().getPath(), is("path"));
+    assertThat(pfxOptions.get().getPassword(), is(""));
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -17,18 +17,18 @@ package io.confluent.ksql.api.server;
 
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_MAX_PUSH_QUERIES_EXCEEDED;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.api.auth.AuthenticationPlugin;
 import io.confluent.ksql.api.spi.Endpoints;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
+import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.rest.entity.PushQueryId;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.state.ServerState;
-import io.confluent.ksql.rest.util.KeystoreUtil;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.VertxCompletableFuture;
+import io.confluent.ksql.util.VertxSslOptionsFactory;
 import io.netty.handler.ssl.OpenSsl;
 import io.vertx.core.Vertx;
 import io.vertx.core.WorkerExecutor;
@@ -54,7 +54,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.config.types.Password;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -343,52 +342,43 @@ public class Server {
 
   private static void configureTlsKeyStore(
       final KsqlRestConfig ksqlRestConfig,
-      final HttpServerOptions options,
+      final HttpServerOptions httpServerOptions,
       final String keyStoreAlias
   ) {
-    final String keyStorePath = ksqlRestConfig
-        .getString(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
-    final Password keyStorePassword = ksqlRestConfig
-        .getPassword(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
-    if (keyStorePath != null && !keyStorePath.isEmpty()) {
-      final String keyStoreType =
-          ksqlRestConfig.getString(KsqlRestConfig.SSL_KEYSTORE_TYPE_CONFIG);
-      if (keyStoreAlias != null && !keyStoreAlias.isEmpty()) {
-        options.setKeyStoreOptions(new JksOptions().setValue(KeystoreUtil.getKeyStore(
-            keyStoreType,
-            keyStorePath,
-            Optional.ofNullable(Strings.emptyToNull(keyStorePassword.value())),
-            Optional.ofNullable(Strings.emptyToNull(keyStorePassword.value())),
-            keyStoreAlias))
-            .setPassword(keyStorePassword.value()));
-      } else if (keyStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_JKS)) {
-        options.setKeyStoreOptions(
-            new JksOptions().setPath(keyStorePath).setPassword(keyStorePassword.value()));
-      } else if (keyStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_PKCS12)) {
-        options.setPfxKeyCertOptions(
-            new PfxOptions().setPath(keyStorePath).setPassword(keyStorePassword.value()));
-      }
+    final Map<String, String> props = PropertiesUtil.toMapStrings(ksqlRestConfig.originals());
+    final String keyStoreType = ksqlRestConfig.getString(KsqlRestConfig.SSL_KEYSTORE_TYPE_CONFIG);
+
+    if (keyStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_JKS)) {
+      final Optional<JksOptions> keyStoreOptions =
+          VertxSslOptionsFactory.buildJksKeyStoreOptions(props, Optional.ofNullable(keyStoreAlias));
+
+      keyStoreOptions.ifPresent(options -> httpServerOptions.setKeyStoreOptions(options));
+    } else if (keyStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_PKCS12)) {
+      final Optional<PfxOptions> keyStoreOptions =
+          VertxSslOptionsFactory.getPfxKeyStoreOptions(props);
+
+      keyStoreOptions.ifPresent(options -> httpServerOptions.setPfxKeyCertOptions(options));
     }
   }
 
   private static void configureTlsTrustStore(
       final KsqlRestConfig ksqlRestConfig,
-      final HttpServerOptions options
+      final HttpServerOptions httpServerOptions
   ) {
-    final String trustStorePath = ksqlRestConfig
-        .getString(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
-    final Password trustStorePassword = ksqlRestConfig
-        .getPassword(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
-    if (trustStorePath != null && !trustStorePath.isEmpty()) {
-      final String trustStoreType =
-          ksqlRestConfig.getString(KsqlRestConfig.SSL_TRUSTSTORE_TYPE_CONFIG);
-      if (trustStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_JKS)) {
-        options.setTrustStoreOptions(
-            new JksOptions().setPath(trustStorePath).setPassword(trustStorePassword.value()));
-      } else if (trustStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_PKCS12)) {
-        options.setPfxTrustOptions(
-            new PfxOptions().setPath(trustStorePath).setPassword(trustStorePassword.value()));
-      }
+    final Map<String, String> props = PropertiesUtil.toMapStrings(ksqlRestConfig.originals());
+    final String trustStoreType =
+        ksqlRestConfig.getString(KsqlRestConfig.SSL_TRUSTSTORE_TYPE_CONFIG);
+
+    if (trustStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_JKS)) {
+      final Optional<JksOptions> trustStoreOptions =
+          VertxSslOptionsFactory.getJksTrustStoreOptions(props);
+
+      trustStoreOptions.ifPresent(options -> httpServerOptions.setTrustOptions(options));
+    } else if (trustStoreType.equals(KsqlRestConfig.SSL_STORE_TYPE_PKCS12)) {
+      final Optional<PfxOptions> trustStoreOptions =
+          VertxSslOptionsFactory.getPfxTrustStoreOptions(props);
+
+      trustStoreOptions.ifPresent(options -> httpServerOptions.setTrustOptions(options));
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.query.id.SpecificQueryIdGenerator;
 import io.confluent.ksql.rest.ErrorMessages;
 import io.confluent.ksql.rest.Errors;
@@ -122,7 +123,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -616,7 +616,7 @@ public final class KsqlRestApplication implements Executable {
             .setMetricsOptions(setUpHttpMetrics(ksqlConfig)));
     vertx.exceptionHandler(t -> log.error("Unhandled exception in Vert.x", t));
     final KsqlClient sharedClient = InternalKsqlClientFactory.createInternalClient(
-        toClientProps(ksqlConfig.originals()),
+        PropertiesUtil.toMapStrings(ksqlConfig.originals()),
         SocketAddress::inetSocketAddress,
         vertx
     );
@@ -1117,14 +1117,4 @@ public final class KsqlRestApplication implements Executable {
     }
     return metricsOptions;
   }
-
-  @VisibleForTesting
-  static Map<String, String> toClientProps(final Map<String, Object> config) {
-    final Map<String, String> clientProps = new HashMap<>();
-    for (Map.Entry<String, Object> entry : config.entrySet()) {
-      clientProps.put(entry.getKey(), entry.getValue().toString());
-    }
-    return clientProps;
-  }
-
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.properties.LocalProperties;
 import io.confluent.ksql.rest.client.KsqlClient;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
-import io.confluent.ksql.rest.util.KeystoreUtil;
+import io.confluent.ksql.util.VertxSslOptionsFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.net.JksOptions;
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.apache.kafka.common.config.SslConfigs;
 
 public final class InternalKsqlClientFactory {
 
@@ -62,34 +61,23 @@ public final class InternalKsqlClientFactory {
       }
       httpClientOptions.setVerifyHost(verifyHost);
       httpClientOptions.setSsl(true);
-      final String trustStoreLocation = clientProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
-      if (!Strings.isNullOrEmpty(trustStoreLocation)) {
-        final String suppliedTruststorePassword = clientProps
-            .get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
-        httpClientOptions.setTrustStoreOptions(new JksOptions().setPath(trustStoreLocation)
-            .setPassword(Strings.nullToEmpty(suppliedTruststorePassword)));
 
-        final String keyStoreLocation = clientProps.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
-        if (!Strings.isNullOrEmpty(keyStoreLocation)) {
-          final String suppliedKeyStorePassword = clientProps
-              .get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
-          final String internalAlias = clientProps
-              .get(KsqlRestConfig.KSQL_SSL_KEYSTORE_ALIAS_INTERNAL_CONFIG);
-          final JksOptions keyStoreOptions = new JksOptions()
-              .setPassword(Strings.nullToEmpty(suppliedKeyStorePassword));
-          if (!Strings.isNullOrEmpty(internalAlias)) {
-            keyStoreOptions.setValue(KeystoreUtil.getKeyStore(
-                KsqlRestConfig.SSL_STORE_TYPE_JKS,
-                keyStoreLocation,
-                Optional.ofNullable(Strings.emptyToNull(suppliedKeyStorePassword)),
-                Optional.ofNullable(Strings.emptyToNull(suppliedKeyStorePassword)),
-                internalAlias));
-          } else {
-            keyStoreOptions.setPath(keyStoreLocation);
-          }
-          httpClientOptions.setKeyStoreOptions(keyStoreOptions);
-        }
+      final Optional<JksOptions> trustStoreOptions =
+          VertxSslOptionsFactory.getJksTrustStoreOptions(clientProps);
+
+      if (trustStoreOptions.isPresent()) {
+        httpClientOptions.setTrustStoreOptions(trustStoreOptions.get());
+
+        final Optional<JksOptions> keyStoreOptions =
+            VertxSslOptionsFactory.buildJksKeyStoreOptions(
+                clientProps,
+                Optional.ofNullable(
+                    clientProps.get(KsqlRestConfig.KSQL_SSL_KEYSTORE_ALIAS_INTERNAL_CONFIG))
+            );
+
+        keyStoreOptions.ifPresent(options -> httpClientOptions.setKeyStoreOptions(options));
       }
+
       return httpClientOptions;
     };
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -21,6 +21,7 @@ import static org.easymock.EasyMock.niceMock;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.client.BasicCredentials;
 import io.confluent.ksql.rest.client.KsqlRestClient;
@@ -305,7 +306,7 @@ public class TestKsqlRestApp extends ExternalResource {
           () -> serviceContext.get().getSchemaRegistryClient(),
           vertx,
           InternalKsqlClientFactory.createInternalClient(
-              KsqlRestApplication.toClientProps(ksqlRestConfig.originals()),
+              PropertiesUtil.toMapStrings(ksqlRestConfig.originals()),
               SocketAddress::inetSocketAddress,
               vertx));
 

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.rest.entity.TopicDescription;
 import io.confluent.ksql.test.util.secure.ClientTrustStore;
 import io.confluent.ksql.test.util.secure.ServerKeyStore;
 import io.confluent.ksql.util.VertxCompletableFuture;
+import io.confluent.ksql.util.VertxSslOptionsFactory;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -728,13 +729,13 @@ public class KsqlClientTest {
   }
 
   private void startServerWithTls() throws Exception {
+    final Optional<JksOptions> keyStoreOptions = VertxSslOptionsFactory.buildJksKeyStoreOptions(
+    SERVER_KEY_STORE.keyStoreProps(), Optional.empty());
+
     HttpServerOptions serverOptions = new HttpServerOptions().setPort(0)
         .setHost("localhost")
         .setSsl(true)
-        .setKeyStoreOptions(new JksOptions()
-            .setPath(SERVER_KEY_STORE.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
-            .setPassword(
-                SERVER_KEY_STORE.keyStoreProps().get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)));
+        .setKeyStoreOptions(keyStoreOptions.get());
 
     startServer(serverOptions);
     serverUri = URI.create("https://localhost:" + server.getPort());


### PR DESCRIPTION
### Description 
This refactor is part of https://github.com/confluentinc/ksql/pull/6763. I split the previous PR to make the review easier.

This refactor creates a new class, `VertxSslOptionsFactory`, that builds the `JksOptions` and `PfxOptions` objects using the SSL truststore & keystore configs. The class is a util that avoids repeating code to build these objects.

### Testing done 
Unit tests are passing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

