### PR TITLE
docs: cherry-pick: bump versions for 0.15.0 docs (DOCS-6397)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -223,12 +223,12 @@ extra:
         zk: ZooKeeper
 
         # Build-related string tokens
-        kafkaversion: 2.6
-        ksqldbversion: 0.14.0
+        kafkaversion: 2.7
+        ksqldbversion: 0.15.0
         kstreamsbetatag: 6.1.0-beta201006024150
-        release: 0.14.0
-        cprelease: 6.0.1
-        releasepostbranch: 6.0.1-post
+        release: 0.15.0
+        cprelease: 6.1.0
+        releasepostbranch: 6.1.0-post
         scalaversion: 2.13
         voluble_version: 0.3.1
         jdbc_connector_version: 10.0.0


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/6781.