### PR TITLE
docs: adds back text for making input files

### DIFF
--- a/docs/how-to-guides/test-an-app.md
+++ b/docs/how-to-guides/test-an-app.md
@@ -229,3 +229,20 @@ the testing tool inspects the source topics for the query in the simulated
 Kafka cluster and processes any messages in these topics. For `JOIN` queries
 that have more than one source topic, the testing tool first processes the
 left-side topic and then processes the right-side topic.
+
+## Generate an input file from an existing topic
+
+You can use [`kafkacat`](https://github.com/edenhill/kafkacat) and
+[`jq`](https://stedolan.github.io/jq/) in combination to create an input file
+based on data already in a Kafka topic:
+
+```bash
+kafkacat -b broker:29092 -t my_topic -C -e -J | \
+  jq --slurp '{inputs:[.[]|{topic:.topic,timestamp: .ts, key: .key, value: .payload|fromjson}]}' \
+  > input.json
+```
+
+Replace `broker:29092` with your broker host and port, and `my_topic` with the
+name of your topic. You can limit how many messages are written to the file by
+adding a `-c` flag to the `kafkacat` statement—for example, `-c42` would write
+the first 42 messages from the topic.


### PR DESCRIPTION
### Description 

See https://github.com/confluentinc/ksql/pull/6713#discussion_r551358794. Based on the previous PR, I assume this needs to be cherry-picked to `6.1.x` and `0.14.0-ksqldb` -- can either @MichaelDrogalis or @JimGalasyn confirm?

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

