### PR TITLE
chore: set io.confluent.ksql.version for release builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,6 +214,8 @@ def job = {
 
                             // Set the version of the parent project to use.
                             sh "mvn --batch-mode versions:update-parent -DparentVersion=\"[${config.cp_version}]\" -DgenerateBackupPoms=false"
+                            // Set the ksql version to use for dependencies.
+                            sh "mvn --batch-mode versions:set-property -Dproperty=io.confluent.ksql.version -DnewVersion=${config.ksql_db_artifact_version}"
 
                             cmd = "mvn --batch-mode -Pjenkins clean package dependency:analyze site validate -U "
                             cmd += "-DskipTests "


### PR DESCRIPTION
### Description 
set the ksql version for nightlies/release builds. this ensures in-repo dependencies use the right
version.
