### PR TITLE
docs: fix ksql.advertised.listener setting (DOCS-6436)

### DIFF
--- a/docs/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs/operate-and-deploy/installation/server-config/config-reference.md
@@ -461,7 +461,7 @@ If not set, the default behavior is to use the internal listener, which is contr
 
 If `ksql.internal.listener` resolves to a URL that uses `localhost`, a wildcard IP address,
 like `0.0.0.0`, or a hostname that other ksqlDB nodes either can't resolve or can't route requests
-to, set `ksql.advertised.listeners` to a URL that ksqlDB nodes can resolve.
+to, set `ksql.advertised.listener` to a URL that ksqlDB nodes can resolve.
 
 For more information, see [Configuring Listeners of a ksqlDB Cluster](./index.md#configuring-listeners-of-a-ksqldb-cluster)
 


### PR DESCRIPTION
Fixes a reference to `ksql.advertised.listener` in copy. 