### PR TITLE
fix: Make Select * avoid code gen for projections

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/ProjectOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/ProjectOperator.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.physical.pull.operators;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.streams.materialization.PullProcessingContext;
 import io.confluent.ksql.execution.streams.materialization.TableRow;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
@@ -26,9 +27,12 @@ import io.confluent.ksql.execution.transform.select.SelectValueMapperFactory.Sel
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.PullProjectNode;
+import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class ProjectOperator extends AbstractPhysicalOperator implements UnaryPhysicalOperator {
 
@@ -66,6 +70,10 @@ public class ProjectOperator extends AbstractPhysicalOperator implements UnaryPh
   public void open() {
     child.open();
 
+    if (logicalNode.getIsSelectStar()) {
+      return;
+    }
+
     final SelectValueMapper<Object> select = selectValueMapperFactorySupplier.create(
         logicalNode.getSelectExpressions(),
         logicalNode.getCompiledSelectExpressions()
@@ -79,10 +87,14 @@ public class ProjectOperator extends AbstractPhysicalOperator implements UnaryPh
     row = (TableRow)child.next();
     if (row == null) {
       return null;
-    } 
+    }
 
     final GenericRow intermediate = PullPhysicalOperatorUtil.getIntermediateRow(
         row, logicalNode.getAddAdditionalColumnsToIntermediateSchema());
+
+    if (logicalNode.getIsSelectStar()) {
+      return createRowForSelectStar(intermediate);
+    }
 
     final GenericRow mapped = transformer.transform(
         row.key(),
@@ -140,5 +152,21 @@ public class ProjectOperator extends AbstractPhysicalOperator implements UnaryPh
                                           + ", got:" + actual
       );
     }
+  }
+
+  // Optimization for select star, to avoid having to do code generation
+  private List<?> createRowForSelectStar(final GenericRow intermediate) {
+    final List<Object> rowList = new ArrayList<>();
+    for (SelectExpression selectExpression : logicalNode.getSelectExpressions()) {
+      final Optional<Column> column = logicalNode.getIntermediateSchema()
+          .findValueColumn(selectExpression.getAlias());
+      if (!column.isPresent()) {
+        throw new IllegalStateException("Couldn't find alias in intermediate schema "
+            + selectExpression.getAlias());
+      }
+      final int i = column.get().index();
+      rowList.add(intermediate.get(i));
+    }
+    return rowList;
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullProjectNode.java
@@ -123,7 +123,7 @@ public class PullProjectNode extends ProjectNode {
     return compiledSelectExpressions;
   }
 
-  LogicalSchema getIntermediateSchema() {
+  public LogicalSchema getIntermediateSchema() {
     return intermediateSchema;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullProjectNode.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -91,7 +92,9 @@ public class PullProjectNode extends ProjectNode {
           addAdditionalColumnsToIntermediateSchema,
           isWindowed
       );
-    this.compiledSelectExpressions = selectExpressions
+    this.compiledSelectExpressions = isSelectStar
+        ? Collections.emptyList()
+        : selectExpressions
         .stream()
         .map(selectExpression -> CodeGenRunner.compileExpression(
             selectExpression.getExpression(),
@@ -101,7 +104,6 @@ public class PullProjectNode extends ProjectNode {
             metaStore
         ))
         .collect(ImmutableList.toImmutableList());
-
   }
 
   @Override
@@ -115,6 +117,9 @@ public class PullProjectNode extends ProjectNode {
   }
 
   public List<ExpressionMetadata> getCompiledSelectExpressions() {
+    if (isSelectStar) {
+      throw new IllegalStateException("Select expressions aren't compiled for select star");
+    }
     return compiledSelectExpressions;
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullProjectNodeTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.planner.plan;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,8 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -53,6 +56,7 @@ public class PullProjectNodeTest {
   private static final ColumnName K = ColumnName.of("K");
   private static final ColumnName COL0 = ColumnName.of("COL0");
   private static final ColumnName ALIAS = ColumnName.of("GRACE");
+  private static final SourceName SOURCE_NAME = SourceName.of("SOURCE");
 
   private static final UnqualifiedColumnReferenceExp K_REF =
       new UnqualifiedColumnReferenceExp(K);
@@ -262,4 +266,31 @@ public class PullProjectNodeTest {
     assertThat(expected, is(projectNode.getSchema()));
   }
 
+  @Test
+  public void shouldBuildPullQueryOutputSchemaSelectStar() {
+    // Given:
+    selects = ImmutableList.of(new AllColumns(Optional.of(SOURCE_NAME)));
+    when(keyFormat.isWindowed()).thenReturn(false);
+    when(analysis.getSelectColumnNames()).thenReturn(ImmutableSet.of());
+
+    // When:
+    final PullProjectNode projectNode = new PullProjectNode(
+        NODE_ID,
+        source,
+        selects,
+        metaStore,
+        ksqlConfig,
+        analysis,
+        false
+    );
+
+    // Then:
+    final LogicalSchema expectedSchema = INPUT_SCHEMA;
+    assertThat(expectedSchema, is(projectNode.getIntermediateSchema()));
+    assertThat(expectedSchema.withoutPseudoAndKeyColsInValue(), is(projectNode.getSchema()));
+    assertThrows(
+        IllegalStateException.class,
+        projectNode::getCompiledSelectExpressions
+    );
+  }
 }


### PR DESCRIPTION
### Description 
Prior to https://github.com/confluentinc/ksql/pull/6684, select * didn't compile expressions for each of the columns, which makes them much more performant.  This PR remakes that change to avoid a regression.

### Testing done 
Unit tests and local benchmarking

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

