### PR TITLE
docs: add documentation about timestamp data type

### DIFF
--- a/docs/concepts/time-and-windows-in-ksqldb-queries.md
+++ b/docs/concepts/time-and-windows-in-ksqldb-queries.md
@@ -6,6 +6,10 @@ description: Learn how to work with time windows in ksqlDB statements
 keywords: ksqldb, timestamp, window 
 ---
 
+!!! important
+      This page refers to timestamps as a field in records. For information
+      on the TIMESTAMP data type, see [Timestamp types](../reference/sql/data-types.md).
+
 ![Diagram showing records in a ksqlDB stream](../img/ksql-stream-records.png)
 
 In ksqlDB, a record is an immutable representation of an event in time.

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -55,7 +55,7 @@ Converts one type to another. The following casts are supported:
 | any  | `STRING` | Converts the type to its string representation. |
 | `VARCHAR` | `BOOLEAN` | Any string that exactly matches `true`, case-insensitive, is converted to `true`. Any other value is converted to `false`. |
 | `VARCHAR` | `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | Converts string representation of numbers to number types. Conversion will fail if text does not contain a number or the number does not fit in the indicated type. |
-| `VARCHAR` | `TIMESTAMP` | Converts datestrings to `TIMESTAMP`. Conversion will fail if text is not in ISO-8601 format. |
+| `VARCHAR` | `TIMESTAMP` | Converts datestrings to `TIMESTAMP`. Conversion fails if text is not in ISO-8601 format.     |
 | `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | Convert between numeric types. Conversion can result in rounding |
 | `ARRAY` | `ARRAY` | (Since 0.14) Convert between arrays of different element types |   
 | `MAP` | `MAP` | (Since 0.14) Convert between maps of different key and value types |   

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -55,6 +55,7 @@ Converts one type to another. The following casts are supported:
 | any  | `STRING` | Converts the type to its string representation. |
 | `VARCHAR` | `BOOLEAN` | Any string that exactly matches `true`, case-insensitive, is converted to `true`. Any other value is converted to `false`. |
 | `VARCHAR` | `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | Converts string representation of numbers to number types. Conversion will fail if text does not contain a number or the number does not fit in the indicated type. |
+| `VARCHAR` | `TIMESTAMP` | Converts datestrings to `TIMESTAMP`. Conversion will fail if text is not in ISO-8601 format. |
 | `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | `INT`, `BIGINT`, `DECIMAL`, `DOUBLE` | Convert between numeric types. Conversion can result in rounding |
 | `ARRAY` | `ARRAY` | (Since 0.14) Convert between arrays of different element types |   
 | `MAP` | `MAP` | (Since 0.14) Convert between maps of different key and value types |   

--- a/docs/developer-guide/ksqldb-reference/type-coercion.md
+++ b/docs/developer-guide/ksqldb-reference/type-coercion.md
@@ -53,7 +53,7 @@ Literal values support more open coercion rules than other expression types.
   these values that starts with the first character, for example, `fal`, `y`.
   Comparison is case-insensitive.
 * A `STRING` literal containing an ISO-8601 formatted datestring can be coerced
-  to a `TIMESTAMP`. A datestring containing a timezone will be converted to UTC.
+  to a `TIMESTAMP`. A datestring containing a timezone is converted to UTC.
 
 ## Expression lists
 

--- a/docs/developer-guide/ksqldb-reference/type-coercion.md
+++ b/docs/developer-guide/ksqldb-reference/type-coercion.md
@@ -52,6 +52,8 @@ Literal values support more open coercion rules than other expression types.
   Valid boolean values are `true`, `false`, `yes`, `no`, or any substring of
   these values that starts with the first character, for example, `fal`, `y`.
   Comparison is case-insensitive.
+* A `STRING` literal containing an ISO-8601 formatted datestring can be coerced
+  to a `TIMESTAMP`. A datestring containing a timezone will be converted to UTC.
 
 ## Expression lists
 
@@ -68,6 +70,7 @@ behavior depends on the type of the first non-null element.
    type is a numeric type that's wide enough to hold all numbers found in the
    list.
  * `BOOLEAN`: all other expressions must be coercible to `BOOLEAN`.
+ * `TIMESTAMP`: all other expressions must be coercible to `TIMESTAMP`.
  * `ARRAY`: all other expressions must be `ARRAY`s and have element types that
    can be coerced to a common element type.
  * `MAP`: all other expressions must be `MAP`s and have key and value types

--- a/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
@@ -119,7 +119,7 @@ Response JSON Object:
 - **sourceDescription.fields[i].schema** (object): A schema object that describes
   the schema of the field.
 - **sourceDescription.fields[i].schema.type** (string): The type the schema
-  represents. One of INTEGER, BIGINT, BOOLEAN, DOUBLE, STRING, MAP, ARRAY, or
+  represents. One of INTEGER, BIGINT, BOOLEAN, DOUBLE, STRING, TIMESTAMP, MAP, ARRAY, or
   STRUCT.
 - **sourceDescription.fields[i].schema.memberSchema** (object): A schema object.
   For MAP and ARRAY types, contains the schema of the map values and array
@@ -153,7 +153,7 @@ Response JSON Object:
 - **queryDescription.fields** (array): A list of field objects that describes each field in the query output.
 - **queryDescription.fields[i].name** (string): The name of the field.
 - **queryDescription.fields[i].schema** (object): A schema object that describes the schema of the field.
-- **queryDescription.fields[i].schema.type** (string): The type the schema represents. One of INTEGER, BIGINT, BOOLEAN, DOUBLE, STRING, MAP, ARRAY, or STRUCT.
+- **queryDescription.fields[i].schema.type** (string): The type the schema represents. One of INTEGER, BIGINT, BOOLEAN, DOUBLE, STRING, TIMESTAMP, MAP, ARRAY, or STRUCT.
 - **queryDescription.fields[i].schema.memberSchema** (object): A schema object. For MAP and ARRAY types, contains the schema of the map values and array elements, respectively. For other types this field is not used and its value is undefined.
 - **queryDescription.fields[i].schema.fields** (array): For STRUCT types, contains a list of field objects that descrbies each field within the struct. For other types this field is not used and its value is undefined.
 - **queryDescription.sources** (array): The streams and tables being read by the query.

--- a/docs/reference/serialization.md
+++ b/docs/reference/serialization.md
@@ -248,7 +248,7 @@ Decimals with specified precision and scale are serialized as JSON numbers. For 
 #### Timestamp Serialization
 
 Timestamps are serialized as numbers indicating the Unix epoch time in milliseconds. For example,
-a timestamp at `1970-01-01T00:00:00.001` will be serialized as
+a timestamp at `1970-01-01T00:00:00.001` is serialized as
 
 ```json
 {
@@ -256,7 +256,7 @@ a timestamp at `1970-01-01T00:00:00.001` will be serialized as
 }
 ```
 
-ksqlDb will deserialize a number as a `TIMESTAMP` if it corresponds to a `TIMESTAMP` typed field in
+ksqlDb deserializes a number as a `TIMESTAMP` if it corresponds to a `TIMESTAMP` typed field in
 the stream.
 
 #### Field Name Case Sensitivity

--- a/docs/reference/serialization.md
+++ b/docs/reference/serialization.md
@@ -137,7 +137,7 @@ with `ORGID KEY` of `120`, `ID KEY` of `21`, `NAME` of `bob` and `AGE` of `49`.
 
 This data format supports all SQL
 [data types](/reference/sql/data-types) except `ARRAY`, `MAP` and
-`STRUCT`.
+`STRUCT`. `TIMESTAMP` typed data is serialized as a long value indicating the Unix epoch time in milliseconds.
 
 ### JSON
 
@@ -245,6 +245,20 @@ Decimals with specified precision and scale are serialized as JSON numbers. For 
 }
 ```
 
+#### Timestamp Serialization
+
+Timestamps are serialized as numbers indicating the Unix epoch time in milliseconds. For example,
+a timestamp at `1970-01-01T00:00:00.001` will be serialized as
+
+```json
+{
+  "value": 1
+}
+```
+
+ksqlDb will deserialize a number as a `TIMESTAMP` if it corresponds to a `TIMESTAMP` typed field in
+the stream.
+
 #### Field Name Case Sensitivity
 
 The format is case-insensitive when matching a SQL field name with a
@@ -278,7 +292,7 @@ Avro records can be deserialized into matching ksqlDB schemas.
 For example, given a SQL statement such as:
 
 ```sql
-CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT) WITH (VALUE_FORMAT='AVRO', ...);
+CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT, TIME TIMESTAMP) WITH (VALUE_FORMAT='AVRO', ...);
 ```
 
 And an Avro record serialized with the schema:
@@ -291,7 +305,8 @@ And an Avro record serialized with the schema:
   "fields": [
     { "name": "id", "type": "long" },
     { "name": "name", "type": "string" },
-    { "name": "age", "type": "int" }
+    { "name": "age", "type": "int" },
+    { "name": "time", "type": "long", "logicalType": "timestamp-millis"}
   ]
 }
 ```

--- a/docs/reference/sql/appendix.md
+++ b/docs/reference/sql/appendix.md
@@ -104,6 +104,7 @@ The following table shows all keywords in the language.
 | `TABLES`       | list all tables                       | `SHOW TABLES;`                                                       |
 | `TERMINATE`    | end a persistent query                | `TERMINATE query_id;`                                                |
 | `THEN`         | return expression in a CASE block     | `CASE WHEN units<2 THEN 'sm' WHEN units<4 THEN 'med' ELSE 'large' …` |
+| `TIMESTAMP`    | timestamp data type                   |                                                                      |
 | `TIMESTAMP`    | specify a timestamp column            | `CREATE STREAM pageviews WITH (TIMESTAMP='viewtime', …`              |
 | `TOPIC`        | specify {{site.ak}} topic to delete   | `DROP TABLE <table-name> DELETE TOPIC;`                              |
 | `TOPICS`       | list all streams                      | `SHOW TOPICS;`                                                       |

--- a/docs/reference/sql/data-types.md
+++ b/docs/reference/sql/data-types.md
@@ -85,7 +85,7 @@ and a scale of _0_.
 
 | name      | description                                                     | backing Java type
 |-----------|-----------------------------------------------------------------|------------------
-|`timestamp`| value representing a point in time without timezone information | [`java.sql.Timestamp`](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/Timestamp.html)
+|`timestamp`| value representing a point in time in millisecond precision without timezone information | [`java.sql.Timestamp`](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/Timestamp.html)
 
 ## Compound types
 

--- a/docs/reference/sql/data-types.md
+++ b/docs/reference/sql/data-types.md
@@ -81,6 +81,12 @@ and a scale of _0_.
 - Upcasting a `bigint` to a `decimal` produces a `decimal` with a precision of _19_
 and a scale of _0_.
 
+## Timestamp types
+
+| name      | description                                                     | backing Java type
+|-----------|-----------------------------------------------------------------|------------------
+|`timestamp`| value representing a point in time without timezone information | [`java.sql.Timestamp`](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/Timestamp.html)
+
 ## Compound types
 
 !!! note

--- a/docs/reference/sql/time.md
+++ b/docs/reference/sql/time.md
@@ -14,6 +14,10 @@ For more information, see
 
 ### Timestamp formats
 
+!!! important
+      This section refers to timestamps as a field in records. For information
+      on the TIMESTAMP data type, see [Timestamp types](data-types.md).
+
 Time-based operations, like windowing, process records according to the
 timestamp in `ROWTIME`. By default, the implicit `ROWTIME` pseudo column is the
 timestamp of a message in a Kafka topic. Timestamps have an accuracy of

--- a/docs/reference/user-defined-functions.md
+++ b/docs/reference/user-defined-functions.md
@@ -12,6 +12,7 @@ Because SQL has a type system that is independent from Java’s, user-defined fu
 | `DOUBLE`  | `double`, `java.lang.Double`          |
 | `DECIMAL` | `java.math.BigDecimal`                |
 | `VARCHAR` | `java.lang.String`                    |
+|`TIMESTAMP`| `java.sql.Timestamp`                |
 | `ARRAY`   | `java.util.List`                      |
 | `MAP`     | `java.util.Map`                       |
 | `STRUCT`  | `org.apache.kafka.connect.data.Struct`|


### PR DESCRIPTION
### Description 
Docs on: 
 * Timestamp serialization
 * Casting and type coercion
 * Brief description of what the timestamp type is

One thing that's concerning is that the word timestamp is also used to refer to timestamp of a record. I've added warnings in sections that talk about 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

