### PR TITLE
docs: update onboardings docs for CheckStyle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ You can set up IntelliJ for CheckStyle. First install the CheckStyle IDEA plugin
 
     IntelliJ → Preferences → Tools → CheckStyle
 
+    In top left corner select CheckStyle version 8.18 (newer versions fail to parse the provided XML)
+
     - Add a new configurations file using the '+' button:
        Description: Confluent Checks
        URL: https://raw.githubusercontent.com/confluentinc/common/master/build-tools/src/main/resources/checkstyle/checkstyle.xml

--- a/checkstyle/checkstyle.properties
+++ b/checkstyle/checkstyle.properties
@@ -14,10 +14,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-checkstyle.hideutilityclassconstructor.severity=error
-checkstyle.redundantmodifier.severity=error
 checkstyle.customimportorder.severity=error
 checkstyle.finalclass.severity=error
-checkstyle.finalparameters.severity=error
 checkstyle.finallocalvariable.severity=error
+checkstyle.finalparameters.severity=error
+checkstyle.hideutilityclassconstructor.severity=error
+checkstyle.redundantmodifier.severity=error
 checkstyle.todocomment.severity=error


### PR DESCRIPTION
### Description 
I have encountered some problems with Checkstyle as
described here: https://github.com/checkstyle/eclipse-cs/issues/190
Setting the version used by plugin to 8.18 is a good fix until
I understand who depends on the CheckStyle XML and how I can
fix it.

I have also sorted checkstyle.properties so it is easier to
copy it into the editor plugin configuration

### Testing done 
No testing required - made sure IntelliJ works

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

