### PR TITLE
docs: clarify where in-place upgrades are supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 
 
-###Highlights
+### Highlights
 * Add support for IN clause to pull queries ([#6409](https://github.com/confluentinc/ksql/pull/6409)) ([d5fc365](https://github.com/confluentinc/ksql/commit/d5fc3658a8d7df1fe267a416dfcd3e0721b8a9c4))
 * Add support for ALTER STREAM|TABLE ([#6400](https://github.com/confluentinc/ksql/pull/6400)) ([a58e041](https://github.com/confluentinc/ksql/commit/a58e041cba721a1ad5f28bb0be1c792cb73bec14))
 * support variable substitution in SQL statements ([#6504](https://github.com/confluentinc/ksql/pull/6504)) ([e185c1f](https://github.com/confluentinc/ksql/commit/e185c1fcf86821f5024e51736a77c6f2876fb9ab))
@@ -45,36 +45,36 @@
 ### BREAKING CHANGES
 
 * This change fixes a _bug_ where unnecessary tombstones where being emitted when a `HAVING` clause filtered out a row from the source that is not in the output table
-For example, given:
-```sql
--- source stream:
-CREATE STREAM FOO (ID INT KEY, VAL INT) WITH (...);
--- aggregate into a table:
-CREATE TABLE BAR AS
-SELECT ID, SUM(VAL) AS SUM
-FROM FOO
-GROUP BY ID
-HAVING SUM(VAL) > 0;
--- insert some values into the stream:
-INSERT INTO FOO VALUES(1, -5);
-INSERT INTO FOO VALUES(1, 6);
-INSERT INTO FOO VALUES(1, -2);
-INSERT INTO FOO VALUES(1, -1);
-```
-Where previously the contents of the sink topic `BAR` would have contained records:
-| Key | Value | Notes |
-|-----|-------|------|
-| 1.     | null.   | Spurious tombstone: the table does not contain a row with key `1`, so no tombstone is required. |
-| 1.     | {sum=1} | Row added as HAVING criteria now met |
-| 1.     | null.   | Row deleted as HAVING criteria now not met |
-| 1.     | null.   | Spurious tombstone: the table does not contain a row with key `1`, so no tombstone is required. |
-Note: the first record in the tom
-The topic will now contain:
-| Key | Value |
-|-----|-------|
-| 1.     | {sum=1} |
-| 1.     | null.   |
-Co-authored-by: Andy Coates <big-andy-coates@users.noreply.github.com>
+    For example, given:
+    ```sql
+    -- source stream:
+    CREATE STREAM FOO (ID INT KEY, VAL INT) WITH (...);
+    -- aggregate into a table:
+    CREATE TABLE BAR AS
+    SELECT ID, SUM(VAL) AS SUM
+    FROM FOO
+    GROUP BY ID
+    HAVING SUM(VAL) > 0;
+    -- insert some values into the stream:
+    INSERT INTO FOO VALUES(1, -5);
+    INSERT INTO FOO VALUES(1, 6);
+    INSERT INTO FOO VALUES(1, -2);
+    INSERT INTO FOO VALUES(1, -1);
+    ```
+    Where previously the contents of the sink topic `BAR` would have contained records:
+    | Key | Value | Notes |
+    |-----|-------|------|
+    | 1.     | null.   | Spurious tombstone: the table does not contain a row with key `1`, so no tombstone is required. |
+    | 1.     | {sum=1} | Row added as HAVING criteria now met |
+    | 1.     | null.   | Row deleted as HAVING criteria now not met |
+    | 1.     | null.   | Spurious tombstone: the table does not contain a row with key `1`, so no tombstone is required. |
+    
+    The topic will now contain:
+    | Key | Value |
+    |-----|-------|
+    | 1.     | {sum=1} |
+    | 1.     | null.   |
+
 * Adds support for using primitive types in joins. (#4132) ([d595985](https://github.com/confluentinc/ksql/commit/d595985853703f19611bac1a63957b447260b38e)), closes [#4132](https://github.com/confluentinc/ksql/issues/4132)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 ### BREAKING CHANGES
 
-* This change fixes a _bug_ where unnecessary tombstones where being emitted when a `HAVING` clause filtered out a row from the source that is not in the output table
+* This change fixes a _bug_ where unnecessary tombstones where being emitted when a `HAVING` clause filtered out a row from the source that is not in the output table.
     For example, given:
     ```sql
     -- source stream:

--- a/docs/operate-and-deploy/installation/upgrading.md
+++ b/docs/operate-and-deploy/installation/upgrading.md
@@ -8,10 +8,10 @@ keywords: ksqldb, install, upgrade
 
 ## About backward compatibility
 
-Past releases of KSQL were backward compatible. But there was a cost to this backward compatibility:
-progress was slower and the code base incurred increased complexity. ksqlDB is a young product and
+Most releases of ksqlDB are backward compatible. But backward compatibility comes at a cost:
+progress is slower and the code base incurs increased complexity. ksqlDB is a young product and
 we want to move fast, so we have decided to choose speed of development over strong backward
-compatibility guarantees for a few releases.
+compatibility guarantees.
 
 Until version 1.0 of ksqlDB, each minor release will potentially have breaking changes in it,
 which may mean that you can't simply update the ksqlDB binaries and restart the server(s).
@@ -120,8 +120,8 @@ for new queries.
 ### Upgrading from ksqlDB 0.9.0 to 0.10.0
 
 In-place upgrades are supported from ksqlDB 0.9.0 to 0.10.0. However, in-place upgrades
-from pre-0.8.0 versions to 0.10.0 are not supported, as ksqlDB 0.8.0 is not backward compatible.
-Do not upgrade in place from a pre-0.8.0 version to 0.10.0.
+from pre-0.7.0 versions to 0.10.0 are not supported, as ksqlDB 0.7.0 is not backward compatible.
+Do not upgrade in place from a pre-0.7.0 version to 0.10.0.
 
 The following changes in SQL syntax and functionality may mean SQL statements
 that ran previously no longer run.
@@ -380,8 +380,8 @@ CREATE TABLE INPUT (
 ### Upgrading from ksqlDB 0.8.0 to 0.9.0
 
 In-place upgrades are supported from ksqlDB 0.8.0 to 0.9.0. However, in-place upgrades
-from earlier versions to 0.9.0 are not supported, as ksqlDB 0.8.0 is not backward compatible.
-Do not upgrade in place from a pre-0.8.0 version to 0.9.0.
+from pre-0.7.0 versions to 0.9.0 are not supported, as ksqlDB 0.7.0 is not backward compatible.
+Do not upgrade in place from a pre-0.7.0 version to 0.9.0.
 
 The following changes in SQL syntax and functionality may mean SQL statements
 that ran previously no longer run.
@@ -404,8 +404,9 @@ CREATE TABLE OUTPUT (ROWKEY INT PRIMARY KEY, V0 STRING, V1 DOUBLE) WITH (...);
 
 ### Upgrading from ksqlDB 0.7.0 to 0.8.0
 
-!!! important
-    ksqlDB 0.8.0 is not backward compatible. Do not upgrade in-place.
+In-place upgrades are supported from ksqlDB 0.7.0 to 0.8.0.
+See the [changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md)
+for bug fixes and other changes.
 
 ### Upgrading from ksqlDB 0.6.0 to 0.7.0
 

--- a/docs/operate-and-deploy/installation/upgrading.md
+++ b/docs/operate-and-deploy/installation/upgrading.md
@@ -14,7 +14,7 @@ we want to move fast, so we have decided to choose speed of development over str
 compatibility guarantees for a few releases.
 
 Until version 1.0 of ksqlDB, each minor release will potentially have breaking changes in it,
-which means that you can't simply update the ksqlDB binaries and restart the server(s).
+which may mean that you can't simply update the ksqlDB binaries and restart the server(s).
 
 The data models and binary formats used within ksqlDB are in flux. This means data local to each
 ksqlDB node and stored centrally within internal {{ site.ak }} topics may not be compatible with
@@ -32,8 +32,15 @@ need, or until ksqlDB reaches version 1.0 and promises backward compatibility.
 
 ## How to upgrade
 
-Upgrading a cluster involves leaving the old cluster running on the old version, bringing up a new
+When possible, ksqlDB maintains runtime compatibility between versions, which means you can upgrade
+in-place by stopping your ksqlDB servers and restarting them with the new version, and your existing
+query pipelines will resume from where they left off. New query statements may need to be
+adjusted for syntax changes required by the new version.
+
+However, until ksqlDB 1.0, some ksqlDB versions may not support in-place upgrades. In these situations,
+upgrading a cluster involves leaving the old cluster running on the old version, bringing up a new
 cluster on the new version, porting across your database schema, and finally thinking about your data.
+Read on for details.
 
 ### Port the database schema
 
@@ -103,7 +110,18 @@ This will stop all processing and delete any internal topics in Kafka.
 
 ## Upgrade notes
 
+### Upgrading from ksqlDB 0.10.0 to 0.14.0
+
+In-place upgrades are supported from ksqlDB 0.10.0 to 0.14.0.
+See the [changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md)
+for potential breaking changes that may affect the behavior or required syntax
+for new queries.
+
 ### Upgrading from ksqlDB 0.9.0 to 0.10.0
+
+In-place upgrades are supported from ksqlDB 0.9.0 to 0.10.0. However, in-place upgrades
+from pre-0.8.0 versions to 0.10.0 are not supported, as ksqlDB 0.8.0 is not backward compatible.
+Do not upgrade in place from a pre-0.8.0 version to 0.10.0.
 
 The following changes in SQL syntax and functionality may mean SQL statements
 that ran previously no longer run.
@@ -359,10 +377,11 @@ CREATE TABLE INPUT (
   ) WITH (...);
 ```
 
-### Upgrading from ksqlDB 0.7.0+ to 0.9.0
+### Upgrading from ksqlDB 0.8.0 to 0.9.0
 
-!!! important
-    ksqlDB 0.8.0 is not backward compatible. Do not upgrade in-place.
+In-place upgrades are supported from ksqlDB 0.8.0 to 0.9.0. However, in-place upgrades
+from earlier versions to 0.9.0 are not supported, as ksqlDB 0.8.0 is not backward compatible.
+Do not upgrade in place from a pre-0.8.0 version to 0.9.0.
 
 The following changes in SQL syntax and functionality may mean SQL statements
 that ran previously no longer run.
@@ -371,7 +390,7 @@ that ran previously no longer run.
 
 Tables now use `PRIMARY KEY` to define their primary key column rather than `KEY`.
 Update your `CREATE TABLE` statements as required. For example, statements like
-the this:
+this:
 
 ```sql
 CREATE TABLE OUTPUT (ROWKEY INT KEY, V0 STRING, V1 DOUBLE) WITH (...);
@@ -382,6 +401,11 @@ Must be updated to:
 ```sql
 CREATE TABLE OUTPUT (ROWKEY INT PRIMARY KEY, V0 STRING, V1 DOUBLE) WITH (...);
 ```
+
+### Upgrading from ksqlDB 0.7.0 to 0.8.0
+
+!!! important
+    ksqlDB 0.8.0 is not backward compatible. Do not upgrade in-place.
 
 ### Upgrading from ksqlDB 0.6.0 to 0.7.0
 


### PR DESCRIPTION
### Description 

The upgrade guide is confusing right now since it suggests we don't support in-place upgrades at all, but we actually do for all the newer versions. This PR clarifies this.

Also, we DO support in-place upgrades from 0.7.0 to 0.8.0, whereas the current guide suggests we don't.

@JimGalasyn it'd be great if this could be backported to the live docs branch (0.14.0-ksqldb) once approved and merged. Thanks!

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

