### PR TITLE
feat: add lambda syntax to grammar

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -40,6 +40,7 @@ public final class KsqlConstants {
 
   public static final String DOT = ".";
   public static final String STRUCT_FIELD_REF = "->";
+  public static final String LAMBDA_FUNCTION = "=>";
 
   public static final String KSQL_SERVICE_ID_METRICS_TAG = "ksql_service_id";
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -17,11 +17,12 @@ package io.confluent.ksql.engine.rewrite;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
 import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter.Context;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
@@ -43,8 +44,10 @@ import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.AmbiguousColumnException;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.UnknownSourceException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -75,15 +78,15 @@ public final class AstSanitizer {
     final ExpressionRewriterPlugin expressionRewriterPlugin =
         new ExpressionRewriterPlugin(dataSourceExtractor);
 
-    final BiFunction<Expression, Object, Expression> expressionRewriter =
-        (e, v) -> ExpressionTreeRewriter.rewriteWith(expressionRewriterPlugin::process, e, v);
+    final BiFunction<Expression, SanitizerContext, Expression> expressionRewriter =
+        (e,v) -> ExpressionTreeRewriter.rewriteWith(expressionRewriterPlugin::process, e, v);
 
     return (Statement) new StatementRewriter<>(expressionRewriter, rewriterPlugin::process)
-        .rewrite(node, null);
+        .rewrite(node, new SanitizerContext());
   }
 
   private static final class RewriterPlugin extends
-      AstVisitor<Optional<AstNode>, StatementRewriter.Context<Object>> {
+      AstVisitor<Optional<AstNode>, StatementRewriter.Context<SanitizerContext>> {
 
     private final MetaStore metaStore;
     private final DataSourceExtractor dataSourceExtractor;
@@ -106,7 +109,7 @@ public final class AstSanitizer {
     @Override
     protected Optional<AstNode> visitInsertInto(
         final InsertInto node,
-        final StatementRewriter.Context<Object> ctx
+        final StatementRewriter.Context<SanitizerContext> ctx
     ) {
       final DataSource target = metaStore.getSource(node.getTarget());
       if (target == null) {
@@ -133,7 +136,7 @@ public final class AstSanitizer {
     @Override
     protected Optional<AstNode> visitSingleColumn(
         final SingleColumn singleColumn,
-        final StatementRewriter.Context<Object> ctx
+        final StatementRewriter.Context<SanitizerContext> ctx
     ) {
       if (singleColumn.getAlias().isPresent()) {
         return Optional.empty();
@@ -161,7 +164,8 @@ public final class AstSanitizer {
   }
 
   private static final class ExpressionRewriterPlugin extends
-      VisitParentExpressionVisitor<Optional<Expression>, Object> {
+      VisitParentExpressionVisitor<Optional<Expression>,
+      ExpressionTreeRewriter.Context<SanitizerContext>> {
 
     private final DataSourceExtractor dataSourceExtractor;
 
@@ -173,20 +177,14 @@ public final class AstSanitizer {
     @Override
     public Optional<Expression> visitUnqualifiedColumnReference(
         final UnqualifiedColumnReferenceExp expression,
-        final Object ctx
+        final ExpressionTreeRewriter.Context<SanitizerContext> ctx
     ) {
       final ColumnName columnName = expression.getColumnName();
-      if (ctx != null && ctx instanceof Context) {
-        final Context currentContext = (Context) ctx;
-        if (currentContext.getContext() instanceof LambdaContext) {
-          final LambdaContext lambdaContext =
-              (LambdaContext) currentContext.getContext();
-          if (lambdaContext.getLambdaArguments().size() > 0
-              && lambdaContext.getLambdaArguments().contains(columnName.text())) {
-            return Optional.of(new LambdaLiteral(columnName.text()));
-          }
-        }
+      if (ctx.getContext().getLambdaArgs().size() > 0
+          && ctx.getContext().getLambdaArgs().contains(columnName.text())) {
+        return Optional.of(new LambdaLiteral(columnName.text()));
       }
+
       final List<SourceName> sourceNames = dataSourceExtractor.getSourcesFor(columnName);
 
       if (sourceNames.size() > 1) {
@@ -209,19 +207,41 @@ public final class AstSanitizer {
 
     @Override
     public Optional<Expression> visitLambdaExpression(
-        final LambdaFunctionExpression expression,
-        final Object ctx
+        final LambdaFunctionCall expression,
+        final ExpressionTreeRewriter.Context<SanitizerContext> ctx
     ) {
       dataSourceExtractor.getAllSources().forEach(aliasedDataSource -> {
         for (String argument : expression.getArguments()) {
           if (aliasedDataSource.getDataSource().getSchema().columns().stream()
               .map(column -> column.name().text()).collect(Collectors.toList())
               .contains(argument)) {
-            throw new KsqlException("Lambda argument can't be a column name.");
+            throw new KsqlException(
+                String.format(
+                    "Lambda function argument can't be a column name: %s", argument));
           }
         }
       });
+
+      ctx.getContext().addLambdaArg(expression.getArguments());
       return visitExpression(expression, ctx);
+    }
+  }
+
+  private static class SanitizerContext {
+    final Set<String> lambdaArgs = new HashSet<>();
+
+    private void addLambdaArg(final List<String> newArguments) {
+      final int previousLambdaArgumentsLength = lambdaArgs.size();
+      lambdaArgs.addAll(newArguments);
+      if (new HashSet<>(lambdaArgs).size()
+          < previousLambdaArgumentsLength + 1) {
+        throw new KsqlException(
+            "Reusing lambda arguments in nested lambda is not allowed");
+      }
+    }
+
+    private Set<String> getLambdaArgs() {
+      return ImmutableSet.copyOf(lambdaArgs);
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/LambdaContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/LambdaContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine.rewrite;
+
+import io.confluent.ksql.util.KsqlException;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+
+public class LambdaContext {
+  private final List<String> lambdaArguments;
+  
+  public LambdaContext(final List<String> lambdaArguments) {
+    this.lambdaArguments = new ArrayList<>(
+        Objects.requireNonNull(lambdaArguments, "lambdaArguments"));
+  }
+  
+  public void addLambdaArguments(final List<String> newArguments) {
+    final int previousLambdaArgumentsLength = lambdaArguments.size();
+    lambdaArguments.addAll(newArguments);
+    if (new HashSet<>(lambdaArguments).size()
+        < previousLambdaArgumentsLength + newArguments.size()) {
+      throw new KsqlException("Duplicate lambda arguments are not allowed.");
+    }
+  }
+
+  public List<String> getLambdaArguments() {
+    return lambdaArguments;
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
@@ -25,13 +25,15 @@ import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
-import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.AstBuilder;
 import io.confluent.ksql.parser.DefaultKsqlParser;
@@ -202,10 +204,10 @@ public class AstSanitizerTest {
   }
 
   @Test
-  public void shouldAdt() {
+  public void shouldSanitizeLambdaArguments() {
     // Given:
     final Statement stmt = givenQuery(
-        "SELECT X => X + 5 FROM TEST2;");
+        "SELECT TRANSFORM_ARRAY(Col4, X => X + 5) FROM TEST1;");
 
     // When:
     final Query result = (Query) AstSanitizer.sanitize(stmt, META_STORE);
@@ -213,13 +215,55 @@ public class AstSanitizerTest {
     // Then:
     assertThat(result.getSelect(), is(new Select(ImmutableList.of(
         new SingleColumn(
-            new LambdaFunctionExpression(
-                ImmutableList.of("X"),
-                new ArithmeticBinaryExpression(Operator.ADD, new LambdaLiteral("X"), new IntegerLiteral(5))
+            new FunctionCall(
+                FunctionName.of("TRANSFORM_ARRAY"),
+                ImmutableList.of(
+                    column(TEST1_NAME, "COL4"),
+                    new LambdaFunctionCall(
+                        ImmutableList.of("X"),
+                        new ArithmeticBinaryExpression(
+                            Operator.ADD,
+                            new LambdaLiteral("X"),
+                            new IntegerLiteral(5))
+                    )
+                )
             ),
             Optional.of(ColumnName.of("KSQL_COL_0")))
     ))));
 
+  }
+
+  @Test
+  public void shouldThrowOnColumnNamesUsedForLambdaArguments() {
+    // Given:
+    final Statement stmt = givenQuery(
+        "SELECT TRANSFORM_ARRAY(Col4, Col0 => Col0 + 5) FROM TEST1;");
+
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> AstSanitizer.sanitize(stmt, META_STORE)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Lambda function argument can't be a column name: COL0"));
+
+  }
+
+  @Test
+  public void shouldThrowOnDuplicateLambdaArguments() {
+    // Given:
+    final Statement stmt = givenQuery(
+        "SELECT TRANSFORM_ARRAY(Col4, X => TRANSFORM_ARRAY(Col4, X => X)) FROM TEST1;");
+
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> AstSanitizer.sanitize(stmt, META_STORE)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Reusing lambda arguments in nested lambda is not allowed"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
@@ -185,7 +185,7 @@ public class ExpressionTreeRewriterTest {
   @Test
   public void shouldRewriteLambdaFunctionUsingPlugin() {
     // Given:
-    final Expression parsed = parseExpression("X => X + Col0");
+    final Expression parsed = parseExpression("TRANSFORM_ARRAY(Array[1,2], X => X + Col0)");
 
     // When/Then:
     shouldRewriteUsingPlugin(parsed);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
@@ -183,6 +183,15 @@ public class ExpressionTreeRewriterTest {
   }
 
   @Test
+  public void shouldRewriteLambdaFunctionUsingPlugin() {
+    // Given:
+    final Expression parsed = parseExpression("X => X + Col0");
+
+    // When/Then:
+    shouldRewriteUsingPlugin(parsed);
+  }
+
+  @Test
   public void shouldRewriteBetweenPredicate() {
     // Given:
     final BetweenPredicate parsed = parseExpression("1 BETWEEN 0 AND 2");

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/LambdaContextTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/LambdaContextTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.confluent.ksql.engine.rewrite;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Test;
+
+public class LambdaContextTest {
+    @Test
+    public void shouldThrowIfSourceDoesNotExist() {
+        // Given:
+        final LambdaContext context = new LambdaContext(ImmutableList.of("X"));
+
+        // When:
+        context.addLambdaArguments(ImmutableList.of("Z", "Y"));
+
+        // Then:
+        assertThat(context.getLambdaArguments(), is(ImmutableList.of("X", "Z", "Y")));
+    }
+
+    @Test
+    public void shouldThrowIfLambdaArgumentAlreadyUsed() {
+        // Given:
+        final LambdaContext context = new LambdaContext(ImmutableList.of("X"));
+
+        // When:
+        final Exception e = assertThrows(
+            KsqlException.class,
+            () -> context.addLambdaArguments(ImmutableList.of("X", "Y"))
+        );
+
+        // Then:
+        assertThat(e.getMessage(), containsString(
+        "Duplicate lambda arguments are not allowed."));
+    }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -24,7 +24,7 @@ import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
-import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TraversalExpressionVisitor;
@@ -256,7 +256,7 @@ public class CodeGenRunner {
     }
 
     @Override
-    public Void visitLambdaExpression(final LambdaFunctionExpression node, final Void context) {
+    public Void visitLambdaExpression(final LambdaFunctionCall node, final Void context) {
       process(node.getBody(), null);
       return null;
     }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TraversalExpressionVisitor;
@@ -251,6 +252,12 @@ public class CodeGenRunner {
     @Override
     public Void visitDereferenceExpression(final DereferenceExpression node, final Void context) {
       process(node.getBase(), null);
+      return null;
+    }
+
+    @Override
+    public Void visitLambdaExpression(final LambdaFunctionExpression node, final Void context) {
+      process(node.getBody(), null);
       return null;
     }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -54,7 +54,7 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
-import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
@@ -351,8 +351,8 @@ public class SqlToJavaVisitor {
 
     @Override
     public Pair<String, SqlType> visitLambdaExpression(
-        final LambdaFunctionExpression lambdaFunctionExpression, final Void context) {
-      return visitUnsupported(lambdaFunctionExpression);
+        final LambdaFunctionCall lambdaFunctionCall, final Void context) {
+      return visitUnsupported(lambdaFunctionCall);
     }
 
     @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -54,6 +54,8 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -104,6 +106,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -118,6 +121,7 @@ public class SqlToJavaVisitor {
   public static final List<String> JAVA_IMPORTS = ImmutableList.of(
       "io.confluent.ksql.execution.codegen.helpers.ArrayAccess",
       "io.confluent.ksql.execution.codegen.helpers.SearchedCaseFunction",
+      "io.confluent.ksql.execution.codegen.helpers.TriFunction",
       "io.confluent.ksql.execution.codegen.helpers.SearchedCaseFunction.LazyWhenClause",
       "java.sql.Timestamp",
       "java.util.Arrays",
@@ -130,6 +134,7 @@ public class SqlToJavaVisitor {
       "com.google.common.collect.ImmutableMap",
       "java.util.function.Supplier",
       Function.class.getCanonicalName(),
+      BiFunction.class.getCanonicalName(),
       DecimalUtil.class.getCanonicalName(),
       BigDecimal.class.getCanonicalName(),
       MathContext.class.getCanonicalName(),
@@ -342,6 +347,18 @@ public class SqlToJavaVisitor {
     @Override
     public Pair<String, SqlType> visitNullLiteral(final NullLiteral node, final Void context) {
       return new Pair<>("null", null);
+    }
+
+    @Override
+    public Pair<String, SqlType> visitLambdaExpression(
+        final LambdaFunctionExpression lambdaFunctionExpression, final Void context) {
+      return visitUnsupported(lambdaFunctionExpression);
+    }
+
+    @Override
+    public Pair<String, SqlType> visitLambdaLiteral(
+        final LambdaLiteral lambdaLiteral, final Void context) {
+      return visitUnsupported(lambdaLiteral);
     }
 
     @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/TriFunction.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/TriFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.codegen.helpers;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface TriFunction<A,B,C,R> {
+
+  R apply(A a, B b, C c);
+
+  default <V> TriFunction<A, B, C, V> andThen(
+      Function<? super R, ? extends V> after) {
+    Objects.requireNonNull(after);
+    return (A a, B b, C c) -> after.apply(apply(a, b, c));
+  }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -40,7 +40,7 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
-import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
@@ -396,7 +396,7 @@ public final class ExpressionFormatter {
 
     @Override
     public String visitLambdaExpression(
-        final LambdaFunctionExpression node, final Context context) {
+        final LambdaFunctionCall node, final Context context) {
       final StringBuilder builder = new StringBuilder();
 
       builder.append('(');

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -40,6 +40,8 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -102,6 +104,11 @@ public final class ExpressionFormatter {
     @Override
     public String visitStringLiteral(final StringLiteral node, final Context context) {
       return formatStringLiteral(node.getValue());
+    }
+
+    @Override
+    public String visitLambdaLiteral(final LambdaLiteral node, final Context context) {
+      return String.valueOf(node.getValue());
     }
 
     @Override
@@ -385,6 +392,18 @@ public final class ExpressionFormatter {
     @Override
     public String visitInListExpression(final InListExpression node, final Context context) {
       return "(" + joinExpressions(node.getValues(), context) + ")";
+    }
+
+    @Override
+    public String visitLambdaExpression(
+        final LambdaFunctionExpression node, final Context context) {
+      final StringBuilder builder = new StringBuilder();
+
+      builder.append('(');
+      Joiner.on(", ").appendTo(builder, node.getArguments());
+      builder.append(") => ");
+      builder.append(process(node.getBody(), context));
+      return builder.toString();
     }
 
     private String formatBinaryExpression(

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
@@ -87,7 +87,7 @@ public interface ExpressionVisitor<R, C> {
 
   R visitWhenClause(WhenClause exp, C context);
 
-  R visitLambdaExpression(LambdaFunctionExpression exp, C context);
+  R visitLambdaExpression(LambdaFunctionCall exp, C context);
 
   R visitLambdaLiteral(LambdaLiteral exp, C context);
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
@@ -87,4 +87,7 @@ public interface ExpressionVisitor<R, C> {
 
   R visitWhenClause(WhenClause exp, C context);
 
+  R visitLambdaExpression(LambdaFunctionExpression exp, C context);
+
+  R visitLambdaLiteral(LambdaLiteral exp, C context);
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LambdaFunctionCall.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LambdaFunctionCall.java
@@ -27,19 +27,19 @@ import java.util.Optional;
 import java.util.Set;
 
 
-public class LambdaFunctionExpression extends Expression {
+public class LambdaFunctionCall extends Expression {
 
   private final ImmutableList<String> arguments;
   private final Expression body;
 
-  public LambdaFunctionExpression(
+  public LambdaFunctionCall(
       final List<String> name,
       final Expression body
   ) {
     this(Optional.empty(), name, body);
   }
 
-  public LambdaFunctionExpression(
+  public LambdaFunctionCall(
       final Optional<NodeLocation> location,
       final List<String> arguments,
       final Expression body
@@ -53,7 +53,7 @@ public class LambdaFunctionExpression extends Expression {
     final Set<String> set = new HashSet<>(arguments);
     if (set.size() < arguments.size()) {
       throw new IllegalArgumentException(
-          String.format("Lambda arguments are duplicates: %s", arguments.toString()));
+          String.format("Lambda arguments have duplicates: %s", arguments.toString()));
     }
     this.body = requireNonNull(body, "body is null");
   }
@@ -79,7 +79,7 @@ public class LambdaFunctionExpression extends Expression {
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
-    final LambdaFunctionExpression that = (LambdaFunctionExpression) obj;
+    final LambdaFunctionCall that = (LambdaFunctionCall) obj;
     return Objects.equals(arguments, that.arguments)
         && Objects.equals(body, that.body);
   }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LambdaFunctionExpression.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LambdaFunctionExpression.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.expression.tree;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.parser.NodeLocation;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+
+public class LambdaFunctionExpression extends Expression {
+
+  private final ImmutableList<String> arguments;
+  private final Expression body;
+
+  public LambdaFunctionExpression(
+      final List<String> name,
+      final Expression body
+  ) {
+    this(Optional.empty(), name, body);
+  }
+
+  public LambdaFunctionExpression(
+      final Optional<NodeLocation> location,
+      final List<String> arguments,
+      final Expression body
+  ) {
+    super(location);
+    this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments"));
+    if (arguments.size() == 0) {
+      throw new IllegalArgumentException(
+          String.format("Lambda expression must have at least 1 argument. => %s", body.toString()));
+    }
+    final Set<String> set = new HashSet<>(arguments);
+    if (set.size() < arguments.size()) {
+      throw new IllegalArgumentException(
+          String.format("Lambda arguments are duplicates: %s", arguments.toString()));
+    }
+    this.body = requireNonNull(body, "body is null");
+  }
+
+  public List<String> getArguments() {
+    return arguments;
+  }
+
+  public Expression getBody() {
+    return body;
+  }
+
+  @Override
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
+    return visitor.visitLambdaExpression(this, context);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final LambdaFunctionExpression that = (LambdaFunctionExpression) obj;
+    return Objects.equals(arguments, that.arguments)
+        && Objects.equals(body, that.body);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(arguments, body);
+  }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LambdaLiteral.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LambdaLiteral.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.expression.tree;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.NodeLocation;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class LambdaLiteral extends Literal {
+
+  private final String lambdaCharacter;
+
+  public LambdaLiteral(final String lambdaCharacter) {
+    this(Optional.empty(), lambdaCharacter);
+  }
+
+  public LambdaLiteral(final Optional<NodeLocation> location, final String lambdaCharacter) {
+    super(location);
+    this.lambdaCharacter = lambdaCharacter;
+  }
+
+  @Override
+  public String getValue() {
+    return lambdaCharacter;
+  }
+
+  @Override
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
+    return visitor.visitLambdaLiteral(this, context);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final LambdaLiteral that = (LambdaLiteral) o;
+    return lambdaCharacter.equals(that.lambdaCharacter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(lambdaCharacter);
+  }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
@@ -99,7 +99,7 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
   }
 
   @Override
-  public Void visitLambdaExpression(final LambdaFunctionExpression node, final C context) {
+  public Void visitLambdaExpression(final LambdaFunctionCall node, final C context) {
     process(node.getBody(), context);
     return null;
   }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
@@ -99,6 +99,12 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
   }
 
   @Override
+  public Void visitLambdaExpression(final LambdaFunctionExpression node, final C context) {
+    process(node.getBody(), context);
+    return null;
+  }
+
+  @Override
   public Void visitDereferenceExpression(final DereferenceExpression node, final C context) {
     process(node.getBase(), context);
     return null;
@@ -194,6 +200,11 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
 
   @Override
   public Void visitBooleanLiteral(final BooleanLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitLambdaLiteral(final LambdaLiteral node, final C context) {
     return null;
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
@@ -215,7 +215,7 @@ public abstract class VisitParentExpressionVisitor<R, C> implements ExpressionVi
   }
 
   @Override
-  public R visitLambdaExpression(final LambdaFunctionExpression node, final C context) {
+  public R visitLambdaExpression(final LambdaFunctionCall node, final C context) {
     return visitExpression(node, context);
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
@@ -213,4 +213,14 @@ public abstract class VisitParentExpressionVisitor<R, C> implements ExpressionVi
   public R visitCast(final Cast node, final C context) {
     return visitExpression(node, context);
   }
+
+  @Override
+  public R visitLambdaExpression(final LambdaFunctionExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitLambdaLiteral(final LambdaLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -37,6 +37,8 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -133,6 +135,27 @@ public class ExpressionTypeManager {
         final ArithmeticUnaryExpression node, final ExpressionTypeContext context
     ) {
       process(node.getValue(), context);
+      return null;
+    }
+
+    @Override
+    // CHECKSTYLE_RULES.OFF: TodoComment
+    public Void visitLambdaExpression(
+        final LambdaFunctionExpression node, final ExpressionTypeContext context
+    ) {
+      process(node.getBody(), context);
+      // TODO: add proper type inference
+      context.setSqlType(SqlTypes.INTEGER);
+      return null;
+    }
+
+    @Override
+    // CHECKSTYLE_RULES.OFF: TodoComment
+    public Void visitLambdaLiteral(
+        final LambdaLiteral node, final ExpressionTypeContext expressionTypeContext
+    ) {
+      // TODO: add proper type inference
+      expressionTypeContext.setSqlType(SqlTypes.INTEGER);
       return null;
     }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -37,7 +37,7 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
-import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
@@ -141,7 +141,7 @@ public class ExpressionTypeManager {
     @Override
     // CHECKSTYLE_RULES.OFF: TodoComment
     public Void visitLambdaExpression(
-        final LambdaFunctionExpression node, final ExpressionTypeContext context
+        final LambdaFunctionCall node, final ExpressionTypeContext context
     ) {
       process(node.getBody(), context);
       // TODO: add proper type inference

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/helpers/LambdaUtilTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/helpers/LambdaUtilTest.java
@@ -19,8 +19,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.codegen.CodeGenTestUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.Pair;
 import org.junit.Test;
 
 @SuppressWarnings("unchecked")
@@ -34,11 +42,60 @@ public class LambdaUtilTest {
 
     // When:
     final String javaCode = LambdaUtil
-        .function(argName, argType, argName + ".longValue() + 1");
+        .function(argName, argType, argName + " + 1");
 
     // Then:
     final Object result = CodeGenTestUtil.cookAndEval(javaCode, Function.class);
     assertThat(result, is(instanceOf(Function.class)));
     assertThat(((Function<Object, Object>) result).apply(10L), is(11L));
+  }
+
+  @Test
+  public void shouldGenerateBiFunction() {
+    // Given:
+    final Pair<String, Class<?>> argName1 = new Pair<>("fred", Long.class);
+    final Pair<String, Class<?>> argName2 = new Pair<>("bob", Long.class);
+    
+    final List<Pair<String, Class<?>>> argList = ImmutableList.of(argName1, argName2);
+
+    // When:
+    final String javaCode = LambdaUtil.function(argList, "fred + bob + 2");
+
+    // Then:
+    final Object result = CodeGenTestUtil.cookAndEval(javaCode, BiFunction.class);
+    assertThat(result, is(instanceOf(BiFunction.class)));
+    assertThat(((BiFunction<Object, Object, Object>) result).apply(10L, 15L), is(27L));
+  }
+
+  @Test
+  public void shouldGenerateTriFunction() {
+    // Given:
+    final Pair<String, Class<?>> argName1 = new Pair<>("fred", Long.class);
+    final Pair<String, Class<?>> argName2 = new Pair<>("bob", Long.class);
+    final Pair<String, Class<?>> argName3 = new Pair<>("tim", Long.class);
+
+    final List<Pair<String, Class<?>>> argList = ImmutableList.of(argName1, argName2, argName3);
+
+    // When:
+    final String javaCode = LambdaUtil.function(argList, "fred + bob + tim + 1");
+
+    // Then:
+    final Object result = CodeGenTestUtil.cookAndEval(javaCode, TriFunction.class);
+    assertThat(result, is(instanceOf(TriFunction.class)));
+    assertThat(((TriFunction<Object, Object, Object, Object>) result).apply(10L, 15L, 3L), is(29L));
+  }
+
+  @Test(expected= KsqlException.class)
+  public void shouldThrowOnNonSupportedArguments() {
+    // Given:
+    final Pair<String, Class<?>> argName1 = new Pair<>("fred", Long.class);
+    final Pair<String, Class<?>> argName2 = new Pair<>("bob", Long.class);
+    final Pair<String, Class<?>> argName3 = new Pair<>("tim", Long.class);
+    final Pair<String, Class<?>> argName4 = new Pair<>("hello", Long.class);
+
+    final List<Pair<String, Class<?>>> argList = ImmutableList.of(argName1, argName2, argName3, argName4);
+
+    // When:
+    LambdaUtil.function(argList, "fred + bob + tim + hello + 1");
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -41,7 +41,7 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
-import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
@@ -205,7 +205,7 @@ public class ExpressionFormatterTest {
   @Test
   public void shouldFormatLambdaExpression() {
     // Given:
-    final LambdaFunctionExpression expression = new LambdaFunctionExpression(
+    final LambdaFunctionCall expression = new LambdaFunctionCall(
         Optional.of(LOCATION),
         ImmutableList.of("X", "Y"),
         new LogicalBinaryExpression(LogicalBinaryExpression.Type.OR,

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -41,6 +41,8 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -198,6 +200,24 @@ public class ExpressionFormatterTest {
 
     // Then:
     assertThat(text, equalTo("'foo'->name"));
+  }
+
+  @Test
+  public void shouldFormatLambdaExpression() {
+    // Given:
+    final LambdaFunctionExpression expression = new LambdaFunctionExpression(
+        Optional.of(LOCATION),
+        ImmutableList.of("X", "Y"),
+        new LogicalBinaryExpression(LogicalBinaryExpression.Type.OR,
+            new LambdaLiteral("X"),
+            new LambdaLiteral("Y"))
+    );
+
+    // When:
+    final String text = ExpressionFormatter.formatExpression(expression);
+
+    // Then:
+    assertThat(text, equalTo("(X, Y) => (X OR Y)"));
   }
 
   @Test

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/tree/LambdaFunctionCallTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/tree/LambdaFunctionCallTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
 
-public class LambdaFunctionExpressionTest {
+public class LambdaFunctionCallTest {
 
     public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
     public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
@@ -36,37 +36,37 @@ public class LambdaFunctionExpressionTest {
         new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new LambdaFunctionExpression(SOME_ARGUMENTS, SOME_EXPRESSION),
-            new LambdaFunctionExpression(SOME_ARGUMENTS, SOME_EXPRESSION),
-            new LambdaFunctionExpression(Optional.of(SOME_LOCATION), SOME_ARGUMENTS, SOME_EXPRESSION),
-            new LambdaFunctionExpression(Optional.of(OTHER_LOCATION), SOME_ARGUMENTS, SOME_EXPRESSION)
+            new LambdaFunctionCall(SOME_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionCall(SOME_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionCall(Optional.of(SOME_LOCATION), SOME_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionCall(Optional.of(OTHER_LOCATION), SOME_ARGUMENTS, SOME_EXPRESSION)
         )
         .addEqualityGroup(
-            new LambdaFunctionExpression(SOME_ARGUMENTS, OTHER_EXPRESSION),
-            new LambdaFunctionExpression(SOME_ARGUMENTS, OTHER_EXPRESSION),
-            new LambdaFunctionExpression(Optional.of(SOME_LOCATION), SOME_ARGUMENTS, OTHER_EXPRESSION),
-            new LambdaFunctionExpression(Optional.of(OTHER_LOCATION), SOME_ARGUMENTS, OTHER_EXPRESSION)
+            new LambdaFunctionCall(SOME_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionCall(SOME_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionCall(Optional.of(SOME_LOCATION), SOME_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionCall(Optional.of(OTHER_LOCATION), SOME_ARGUMENTS, OTHER_EXPRESSION)
         ).addEqualityGroup(
-            new LambdaFunctionExpression(OTHER_ARGUMENTS, SOME_EXPRESSION),
-            new LambdaFunctionExpression(OTHER_ARGUMENTS, SOME_EXPRESSION),
-            new LambdaFunctionExpression(Optional.of(SOME_LOCATION), OTHER_ARGUMENTS, SOME_EXPRESSION),
-            new LambdaFunctionExpression(Optional.of(OTHER_LOCATION), OTHER_ARGUMENTS, SOME_EXPRESSION)
+            new LambdaFunctionCall(OTHER_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionCall(OTHER_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionCall(Optional.of(SOME_LOCATION), OTHER_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionCall(Optional.of(OTHER_LOCATION), OTHER_ARGUMENTS, SOME_EXPRESSION)
         ).addEqualityGroup(
-            new LambdaFunctionExpression(OTHER_ARGUMENTS, OTHER_EXPRESSION),
-            new LambdaFunctionExpression(OTHER_ARGUMENTS, OTHER_EXPRESSION),
-            new LambdaFunctionExpression(Optional.of(SOME_LOCATION), OTHER_ARGUMENTS, OTHER_EXPRESSION),
-            new LambdaFunctionExpression(Optional.of(OTHER_LOCATION), OTHER_ARGUMENTS, OTHER_EXPRESSION)
+            new LambdaFunctionCall(OTHER_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionCall(OTHER_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionCall(Optional.of(SOME_LOCATION), OTHER_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionCall(Optional.of(OTHER_LOCATION), OTHER_ARGUMENTS, OTHER_EXPRESSION)
         )
         .testEquals();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowOnDuplicateArguments() {
-        new LambdaFunctionExpression(ImmutableList.of("X", "X", "Y"), SOME_EXPRESSION);
+        new LambdaFunctionCall(ImmutableList.of("X", "X", "Y"), SOME_EXPRESSION);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowOnNoArguments() {
-        new LambdaFunctionExpression(ImmutableList.of(), SOME_EXPRESSION);
+        new LambdaFunctionCall(ImmutableList.of(), SOME_EXPRESSION);
     }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/tree/LambdaFunctionExpressionTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/tree/LambdaFunctionExpressionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.expression.tree;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+
+public class LambdaFunctionExpressionTest {
+
+    public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
+    public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
+    private static final List<String> SOME_ARGUMENTS = ImmutableList.of("X", "Y");
+    private static final List<String> OTHER_ARGUMENTS = ImmutableList.of("X");
+    private static final Expression SOME_EXPRESSION = new StringLiteral("steven");
+    private static final Expression OTHER_EXPRESSION = new StringLiteral("steve");
+
+    @Test
+    public void shouldImplementHashCodeAndEqualsProperty() {
+        new EqualsTester()
+        .addEqualityGroup(
+            // Note: At the moment location does not take part in equality testing
+            new LambdaFunctionExpression(SOME_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionExpression(SOME_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionExpression(Optional.of(SOME_LOCATION), SOME_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionExpression(Optional.of(OTHER_LOCATION), SOME_ARGUMENTS, SOME_EXPRESSION)
+        )
+        .addEqualityGroup(
+            new LambdaFunctionExpression(SOME_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionExpression(SOME_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionExpression(Optional.of(SOME_LOCATION), SOME_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionExpression(Optional.of(OTHER_LOCATION), SOME_ARGUMENTS, OTHER_EXPRESSION)
+        ).addEqualityGroup(
+            new LambdaFunctionExpression(OTHER_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionExpression(OTHER_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionExpression(Optional.of(SOME_LOCATION), OTHER_ARGUMENTS, SOME_EXPRESSION),
+            new LambdaFunctionExpression(Optional.of(OTHER_LOCATION), OTHER_ARGUMENTS, SOME_EXPRESSION)
+        ).addEqualityGroup(
+            new LambdaFunctionExpression(OTHER_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionExpression(OTHER_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionExpression(Optional.of(SOME_LOCATION), OTHER_ARGUMENTS, OTHER_EXPRESSION),
+            new LambdaFunctionExpression(Optional.of(OTHER_LOCATION), OTHER_ARGUMENTS, OTHER_EXPRESSION)
+        )
+        .testEquals();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowOnDuplicateArguments() {
+        new LambdaFunctionExpression(ImmutableList.of("X", "X", "Y"), SOME_EXPRESSION);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowOnNoArguments() {
+        new LambdaFunctionExpression(ImmutableList.of(), SOME_EXPRESSION);
+    }
+}

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -296,7 +296,7 @@ primaryExpression
     | MAP '(' (expression ASSIGN expression (',' expression ASSIGN expression)*)? ')'     #mapConstructor
     | STRUCT '(' (identifier ASSIGN expression (',' identifier ASSIGN expression)*)? ')'  #structConstructor
     | identifier '(' ASTERISK ')'                              		                        #functionCall
-    | identifier'(' (expression (',' expression)* (',' lambdaFunction)*)? ')'             #functionCall
+    | identifier '(' (expression (',' expression)* (',' lambdaFunction)*)? ')'             #functionCall
     | value=primaryExpression '[' index=valueExpression ']'                               #subscript
     | identifier                                                                          #columnReference
     | identifier '.' identifier                                                           #qualifiedColumnReference

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -292,11 +292,13 @@ primaryExpression
     | CASE valueExpression whenClause+ (ELSE elseExpression=expression)? END              #simpleCase
     | CASE whenClause+ (ELSE elseExpression=expression)? END                              #searchedCase
     | CAST '(' expression AS type ')'                                                     #cast
+    | identifier '=>' expression                                                          #lambda
+    | '(' identifier (',' identifier)*  ')' '=>' expression                               #lambda
     | ARRAY '[' (expression (',' expression)*)? ']'                                       #arrayConstructor
     | MAP '(' (expression ASSIGN expression (',' expression ASSIGN expression)*)? ')'     #mapConstructor
     | STRUCT '(' (identifier ASSIGN expression (',' identifier ASSIGN expression)*)? ')'  #structConstructor
-    | identifier '(' ASTERISK ')'                              		                        #functionCall
-    | identifier'(' (expression (',' expression)*)? ')' 						                      #functionCall
+    | identifier '(' ASTERISK ')'                              		                      #functionCall
+    | identifier'(' (expression (',' expression)*)? ')' 						          #functionCall
     | value=primaryExpression '[' index=valueExpression ']'                               #subscript
     | identifier                                                                          #columnReference
     | identifier '.' identifier                                                           #qualifiedColumnReference
@@ -544,6 +546,8 @@ CONCAT: '||';
 
 ASSIGN: ':=';
 STRUCT_FIELD_REF: '->';
+
+LAMBDA_EXPRESSION: '=>';
 
 STRING
     : '\'' ( ~'\'' | '\'\'' )* '\''

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -292,13 +292,11 @@ primaryExpression
     | CASE valueExpression whenClause+ (ELSE elseExpression=expression)? END              #simpleCase
     | CASE whenClause+ (ELSE elseExpression=expression)? END                              #searchedCase
     | CAST '(' expression AS type ')'                                                     #cast
-    | identifier '=>' expression                                                          #lambda
-    | '(' identifier (',' identifier)*  ')' '=>' expression                               #lambda
     | ARRAY '[' (expression (',' expression)*)? ']'                                       #arrayConstructor
     | MAP '(' (expression ASSIGN expression (',' expression ASSIGN expression)*)? ')'     #mapConstructor
     | STRUCT '(' (identifier ASSIGN expression (',' identifier ASSIGN expression)*)? ')'  #structConstructor
-    | identifier '(' ASTERISK ')'                              		                      #functionCall
-    | identifier'(' (expression (',' expression)*)? ')' 						          #functionCall
+    | identifier '(' ASTERISK ')'                              		                        #functionCall
+    | identifier'(' (expression (',' expression)* (',' lambdaFunction)*)? ')'             #functionCall
     | value=primaryExpression '[' index=valueExpression ']'                               #subscript
     | identifier                                                                          #columnReference
     | identifier '.' identifier                                                           #qualifiedColumnReference
@@ -346,6 +344,11 @@ identifier
     | nonReserved            #unquotedIdentifier
     | BACKQUOTED_IDENTIFIER  #backQuotedIdentifier
     | DIGIT_IDENTIFIER       #digitIdentifier
+    ;
+
+lambdaFunction
+    :  identifier '=>' expression                            #lambda
+    | '(' identifier (',' identifier)*  ')' '=>' expression  #lambda
     ;
 
 variableName

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -42,7 +42,7 @@ import io.confluent.ksql.execution.expression.tree.InListExpression;
 import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
-import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
@@ -646,7 +646,7 @@ public class AstBuilder {
 
       final Expression body = (Expression) visit(context.expression());
 
-      return new LambdaFunctionExpression(getLocation(context), arguments, body);
+      return new LambdaFunctionCall(getLocation(context), arguments, body);
     }
 
     @Override
@@ -1185,10 +1185,12 @@ public class AstBuilder {
 
     @Override
     public Node visitFunctionCall(final SqlBaseParser.FunctionCallContext context) {
+      final List<Expression> expressionList = visit(context.expression(), Expression.class);
+      expressionList.addAll(visit(context.lambdaFunction(), Expression.class));
       return new FunctionCall(
           getLocation(context),
           FunctionName.of(ParserUtil.getIdentifierText(context.identifier())),
-          visit(context.expression(), Expression.class)
+          expressionList
       );
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.execution.expression.tree.InListExpression;
 import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
+import io.confluent.ksql.execution.expression.tree.LambdaFunctionExpression;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
@@ -635,6 +636,17 @@ public class AstBuilder {
       } else {
         return new SingleColumn(getLocation(context), selectItem, Optional.empty());
       }
+    }
+
+    @Override
+    public Node visitLambda(final SqlBaseParser.LambdaContext context) {
+      final List<String> arguments = context.identifier().stream()
+          .map(ParserUtil::getIdentifierText)
+          .collect(toList());
+
+      final Expression body = (Expression) visit(context.expression());
+
+      return new LambdaFunctionExpression(getLocation(context), arguments, body);
     }
 
     @Override


### PR DESCRIPTION
### Description 
Adds syntax for lambda functions to the KSQL grammar

LambdaFunctionExpression for representing a lambda function node
LambdaLiteral for representing a lambda variable

During the AstBuilder phase, the lambda variables are treated as UnqualifiedColumnReferences since I couldn't pass in a proper context, so I decided to convert them with the AstSanitizer.

Currently, lambdas won't work properly because the corresponding SqlToJavaVisitor methods haven't been implemented yet.

### Testing done 
Unit test
Manual test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

