### PR TITLE
test: add integration test for incompatible command detection with backups enabled

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -694,7 +694,7 @@ public class KsqlRestConfig extends AbstractConfig {
     return getPropertiesWithOverrides(COMMAND_CONSUMER_PREFIX);
   }
 
-  Map<String, Object> getCommandProducerProperties() {
+  public Map<String, Object> getCommandProducerProperties() {
     return getPropertiesWithOverrides(COMMAND_PRODUCER_PREFIX);
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/BackupRollbackIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/BackupRollbackIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,8 +13,9 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.api.integration;
+package io.confluent.ksql.rest.integration;
 
+import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.COMMAND_RUNNER_CHECK_NAME;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_METASTORE_BACKUP_LOCATION;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
@@ -26,20 +27,21 @@ import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.rest.DefaultErrorMessages;
 import io.confluent.ksql.rest.entity.CommandId;
+import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamsList;
-import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
-import io.confluent.ksql.rest.server.BackupReplayFile;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
-import io.confluent.ksql.rest.server.restore.KsqlRestoreCommandTopic;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import kafka.zookeeper.ZooKeeperClientException;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
 import org.junit.Before;
@@ -52,10 +54,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +68,7 @@ import java.util.stream.Collectors;
  * Tests covering integration tests for backup/restore the command topic.
  */
 @Category({IntegrationTest.class})
-public class RestoreCommandTopicIntegrationTest {
+public class BackupRollbackIntegrationTest {
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
   @ClassRule
@@ -83,7 +83,8 @@ public class RestoreCommandTopicIntegrationTest {
   private static TestKsqlRestApp REST_APP;
   private String commandTopic;
   private Path backupFile;
-  private Path propertiesFile;
+  private KsqlRestConfig ksqlRestConfig;
+  private KsqlConfig ksqlConfig;
 
   @BeforeClass
   public static void classSetUp() throws IOException {
@@ -99,11 +100,10 @@ public class RestoreCommandTopicIntegrationTest {
   @Before
   public void setup() throws IOException {
     REST_APP.start();
-    final KsqlConfig ksqlConfig = new KsqlConfig(REST_APP.getKsqlRestConfig().getKsqlConfigProperties());
+    ksqlRestConfig = REST_APP.getKsqlRestConfig();
+    ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlConfigProperties());
     commandTopic = ReservedInternalTopics.commandTopic(ksqlConfig);
     backupFile = Files.list(BACKUP_LOCATION.toPath()).findFirst().get();
-    propertiesFile = TMP_FOLDER.newFile().toPath();
-    writeServerProperties(propertiesFile);
   }
 
   @After
@@ -117,19 +117,6 @@ public class RestoreCommandTopicIntegrationTest {
     TMP_FOLDER.delete();
   }
 
-  private static void writeServerProperties(final Path propertiesFile) throws IOException {
-    final Map<String, Object> map = REST_APP.getKsqlRestConfig().getKsqlConfigProperties();
-
-    Files.write(
-            propertiesFile,
-        map.keySet().stream()
-            .map((key -> key + "=" + map.get(key)))
-            .collect(Collectors.joining("\n"))
-            .getBytes(StandardCharsets.UTF_8),
-        StandardOpenOption.CREATE
-    );
-  }
-
   @Test
   public void shouldBackupAndRestoreCommandTopic() throws Exception {
     // Given
@@ -141,20 +128,45 @@ public class RestoreCommandTopicIntegrationTest {
         + "WITH (KAFKA_TOPIC='topic2', VALUE_FORMAT='JSON');");
     makeKsqlRequest("CREATE STREAM stream1 AS SELECT * FROM topic1;");
     makeKsqlRequest("CREATE STREAM stream2 AS SELECT * FROM topic2;");
-
+    
     // When
+    final CommandId commandId = new CommandId("TOPIC", "entity", "CREATE");
+    final Command command = new Command(
+        "statement",
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Optional.empty(),
+        Optional.of(Command.VERSION + 1),
+        Command.VERSION + 1);
 
-    // Delete the command topic and check the server is in degraded state
-    TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
+    final Map<String, Object> kafkaProducerProperties = REST_APP.getKsqlRestConfig().getCommandProducerProperties();
+    kafkaProducerProperties.put(
+        ProducerConfig.TRANSACTIONAL_ID_CONFIG,
+        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
+    );
+    kafkaProducerProperties.put(
+        ProducerConfig.ACKS_CONFIG,
+        "all"
+    );
+    final KafkaProducer<CommandId, Command> producer = new KafkaProducer<>(
+        kafkaProducerProperties,
+        InternalTopicSerdes.serializer(),
+        InternalTopicSerdes.serializer()
+    );
+
+    produceToCommandTopic(producer, commandId, command);
+
+    // Server should enter degraded state due to incompatible command
     assertThatEventually("Degraded State", this::isDegradedState, is(true));
-
-    // Restore the command topic
-    KsqlRestoreCommandTopic.main(
-        new String[]{
-            "--yes",
-            "--config-file", propertiesFile.toString(),
-            backupFile.toString()
-        });
+    try {
+      List<String> allLines = Files.readAllLines(backupFile);
+      assertThat("All commands backed up from command topic", allLines.size() == 5);
+      assertThat("Incompatible command in backup", allLines.get(allLines.size() - 1).contains("\"version\":" + (Command.VERSION + 1)));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  
+    
 
     // Re-load the command topic
     REST_APP.stop();
@@ -166,62 +178,20 @@ public class RestoreCommandTopicIntegrationTest {
     assertThat("Should have TOPIC2", streamsNames.contains("TOPIC2"), is(true));
     assertThat("Should have STREAM1", streamsNames.contains("STREAM1"), is(true));
     assertThat("Should have STREAM2", streamsNames.contains("STREAM2"), is(true));
-    assertThat("Server should NOT be in degraded state", isDegradedState(), is(false));
-  }
-
-  @Test
-  public void shouldSkipIncompatibleCommands() throws Exception {
-    // Given
-    TEST_HARNESS.ensureTopics("topic3", "topic4");
-
-    makeKsqlRequest("CREATE STREAM TOPIC3 (ID INT) "
-        + "WITH (KAFKA_TOPIC='topic3', VALUE_FORMAT='JSON');");
-    makeKsqlRequest("CREATE STREAM TOPIC4 (ID INT) "
-        + "WITH (KAFKA_TOPIC='topic4', VALUE_FORMAT='JSON');");
-    makeKsqlRequest("CREATE STREAM stream3 AS SELECT * FROM topic3;");
-
-    final CommandId commandId = new CommandId("TOPIC", "entity", "CREATE");
-    final Command command = new Command(
-        "statement",
-        Collections.emptyMap(),
-        Collections.emptyMap(),
-        Optional.empty(),
-        Optional.of(Command.VERSION + 1),
-        Command.VERSION + 1);
-
-    writeToBackupFile(commandId, command, backupFile);
-
-    // Delete the command topic again and restore with skip flag
-    TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
-    REST_APP.stop();
-    KsqlRestoreCommandTopic.main(
-        new String[]{
-            "--yes",
-            "-s",
-            "--config-file", propertiesFile.toString(),
-            backupFile.toString()
-        });
-
-    // Re-load the command topic
-    REST_APP.start();
-    final List<String> streamsNames = showStreams();
-    assertThat("Should have TOPIC3", streamsNames.contains("TOPIC3"), is(true));
-    assertThat("Should have TOPIC4", streamsNames.contains("TOPIC4"), is(true));
-    assertThat("Should have STREAM3", streamsNames.contains("STREAM3"), is(true));
-    assertThat("Server should not be in degraded state", isDegradedState(), is(false));
+    assertThat("Server should be in degraded state", isDegradedState(), is(true));
   }
 
   private boolean isDegradedState() {
     // If in degraded state, then the following command will return a warning
-    final List<KsqlEntity> response = makeKsqlRequest(
-        "Show Streams;");
+    final List<KsqlEntity> response = makeKsqlRequest("Show Streams;");
 
     final List<KsqlWarning> warnings = response.get(0).getWarnings();
-    return warnings.size() > 0 &&
-        (warnings.get(0).getMessage().contains(
-            DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_CORRUPTED_ERROR_MESSAGE) ||
-            warnings.get(0).getMessage().contains(
-                DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_INCOMPATIBLE_COMMANDS_ERROR_MESSAGE));
+
+    final HealthCheckResponse res = RestIntegrationTestUtil.makeHealthCheck(REST_APP);
+    
+    return !res.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy() &&(warnings.size() > 0 &&
+        warnings.get(0).getMessage().contains(
+            DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_INCOMPATIBLE_COMMANDS_ERROR_MESSAGE));
   }
 
   private List<String> showStreams() {
@@ -232,19 +202,32 @@ public class RestoreCommandTopicIntegrationTest {
   private List<KsqlEntity> makeKsqlRequest(final String sql) {
     return RestIntegrationTestUtil.makeKsqlRequest(REST_APP, sql);
   }
-
-  private static void writeToBackupFile(
+  
+  private void produceToCommandTopic(
+      final KafkaProducer<CommandId, Command> producer, 
       final CommandId commandId,
-      final Command command,
-      final Path backUpFileLocation
-  ) throws IOException {
-    BackupReplayFile.writable(new File(String.valueOf(backUpFileLocation)))
-        .write(new ConsumerRecord<>(
-            "",
-            0,
-            0L,
-            InternalTopicSerdes.serializer().serialize("", commandId),
-            InternalTopicSerdes.serializer().serialize("", command))
-        );
+      final Command command
+  ) {
+    try {
+      producer.initTransactions();
+    } catch (final Exception e) {
+      assertThat("Fail due to not initializing transaction properly", false);
+    }
+
+    try {
+      producer.beginTransaction();
+      assertThatEventually("CommandRunner up to date", () -> showStreams().size(), is(4));
+      producer.send(new ProducerRecord<>(
+          ReservedInternalTopics.commandTopic(ksqlConfig),
+          0,
+          commandId,
+          command));
+      producer.commitTransaction();
+    } catch (final Exception e) {
+      producer.abortTransaction();
+      assertThat("Failed to produce to command topic properly", false);
+    } finally {
+      producer.close();
+    }
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/BackupRollbackIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/BackupRollbackIntegrationTest.java
@@ -118,7 +118,7 @@ public class BackupRollbackIntegrationTest {
   }
 
   @Test
-  public void shouldBackupAndRestoreCommandTopic() throws Exception {
+  public void shouldEnterDegradedStateWithBackupEnabled() {
     // Given
     TEST_HARNESS.ensureTopics("topic1", "topic2");
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/CommandTopicFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/CommandTopicFunctionalTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.integration;
 
+import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.COMMAND_RUNNER_CHECK_NAME;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -23,6 +24,7 @@ import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.rest.DefaultErrorMessages;
+import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
@@ -97,7 +99,12 @@ public class CommandTopicFunctionalTest {
     results1.forEach(ksqlEntity -> {
       assertThat("Warning shouldn't be present in response", ksqlEntity.getWarnings().size() == 0);
     });
-  
+
+    HealthCheckResponse healthCheckResponse = RestIntegrationTestUtil.makeHealthCheck(REST_APP_1);
+    assertThat(
+        "CommandRunner healthcheck is healthy for server 1",
+        healthCheckResponse.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy());
+
     // Delete command topic while server 1 still running
     TEST_HARNESS.deleteTopics(Collections.singletonList(ReservedInternalTopics.commandTopic(new KsqlConfig(Collections.emptyMap()))));
 
@@ -113,8 +120,18 @@ public class CommandTopicFunctionalTest {
       },
       is(true));
 
+    // need healthcheck cache to expire
+    assertThatEventually(
+        "CommandRunner healthcheck is unhealthy for server 1",
+        () -> {
+          final HealthCheckResponse newHealthCheckResponse = RestIntegrationTestUtil.makeHealthCheck(REST_APP_1);
+          return newHealthCheckResponse.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy();
+        }, is(false));
+
     // Corrupted backup test
     REST_APP_2.start();
+
+    // new DDL that diverges from backup triggers the corruption detection
     final List<KsqlEntity> results3 = makeKsqlRequest(REST_APP_2,
     "CREATE STREAM pageviews_divergent"
         + "(" + PAGE_VIEWS_PROVIDER.ksqlSchemaString(false) + ") "
@@ -123,11 +140,18 @@ public class CommandTopicFunctionalTest {
     results3.forEach(ksqlEntity -> {
       assertThat("Warning should be present in response",
           ksqlEntity.getWarnings().size() == 1);
-      assertThat("Warning isn't corrupted warning",
+      assertThat("Warning is corrupted warning",
           ksqlEntity.getWarnings()
               .get(0).getMessage()
               .equals(DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_CORRUPTED_ERROR_MESSAGE));
     });
+
+    assertThatEventually(
+        "CommandRunner healthcheck is unhealthy for server 2",
+        () -> {
+          final HealthCheckResponse newHealthCheckResponse = RestIntegrationTestUtil.makeHealthCheck(REST_APP_2);
+          return newHealthCheckResponse.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy();
+        }, is(false));
     
     // First server should still be in DEGRADED state even though second server created command topic on start up
     final List<KsqlEntity> results4 = makeKsqlRequest(REST_APP_1, "show streams;");
@@ -138,6 +162,11 @@ public class CommandTopicFunctionalTest {
               .get(0).getMessage()
               .equals(DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_CORRUPTED_ERROR_MESSAGE));
     });
+
+    healthCheckResponse = RestIntegrationTestUtil.makeHealthCheck(REST_APP_1);
+    assertThat(
+        "CommandRunner healthcheck is unhealthy for server 1",
+        !healthCheckResponse.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy());
   }
 
   private static List<KsqlEntity> makeKsqlRequest(final TestKsqlRestApp restApp, final String sql) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/CommandTopicFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/CommandTopicFunctionalTest.java
@@ -100,7 +100,7 @@ public class CommandTopicFunctionalTest {
       assertThat("Warning shouldn't be present in response", ksqlEntity.getWarnings().size() == 0);
     });
 
-    HealthCheckResponse healthCheckResponse = RestIntegrationTestUtil.makeHealthCheck(REST_APP_1);
+    HealthCheckResponse healthCheckResponse = RestIntegrationTestUtil.checkServerHealth(REST_APP_1);
     assertThat(
         "CommandRunner healthcheck is healthy for server 1",
         healthCheckResponse.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy());
@@ -124,7 +124,7 @@ public class CommandTopicFunctionalTest {
     assertThatEventually(
         "CommandRunner healthcheck is unhealthy for server 1",
         () -> {
-          final HealthCheckResponse newHealthCheckResponse = RestIntegrationTestUtil.makeHealthCheck(REST_APP_1);
+          final HealthCheckResponse newHealthCheckResponse = RestIntegrationTestUtil.checkServerHealth(REST_APP_1);
           return newHealthCheckResponse.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy();
         }, is(false));
 
@@ -149,7 +149,7 @@ public class CommandTopicFunctionalTest {
     assertThatEventually(
         "CommandRunner healthcheck is unhealthy for server 2",
         () -> {
-          final HealthCheckResponse newHealthCheckResponse = RestIntegrationTestUtil.makeHealthCheck(REST_APP_2);
+          final HealthCheckResponse newHealthCheckResponse = RestIntegrationTestUtil.checkServerHealth(REST_APP_2);
           return newHealthCheckResponse.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy();
         }, is(false));
     
@@ -163,7 +163,7 @@ public class CommandTopicFunctionalTest {
               .equals(DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_CORRUPTED_ERROR_MESSAGE));
     });
 
-    healthCheckResponse = RestIntegrationTestUtil.makeHealthCheck(REST_APP_1);
+    healthCheckResponse = RestIntegrationTestUtil.checkServerHealth(REST_APP_1);
     assertThat(
         "CommandRunner healthcheck is unhealthy for server 1",
         !healthCheckResponse.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.integration;
 
+import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.COMMAND_RUNNER_CHECK_NAME;
 import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.KAFKA_CHECK_NAME;
 import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.METASTORE_CHECK_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,24 +54,12 @@ public class HealthCheckResourceFunctionalTest {
   @Test
   public void shouldCheckHealth() {
     // When:
-    final HealthCheckResponse response = checkServerHealth();
+    final HealthCheckResponse response = RestIntegrationTestUtil.makeHealthCheck(REST_APP);
 
     // Then:
     assertThat("server should be healthy", response.getIsHealthy());
     assertThat(response.getDetails().get(KAFKA_CHECK_NAME).getIsHealthy(), is(true));
     assertThat(response.getDetails().get(METASTORE_CHECK_NAME).getIsHealthy(), is(true));
-  }
-
-  private static HealthCheckResponse checkServerHealth() {
-    try (final KsqlRestClient restClient = REST_APP.buildKsqlClient()) {
-
-      final RestResponse<HealthCheckResponse> res = restClient.getServerHealth();
-
-      if (res.isErroneous()) {
-        throw new AssertionError("Erroneous result: " + res.getErrorMessage());
-      }
-
-      return res.getResponse();
-    }
+    assertThat(response.getDetails().get(COMMAND_RUNNER_CHECK_NAME).getIsHealthy(), is(true));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HealthCheckResourceFunctionalTest.java
@@ -24,8 +24,6 @@ import static org.hamcrest.Matchers.is;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
-import io.confluent.ksql.rest.client.KsqlRestClient;
-import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +52,7 @@ public class HealthCheckResourceFunctionalTest {
   @Test
   public void shouldCheckHealth() {
     // When:
-    final HealthCheckResponse response = RestIntegrationTestUtil.makeHealthCheck(REST_APP);
+    final HealthCheckResponse response = RestIntegrationTestUtil.checkServerHealth(REST_APP);
 
     // Then:
     assertThat("server should be healthy", response.getIsHealthy());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatus.Status;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.CommandStatuses;
+import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
@@ -69,6 +70,19 @@ import java.util.stream.Collectors;
 public final class RestIntegrationTestUtil {
 
   private RestIntegrationTestUtil() {
+  }
+
+  public static HealthCheckResponse makeHealthCheck(final TestKsqlRestApp restApp) {
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
+
+      final RestResponse<HealthCheckResponse> res = restClient.getServerHealth();
+
+      if (res.isErroneous()) {
+        throw new AssertionError("Erroneous result: " + res.getErrorMessage());
+      }
+
+      return res.getResponse();
+    }
   }
 
   public static List<KsqlEntity> makeKsqlRequest(final TestKsqlRestApp restApp, final String sql) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -72,7 +72,7 @@ public final class RestIntegrationTestUtil {
   private RestIntegrationTestUtil() {
   }
 
-  public static HealthCheckResponse makeHealthCheck(final TestKsqlRestApp restApp) {
+  public static HealthCheckResponse checkServerHealth(final TestKsqlRestApp restApp) {
     try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
 
       final RestResponse<HealthCheckResponse> res = restClient.getServerHealth();


### PR DESCRIPTION
### Description 
There's a bug in 0.14.0 that causes the server to not enter degraded state when backups are enabled.
The bug is fixed in https://github.com/confluentinc/ksql/pull/6524 (removing deserialization from the CommandTopicBackupImpl)

This adds an integration test to check that incompatible commands are properly processed.
Also, enhanced the corruption integration test and cleaned up some other tests.

### Testing done 
test only change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

