### PR TITLE
fix: fix how the buffer limit check evaluates streams config

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -20,7 +20,8 @@
 # The default is any IPv4 interface on the machine.
 # NOTE: If set to wildcard or loopback set 'advertised.listener' to enable pull queries across machines
 listeners=http://0.0.0.0:8088
-
+ksql.service.id=test
+ksql.query.persistent.max.bytes.buffering.total=15000000
 # Use the 'listeners' line below for any IPv6 interface on the machine.
 # listeners=http://[::]:8088
 

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -20,8 +20,7 @@
 # The default is any IPv4 interface on the machine.
 # NOTE: If set to wildcard or loopback set 'advertised.listener' to enable pull queries across machines
 listeners=http://0.0.0.0:8088
-ksql.service.id=test
-ksql.query.persistent.max.bytes.buffering.total=15000000
+
 # Use the 'listeners' line below for any IPv6 interface on the machine.
 # listeners=http://[::]:8088
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.query;
 
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.physical.PhysicalPlan;
 import io.confluent.ksql.util.KsqlConfig;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -23,6 +23,8 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsConfig;
 
@@ -87,12 +89,10 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
 
   private StreamsConfig getDummyStreamsConfig(final SessionConfig config) {
     // hack to get at default config value
-    return new StreamsConfig(
-        ImmutableMap.<String, Object>builder()
-            .put(StreamsConfig.APPLICATION_ID_CONFIG, "dummy.app.id")
-            .put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy.bootstrap")
-            .putAll(config.getConfig(true).getKsqlStreamConfigProps())
-            .build()
-    );
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "dummy.app.id");
+    properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy.bootstrap");
+    properties.putAll(config.getConfig(true).getKsqlStreamConfigProps());
+    return new StreamsConfig(properties);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
@@ -27,7 +27,6 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.OptionalLong;
 import org.apache.kafka.streams.StreamsConfig;
@@ -39,6 +38,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KafkaStreamsQueryValidatorTest {
+  private static final Map<String, Object> BASE_STREAMS_PROPERTIES = ImmutableMap.of(
+      StreamsConfig.APPLICATION_ID_CONFIG, "fake-app-id",
+      StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "fake-bootstrap"
+  );
+
   @Mock
   private TransientQueryMetadata transientQueryMetadata1;
   @Mock
@@ -156,7 +160,9 @@ public class KafkaStreamsQueryValidatorTest {
       final OptionalLong globalLimit
   ) {
     final Map<String, Object> ksqlProperties = globalLimit.isPresent()
-        ? ImmutableMap.of(config, globalLimit.getAsLong()) : Collections.emptyMap();
+        ? ImmutableMap.<String, Object>builder()
+            .putAll(BASE_STREAMS_PROPERTIES).put(config, globalLimit.getAsLong()).build()
+        : BASE_STREAMS_PROPERTIES;
     return SessionConfig.of(
         new KsqlConfig(ksqlProperties),
         ImmutableMap.of(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, queryLimit)
@@ -164,10 +170,9 @@ public class KafkaStreamsQueryValidatorTest {
   }
 
   private Map<String, Object> streamPropsWithCacheLimit(long limit) {
-    return ImmutableMap.of(
-        StreamsConfig.APPLICATION_ID_CONFIG, "fake-app-id",
-        StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "fake-bootstrap",
-        StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, limit
-    );
+    return ImmutableMap.<String, Object>builder()
+        .putAll(BASE_STREAMS_PROPERTIES)
+        .put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, limit)
+        .build();
   }
 }


### PR DESCRIPTION
The buffer limit check first creates a dummy streams config to get the current
max bytes buffering value. To do this it creates a map of the streams props and
creates the config (with dummy values for all the required fields). However
sometimes those fields are already provided and ImmutableMap doesn't like
overwrites in the builder. So, use a plain old HashMap.