### PR TITLE
feat: enable decimal for Protobuf

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -38,6 +38,9 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     <Match>
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
     </Match>
+    <Match>
+        <Bug pattern="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS"/>
+    </Match>
 
     <!--
       DO NOT USE THIS EXCLUSION FILE FOR NON-GENERATED CODE

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_in_out/6.2.0_1611359934407/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_in_out/6.2.0_1611359934407/plan.json
@@ -1,0 +1,145 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, DEC DECIMAL(21, 19)) WITH (KAFKA_TOPIC='test', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(21, 19)",
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 AS SELECT *\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(21, 19)",
+      "topicName" : "TEST2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TEST2",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TEST2"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `DEC` DECIMAL(21, 19)"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "DEC AS DEC" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "TEST2"
+      },
+      "queryId" : "CSAS_TEST2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_in_out/6.2.0_1611359934407/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_in_out/6.2.0_1611359934407/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1611359934407,
+  "path" : "query-validation-tests/decimal.json",
+  "schemas" : {
+    "CSAS_TEST2_0.TEST2" : {
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(21, 19)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CSAS_TEST2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(21, 19)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "PROTOBUF in/out",
+    "inputs" : [ {
+      "topic" : "test",
+      "key" : null,
+      "value" : {
+        "DEC" : 10.1234512345123451234
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "TEST2",
+      "key" : null,
+      "value" : {
+        "DEC" : 10.1234512345123451234
+      }
+    } ],
+    "topics" : [ {
+      "name" : "TEST2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConnectDefault1 {\n  confluent.type.Decimal DEC = 1 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"21\",\n        key: \"precision\"\n      },\n      {\n        value: \"19\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, dec DECIMAL(21,19)) WITH (kafka_topic='test', value_format='PROTOBUF');", "CREATE STREAM TEST2 AS SELECT * FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `DEC` DECIMAL(21, 19)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST2",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `DEC` DECIMAL(21, 19)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConnectDefault1 {\n  confluent.type.Decimal DEC = 1 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"21\",\n        key: \"precision\"\n      },\n      {\n        value: \"19\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n"
+        }, {
+          "name" : "TEST2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConnectDefault1 {\n  confluent.type.Decimal DEC = 1 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"21\",\n        key: \"precision\"\n      },\n      {\n        value: \"19\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_in_out/6.2.0_1611359934407/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_in_out/6.2.0_1611359934407/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_should_not_trim_trailing_zeros/6.2.0_1611176012228/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_should_not_trim_trailing_zeros/6.2.0_1611176012228/plan.json
@@ -1,0 +1,145 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, DEC DECIMAL(6, 4)) WITH (KAFKA_TOPIC='test', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)",
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "DEC AS DEC" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_should_not_trim_trailing_zeros/6.2.0_1611176012228/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_should_not_trim_trailing_zeros/6.2.0_1611176012228/spec.json
@@ -1,0 +1,112 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1611176012228,
+  "path" : "query-validation-tests/decimal.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "PROTOBUF should not trim trailing zeros",
+    "inputs" : [ {
+      "topic" : "test",
+      "key" : null,
+      "value" : {
+        "DEC" : 10.0
+      }
+    }, {
+      "topic" : "test",
+      "key" : null,
+      "value" : {
+        "DEC" : 1.0000
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "DEC" : 10.0000
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "DEC" : 1.0000
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConnectDefault1 {\n  confluent.type.Decimal DEC = 1 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"6\",\n        key: \"precision\"\n      },\n      {\n        value: \"4\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');", "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `DEC` DECIMAL(6, 4)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConnectDefault1 {\n  confluent.type.Decimal DEC = 1 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"6\",\n        key: \"precision\"\n      },\n      {\n        value: \"4\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConnectDefault1 {\n  confluent.type.Decimal DEC = 1 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"6\",\n        key: \"precision\"\n      },\n      {\n        value: \"4\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_should_not_trim_trailing_zeros/6.2.0_1611176012228/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/decimal_-_PROTOBUF_should_not_trim_trailing_zeros/6.2.0_1611176012228/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_inference_-_partial_schema/6.2.0_1611365298133/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_inference_-_partial_schema/6.2.0_1611365298133/plan.json
@@ -1,0 +1,145 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, C1 BOOLEAN, C2 INTEGER, C3 BIGINT, C4 DOUBLE, C5 STRING, C6 DECIMAL(4, 2)) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF', VALUE_SCHEMA_ID=1);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `C1` BOOLEAN, `C2` INTEGER, `C3` BIGINT, `C4` DOUBLE, `C5` STRING, `C6` DECIMAL(4, 2)",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `C1` BOOLEAN, `C2` INTEGER, `C3` BIGINT, `C4` DOUBLE, `C5` STRING, `C6` DECIMAL(4, 2)",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `C1` BOOLEAN, `C2` INTEGER, `C3` BIGINT, `C4` DOUBLE, `C5` STRING, `C6` DECIMAL(4, 2)"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "C1 AS C1", "C2 AS C2", "C3 AS C3", "C4 AS C4", "C5 AS C5", "C6 AS C6" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_inference_-_partial_schema/6.2.0_1611365298133/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_inference_-_partial_schema/6.2.0_1611365298133/spec.json
@@ -1,0 +1,110 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1611365298133,
+  "path" : "query-validation-tests/protobuf.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `C1` BOOLEAN, `C2` INTEGER, `C3` BIGINT, `C4` DOUBLE, `C5` STRING, `C6` DECIMAL(4, 2)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `C1` BOOLEAN, `C2` INTEGER, `C3` BIGINT, `C4` DOUBLE, `C5` STRING, `C6` DECIMAL(4, 2)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "protobuf inference - partial schema",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : "a",
+      "value" : {
+        "c1" : true,
+        "c2" : 1,
+        "c3" : 400000000000,
+        "c4" : 1.284765648,
+        "c5" : "hello",
+        "c6" : 10.01
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "a",
+      "value" : {
+        "C1" : true,
+        "C2" : 1,
+        "C3" : 400000000000,
+        "C4" : 1.284765648,
+        "C5" : "hello",
+        "C6" : 10.01
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConfluentDefault1 {\n  bool c1 = 1;\n  int32 c2 = 2;\n  int64 c3 = 3;\n  double c4 = 4;\n  string c5 = 5;\n  confluent.type.Decimal c6 = 6 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"4\",\n        key: \"precision\"\n      },\n      {\n        value: \"2\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY) WITH (kafka_topic='input', value_format='PROTOBUF');", "CREATE STREAM OUTPUT AS SELECT * FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `C1` BOOLEAN, `C2` INTEGER, `C3` BIGINT, `C4` DOUBLE, `C5` STRING, `C6` DECIMAL(4, 2)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `C1` BOOLEAN, `C2` INTEGER, `C3` BIGINT, `C4` DOUBLE, `C5` STRING, `C6` DECIMAL(4, 2)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 1,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConfluentDefault1 {\n  bool c1 = 1;\n  int32 c2 = 2;\n  int64 c3 = 3;\n  double c4 = 4;\n  string c5 = 5;\n  confluent.type.Decimal c6 = 6 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"4\",\n        key: \"precision\"\n      },\n      {\n        value: \"2\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"confluent/type/decimal.proto\";\n\nmessage ConnectDefault1 {\n  bool C1 = 1;\n  int32 C2 = 2;\n  int64 C3 = 3;\n  double C4 = 4;\n  string C5 = 5;\n  confluent.type.Decimal C6 = 6 [(confluent.field_meta) = {\n    params: [\n      {\n        value: \"4\",\n        key: \"precision\"\n      },\n      {\n        value: \"2\",\n        key: \"scale\"\n      }\n    ]\n  }];\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_inference_-_partial_schema/6.2.0_1611365298133/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_protobuf_inference_-_partial_schema/6.2.0_1611365298133/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -159,20 +159,8 @@
       }
     },
     {
-      "name": "PROTOBUF does not yet support DECIMAL",
-      "comment": "Adding support covered by https://github.com/confluentinc/ksql/issues/5762",
-      "statements": [
-        "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "The 'PROTOBUF' format does not support type 'DECIMAL'. See https://github.com/confluentinc/ksql/issues/5762."
-      }
-    },
-    {
-      "enabled": false,
+      "enabled": true,
       "name": "PROTOBUF should not trim trailing zeros",
-      "comment": "Enable once https://github.com/confluentinc/ksql/issues/5762 fixed",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
@@ -182,7 +170,7 @@
         {"topic": "test", "value": {"DEC": 1.0000}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "value": {"DEC": 10.0}},
+        {"topic": "OUTPUT", "value": {"DEC": 10.0000}},
         {"topic": "OUTPUT", "value": {"DEC": 1.0000}}
       ],
       "post": {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -45,6 +45,19 @@
       ]
     },
     {
+      "name": "PROTOBUF in/out",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, dec DECIMAL(21,19)) WITH (kafka_topic='test', value_format='PROTOBUF');",
+        "CREATE STREAM TEST2 AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "value": {"DEC": 10.1234512345123451234}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "value": {"DEC": 10.1234512345123451234}}
+      ]
+    },
+    {
       "name": "JSON scale in data less than scale in type",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='JSON');",
@@ -159,7 +172,6 @@
       }
     },
     {
-      "enabled": true,
       "name": "PROTOBUF should not trim trailing zeros",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, dec DECIMAL(6,4)) WITH (kafka_topic='test', value_format='PROTOBUF');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -161,7 +161,7 @@
       }
     },
     {
-      "name": "protobuf inference - partital schema",
+      "name": "protobuf inference - partial schema",
       "statements": [
         "CREATE STREAM INPUT (K STRING KEY) WITH (kafka_topic='input', value_format='PROTOBUF');",
         "CREATE STREAM OUTPUT AS SELECT * FROM input;"
@@ -170,18 +170,18 @@
         {
           "name": "input",
           "valueFormat": "PROTOBUF",
-          "valueSchema": "syntax = \"proto3\"; message ConfluentDefault1 {bool c1 = 1; int32 c2 = 2; int64 c3 = 3; double c4 = 4; string c5 = 5;}"
+          "valueSchema" : "syntax = \"proto3\"; import \"confluent/type/decimal.proto\"; message ConfluentDefault1 {bool c1 = 1; int32 c2 = 2; int64 c3 = 3; double c4 = 4; string c5 = 5; confluent.type.Decimal c6 = 6 [(confluent.field_meta) = { params: [{ value: \"4\", key: \"precision\" }, { value: \"2\", key: \"scale\" }]}];}"
         }
       ],
       "inputs": [
-        {"topic": "input", "key": "a", "value": {"c1": true, "c2": 1, "c3": 400000000000, "c4": 1.284765648, "c5": "hello"}}
+        {"topic": "input", "key": "a", "value": {"c1": true, "c2": 1, "c3": 400000000000, "c4": 1.284765648, "c5": "hello", "c6": 10.01 }}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "a", "value": {"C1": true, "C2": 1, "C3": 400000000000, "C4": 1.284765648, "C5": "hello"}}
+        {"topic": "OUTPUT", "key": "a", "value": {"C1": true, "C2": 1, "C3": 400000000000, "C4": 1.284765648, "C5": "hello", "C6":  10.01 }}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "K STRING KEY, C1 BOOLEAN, C2 INT, C3 BIGINT, C4 DOUBLE, C5 STRING"}
+          {"name": "OUTPUT", "type": "stream", "schema": "K STRING KEY, C1 BOOLEAN, C2 INT, C3 BIGINT, C4 DOUBLE, C5 STRING, C6 DECIMAL(4,2)"}
         ]
       }
     },

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactory.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.serde.connect.KsqlConnectDeserializer;
 import io.confluent.ksql.serde.connect.KsqlConnectSerializer;
 import io.confluent.ksql.serde.tls.ThreadLocalDeserializer;
 import io.confluent.ksql.serde.tls.ThreadLocalSerializer;
-import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
@@ -132,14 +131,6 @@ final class ProtobufSerdeFactory {
   }
 
   private static class SchemaValidator implements SchemaWalker.Visitor<Void, Void> {
-
-    public Void visitBytes(final Schema schema) {
-      if (DecimalUtil.isDecimal(schema)) {
-        throw new KsqlException("The '" + ProtobufFormat.NAME + "' format does not support type "
-            + "'DECIMAL'. See https://github.com/confluentinc/ksql/issues/5762.");
-      }
-      return null;
-    }
 
     @Override
     public Void visitMap(final Schema schema, final Void key, final Void value) {

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.protobuf;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+
+import io.confluent.connect.protobuf.ProtobufConverter;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import io.confluent.ksql.util.DecimalUtil;
+import io.confluent.ksql.util.KsqlConfig;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("rawtypes")
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlProtobufDeserializerTest {
+
+  private static final String SOME_TOPIC = "bob";
+
+  private static final KsqlConfig KSQL_CONFIG = new KsqlConfig(Collections.singletonMap(
+      KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "fake-schema-registry-url"));
+
+  private SchemaRegistryClient schemaRegistryClient;
+  private ProtobufConverter converter;
+  private KafkaProtobufSerializer serializer;
+
+  @Before
+  public void setUp() {
+    final ImmutableMap<String, Object> configs = ImmutableMap.of(
+        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, true,
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
+    );
+
+    schemaRegistryClient = new MockSchemaRegistryClient();
+
+    converter = new ProtobufConverter(schemaRegistryClient);
+    converter.configure(configs, false);
+
+    serializer = new KafkaProtobufSerializer(schemaRegistryClient, configs);
+  }
+
+  @Test
+  public void shouldDeserializeDecimalField() {
+    final ConnectSchema schema = (ConnectSchema) SchemaBuilder.struct()
+            .field("f0", DecimalUtil.builder(10, 2))
+            .build();
+
+    // Given:
+    final Deserializer<Struct> deserializer =
+        givenDeserializerForSchema(schema,
+            Struct.class);
+    final Struct value = new Struct(schema).put("f0", new BigDecimal("12.34"));
+    final byte[] bytes = givenConnectSerialized(value, schema);
+
+    // When:
+    final Object result = deserializer.deserialize(SOME_TOPIC, bytes);
+
+    // Then:
+    assertThat(result, is(value));
+  }
+
+  private byte[] givenConnectSerialized(
+          final Object value,
+          final Schema connectSchema
+  ) {
+    return serializeAsBinaryProtobuf(SOME_TOPIC, connectSchema, value);
+  }
+
+  private byte[] serializeAsBinaryProtobuf(
+          final String topicName,
+          final Schema schema,
+          final Object value
+  ) {
+    return converter.fromConnectData(topicName, schema, value);
+  }
+
+  private <T> Deserializer<T> givenDeserializerForSchema(
+      final ConnectSchema schema,
+      final Class<T> targetType
+  ) {
+    final Deserializer<T> deserializer = ProtobufSerdeFactory.createSerde(
+        schema,
+        KSQL_CONFIG,
+        () -> schemaRegistryClient,
+        targetType,
+        false).deserializer();
+
+    deserializer.configure(Collections.emptyMap(), false);
+
+    return deserializer;
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
@@ -51,7 +51,6 @@ public class KsqlProtobufDeserializerTest {
 
   private SchemaRegistryClient schemaRegistryClient;
   private ProtobufConverter converter;
-  private KafkaProtobufSerializer serializer;
 
   @Before
   public void setUp() {
@@ -64,8 +63,6 @@ public class KsqlProtobufDeserializerTest {
 
     converter = new ProtobufConverter(schemaRegistryClient);
     converter.configure(configs, false);
-
-    serializer = new KafkaProtobufSerializer(schemaRegistryClient, configs);
   }
 
   @Test

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.protobuf;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.math.BigDecimal;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+import io.confluent.ksql.util.DecimalUtil;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.protobuf.type.Decimal;
+import io.confluent.protobuf.type.utils.DecimalUtils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@SuppressWarnings({"SameParameterValue", "rawtypes", "unchecked"})
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlProtobufSerializerTest {
+
+  private static final ParsedSchema DECIMAL_SCHEMA =
+          parseProtobufSchema(
+                  "syntax = \"proto3\";\n" +
+                          "\n" +
+                          "import \"confluent/meta.proto\";\n" +
+                          "import \"confluent/type/decimal.proto\";\n" +
+                          "\n" +
+                          "message DecimalValue {\n" +
+                          "  confluent.type.Decimal field0 = 1 [(confluent.field_meta) = { " +
+                          "params: [\n" +
+                          "    { key: \"precision\", value: \"4\" },\n" +
+                          "    { key: \"scale\", value: \"2\" }\n" +
+                          "  ]}];\n" +
+                          "}\n");
+
+  private static final String SOME_TOPIC = "bob";
+
+  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+
+  private final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+
+  private Deserializer<Object> deserializer;
+
+  @Before
+  public void setup() {
+    final ImmutableMap<String, Object> configs = ImmutableMap.of(
+        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, true,
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
+    );
+
+    deserializer = new KafkaProtobufDeserializer(schemaRegistryClient, configs);
+  }
+
+  @Test
+  public void shouldSerializeDecimalField() {
+    final BigDecimal decimal = new BigDecimal("12.34");
+    final Decimal bytes = DecimalUtils.fromBigDecimal(decimal);
+    shouldSerializeFieldTypeCorrectly(
+        DecimalUtil.builder(4, 2).build(),
+        decimal,
+        DECIMAL_SCHEMA,
+        bytes
+    );
+  }
+
+
+  @SuppressWarnings("unchecked")
+  private <T> T deserialize(final byte[] serializedRow) {
+    return (T) deserializer.deserialize(SOME_TOPIC, serializedRow);
+  }
+
+  private void shouldSerializeFieldTypeCorrectly(
+      final Schema ksqlSchema,
+      final Object ksqlValue,
+      final ParsedSchema parsedSchema,
+      final Message protobufValue
+  ) {
+    // Given:
+    final Schema schema = SchemaBuilder.struct()
+        .field("field0", ksqlSchema)
+        .build();
+
+    final Serializer<Struct> serializer = givenSerializerForSchema(schema, Struct.class);
+
+    final Struct ksqlRecord = new Struct(schema)
+        .put("field0", ksqlValue);
+
+    // When:
+    final byte[] bytes = serializer.serialize(SOME_TOPIC, ksqlRecord);
+
+    // Then:
+    final Message record = deserialize(bytes);
+    assertThat(record.getAllFields().size(), equalTo(1));
+    Descriptors.FieldDescriptor field = record.getDescriptorForType().findFieldByName("field0");
+    assertThat(DecimalUtils.toBigDecimal((Message) record.getField(field)),
+            equalTo(DecimalUtils.toBigDecimal(protobufValue)));
+  }
+
+  private <T> Serializer<T> givenSerializerForSchema(
+      final Schema schema,
+      final Class<T> targetType
+  ) {
+    return ProtobufSerdeFactory
+        .createSerde(
+            (ConnectSchema) schema,
+            ksqlConfig,
+            () -> schemaRegistryClient,
+            targetType,
+            false).serializer();
+  }
+
+  private static ParsedSchema parseProtobufSchema(final String protobufSchema) {
+    return new ProtobufSchema(protobufSchema);
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactoryTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSerdeFactoryTest.java
@@ -15,16 +15,14 @@
 
 package io.confluent.ksql.serde.protobuf;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
+
 import java.util.function.Supplier;
+
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -48,21 +46,16 @@ public class ProtobufSerdeFactoryTest {
   }
 
   @Test
-  public void shouldThrowOnDecimal() {
+  public void shouldNotThrowOnDecimal() {
     // Given:
     final ConnectSchema schema = (ConnectSchema) SchemaBuilder.struct()
         .field("f0", SchemaBuilder.array(DecimalUtil.builder(10, 2)))
         .build();
 
     // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> ProtobufSerdeFactory.createSerde(schema, config, srClientFactory, Struct.class, false)
-    );
+    ProtobufSerdeFactory.createSerde(schema, config, srClientFactory, Struct.class, false);
 
-    // Then:
-    assertThat(e.getMessage(), is("The 'PROTOBUF' format does not support type 'DECIMAL'. "
-        + "See https://github.com/confluentinc/ksql/issues/5762."));
+    // Then (did not throw)
   }
 
   @Test


### PR DESCRIPTION
fixes #5762

### Description 
Support for decimal has been added to the Protobuf converter.  This PR enables decimal for Protobuf in ksqlDB.

### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

