### PR TITLE
build: Fix up build process & remove virtual packages from ksqldb

### DIFF
--- a/debian/Makefile
+++ b/debian/Makefile
@@ -71,7 +71,7 @@ INSTALL_X=install -D -m 755
 
 install: build
 	# Safety precatuion to avoid removing of root dir when DESTDIR or PREFIX is not set, for wathever reason
-	if [[ $(DESTDIR)$(PREFIX) != /tmp/confluent/* ]]; then echo "DESTDIR=$(DESTDIR) or PREFIX=$(PREFIX) is weird" ; exit 1 ; fi
+	if [[ "$(DESTDIR)$(PREFIX)" =~ ^/usr* ]] || [[ "$(DESTDIR)$(PREFIX)" == / ]] || [[ "$(DESTDIR)$(PREFIX)" == ""  ]]; then echo "DESTDIR=$(DESTDIR) or PREFIX=$(PREFIX) is weird"; exit 1 ; fi
 	rm -rf $(DESTDIR)$(PREFIX)
 	mkdir -p $(DESTDIR)$(PREFIX)
 	mkdir -p $(DESTDIR)$(BINPATH)

--- a/debian/confluent-ksqldb.spec.in
+++ b/debian/confluent-ksqldb.spec.in
@@ -11,7 +11,6 @@ Vendor: Confluent, Inc.
 Packager: Confluent Packaging <packages@confluent.io>
 BuildArch: noarch
 
-Provides: community-ksqldb = 0.14.0
 %description
 
 Streaming SQL engine for Apache Kafka.

--- a/debian/control
+++ b/debian/control
@@ -10,5 +10,4 @@ Homepage: http://confluent.io
 Package: confluent-ksqldb
 Architecture: all
 Depends: ${misc:Depends}, adduser
-Provides: community-ksqldb (= 0.14.0)
 Description: Streaming SQL engine for Apache Kafka.


### PR DESCRIPTION
- The check in the Makefile was overly strict in an attempt to be safe.
Instead of checking for 1 allowed location of being built
(/tmp/confluent), check for the conditions that would cause an issue the
code was originally trying to prevent (removing `/` or `/usr`)

- Remove virtual packages. Testing didn't go as planned for Debian
packages so this change is being undone from https://github.com/confluentinc/ksql/pull/6812

### Description 
The /tmp/confluent check prevents users from building OS packages from any filesystem location. This check is a good idea to enforce so users don't accidentally remove / or /usr when attempting to build, but it assumes everyone will build the OS packages from /tmp/confluent, which isn't going to be the case always.

### Testing done 
On the location check, see how bash reacts:

```
# Empty vars
root@24f89713e110:/# DESTDIR=
root@24f89713e110:/# PREFIX=
root@24f89713e110:/# if [[ "${DESTDIR}${PREFIX}" =~ ^/usr* ]] || [[ "${DESTDIR}${PREFIX}" == / ]] || [[ "${DESTDIR}${PREFIX}" == "" ]]; then echo "DESTDIR=${DESTDIR} or PREFIX=${PREFIX} is weird" ; fi
DESTDIR= or PREFIX= is weird

# Prefix is /usr, but no DESTDIR was specified
root@24f89713e110:/# PREFIX=/usr
root@24f89713e110:/# if [[ "${DESTDIR}${PREFIX}" =~ ^/usr* ]] || [[ "${DESTDIR}${PREFIX}" == / ]] || [[ "${DESTDIR}${PREFIX}" == "" ]]; then echo "DESTDIR=${DESTDIR} or PREFIX=${PREFIX} is weird" ; fi
DESTDIR= or PREFIX=/usr is weird

# Prefix was /, but no DESTDIR was specified
root@24f89713e110:/# PREFIX=/
root@24f89713e110:/# if [[ "${DESTDIR}${PREFIX}" =~ ^/usr* ]] || [[ "${DESTDIR}${PREFIX}" == / ]] || [[ "${DESTDIR}${PREFIX}" == "" ]]; then echo "DESTDIR=${DESTDIR} or PREFIX=${PREFIX} is weird" ; fi
DESTDIR= or PREFIX=/ is weird

# Both vars are set, so this should continue
root@24f89713e110:/# PREFIX=/usr
root@24f89713e110:/# DESTDIR=/some/path/thats/not/root
root@24f89713e110:/# if [[ "${DESTDIR}${PREFIX}" =~ ^/usr* ]] || [[ "${DESTDIR}${PREFIX}" == / ]] || [[ "${DESTDIR}${PREFIX}" == "" ]]; then echo "DESTDIR=${DESTDIR} or PREFIX=${PREFIX} is weird" ; fi
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

