### PR TITLE
fix: Select star table scans need keys in the intermediate row

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullProjectNode.java
@@ -180,7 +180,8 @@ public class PullProjectNode extends ProjectNode {
         getSource().getSchema().isKeyColumn(cn)
     );
 
-    return hasSystemColumns || hasKeyColumns;
+    // Select * also requires keys, in case it's not explicitly mentioned
+    return hasSystemColumns || hasKeyColumns || isSelectStar;
   }
 
   private boolean isSelectStar() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullProjectNodeTest.java
@@ -286,7 +286,8 @@ public class PullProjectNodeTest {
 
     // Then:
     final LogicalSchema expectedSchema = INPUT_SCHEMA;
-    assertThat(expectedSchema, is(projectNode.getIntermediateSchema()));
+    assertThat(expectedSchema.withPseudoAndKeyColsInValue(false),
+        is(projectNode.getIntermediateSchema()));
     assertThat(expectedSchema.withoutPseudoAndKeyColsInValue(), is(projectNode.getSchema()));
     assertThrows(
         IllegalStateException.class,

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2008,7 +2008,8 @@
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
-        "SELECT ID, COUNT, ROWTIME FROM AGGREGATE;"
+        "SELECT ID, COUNT, ROWTIME FROM AGGREGATE;",
+        "SELECT * FROM AGGREGATE;"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 12365, "key": "10", "value": {}},
@@ -2021,6 +2022,11 @@
           {"header":{"schema":"`ID` STRING KEY, `COUNT` BIGINT, `ROWTIME` BIGINT"}},
           {"row":{"columns":["11", 1, 12345]}},
           {"row":{"columns":["10", 1, 12365]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["11", 1]}},
+          {"row":{"columns":["10", 1]}}
         ]}
       ]
     },
@@ -2029,7 +2035,8 @@
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
-        "SELECT ID, WINDOWSTART, WINDOWEND, COUNT, ROWTIME FROM AGGREGATE;"
+        "SELECT ID, WINDOWSTART, WINDOWEND, COUNT, ROWTIME FROM AGGREGATE;",
+        "SELECT * FROM AGGREGATE;"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"val": 1}},
@@ -2046,6 +2053,13 @@
           {"row":{"columns":["11", 13000, 14000, 1, 13346]}},
           {"row":{"columns":["10", 12000, 13000, 1, 12345]}},
           {"row":{"columns":["10", 13000, 14000, 1, 13345]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["11", 12000, 13000, 1]}},
+          {"row":{"columns":["11", 13000, 14000, 1]}},
+          {"row":{"columns":["10", 12000, 13000, 1]}},
+          {"row":{"columns":["10", 13000, 14000, 1]}}
         ]}
       ]
     },


### PR DESCRIPTION
### Description 
The intermediate row in a projection currently only contains a key if the `PullFilterNode` requires it, which means that `select * ` only works on key lookups.  With this change, we make sure to add keys if it's a `select * ` so that it's now found for table scan.

### Testing done 
RQTT tests and unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

