### PR TITLE
fix: dont use the streamthread to construct the log-metric-and-continue logger

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandler.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandler.java
@@ -20,12 +20,12 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LogMetricAndContinueExceptionHandler implements DeserializationExceptionHandler {
-  private static final Logger log = LoggerFactory.getLogger(StreamThread.class);
+  private static final Logger log
+      = LoggerFactory.getLogger(LogMetricAndContinueExceptionHandler.class);
 
   @Override
   public DeserializationHandlerResponse handle(
@@ -33,7 +33,7 @@ public class LogMetricAndContinueExceptionHandler implements DeserializationExce
       final ConsumerRecord<byte[], byte[]> record,
       final Exception exception
   ) {
-    log.warn(
+    log.debug(
         "Exception caught during Deserialization, "
         + "taskId: {}, topic: {}, partition: {}, offset: {}",
         context.taskId(), record.topic(), record.partition(), record.offset(),


### PR DESCRIPTION
Don't use the streamthread to construct the log-metric-and-continue logger. Also set the level to
debug - this indicates an error with the data. In production usage of ksql, we've frequently seen
these deserialization errors spamming the ksql log. It was hard to tune the log level because we were
logging with the StreamThread category (which has lots of useful logs for streams internals). It also
didn't make sense to log these as warnings/errors since they didn't indicate a ksql bug or error.