### PR TITLE
build: jenkins build now triggers a kafka-tutorial build with latest version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -377,6 +377,7 @@ def job = {
                     ["github/confluent_jenkins", "access_token", "GIT_TOKEN"]]) {
                     withEnv(["GIT_CREDENTIAL=${env.GIT_USER}:${env.GIT_TOKEN}"]) {
                         sh "./tools/update-ksqldb-version.sh ${config.ksql_db_artifact_version} ${config.dockerRegistry}"
+                        // run git diff in order to help debug if something goes wrong
                         sh "git diff"
                         sh "git add _includes/*"
                         sh "git commit --allow-empty -m \"build: set ksql version to ${config.ksql_db_artifact_version}\""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -376,7 +376,7 @@ def job = {
                     ["github/confluent_jenkins", "user", "GIT_USER"],
                     ["github/confluent_jenkins", "access_token", "GIT_TOKEN"]]) {
                     withEnv(["GIT_CREDENTIAL=${env.GIT_USER}:${env.GIT_TOKEN}"]) {
-                        sh "./tools/update-ksqldb-version.sh ${config.ksql_db_artifact_version} 368821881613.dkr.ecr.us-west-2.amazonaws.com"
+                        sh "./tools/update-ksqldb-version.sh ${config.ksql_db_artifact_version} ${config.dockerRegistry}"
                         sh "git diff"
                         sh "git add _includes/*"
                         sh "git commit --allow-empty -m \"build: set ksql version to ${config.ksql_db_artifact_version}\""


### PR DESCRIPTION
### Description 

This is part of the work to automate our testing. This makes it so that whenever we successfully build an RC image via the ksql-db-release jenkins job, it will automatically update and kick off a build for the Kafka Tutorials `ksql-db-release` branch (e.g. https://confluentinc.semaphoreci.com/branches/abe8dbf4-589f-41ac-bb5a-4665fbf40983) and the commit message will have the version that it is kicking off a build for.

We will still occasionally need to maintain the kafka tutorials branch, and after we release the image we should sync between master and the ksql-db-release branch. I recommend we do this using the following process:

- if master has diverged from `ksql-db-release`, we should reset `ksql-db-release` to `master` occasionally
- stabilize KT `ksql-db-release` branch
- after the release, run the update ksql version script on `master` to the released RC version and cherry-pick all required commits from `ksql-db-release`
- reset the `ksql-db-release` branch by force pushing master to it (making sure that all commits that were in master make their way into `ksql-db-release`

That way, after each release, `ksql-db-release` will get all the commits on `master` and vice versa.

### Testing done 

Ran this build: https://jenkins.confluent.io/job/confluentinc/job/ksql/job/ksql-db-release/833/console note that master is failing for an unrelated reason (we need to tag the `0.15.x-ksqldb` branch for the git revision to get a stable build)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

