### PR TITLE
chore: setup the skeleton for a migrations tool

### DIFF
--- a/ksqldb-tools/pom.xml
+++ b/ksqldb-tools/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>ksqldb-tools</artifactId>
 
     <properties>
-        <main-class>io.confluent.ksql.tools.printmetrics.PrintMetrics</main-class>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
 
     <dependencies>
@@ -40,6 +40,16 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.rvesse</groupId>
+            <artifactId>airline</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
 
         <!-- Required for running tests -->

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations;
+
+import com.github.rvesse.airline.Cli;
+import com.github.rvesse.airline.help.Help;
+import io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand;
+import io.confluent.ksql.tools.migrations.commands.CleanMigrationsCommand;
+import io.confluent.ksql.tools.migrations.commands.CreateMigrationCommand;
+import io.confluent.ksql.tools.migrations.commands.MigrationInfoCommand;
+import io.confluent.ksql.tools.migrations.commands.NewMigrationCommand;
+import io.confluent.ksql.tools.migrations.commands.ValidateMigrationsCommand;
+
+/**
+ * This class is the entrypoint to all migration-related tooling. This
+ * tooling is packaged with most ksqlDB distributions. For a full description
+ * of the available functionality, simply run the main method below, which defaults
+ * to the "help" message.
+ */
+@com.github.rvesse.airline.annotations.Cli(
+    name = "ksql-migrations",
+    description = "This tool provides easy and automated schema migrations for "
+        + "ksqlDB environments. This allows control over ksqlDB schemas, recreate schemas "
+        + "from scratch and migrations for current schemas to newer versions.",
+    commands = {
+        NewMigrationCommand.class,
+        CreateMigrationCommand.class,
+        ApplyMigrationCommand.class,
+        MigrationInfoCommand.class,
+        CleanMigrationsCommand.class,
+        ValidateMigrationsCommand.class
+    },
+    defaultCommand = Help.class
+)
+public final class Migrations {
+
+  private Migrations() {}
+
+  public static void main(final String[] args) {
+    // all Migrations commands must implement Runnable, so we
+    // are safe to assume that the type returned is Cli<Runnable>
+    final Cli<Runnable> cli = new Cli<>(Migrations.class);
+    cli.parse(args).run();
+  }
+
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.MutuallyExclusiveWith;
+
+@Command(
+    name = "apply",
+    description = "Migrates a schema to new available schema versions"
+)
+public class ApplyMigrationCommand extends BaseCommand {
+
+  @Option(
+      title = "all",
+      name = {"-a", "--all"},
+      description = "run all available migrations"
+  )
+  @MutuallyExclusiveWith(tag = "target")
+  private boolean all;
+
+  @Option(
+      title = "next",
+      name = {"-n", "--next"},
+      description = "migrate the next available version"
+  )
+  @MutuallyExclusiveWith(tag = "target")
+  private boolean next;
+
+  @Option(
+      title = "version",
+      name = {"-u", "--until"},
+      arity = 1,
+      description = "migrate until the specified version"
+  )
+  @MutuallyExclusiveWith(tag = "target")
+  private int version;
+
+  @Override
+  public void run() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -40,7 +40,7 @@ public abstract class BaseCommand implements Runnable {
   @Option(
       name = {"-n", "--dry-run"},
       title = "dry-run",
-      description = "dry run the clean, don't actually delete any ksqlDB resources",
+      description = "dry run the current command, no ksqlDB statements will be executed",
       type = OptionType.GLOBAL
   )
   protected boolean dryRun = false;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.OptionType;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Defines common options across all of the migration
+ * tool commands.
+ */
+@SuppressFBWarnings(
+    value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+    justification = "code is skeleton only at the moment, used to generate HELP message"
+)
+public abstract class BaseCommand implements Runnable {
+
+  @Option(
+      name = {"-c", "--config-file"},
+      title = "config-file",
+      description = "Specifies a configuration file",
+      type = OptionType.GLOBAL
+  )
+  protected String configFile;
+
+  @Option(
+      name = {"-n", "--dry-run"},
+      title = "dry-run",
+      description = "dry run the clean, don't actually delete any ksqlDB resources",
+      type = OptionType.GLOBAL
+  )
+  protected boolean dryRun = false;
+
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import com.github.rvesse.airline.annotations.Command;
+
+@Command(
+    name = "new",
+    description = "Cleans all resources related to migrations. WARNING: this is not reversible!"
+)
+public class CleanMigrationsCommand extends BaseCommand {
+
+  @Override
+  public void run() {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -23,9 +23,8 @@ import com.github.rvesse.airline.annotations.restrictions.Required;
 
 @Command(
     name = "create",
-    description = "Create a pair of migration files with <desc> as description. "
-        + "This will created a pair of empty migration files based on the "
-        + "next schema version."
+    description = "Create a migration file with <desc> as description, which will be used to "
+        + "apply the next schema version."
 )
 @Examples(
     examples = "$ ksql-migrations create add_users",

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.help.Examples;
+import com.github.rvesse.airline.annotations.restrictions.Required;
+
+@Command(
+    name = "create",
+    description = "Create a pair of migration files with <desc> as description. "
+        + "This will created a pair of empty migration files based on the "
+        + "next schema version."
+)
+@Examples(
+    examples = "$ ksql-migrations create add_users",
+    descriptions = "Creates a new migrations file for adding a users table to ksqlDB "
+        + "(e.g. V000002__Add_users.sql)"
+)
+public class CreateMigrationCommand extends BaseCommand {
+
+  @Option(
+      name = {"-v", "--version"},
+      description = "the schema version to initialize, defaults to the next"
+          + " schema version."
+  )
+  private int version;
+
+  @Required
+  @Arguments(
+      title = "desc",
+      description = "The description for the migration."
+  )
+  private String description;
+
+  @Override
+  public void run() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommand.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import com.github.rvesse.airline.annotations.Command;
+
+@Command(
+    name = "info",
+    description = "Displays information about the current and available migrations"
+)
+public class MigrationInfoCommand extends BaseCommand {
+
+  @Override
+  public void run() {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import com.github.rvesse.airline.annotations.Arguments;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.restrictions.Required;
+
+@Command(
+    name = "new",
+    description = "Creates a new migrations project, directory structure and config file."
+)
+public class NewMigrationCommand extends BaseCommand {
+
+  @Required
+  @Arguments(description = "the project path to create the directory", title = "project-path")
+  private String projectPath;
+
+  @Override
+  public void run() {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.help.Discussion;
+
+@Command(
+    name = "validate",
+    description = "Validate applied migrations against local files."
+)
+@Discussion(
+    paragraphs = {
+      "Compares local files checksum against the current metadata checksums to check "
+          + "for migrations files that have changed."
+          + "This tells the user that their schema might be not valid against their local files."
+    }
+)
+public class ValidateMigrationsCommand extends BaseCommand {
+
+  @Override
+  public void run() {
+    throw new UnsupportedOperationException();
+  }
+
+}


### PR DESCRIPTION
### Description 

Set up all the boilerplate for the new migrations tool (see #6721)

### Testing done 

Ran the `help` commands for various use cases to make sure that it works as expected:

#### Help Command

This is the default command that runs with no arguments

```
usage: ksql-migrations [ {-c | --config-file} <config-file> ]
        [ {-n | --dry-run} ] <command> [ <args> ]

Commands are:
    apply      Migrates a schema to new available schema versions
    create     Create a pair of migration files with <desc> as description. This will created a pair of empty migration files based on the next schema version.
    info       Displays information about the current and available migrations
    new        Cleans all resources related to migrations. WARNING: this is not reversible!
    validate   Validate applied migrations against local files.

See 'ksql-migrations help <command>' for more information on a specific
command.
```

---

#### Apply Command

```
NAME
        ksql-migrations apply - Migrates a schema to new available schema
        versions

SYNOPSIS
        ksql-migrations [ {-c | --config-file} <config-file> ]
                [ {-n | --dry-run} ] apply [ {-a | --all} ] [ {-n | --next} ]
                [ {-u | --until} <version> ]

OPTIONS
        -a, --all
            run all available migrations

            This option is part of the group 'target' from which only one
            option may be specified


        -c <config-file>, --config-file <config-file>
            Specifies a configuration file

        -n, --dry-run
            dry run the clean, don't actually delete any ksqlDB resources

        -n, --next
            migrate the next available version

            This option is part of the group 'target' from which only one
            option may be specified


        -u <version>, --until <version>
            migrate until the specified version

            This option is part of the group 'target' from which only one
            option may be specified
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

