### PR TITLE
docs: restores logging page

### DIFF
--- a/docs/operate-and-deploy/logging.md
+++ b/docs/operate-and-deploy/logging.md
@@ -1,0 +1,13 @@
+# Logging
+
+To get `DEBUG` or `INFO` output from ksqlDB Server, configure a {{ site.ak }}
+appender for the server logs. Assign the following configuration settings in
+the ksqlDB Server config file.
+
+```properties
+log4j.appender.kafka_appender=org.apache.kafka.log4jappender.KafkaLog4jAppender
+log4j.appender.kafka_appender.layout=io.confluent.common.logging.log4j.StructuredJsonLayout
+log4j.appender.kafka_appender.BrokerList=localhost:9092
+log4j.appender.kafka_appender.Topic=KSQL_LOG
+log4j.logger.io.confluent.ksql=INFO,kafka_appender
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
               - Configure ksqlDB for Avro, Protobuf, and JSON schemas: operate-and-deploy/installation/server-config/avro-schema.md
               - Configure Security for ksqlDB: operate-and-deploy/installation/server-config/security.md
           - Upgrade ksqlDB: operate-and-deploy/installation/upgrading.md
+      - Logging: operate-and-deploy/logging.md
       - Monitoring: operate-and-deploy/monitoring.md
       - Exactly once semantics: operate-and-deploy/exactly-once-semantics.md
       - Schema Registry integration: operate-and-deploy/schema-registry-integration.md


### PR DESCRIPTION
### Description 

I accidentally deleted the logging guide as part of #6915. This patch restores it to a dedicated page.
