### PR TITLE
fix: Spotbugs raising RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE during build

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/AppInfo.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/AppInfo.java
@@ -40,13 +40,13 @@ public final class AppInfo {
 
     try {
       final Properties props = new Properties();
-      try (InputStream resourceAsStream = AppInfo.class.getResourceAsStream(
-          "/git.properties")) {
-        if (resourceAsStream != null) {
+      if (AppInfo.class.getResource("/git.properties") != null) {
+        try (InputStream resourceAsStream = AppInfo.class.getResourceAsStream(
+                "/git.properties")) {
           props.load(resourceAsStream);
         }
+        commitId = props.getProperty("git.commit.id", commitId).trim();
       }
-      commitId = props.getProperty("git.commit.id", commitId).trim();
     } catch (final Exception e) {
       log.warn("Error while loading git properties:", e);
     }


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
**Problem**
I was not able to build the master branch of ksql project on my Ubuntu 20.10 System with openjdk version "14.0.2" using "mvn clean package -DskipTests" command. I was getting the following error: 
`[ERROR] Medium: Redundant nullcheck of resourceAsStream, which is known to be non-null in io.confluent.ksql.util.AppInfo.<static initializer for AppInfo>() [io.confluent.ksql.util.AppInfo] Redundant null check at AppInfo.java:[line 43] RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE`

There is an issue that is very similar to the one I am trying to fix: https://github.com/confluentinc/ksql/issues/6596

My environment details:
```
mvn --version
Apache Maven 3.6.3
Maven home: /usr/share/maven
Java version: 14.0.2, vendor: Private Build, runtime: /usr/lib/jvm/java-14-openjdk-amd64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.8.0-41-generic", arch: "amd64", family: "unix"
```
**Solution**
To get rid of the SpotBugs error, I have removed the null check and introduced a check for resource existence before getting it in a stream. After that, the build of ksql has succeeded.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
Because the problem was caused by SpotBugs, I only did a manual testing by running the build with and without the change. The behavior was not changed, therefore no unit or integration tests included. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

