### PR TITLE
chore: dont log at error level when client closes connection (#6062)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -39,6 +39,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
+import java.nio.channels.ClosedChannelException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -326,7 +327,11 @@ public class ServerVerticle extends AbstractVerticle {
   }
 
   private static void unhandledExceptionHandler(final Throwable t) {
-    log.error("Unhandled exception", t);
+    if (t instanceof ClosedChannelException) {
+      log.debug("Unhandled ClosedChannelException (connection likely closed early)", t);
+    } else {
+      log.error("Unhandled exception", t);
+    }
   }
 
   /**


### PR DESCRIPTION
### Description 
Backport of https://github.com/confluentinc/ksql/pull/6062 to prevent excessive logging while the server is running.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

