### PR TITLE
fix: Adds groupMetadata as a faked method of SandboxedConsumer

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedConsumer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedConsumer.java
@@ -20,6 +20,7 @@ import static io.confluent.ksql.util.LimitedProxyBuilder.noParams;
 
 import io.confluent.ksql.util.LimitedProxyBuilder;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 
 /**
  * A limited consumer that can be used while trying out operations.
@@ -36,6 +37,7 @@ final class SandboxedConsumer {
         .swallow("close", anyParams())
         .swallow("wakeup", noParams())
         .swallow("unsubscribe", noParams())
+        .swallow("groupMetadata", noParams(), new ConsumerGroupMetadata("group"))
         .build();
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedConsumerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedConsumerTest.java
@@ -46,6 +46,7 @@ public final class SandboxedConsumerTest {
           .ignore("close", long.class, TimeUnit.class)
           .ignore("close", Duration.class)
           .ignore("wakeup")
+          .ignore("groupMetadata")
           .setDefault(TopicPartition.class, new TopicPartition("t", 1))
           .build();
     }


### PR DESCRIPTION
### Description 
Stubs out the call `groupMetadata()` in the `Consumer` used in our sandbox.

### Testing done 
Ran unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

