### PR TITLE
chore: fix the build after AK update

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
@@ -79,7 +79,7 @@ public final class RecordFormatter {
 
   // Use a default window size of 1ms for time windows to avoid warnings on deserialization.
   // The window size, or the end time computed from it, is not shown to the user.
-  private static final int DEFAULT_WINDOW_SIZE = 1;
+  private static final long DEFAULT_WINDOW_SIZE = 1L;
 
   private final Deserializers keyDeserializers;
   private final Deserializers valueDeserializers;


### PR DESCRIPTION
### Description 

When `TimeWindowedDeserializer` was updated to take a `Long` instead of a `long` java can no longer deduce generics because it can't accept an `int` constant in that slot 🤦 

### Testing done 

IntelliJ doesn't show an error anymore

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

