### PR TITLE
feat: Allows pull queries with generic WHERE clauses

### DIFF
--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -507,7 +507,8 @@ Also, note that this config can be set on the CLI, but only used to disable tabl
 SET 'ksql.query.pull.table.scan.enabled'='false';
 ```
 
-The server will reject requests that attempt to enable table scans.
+The server will reject requests that attempt to enable table scans. Disabling table scans per 
+request can be useful when throwing an error is preferable to doing the potentially expensive scan.
 
 ## `ksql.variable.substitution.enable`
 

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -492,7 +492,7 @@ By default, any amount of lag is allowed. For using this functionality, the serv
 **Per query:** yes
 
 Config to control whether table scans are permitted when executing pull queries. Without this enabled, only key lookups are used. Enabling table scans
-removes various restrictions on what types of queries are allowed.  In particular these pull query types are now permitted:
+removes various restrictions on what types of queries are allowed. In particular, these pull query types are now permitted:
 
 - No WHERE clause
 - Range queries on keys

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -501,6 +501,14 @@ removes various restrictions on what types of queries are allowed.  In particula
 
 There may be significant performance implications to using these types of queries, depending on the size of the data and other workloads running, so use this config carefully.
 
+Also, note that this config can be set on the CLI, but only used to disable table scans:
+
+```sql
+SET 'ksql.query.pull.table.scan.enabled'='false';
+```
+
+The server will reject requests that attempt to enable table scans.
+
 ## `ksql.variable.substitution.enable`
 
 Enables variable substitution through [`DEFINE`](../../../../developer-guide/ksqldb-reference/define) statements.

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -487,6 +487,20 @@ the pull query REST endpoint (by including it in the request e.g: `"streamsPrope
 By default, any amount of lag is allowed. For using this functionality, the server must be configured with `ksql.heartbeat.enable=true` and 
 `ksql.lag.reporting.enable=true`, so the servers can exchange lag information between themselves ahead of time, to validate pull queries against the allowed lag.
 
+## `ksql.query.pull.table.scan.enabled`
+
+**Per query:** yes
+
+Config to control whether table scans are permitted when executing pull queries. Without this enabled, only key lookups are used. Enabling table scans
+removes various restrictions on what types of queries are allowed.  In particular these pull query types are now permitted:
+
+- No WHERE clause
+- Range queries on keys
+- Equality and range queries on non-key columns
+- Multi-column key queries without specifying all key columns
+
+There may be significant performance implications to using these types of queries, depending on the size of the data and other workloads running, so use this config carefully.
+
 ## `ksql.variable.substitution.enable`
 
 Enables variable substitution through [`DEFINE`](../../../../developer-guide/ksqldb-reference/define) statements.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
+import io.confluent.ksql.planner.PullPlannerOptions;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.services.ServiceContext;
@@ -155,6 +156,7 @@ public interface KsqlExecutionContext {
       ConfiguredStatement<Query> statement,
       HARouting routing,
       RoutingOptions routingOptions,
+      PullPlannerOptions pullPlannerOptions,
       Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       boolean startImmediately
   );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.physical.pull.PullQueryQueuePopulator;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.planner.LogicalPlanNode;
 import io.confluent.ksql.planner.LogicalPlanner;
+import io.confluent.ksql.planner.PullPlannerOptions;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.KsqlBareOutputNode;
 import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
@@ -146,6 +147,7 @@ final class EngineExecutor {
       final ConfiguredStatement<Query> statement,
       final HARouting routing,
       final RoutingOptions routingOptions,
+      final PullPlannerOptions pullPlannerOptions,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final boolean startImmediately
   ) {
@@ -163,7 +165,7 @@ final class EngineExecutor {
       );
       final KsqlConfig ksqlConfig = sessionConfig.getConfig(false);
       final LogicalPlanNode logicalPlan = buildAndValidateLogicalPlan(
-          statement, analysis, ksqlConfig);
+          statement, analysis, ksqlConfig, pullPlannerOptions);
       final PullPhysicalPlan physicalPlan = buildPullPhysicalPlan(
           logicalPlan,
           analysis
@@ -323,10 +325,11 @@ final class EngineExecutor {
   private LogicalPlanNode buildAndValidateLogicalPlan(
       final ConfiguredStatement<?> statement,
       final ImmutableAnalysis analysis,
-      final KsqlConfig config
+      final KsqlConfig config,
+      final PullPlannerOptions pullPlannerOptions
   ) {
     final OutputNode outputNode = new LogicalPlanner(config, analysis, engineContext.getMetaStore())
-        .buildPullLogicalPlan();
+        .buildPullLogicalPlan(pullPlannerOptions);
     return new LogicalPlanNode(
         statement.getStatementText(),
         Optional.of(outputNode)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
+import io.confluent.ksql.planner.PullPlannerOptions;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
@@ -270,6 +271,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       final ConfiguredStatement<Query> statement,
       final HARouting routing,
       final RoutingOptions routingOptions,
+      final PullPlannerOptions plannerOptions,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final boolean startImmediately
   ) {
@@ -283,6 +285,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
             statement,
             routing,
             routingOptions,
+            plannerOptions,
             pullQueryMetrics,
             startImmediately
         );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
+import io.confluent.ksql.planner.PullPlannerOptions;
 import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.services.ServiceContext;
@@ -164,6 +165,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
       final ConfiguredStatement<Query> statement,
       final HARouting routing,
       final RoutingOptions routingOptions,
+      final PullPlannerOptions pullPlannerOptions,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final boolean startImmediately
   ) {
@@ -175,6 +177,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
         statement,
         routing,
         routingOptions,
+        pullPlannerOptions,
         pullQueryMetrics,
         startImmediately
     );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
@@ -274,8 +274,8 @@ public final class HARouting implements AutoCloseable {
             .ifPresent(queryExecutorMetrics -> queryExecutorMetrics.recordLocalRequests(1));
         pullPhysicalPlan.execute(locations, pullQueryQueue,  rowFactory);
       } catch (Exception e) {
-        LOG.error(String.format("Error executing query %s locally at node %s with exception",
-            statement.getStatementText(), node.toString()), e.getCause());
+        LOG.error("Error executing query {} locally at node {} with exception",
+            statement.getStatementText(), node.toString(), e.getCause());
         throw new KsqlException(
             String.format("Error executing query %s locally at node %s",
                           statement.getStatementText(), node),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
@@ -274,8 +274,8 @@ public final class HARouting implements AutoCloseable {
             .ifPresent(queryExecutorMetrics -> queryExecutorMetrics.recordLocalRequests(1));
         pullPhysicalPlan.execute(locations, pullQueryQueue,  rowFactory);
       } catch (Exception e) {
-        LOG.error("Error executing query {} locally at node {} with exception {}",
-                 statement.getStatementText(), node, e.getCause());
+        LOG.error(String.format("Error executing query %s locally at node %s with exception",
+            statement.getStatementText(), node.toString()), e.getCause());
         throw new KsqlException(
             String.format("Error executing query %s locally at node %s",
                           statement.getStatementText(), node),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/HARouting.java
@@ -275,7 +275,7 @@ public final class HARouting implements AutoCloseable {
         pullPhysicalPlan.execute(locations, pullQueryQueue,  rowFactory);
       } catch (Exception e) {
         LOG.error("Error executing query {} locally at node {} with exception",
-            statement.getStatementText(), node.toString(), e.getCause());
+            statement.getStatementText(), node, e.getCause());
         throw new KsqlException(
             String.format("Error executing query %s locally at node %s",
                           statement.getStatementText(), node),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/SelectOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/SelectOperator.java
@@ -30,7 +30,6 @@ import io.confluent.ksql.planner.plan.PullFilterNode;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 
 public class SelectOperator extends AbstractPhysicalOperator implements UnaryPhysicalOperator {
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -178,7 +178,7 @@ public class LogicalPlanner {
     return buildOutputNode(currentNode);
   }
 
-  public OutputNode buildPullLogicalPlan() {
+  public OutputNode buildPullLogicalPlan(final PullPlannerOptions pullPlannerOptions) {
     final boolean isWindowed = analysis
         .getFrom()
         .getDataSource()
@@ -202,9 +202,10 @@ public class LogicalPlanner {
           whereExpression,
           metaStore,
           ksqlConfig,
-          isWindowed);
+          isWindowed,
+          pullPlannerOptions);
     } else {
-      if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED)) {
+      if (!pullPlannerOptions.getTableScansEnabled()) {
         throw PullFilterNode.invalidWhereClauseException("Missing WHERE clause", isWindowed);
       }
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/PullPlannerOptions.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/PullPlannerOptions.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner;
+
+public interface PullPlannerOptions {
+
+  boolean getTableScansEnabled();
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.execution.expression.tree.TraversalExpressionVisitor;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.planner.PullPlannerOptions;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
@@ -55,9 +56,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PullFilterNode extends SingleSourcePlanNode {
+  private static final Logger LOG = LoggerFactory.getLogger(PullFilterNode.class);
 
   private static final Set<Type> VALID_WINDOW_BOUND_COMPARISONS = ImmutableSet.of(
       Type.EQUAL,
@@ -82,6 +87,8 @@ public class PullFilterNode extends SingleSourcePlanNode {
   private final List<LookupConstraint> lookupConstraints;
   private final Set<UnqualifiedColumnReferenceExp> keyColumns = new HashSet<>();
   private final Set<UnqualifiedColumnReferenceExp> systemColumns = new HashSet<>();
+  private final PullPlannerOptions pullPlannerOptions;
+  private final boolean requiresTableScan;
 
   public PullFilterNode(
       final PlanNodeId id,
@@ -89,13 +96,15 @@ public class PullFilterNode extends SingleSourcePlanNode {
       final Expression predicate,
       final MetaStore metaStore,
       final KsqlConfig ksqlConfig,
-      final boolean isWindowed
+      final boolean isWindowed,
+      final PullPlannerOptions pullPlannerOptions
   ) {
     super(id, source.getNodeOutputType(), source.getSourceName(), source);
 
     Objects.requireNonNull(predicate, "predicate");
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
+    this.pullPlannerOptions = pullPlannerOptions;
     // The predicate is rewritten as DNF.  Discussion for why this format is chosen and how it helps
     // to extract keys in various scenarios can be found here:
     // https://github.com/confluentinc/ksql/pull/6874
@@ -104,7 +113,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
     this.isWindowed = isWindowed;
 
     // Basic validation of WHERE clause
-    validateWhereClause();
+    this.requiresTableScan = validateWhereClause();
 
     // Extraction of key and system columns
     extractKeysAndSystemCols();
@@ -115,7 +124,8 @@ public class PullFilterNode extends SingleSourcePlanNode {
     // Compiling expression into byte code
     this.addAdditionalColumnsToIntermediateSchema = shouldAddAdditionalColumnsInSchema();
     this.intermediateSchema = PullLogicalPlanUtil.buildIntermediateSchema(
-        source.getSchema(), addAdditionalColumnsToIntermediateSchema, isWindowed);
+        source.getSchema().withoutPseudoAndKeyColsInValue(),
+        addAdditionalColumnsToIntermediateSchema, isWindowed);
     compiledWhereClause = CodeGenRunner.compileExpression(
         rewrittenPredicate,
         "Predicate",
@@ -159,13 +169,19 @@ public class PullFilterNode extends SingleSourcePlanNode {
     return intermediateSchema;
   }
 
-  private void validateWhereClause() {
+  private boolean validateWhereClause() {
+    boolean requiresTableScan = false;
     for (Expression disjunct : disjuncts) {
       final Validator validator = new Validator();
       validator.process(disjunct, null);
+      requiresTableScan = requiresTableScan || validator.requiresTableScan;
       if (!validator.isKeyedQuery) {
-        throw invalidWhereClauseException("WHERE clause missing key column for disjunct: "
-                + disjunct.toString(), isWindowed);
+        if (pullPlannerOptions.getTableScansEnabled()) {
+          requiresTableScan = true;
+        } else {
+          throw invalidWhereClauseException("WHERE clause missing key column for disjunct: "
+              + disjunct.toString(), isWindowed);
+        }
       }
 
       if (!validator.seenKeys.isEmpty()
@@ -176,11 +192,16 @@ public class PullFilterNode extends SingleSourcePlanNode {
             .map(i -> schema.key().get(i))
             .map(Column::name)
             .collect(Collectors.toList());
-        throw invalidWhereClauseException(
-            "Multi-column sources must specify every key in the WHERE clause. Specified: "
-                + seenKeyNames + " Expected: " + schema.key(), isWindowed);
+        if (pullPlannerOptions.getTableScansEnabled()) {
+          requiresTableScan = true;
+        } else {
+          throw invalidWhereClauseException(
+              "Multi-column sources must specify every key in the WHERE clause. Specified: "
+                  + seenKeyNames + " Expected: " + schema.key(), isWindowed);
+        }
       }
     }
+    return requiresTableScan;
   }
 
   private void extractKeysAndSystemCols() {
@@ -199,6 +220,10 @@ public class PullFilterNode extends SingleSourcePlanNode {
    * @return the constraints on the key values used to to do keyed lookup.
    */
   private List<LookupConstraint> extractLookupConstraints() {
+    if (requiresTableScan) {
+      LOG.debug("Skipping extracting key value extraction. Already requires table scan");
+      return ImmutableList.of(new NonKeyConstraint());
+    }
     final ImmutableList.Builder<LookupConstraint> constraintPerDisjunct = ImmutableList.builder();
     for (Expression disjunct : disjuncts) {
       final KeyValueExtractor keyValueExtractor = new KeyValueExtractor();
@@ -234,12 +259,15 @@ public class PullFilterNode extends SingleSourcePlanNode {
    * 4. If there is a multi-key, conditions on all keys must be specified.
    */
   private final class Validator extends TraversalExpressionVisitor<Object> {
+
     private final BitSet seenKeys;
     private boolean isKeyedQuery;
+    private boolean requiresTableScan;
 
     Validator() {
       isKeyedQuery = false;
       seenKeys = new BitSet(schema.key().size());
+      requiresTableScan = false;
     }
 
     @Override
@@ -258,7 +286,8 @@ public class PullFilterNode extends SingleSourcePlanNode {
         final Object context
     ) {
       if (node.getType() != LogicalBinaryExpression.Type.AND) {
-        throw invalidWhereClauseException("Only AND expressions are supported: " + node, false);
+        setTableScanOrElseThrow(() ->
+            invalidWhereClauseException("Only AND expressions are supported: " + node, false));
       }
       process(node.getLeft(), context);
       process(node.getRight(), context);
@@ -289,30 +318,36 @@ public class PullFilterNode extends SingleSourcePlanNode {
       } else {
         final Column col = schema.findColumn(columnName)
             .orElseThrow(() -> invalidWhereClauseException(
-                "Bound on non-key column " + columnName, isWindowed));
+                "Bound on non-existent column " + columnName, isWindowed));
 
         if (col.namespace() == Namespace.KEY) {
           if (node.getType() != Type.EQUAL) {
-            throw invalidWhereClauseException(
-                "Bound on key columns '" + getSource().getSchema().key()
-                    + "' must currently be '='",
-                isWindowed);
+            setTableScanOrElseThrow(() ->
+                invalidWhereClauseException("Bound on key columns '"
+                        + getSource().getSchema().key() + "' must currently be '='", isWindowed));
           }
           if (seenKeys.get(col.index())) {
-            throw invalidWhereClauseException(
+            setTableScanOrElseThrow(() -> invalidWhereClauseException(
                 "An equality condition on the key column cannot be combined with other comparisons"
                     + " such as an IN predicate",
-                isWindowed);
+                isWindowed));
           }
           seenKeys.set(col.index());
           isKeyedQuery = true;
           return null;
         }
 
-        throw invalidWhereClauseException(
-            "WHERE clause on non-key column: " + columnName.text(),
-            false
-        );
+        setTableScanOrElseThrow(() -> invalidWhereClauseException(
+            "WHERE clause on non-key column: " + columnName.text(), false));
+        return null;
+      }
+    }
+
+    private void setTableScanOrElseThrow(final Supplier<KsqlException> exceptionSupplier) {
+      if (pullPlannerOptions.getTableScansEnabled()) {
+        requiresTableScan = true;
+      } else {
+        throw exceptionSupplier.get();
       }
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -604,11 +604,15 @@ public class PullFilterNode extends SingleSourcePlanNode {
             + System.lineSeparator()
             + "Pull queries require a WHERE clause that:"
             + System.lineSeparator()
-            + " - limits the query to keys only, e.g. `SELECT * FROM X WHERE <key-column>=Y;`."
+            + " - includes a key equality expression, e.g. `SELECT * FROM X WHERE <key-column>=Y;`."
             + System.lineSeparator()
-            + " - specifies an equality condition that is a conjunction of equality expressions "
-            + "that cover all keys."
+            + " - in the case of a multi-column key, is a conjunction of equality expressions "
+            + "that cover all key columns."
+            + System.lineSeparator()
             + additional
+            + System.lineSeparator()
+            + "If more flexible queries are needed, table scans can be enabled by "
+            + "setting ksql.query.pull.table.scan.enabled=true."
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -336,9 +336,6 @@ public class PullFilterNode extends SingleSourcePlanNode {
           isKeyedQuery = true;
           return null;
         }
-
-        setTableScanOrElseThrow(() -> invalidWhereClauseException(
-            "WHERE clause on non-key column: " + columnName.text(), false));
         return null;
       }
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullFilterNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullFilterNodeTest.java
@@ -1228,7 +1228,8 @@ public class PullFilterNodeTest {
         ));
 
     // Then:
-    assertThat(e.getMessage(), containsString("WHERE clause on non-key column: COL0"));
+    assertThat(e.getMessage(), containsString("WHERE clause missing key column for disjunct: "
+        + "(COL0 = 'abc')"));
   }
 
   @SuppressWarnings("unchecked")

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullFilterNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullFilterNodeTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.planner.plan;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -41,6 +42,7 @@ import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.planner.PullPlannerOptions;
 import io.confluent.ksql.planner.plan.PullFilterNode.WindowBounds;
 import io.confluent.ksql.planner.plan.PullFilterNode.WindowBounds.WindowRange;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -83,6 +85,8 @@ public class PullFilterNodeTest {
   private MetaStore metaStore;
   @Mock
   private KsqlConfig ksqlConfig;
+  @Mock
+  private PullPlannerOptions plannerOptions;
 
   @Before
   public void setUp() {
@@ -104,7 +108,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        false
+        false,
+        plannerOptions
     );
 
     // When:
@@ -136,7 +141,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
@@ -158,7 +164,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        false
+        false,
+        plannerOptions
     );
 
     // When:
@@ -196,8 +203,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        false
-    );
+        false,
+        plannerOptions);
 
     // When:
     final List<LookupConstraint> keys = filterNode.getLookupConstraints();
@@ -228,8 +235,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        false
-    );
+        false,
+        plannerOptions);
 
     // When:
     final List<LookupConstraint> keys = filterNode.getLookupConstraints();
@@ -261,7 +268,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -299,7 +307,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -343,7 +352,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -387,7 +397,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -431,7 +442,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -475,7 +487,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -519,7 +532,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -563,7 +577,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -607,7 +622,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -651,7 +667,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -706,7 +723,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -755,7 +773,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -800,7 +819,8 @@ public class PullFilterNodeTest {
         expression,
         metaStore,
         ksqlConfig,
-        true
+        true,
+        plannerOptions
     );
 
     // When:
@@ -831,12 +851,28 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            true
+            true,
+            plannerOptions
         ));
 
     // Then:
     assertThat(e.getMessage(), containsString("WHERE clause missing key column for disjunct: "
         + "(WINDOWSTART = 1234)"));
+  }
+
+  @Test
+  public void shouldExtractConstraintForSpecialCol_tableScan() {
+    // Given:
+    when(plannerOptions.getTableScansEnabled()).thenReturn(true);
+    when(source.getSchema()).thenReturn(INPUT_SCHEMA);
+    final Expression expression = new ComparisonExpression(
+        Type.EQUAL,
+        new UnqualifiedColumnReferenceExp(ColumnName.of("WINDOWSTART")),
+        new IntegerLiteral(1234)
+    );
+
+    // Then:
+    expectTableScan(expression, true);
   }
 
   @Test
@@ -868,7 +904,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            true
+            true,
+            plannerOptions
         ));
 
     // Then:
@@ -896,13 +933,28 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
-        ));
+            false,
+            plannerOptions));
 
     // Then:
     assertThat(e.getMessage(), containsString(
         "Multi-column sources must specify every key in the WHERE clause. "
             + "Specified: [`K1`] Expected: [`K1` INTEGER KEY, `K2` INTEGER KEY]"));
+  }
+
+  @Test
+  public void shouldExtractConstraintForMultiKeyExpressionsThatDontCoverAllKeys_tableScan() {
+    // Given:
+    when(plannerOptions.getTableScansEnabled()).thenReturn(true);
+    when(source.getSchema()).thenReturn(MULTI_KEY_SCHEMA);
+    final Expression expression = new ComparisonExpression(
+        Type.EQUAL,
+        new UnqualifiedColumnReferenceExp(ColumnName.of("K1")),
+        new IntegerLiteral(1)
+    );
+
+    // Then:
+    expectTableScan(expression, false);
   }
 
 
@@ -924,11 +976,12 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
-    assertThat(e.getMessage(), containsString("Bound on non-key column `C1`."));
+    assertThat(e.getMessage(), containsString("Bound on non-existent column `C1`."));
   }
 
   @Test
@@ -945,7 +998,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
@@ -971,11 +1025,27 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
     assertThat(e.getMessage(), containsString("Bound on key columns '[`K` INTEGER KEY]' must currently be '='."));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldExtractConstraintWithLiteralRange_tableScan() {
+    // Given:
+    when(plannerOptions.getTableScansEnabled()).thenReturn(true);
+    final Expression expression = new ComparisonExpression(
+        Type.GREATER_THAN,
+        new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
+        new IntegerLiteral(1)
+    );
+
+    // Then:
+    expectTableScan(expression, false);
   }
 
   @Test
@@ -1007,7 +1077,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
@@ -1033,7 +1104,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
@@ -1064,7 +1136,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
@@ -1099,11 +1172,78 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
     assertThat(e.getMessage(), containsString("An equality condition on the key column cannot be combined with other comparisons"));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldExtractConstraintWithMultiKeyExpressions_tableScan() {
+    // Given:
+    when(plannerOptions.getTableScansEnabled()).thenReturn(true);
+    final Expression expression1 = new ComparisonExpression(
+        Type.EQUAL,
+        new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
+        new IntegerLiteral(1)
+    );
+    final Expression expression2 = new ComparisonExpression(
+        Type.EQUAL,
+        new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
+        new IntegerLiteral(2)
+    );
+    final Expression expression  = new LogicalBinaryExpression(
+        LogicalBinaryExpression.Type.AND,
+        expression1,
+        expression2
+    );
+
+    // Then:
+    expectTableScan(expression, false);
+  }
+
+  @Test
+  public void shouldThrowOnNonKeyCol() {
+    // Given:
+    final Expression expression = new ComparisonExpression(
+        Type.EQUAL,
+        new UnqualifiedColumnReferenceExp(ColumnName.of("COL0")),
+        new StringLiteral("abc")
+    );
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> new PullFilterNode(
+            NODE_ID,
+            source,
+            expression,
+            metaStore,
+            ksqlConfig,
+            false,
+            plannerOptions
+        ));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("WHERE clause on non-key column: COL0"));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldExtractConstraintWithNonKeyCol_tableScan() {
+    // Given:
+    when(plannerOptions.getTableScansEnabled()).thenReturn(true);
+    final Expression expression = new ComparisonExpression(
+        Type.EQUAL,
+        new UnqualifiedColumnReferenceExp(ColumnName.of("COL0")),
+        new StringLiteral("abc")
+    );
+
+    // Then:
+    expectTableScan(expression, false);
   }
 
   @Test
@@ -1134,7 +1274,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
@@ -1169,7 +1310,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            true
+            true,
+            plannerOptions
         ));
 
     // Then:
@@ -1216,7 +1358,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            true
+            true,
+            plannerOptions
         ));
 
     // Then:
@@ -1262,7 +1405,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            true
+            true,
+            plannerOptions
         ));
 
     // Then:
@@ -1297,7 +1441,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            true
+            true,
+            plannerOptions
         ));
 
     // Then:
@@ -1343,7 +1488,8 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            true
+            true,
+            plannerOptions
         ));
 
     // Then:
@@ -1378,10 +1524,33 @@ public class PullFilterNodeTest {
             expression,
             metaStore,
             ksqlConfig,
-            false
+            false,
+            plannerOptions
         ));
 
     // Then:
     assertThat(e.getMessage(), containsString("Cannot use WINDOWSTART/WINDOWEND on non-windowed source."));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void expectTableScan(final Expression expression, final boolean windowed) {
+    // Given:
+    PullFilterNode filterNode = new PullFilterNode(
+        NODE_ID,
+        source,
+        expression,
+        metaStore,
+        ksqlConfig,
+        windowed,
+        plannerOptions
+    );
+
+    // When:
+    final List<LookupConstraint> keys = filterNode.getLookupConstraints();
+
+    // Then:
+    assertThat(filterNode.isWindowed(), is(windowed));
+    assertThat(keys.size(), is(1));
+    assertThat(keys.get(0), isA((Class) NonKeyConstraint.class));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullFilterNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullFilterNodeTest.java
@@ -1145,7 +1145,7 @@ public class PullFilterNodeTest {
   }
 
   @Test
-  public void shouldThrowOnMultiKeyExpressions() {
+  public void shouldThrowOnMultipleKeyExpressions() {
     // Given:
     final Expression expression1 = new ComparisonExpression(
         Type.EQUAL,
@@ -1182,7 +1182,7 @@ public class PullFilterNodeTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void shouldExtractConstraintWithMultiKeyExpressions_tableScan() {
+  public void shouldExtractConstraintWithMultipleKeyExpressions_tableScan() {
     // Given:
     when(plannerOptions.getTableScansEnabled()).thenReturn(true);
     final Expression expression1 = new ComparisonExpression(

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -73,7 +73,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class RestQueryTranslationTest {
 
-  private static final Path TEST_DIR = Paths.get("rest-query-validation-tests/alan");
+  private static final Path TEST_DIR = Paths.get("rest-query-validation-tests");
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -73,7 +73,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class RestQueryTranslationTest {
 
-  private static final Path TEST_DIR = Paths.get("rest-query-validation-tests");
+  private static final Path TEST_DIR = Paths.get("rest-query-validation-tests/alan");
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1033,12 +1033,15 @@
       }
     },
     {
-      "name": "fail on unsupported query feature: where key range",
+      "name": "fail on unsupported query feature: where key range string",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
         "SELECT * FROM AGGREGATE WHERE '0'<ID AND ID<'100';"
       ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
         "message": "Bound on key columns '[`ID` STRING KEY]' must currently be '='.",
@@ -1052,6 +1055,9 @@
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
         "SELECT * FROM AGGREGATE WHERE ID != '100';"
       ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
         "message": "Bound on key columns '[`ID` STRING KEY]' must currently be '='. ",
@@ -1065,6 +1071,9 @@
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
         "SELECT * FROM AGGREGATE WHERE COUNT = 100;"
       ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
         "message": "WHERE clause on non-key column: COUNT",
@@ -2173,6 +2182,415 @@
           {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
           {"row":{"columns":["8", 12000, 13000, 1]}},
           {"row":{"columns":["8", 14000, 15000, 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "fail on unsupported query feature: where key range",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE 0 < ID AND ID < 100;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Bound on key columns '[`ID` INTEGER KEY]' must currently be '='.",
+        "status": 400
+      }
+    },
+    {
+      "name": "Generalized WHERE: key range",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE 10 < ID AND ID < 100;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": -1, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582401512456, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501552456, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 75, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[75, 1]}},
+          {"row":{"columns":[50, 1]}},
+          {"row":{"columns":[11, 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "Generalized WHERE: key range - windowed",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE 10 < ID AND ID < 100;",
+        "SELECT * FROM AGGREGATE WHERE 10 < ID AND ID < 100 AND WINDOWEND < 14000;",
+        "SELECT * FROM AGGREGATE WHERE 10 < ID AND ID < 100 AND WINDOWSTART > 12000;",
+        "SELECT * FROM AGGREGATE WHERE 10 < ID AND ID < 100 AND WINDOWSTART > 12000 AND WINDOWEND < 15000;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": -1, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12445, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12445, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 13445, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 75, "value": {}},
+        {"topic": "test_topic", "timestamp": 14345, "key": 75, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[75, 12000, 13000, 1]}},
+          {"row":{"columns":[75, 14000, 15000, 1]}},
+          {"row":{"columns":[50, 12000, 13000, 1]}},
+          {"row":{"columns":[50, 13000, 14000, 1]}},
+          {"row":{"columns":[11, 12000, 13000, 2]}},
+          {"row":{"columns":[11, 13000, 14000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[75, 12000, 13000, 1]}},
+          {"row":{"columns":[50, 12000, 13000, 1]}},
+          {"row":{"columns":[11, 12000, 13000, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[75, 14000, 15000, 1]}},
+          {"row":{"columns":[50, 13000, 14000, 1]}},
+          {"row":{"columns":[11, 13000, 14000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[50, 13000, 14000, 1]}},
+          {"row":{"columns":[11, 13000, 14000, 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "fail on unsupported query feature: where key multiple times",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID = 10 AND ID IN (1, 2, 3, 10);"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "An equality condition on the key column cannot be combined with other comparisons such as an IN predicate",
+        "status": 400
+      }
+    },
+    {
+      "name": "Generalized WHERE: multiple same key references ",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID = 10 AND ID IN (1, 2, 3, 10);"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": -1, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582401512456, "key": 11, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "Generalized WHERE: multiple same key references - windowed",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE (ID = 10 OR ID = 50) AND ID IN (50, 1, 2, 3, 10);"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": -1, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12445, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12445, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 13445, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 75, "value": {}},
+        {"topic": "test_topic", "timestamp": 14345, "key": 75, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 12000, 13000, 2]}},
+          {"row":{"columns":[50, 12000, 13000, 1]}},
+          {"row":{"columns":[50, 13000, 14000, 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "fail on unsupported query feature: where range on non key",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE COUNT > 1;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "WHERE clause on non-key column: COUNT.",
+        "status": 400
+      }
+    },
+    {
+      "name": "Generalized WHERE: non key range",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE COUNT > 1;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 1582501512451, "key": -1, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512452, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582401512453, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582401512454, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512455, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501552456, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501552457, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501552458, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512459, "key": 75, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[101, 3]}},
+          {"row":{"columns":[11, 2]}}
+        ]}
+      ]
+    },
+    {
+      "name": "Generalized WHERE: non key range - windowed",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE COUNT > 1;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": -1, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12445, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12445, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 13445, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 75, "value": {}},
+        {"topic": "test_topic", "timestamp": 14345, "key": 75, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 12000, 13000, 2]}},
+          {"row":{"columns":[11, 12000, 13000, 2]}}
+        ]}
+      ]
+    },
+    {
+      "name": "fail on unsupported query feature: where missing key column",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE WINDOWSTART >= 12000;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "WHERE clause missing key column for disjunct",
+        "status": 400
+      }
+    },
+    {
+      "name": "Generalized WHERE: non key special column reference - windowed",
+      "statements": [
+        "CREATE STREAM INPUT (ID STRING KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE WINDOWSTART >= 13000;",
+        "SELECT * FROM AGGREGATE WHERE WINDOWSTART >= 13000 AND WINDOWEND <= 15000;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12346, "key": "11", "value": {"val": 1}},
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {"val": 2}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"val": 2}},
+        {"topic": "test_topic", "timestamp": 12366, "key": "9", "value": {"val": 3}},
+        {"topic": "test_topic", "timestamp": 12367, "key": "8", "value": {"val": 4}},
+        {"topic": "test_topic", "timestamp": 14367, "key": "8", "value": {"val": 4}},
+        {"topic": "test_topic", "timestamp": 15367, "key": "8", "value": {"val": 4}},
+        {"topic": "test_topic", "timestamp": 12368, "key": "12", "value": {"val": 5}},
+        {"topic": "test_topic", "timestamp": 13368, "key": "12", "value": {"val": 5}},
+        {"topic": "test_topic", "timestamp": 16369, "key": "13", "value": {"val": 6}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["12", 13000, 14000,1]}},
+          {"row":{"columns":["13", 16000, 17000,1]}},
+          {"row":{"columns":["8", 14000, 15000,1]}},
+          {"row":{"columns":["8", 15000, 16000,1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["12", 13000, 14000,1]}},
+          {"row":{"columns":["8", 14000, 15000,1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "fail on unsupported query feature: where missing column from multi-column key",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, COL INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COL, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID, COL;",
+        "SELECT * FROM AGGREGATE WHERE ID = 10;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Multi-column sources must specify every key in the WHERE clause",
+        "status": 400
+      }
+    },
+    {
+      "name": "Generalized WHERE: single column from multi-column key",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, COL INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COL, COUNT(1) AS COUNT FROM INPUT GROUP BY ID, COL;",
+        "SELECT * FROM AGGREGATE WHERE ID = 10;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 5, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 5, "value": {"col": 2}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 10, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 10, "value": {"col": 2}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 15, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 1582501512456, "key": 15, "value": {"col": 2}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COL` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 1, 1]}},
+          {"row":{"columns":[10, 2, 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "Generalized WHERE: single column from multi-column key - windowed",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, COL INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COL, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID, COL;",
+        "SELECT * FROM AGGREGATE WHERE ID = 10;",
+        "SELECT * FROM AGGREGATE WHERE COL > 1;",
+        "SELECT * FROM AGGREGATE WHERE COL = 1;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": -1, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 10, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 12445, "key": 10, "value": {"col": 2}},
+        {"topic": "test_topic", "timestamp": 12545, "key": 10, "value": {"col": 2}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 12445, "key": 11, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 13445, "key": 11, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 50, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 13345, "key": 50, "value": {"col": 2}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 101, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 75, "value": {"col": 1}},
+        {"topic": "test_topic", "timestamp": 14345, "key": 75, "value": {"col": 2}},
+        {"topic": "test_topic", "timestamp": 14445, "key": 75, "value": {"col": 2}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COL` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 1, 12000, 13000, 1]}},
+          {"row":{"columns":[10, 2, 12000, 13000, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COL` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[50, 2, 13000, 14000, 1]}},
+          {"row":{"columns":[75, 2, 14000, 15000, 2]}},
+          {"row":{"columns":[10, 2, 12000, 13000, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COL` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 1, 12000, 13000, 1]}},
+          {"row":{"columns":[50, 1, 12000, 13000, 1]}},
+          {"row":{"columns":[75, 1, 12000, 13000, 1]}},
+          {"row":{"columns":[-1, 1, 12000, 13000, 1]}},
+          {"row":{"columns":[11, 1, 12000, 13000, 2]}},
+          {"row":{"columns":[11, 1, 13000, 14000, 1]}},
+          {"row":{"columns":[101, 1, 12000, 13000, 1]}}
         ]}
       ]
     }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1076,7 +1076,7 @@
       },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "WHERE clause on non-key column: COUNT",
+        "message": "WHERE clause missing key column for disjunct: (COUNT = 100)",
         "status": 400
       }
     },
@@ -2373,7 +2373,7 @@
       },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "WHERE clause on non-key column: COUNT.",
+        "message": "WHERE clause missing key column for disjunct: (COUNT > 1)",
         "status": 400
       }
     },
@@ -2591,6 +2591,37 @@
           {"row":{"columns":[11, 1, 12000, 13000, 2]}},
           {"row":{"columns":[11, 1, 13000, 14000, 1]}},
           {"row":{"columns":[101, 1, 12000, 13000, 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "Generalized WHERE: key fetch plus additional filters",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID IN (10, 11, 50, 101, 75) AND COUNT > 1;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 1582501512451, "key": -1, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512452, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582401512453, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582401512454, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512455, "key": 50, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501552456, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501552457, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501552458, "key": 101, "value": {}},
+        {"topic": "test_topic", "timestamp": 1582501512459, "key": 75, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[11, 2]}},
+          {"row":{"columns":[101, 3]}}
         ]}
       ]
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.rest.server.LocalCommands;
+import io.confluent.ksql.rest.server.resources.streaming.PullQueryConfigPlannerOptions;
 import io.confluent.ksql.rest.server.resources.streaming.PullQueryConfigRoutingOptions;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.utils.FormatOptions;
@@ -137,6 +138,11 @@ public class QueryEndpoint {
         ImmutableMap.of()
     );
 
+    final PullQueryConfigPlannerOptions plannerOptions = new PullQueryConfigPlannerOptions(
+        ksqlConfig,
+        statement.getSessionConfig().getOverrides()
+    );
+
     PullQueryExecutionUtil.checkRateLimit(rateLimiter);
 
     final PullQueryResult result = ksqlEngine.executePullQuery(
@@ -144,6 +150,7 @@ public class QueryEndpoint {
         statement,
         routing,
         routingOptions,
+        plannerOptions,
         pullQueryMetrics,
         false
     );

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import io.confluent.ksql.planner.PullPlannerOptions;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Map;
+
+public class PullQueryConfigPlannerOptions implements PullPlannerOptions {
+
+  private final KsqlConfig ksqlConfig;
+  private final Map<String, ?> configOverrides;
+
+  public PullQueryConfigPlannerOptions(final KsqlConfig ksqlConfig,
+      final Map<String, ?> configOverrides) {
+    this.ksqlConfig = ksqlConfig;
+    this.configOverrides = configOverrides;
+  }
+
+  @Override
+  public boolean getTableScansEnabled() {
+    boolean configured = ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
+    if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED)) {
+      boolean override
+          = (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
+      if (override && !configured) {
+        throw new KsqlException("You can only disable table scans with an override, "
+            + "not enable them.");
+      }
+      return override;
+    }
+    return configured;
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
@@ -33,9 +33,9 @@ public class PullQueryConfigPlannerOptions implements PullPlannerOptions {
 
   @Override
   public boolean getTableScansEnabled() {
-    boolean configured = ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
+    final boolean configured = ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
     if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED)) {
-      boolean override
+      final boolean override
           = (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
       if (override && !configured) {
         throw new KsqlException("You can only disable table scans with an override, "

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -84,6 +84,11 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
         ImmutableMap.of()
     );
 
+    final PullQueryConfigPlannerOptions plannerOptions = new PullQueryConfigPlannerOptions(
+        query.getSessionConfig().getConfig(false),
+        query.getSessionConfig().getOverrides()
+    );
+
     PullQueryExecutionUtil.checkRateLimit(rateLimiter);
 
     final PullQueryResult result = ksqlEngine.executePullQuery(
@@ -91,6 +96,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
         query,
         routing,
         routingOptions,
+        plannerOptions,
         pullQueryMetrics,
         true
     );

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -306,6 +306,11 @@ public class StreamedQueryResource implements KsqlConfigurable {
         requestProperties
     );
 
+    final PullQueryConfigPlannerOptions plannerOptions = new PullQueryConfigPlannerOptions(
+        sessionConfig.getConfig(false),
+        configured.getSessionConfig().getOverrides()
+    );
+
     // A request is considered forwarded if the request has the forwarded flag or if the request
     // is from an internal listener.
     final boolean isAlreadyForwarded = routingOptions.getIsSkipForwardRequest()
@@ -322,6 +327,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
         configured,
         routing,
         routingOptions,
+        plannerOptions,
         pullQueryMetrics,
         true
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -328,7 +328,7 @@ public class ApiIntegrationTest {
     String sql = "SELECT * from " + AGG_TABLE + " WHERE LONG=12345;";
 
     // Then:
-    shouldFailToExecuteQuery(sql, "WHERE clause on non-key column: LONG");
+    shouldFailToExecuteQuery(sql, "WHERE clause missing key column for disjunct: (LONG = 12345).");
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -145,7 +145,7 @@ public class PullQueryPublisherTest {
       times[0]++;
       return null;
     }).when(pullQueryQueue).drainTo(any());
-    when(engine.executePullQuery(any(), any(), any(), any(), any(), anyBoolean()))
+    when(engine.executePullQuery(any(), any(), any(), any(), any(), any(), anyBoolean()))
         .thenReturn(pullQueryResult);
     when(exec.submit(any(Runnable.class))).thenAnswer(inv -> {
       Runnable runnable = inv.getArgument(0);
@@ -173,7 +173,7 @@ public class PullQueryPublisherTest {
 
     // Then:
     verify(engine).executePullQuery(
-        eq(serviceContext), eq(statement), eq(haRouting), any(), eq(Optional.empty()),
+        eq(serviceContext), eq(statement), eq(haRouting), any(), any(), eq(Optional.empty()),
         anyBoolean());
   }
 
@@ -188,7 +188,7 @@ public class PullQueryPublisherTest {
     // Then:
     verify(subscriber).onNext(any());
     verify(engine).executePullQuery(
-        eq(serviceContext), eq(statement), eq(haRouting), any(),
+        eq(serviceContext), eq(statement), eq(haRouting), any(), any(),
         eq(Optional.empty()), anyBoolean());
   }
 
@@ -224,7 +224,7 @@ public class PullQueryPublisherTest {
   @Test
   public void shouldCallOnErrorOnFailure_initial() {
     // Given:
-    when(engine.executePullQuery(any(), any(), any(), any(), any(), anyBoolean()))
+    when(engine.executePullQuery(any(), any(), any(), any(), any(), any(), anyBoolean()))
         .thenThrow(new RuntimeException("Boom!"));
 
     // When:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -315,7 +315,7 @@ public class StreamedQueryResourceTest {
         Optional.empty()
     );
     testResource.configure(VALID_CONFIG);
-    when(mockKsqlEngine.executePullQuery(any(), any(), any(), any(), any(), anyBoolean()))
+    when(mockKsqlEngine.executePullQuery(any(), any(), any(), any(), any(), any(), anyBoolean()))
         .thenReturn(pullQueryResult);
     when(pullQueryResult.getPullQueryQueue()).thenReturn(pullQueryQueue);
 


### PR DESCRIPTION
### Description 
Now that we have both codegen for the filter condition and table scan functionality, this PR removes some restrictions that were formerly in place including disallowing:
- Key range queries
- Multiple constraints on the key
- Non-Key equality, range queries (or any non-key reference!)
- Queries missing columns from multi-column keys

These restrictions are only lifted when the config `ksql.query.pull.table.scan.enabled` is set to true.  Otherwise, the former restrictions are still in place.

One exception to this is that now, if you specify both a key equality and non-key constraint, it's done with a key lookup and no table scan is required.

### Testing done 
Many RQTT and unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

