### PR TITLE
minor: add parameters for specifying more stuff about releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ def defaultParams = [
         description: 'Is this a release build. If so, GIT_REVISION and KSQLDB_VERSION must be specified, and the downstream CCloud job will not be triggered.',
         defaultValue: false),
     string(name: 'GIT_REVISION',
-        description: 'The git SHA to build ksqlDB from.',
+        description: 'The git ref (SHA or branch or tag) to build ksqlDB from.',
         defaultValue: ''),
     booleanParam(name: 'PROMOTE_TO_PRODUCTION',
         defaultValue: false,
@@ -30,7 +30,19 @@ def defaultParams = [
         description: 'If PROMOTE_TO_PRODUCTION, ksqlDB version to promote to production. Else, override the ksql_db_version defined in the Jenkinsfile, representing the next version to be released.'),
     booleanParam(name: 'UPDATE_LATEST_TAG',
         defaultValue: false,
-        description: 'Should the latest tag on docker hub be updated to point at this new image version. Only relevant if PROMOTE_TO_PRODUCTION is true.')
+        description: 'Should the latest tag on docker hub be updated to point at this new image version. Only relevant if PROMOTE_TO_PRODUCTION is true.'),
+    string(name: 'CP_VERSION',
+        description: 'the CP version to build ksqlDB against',
+        defaultValue: ''),
+    string(name: 'CP_BUILD_NUMBER',
+        description: 'the packaging build number that published beta artifacts',
+        defaultValue: ''),
+    string(name: 'CCLOUD_GIT_REVISION',
+        description: 'The git ref (SHA or branch or tag) to base the cc-docker-ksql build from.',
+        defaultValue: ''),
+    string(name: 'CCOUD_KSQL_BASE_VERSION',
+        description: 'The version of the initial cc-ksql RC we're basing our cloud release off of (e.g. v0.15.0-rc123-456)',
+        defaultValue: '')
 ]
 
 def updateConfig = { c ->
@@ -75,6 +87,14 @@ def job = {
     // Use ksqlDB version param if provided
     if (params.KSQLDB_VERSION != '') {
         config.ksql_db_version = params.KSQLDB_VERSION
+    }
+
+    if (params.CP_VERSION != '') {
+        config.cp_version = params.CP_VERSION
+    }
+
+    if (params.CP_BUILD_NUMBER != '') {
+        config.packaging_build_number = params.CP_BUILD_NUMBER
     }
 
     if (config.release) {
@@ -352,7 +372,9 @@ def job = {
                     string(name: "NIGHTLY_BUILD_NUMBER", value: "${env.BUILD_NUMBER}"),
                     string(name: "CP_BETA_VERSION", value: "${config.cp_version}"),
                     string(name: "CP_BETA_BUILD_NUMBER", value: "${config.packaging_build_number}"),
-                    string(name: "KSQLDB_ARTIFACT_VERSION", value: "${config.ksql_db_artifact_version}")
+                    string(name: "KSQLDB_ARTIFACT_VERSION", value: "${config.ksql_db_artifact_version}"),
+                    string(name: "CCLOUD_GIT_REVISION", value: "${params.CCLOUD_GIT_REVISION}"),
+                    string(name: "CCOUD_KSQL_BASE_VERSION", value: "${params.CCOUD_KSQL_BASE_VERSION}")
                 ]
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ def defaultParams = [
     string(name: 'CCLOUD_GIT_REVISION',
         description: 'The git ref (SHA or branch or tag) to base the cc-docker-ksql build from.',
         defaultValue: ''),
-    string(name: 'CCOUD_KSQL_BASE_VERSION',
+    string(name: 'CCLOUD_KSQL_BASE_VERSION',
         description: 'The version of the initial cc-ksql RC we're basing our cloud release off of (e.g. v0.15.0-rc123-456)',
         defaultValue: '')
 ]
@@ -374,7 +374,7 @@ def job = {
                     string(name: "CP_BETA_BUILD_NUMBER", value: "${config.packaging_build_number}"),
                     string(name: "KSQLDB_ARTIFACT_VERSION", value: "${config.ksql_db_artifact_version}"),
                     string(name: "CCLOUD_GIT_REVISION", value: "${params.CCLOUD_GIT_REVISION}"),
-                    string(name: "CCOUD_KSQL_BASE_VERSION", value: "${params.CCOUD_KSQL_BASE_VERSION}")
+                    string(name: "CCLOUD_KSQL_BASE_VERSION", value: "${params.CCLOUD_KSQL_BASE_VERSION}")
                 ]
         }
     }


### PR DESCRIPTION
Adds build parameters for specifying:
- beta tag / build number. this should avoid some rebuild/cancel/replay/edit loops
- downstream ccloud git revision and image (for fix builds). This way you can kick
  off the whole pipeline for fix builds with 1 step (or 2 if you need new beta
  pkgs).

This should help us simplify some of our release instructions