### PR TITLE
chore: update how AstBuilder and AstSanitizer handles lambda functions

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -216,9 +216,12 @@ public final class AstSanitizer {
         }
       });
 
-      ctx.getContext().addLambdaArgs(expression.getArguments());
+      final Set<String> previousLambdaArgs = new HashSet<>(ctx.getContext().getLambdaArgs());
+      ctx.getContext().addLambdaArgs(new HashSet<>(expression.getArguments()));
       ctx.process(expression.getBody());
-      ctx.getContext().removeLambdaArgs(expression.getArguments());
+      ctx.getContext().removeLambdaArgs();
+      ctx.getContext().addLambdaArgs(previousLambdaArgs);
+
       return visitExpression(expression, ctx);
     }
   }
@@ -226,7 +229,7 @@ public final class AstSanitizer {
   private static class SanitizerContext {
     final Set<String> lambdaArgs = new HashSet<>();
 
-    private void addLambdaArgs(final List<String> newArguments) {
+    private void addLambdaArgs(final Set<String> newArguments) {
       final int previousLambdaArgumentsLength = lambdaArgs.size();
       lambdaArgs.addAll(newArguments);
       if (new HashSet<>(lambdaArgs).size()
@@ -236,8 +239,8 @@ public final class AstSanitizer {
       }
     }
 
-    private void removeLambdaArgs(final List<String> removeArguments) {
-      lambdaArgs.removeAll(removeArguments);
+    private void removeLambdaArgs() {
+      lambdaArgs.clear();
     }
 
     private Set<String> getLambdaArgs() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -19,11 +19,9 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
-import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter.Context;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
-import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
 import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
@@ -180,10 +178,6 @@ public final class AstSanitizer {
         final ExpressionTreeRewriter.Context<SanitizerContext> ctx
     ) {
       final ColumnName columnName = expression.getColumnName();
-      if (ctx.getContext().getLambdaArgs().size() > 0
-          && ctx.getContext().getLambdaArgs().contains(columnName.text())) {
-        return Optional.of(new LambdaLiteral(columnName.text()));
-      }
 
       final List<SourceName> sourceNames = dataSourceExtractor.getSourcesFor(columnName);
 
@@ -222,7 +216,9 @@ public final class AstSanitizer {
         }
       });
 
-      ctx.getContext().addLambdaArg(expression.getArguments());
+      ctx.getContext().addLambdaArgs(expression.getArguments());
+      ctx.process(expression.getBody());
+      ctx.getContext().removeLambdaArgs(expression.getArguments());
       return visitExpression(expression, ctx);
     }
   }
@@ -230,14 +226,18 @@ public final class AstSanitizer {
   private static class SanitizerContext {
     final Set<String> lambdaArgs = new HashSet<>();
 
-    private void addLambdaArg(final List<String> newArguments) {
+    private void addLambdaArgs(final List<String> newArguments) {
       final int previousLambdaArgumentsLength = lambdaArgs.size();
       lambdaArgs.addAll(newArguments);
       if (new HashSet<>(lambdaArgs).size()
-          < previousLambdaArgumentsLength + 1) {
+          < previousLambdaArgumentsLength + newArguments.size()) {
         throw new KsqlException(
             "Reusing lambda arguments in nested lambda is not allowed");
       }
+    }
+
+    private void removeLambdaArgs(final List<String> removeArguments) {
+      lambdaArgs.removeAll(removeArguments);
     }
 
     private Set<String> getLambdaArgs() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
@@ -40,7 +40,7 @@ import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
-import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
+import io.confluent.ksql.execution.expression.tree.LambdaVariable;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -500,7 +500,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    public Expression visitLambdaLiteral(final LambdaLiteral node, final C context) {
+    public Expression visitLambdaVariable(final LambdaVariable node, final C context) {
       return plugin.apply(node, new Context<>(context, this)).orElse(node);
     }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -55,7 +55,7 @@ import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
-import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
+import io.confluent.ksql.execution.expression.tree.LambdaVariable;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -356,9 +356,9 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    public Pair<String, SqlType> visitLambdaLiteral(
-        final LambdaLiteral lambdaLiteral, final Void context) {
-      return visitUnsupported(lambdaLiteral);
+    public Pair<String, SqlType> visitLambdaVariable(
+        final LambdaVariable lambdaVariable, final Void context) {
+      return visitUnsupported(lambdaVariable);
     }
 
     @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -41,7 +41,7 @@ import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
-import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
+import io.confluent.ksql.execution.expression.tree.LambdaVariable;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -107,7 +107,7 @@ public final class ExpressionFormatter {
     }
 
     @Override
-    public String visitLambdaLiteral(final LambdaLiteral node, final Context context) {
+    public String visitLambdaVariable(final LambdaVariable node, final Context context) {
       return String.valueOf(node.getValue());
     }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
@@ -89,5 +89,5 @@ public interface ExpressionVisitor<R, C> {
 
   R visitLambdaExpression(LambdaFunctionCall exp, C context);
 
-  R visitLambdaLiteral(LambdaLiteral exp, C context);
+  R visitLambdaVariable(LambdaVariable exp, C context);
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LambdaVariable.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LambdaVariable.java
@@ -22,15 +22,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class LambdaLiteral extends Literal {
+public class LambdaVariable extends Literal {
 
   private final String lambdaCharacter;
 
-  public LambdaLiteral(final String lambdaCharacter) {
+  public LambdaVariable(final String lambdaCharacter) {
     this(Optional.empty(), lambdaCharacter);
   }
 
-  public LambdaLiteral(final Optional<NodeLocation> location, final String lambdaCharacter) {
+  public LambdaVariable(final Optional<NodeLocation> location, final String lambdaCharacter) {
     super(location);
     this.lambdaCharacter = lambdaCharacter;
   }
@@ -42,7 +42,7 @@ public class LambdaLiteral extends Literal {
 
   @Override
   public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
-    return visitor.visitLambdaLiteral(this, context);
+    return visitor.visitLambdaVariable(this, context);
   }
 
   @Override
@@ -54,7 +54,7 @@ public class LambdaLiteral extends Literal {
       return false;
     }
 
-    final LambdaLiteral that = (LambdaLiteral) o;
+    final LambdaVariable that = (LambdaVariable) o;
     return lambdaCharacter.equals(that.lambdaCharacter);
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
@@ -204,7 +204,7 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
   }
 
   @Override
-  public Void visitLambdaLiteral(final LambdaLiteral node, final C context) {
+  public Void visitLambdaVariable(final LambdaVariable node, final C context) {
     return null;
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
@@ -220,7 +220,7 @@ public abstract class VisitParentExpressionVisitor<R, C> implements ExpressionVi
   }
 
   @Override
-  public R visitLambdaLiteral(final LambdaLiteral node, final C context) {
+  public R visitLambdaVariable(final LambdaVariable node, final C context) {
     return visitLiteral(node, context);
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -38,7 +38,7 @@ import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
-import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
+import io.confluent.ksql.execution.expression.tree.LambdaVariable;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -151,8 +151,8 @@ public class ExpressionTypeManager {
 
     @Override
     // CHECKSTYLE_RULES.OFF: TodoComment
-    public Void visitLambdaLiteral(
-        final LambdaLiteral node, final ExpressionTypeContext expressionTypeContext
+    public Void visitLambdaVariable(
+        final LambdaVariable node, final ExpressionTypeContext expressionTypeContext
     ) {
       // TODO: add proper type inference
       expressionTypeContext.setSqlType(SqlTypes.INTEGER);

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -42,7 +42,7 @@ import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
-import io.confluent.ksql.execution.expression.tree.LambdaLiteral;
+import io.confluent.ksql.execution.expression.tree.LambdaVariable;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
@@ -209,8 +209,8 @@ public class ExpressionFormatterTest {
         Optional.of(LOCATION),
         ImmutableList.of("X", "Y"),
         new LogicalBinaryExpression(LogicalBinaryExpression.Type.OR,
-            new LambdaLiteral("X"),
-            new LambdaLiteral("Y"))
+            new LambdaVariable("X"),
+            new LambdaVariable("Y"))
     );
 
     // When:

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -296,7 +296,7 @@ primaryExpression
     | MAP '(' (expression ASSIGN expression (',' expression ASSIGN expression)*)? ')'     #mapConstructor
     | STRUCT '(' (identifier ASSIGN expression (',' identifier ASSIGN expression)*)? ')'  #structConstructor
     | identifier '(' ASTERISK ')'                              		                        #functionCall
-    | identifier '(' (expression (',' expression)* (',' lambdaFunction)*)? ')'             #functionCall
+    | identifier '(' (expression (',' expression)* (',' lambdaFunction)*)? ')'            #functionCall
     | value=primaryExpression '[' index=valueExpression ']'                               #subscript
     | identifier                                                                          #columnReference
     | identifier '.' identifier                                                           #qualifiedColumnReference

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -648,9 +648,11 @@ public class AstBuilder {
           .map(ParserUtil::getIdentifierText)
           .collect(toList());
 
+      final Set<String> previousLambdaArgs = new HashSet<>(lambdaArgs);
       lambdaArgs.addAll(arguments);
       final Expression body = (Expression) visit(context.expression());
-      lambdaArgs.removeAll(arguments);
+      lambdaArgs.clear();
+      lambdaArgs.addAll(previousLambdaArgs);
       return new LambdaFunctionCall(getLocation(context), arguments, body);
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.execution.expression.tree.InPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
+import io.confluent.ksql.execution.expression.tree.LambdaVariable;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
@@ -54,6 +55,7 @@ import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
+import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
 import io.confluent.ksql.execution.windows.HoppingWindowExpression;
 import io.confluent.ksql.execution.windows.SessionWindowExpression;
@@ -217,12 +219,14 @@ public class AstBuilder {
 
     private final Optional<Set<SourceName>> sources;
     private final SqlTypeParser typeParser;
+    private final Set<String> lambdaArgs;
 
     private boolean buildingPersistentQuery = false;
 
     Visitor(final Optional<Set<SourceName>> sources, final TypeRegistry typeRegistry) {
       this.sources = Objects.requireNonNull(sources, "sources").map(ImmutableSet::copyOf);
       this.typeParser = SqlTypeParser.create(typeRegistry);
+      this.lambdaArgs = new HashSet<>();
     }
 
     @Override
@@ -644,8 +648,9 @@ public class AstBuilder {
           .map(ParserUtil::getIdentifierText)
           .collect(toList());
 
+      lambdaArgs.addAll(arguments);
       final Expression body = (Expression) visit(context.expression());
-
+      lambdaArgs.removeAll(arguments);
       return new LambdaFunctionCall(getLocation(context), arguments, body);
     }
 
@@ -1144,7 +1149,11 @@ public class AstBuilder {
 
     @Override
     public Node visitColumnReference(final SqlBaseParser.ColumnReferenceContext context) {
-      return ColumnReferenceParser.resolve(context);
+      final UnqualifiedColumnReferenceExp column = ColumnReferenceParser.resolve(context);
+      if (lambdaArgs.contains(column.toString())) {
+        return new LambdaVariable(column.toString());
+      }
+      return column;
     }
 
     @Override

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
+import io.confluent.ksql.execution.expression.tree.LambdaVariable;
 import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -304,7 +305,7 @@ public class AstBuilderTest {
                         ImmutableList.of("X"),
                         new ArithmeticBinaryExpression(
                             Operator.ADD,
-                            column("X"),
+                            new LambdaVariable("X"),
                             new IntegerLiteral(5))
                   )
                 )
@@ -314,7 +315,43 @@ public class AstBuilderTest {
   }
 
   @Test
-  public void shouldNotBuildLambdaFunctionNotLastArgument() {
+  public void shouldBuildLambdaFunctionWithMultipleLambdas() {
+    // Given:
+    final SingleStatementContext stmt = givenQuery("SELECT TRANSFORM_ARRAY(Col4, X => X + 5, (X,Y) => X + Y) FROM TEST1;");
+
+    // When:
+    final Query result = (Query) builder.buildStatement(stmt);
+
+    // Then:
+    assertThat(result.getSelect(), is(new Select(ImmutableList.of(
+        new SingleColumn(
+            new FunctionCall(
+                FunctionName.of("TRANSFORM_ARRAY"),
+                ImmutableList.of(
+                    column("COL4"),
+                    new LambdaFunctionCall(
+                        ImmutableList.of("X"),
+                        new ArithmeticBinaryExpression(
+                            Operator.ADD,
+                            new LambdaVariable("X"),
+                            new IntegerLiteral(5))
+                    ),
+                    new LambdaFunctionCall(
+                        ImmutableList.of("X", "Y"),
+                        new ArithmeticBinaryExpression(
+                            Operator.ADD,
+                            new LambdaVariable("X"),
+                            new LambdaVariable("Y")
+                        )
+                    )
+                )
+            ),
+            Optional.empty())
+    ))));
+  }
+
+  @Test
+  public void shouldNotBuildLambdaFunctionNotLastArguments() {
     // Given:
     final Exception e = assertThrows(
         ParseFailedException.class,


### PR DESCRIPTION
### Description 
Instead of creating LambdaVariables in AstSanitizer, we do it in AstBuilder.
We need to do this because we need to be able to construct the LambdaVariable node from only AstBuilder since that's how KSQL plan's are deserialized (we can't do sanitization on expressions in the plan)

This is done by keeping track of what the LambdaArgs are in AstBuilder. Before visiting the body of the lambda expression, we add the args to the LambdaArgs set while keeping track of what the initial state of the set was before visiting the body. After returning from the body, we set the LambdaArgs set back to the initial state.

Renamed LambdaLiteral -> LambdaVariable 

### Testing done 
Updated unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

