### PR TITLE
fix: make format_timestamp and parse_timestamp default to utc

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/FormatTimestamp.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/FormatTimestamp.java
@@ -55,7 +55,7 @@ public class FormatTimestamp {
       @UdfParameter(
           description = "The format pattern should be in the format expected by"
               + " java.time.format.DateTimeFormatter.") final String formatPattern) {
-    return formatTimestamp(timestamp, formatPattern, ZoneId.systemDefault().getId());
+    return formatTimestamp(timestamp, formatPattern, ZoneId.of("GMT").getId());
   }
 
   @Udf(description = "Converts a TIMESTAMP value into the"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/ParseTimestamp.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/ParseTimestamp.java
@@ -53,7 +53,7 @@ public class ParseTimestamp {
       @UdfParameter(
           description = "The format pattern should be in the format expected by"
               + " java.time.format.DateTimeFormatter.") final String formatPattern) {
-    return parseTimestamp(formattedTimestamp, formatPattern, ZoneId.systemDefault().getId());
+    return parseTimestamp(formattedTimestamp, formatPattern, ZoneId.of("GMT").getId());
   }
 
   @Udf(description = "Converts a string representation of a date at the given time zone"

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/FormatTimestampTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/FormatTimestampTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.util.KsqlException;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,10 +45,11 @@ public class FormatTimestampTest {
     // When:
     final String result = udf.formatTimestamp(new Timestamp(1638360611123L),
         "yyyy-MM-dd HH:mm:ss.SSS");
+    final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
 
     // Then:
-    final String expectedResult = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
-        .format(new Date(1638360611123L));
+    final String expectedResult = sdf.format(new Date(1638360611123L));
     assertThat(result, is(expectedResult));
   }
 
@@ -69,21 +71,6 @@ public class FormatTimestampTest {
 
     // Then:
     assertThat(result, is("2018-08-15 10:10:43"));
-  }
-
-  @Test
-  public void testTimeZoneInLocalTime() {
-    // Given:
-    final Timestamp timestamp = new Timestamp(1534353043000L);
-
-    // When:
-    final String localTime = udf.formatTimestamp(timestamp, "yyyy-MM-dd HH:mm:ss zz");
-
-    // Then:
-    final String expected = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss zz")
-        .format(timestamp);
-
-    assertThat(localTime, is(expected));
   }
 
   @Test
@@ -134,8 +121,9 @@ public class FormatTimestampTest {
         "yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
 
     // Then:
-    final String expectedResult = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'")
-        .format(new Date(1638360611123L));
+    final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+    final String expectedResult = sdf.format(new Date(1638360611123L));
     assertThat(result, is(expectedResult));
   }
 
@@ -170,7 +158,9 @@ public class FormatTimestampTest {
             final String pattern = "yyyy-MM-dd HH:mm:ss.SSS'X" + idx + "'";
             final Timestamp timestamp = new Timestamp(1538361611123L + idx);
             final String result = udf.formatTimestamp(timestamp, pattern);
-            final String expectedResult = new SimpleDateFormat(pattern).format(timestamp);
+            final SimpleDateFormat sdf = new SimpleDateFormat(pattern);
+            sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+            final String expectedResult = sdf.format(timestamp);
             assertThat(result, is(expectedResult));
           } catch (final Exception e) {
             fail(e.getMessage());
@@ -187,7 +177,9 @@ public class FormatTimestampTest {
         .forEach(idx -> {
           final Timestamp timestamp = new Timestamp(1538361611123L + idx);
           final String result = udf.formatTimestamp(timestamp, pattern);
-          final String expectedResult = new SimpleDateFormat(pattern).format(timestamp);
+          final SimpleDateFormat sdf = new SimpleDateFormat(pattern);
+          sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+          final String expectedResult = sdf.format(timestamp);
           assertThat(result, is(expectedResult));
 
           final Timestamp roundtripTimestamp = parseTimestamp.parseTimestamp(result, pattern);
@@ -225,7 +217,9 @@ public class FormatTimestampTest {
   }
 
   private void assertLikeSimpleDateFormat(final String format) {
-    final String expected = new SimpleDateFormat(format).format(1538361611123L);
+    final SimpleDateFormat sdf = new SimpleDateFormat(format);
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+    final String expected = sdf.format(1538361611123L);
     final Object result = new FormatTimestamp()
         .formatTimestamp(new Timestamp(1538361611123L), format);
     assertThat(result, is(expected));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseTimestampTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseTimestampTest.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.function.KsqlFunctionException;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 import java.util.stream.IntStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,10 +44,11 @@ public class ParseTimestampTest {
     // When:
     final Object result = udf.parseTimestamp("2021-12-01 12:10:11.123",
         "yyyy-MM-dd HH:mm:ss.SSS");
+    final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
 
     // Then:
-    final Timestamp expectedResult = Timestamp.from(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
-        .parse("2021-12-01 12:10:11.123").toInstant());
+    final Timestamp expectedResult = Timestamp.from(sdf.parse("2021-12-01 12:10:11.123").toInstant());
     assertThat(result, is(expectedResult));
   }
 
@@ -56,9 +58,11 @@ public class ParseTimestampTest {
     final Object result = udf.parseTimestamp("2021-12-01T12:10:11.123Fred",
         "yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
 
+    final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+
     // Then:
-    final Timestamp expectedResult = Timestamp.from(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'")
-        .parse("2021-12-01T12:10:11.123Fred").toInstant());
+    final Timestamp expectedResult = Timestamp.from(sdf.parse("2021-12-01T12:10:11.123Fred").toInstant());
     assertThat(result, is(expectedResult));
   }
 
@@ -142,7 +146,9 @@ public class ParseTimestampTest {
             final String sourceDate = "2018-12-01 10:12:13.456X" + idx;
             final String pattern = "yyyy-MM-dd HH:mm:ss.SSS'X" + idx + "'";
             final Timestamp result = udf.parseTimestamp(sourceDate, pattern);
-            final Timestamp expectedResult = Timestamp.from(new SimpleDateFormat(pattern).parse(sourceDate).toInstant());
+            final SimpleDateFormat sdf = new SimpleDateFormat(pattern);
+            sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+            final Timestamp expectedResult = Timestamp.from(sdf.parse(sourceDate).toInstant());
             assertThat(result, is(expectedResult));
           } catch (final Exception e) {
             fail(e.getMessage());
@@ -175,7 +181,9 @@ public class ParseTimestampTest {
   }
 
   private void assertLikeSimpleDateFormat(final String value, final String format) throws Exception {
-    final Timestamp expected = Timestamp.from(new SimpleDateFormat(format).parse(value).toInstant());
+    final SimpleDateFormat sdf = new SimpleDateFormat(format);
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+    final Timestamp expected = Timestamp.from(sdf.parse(value).toInstant());
     final Object result = new ParseTimestamp().parseTimestamp(value, format);
     assertThat(result, is(expected));
   }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp/6.2.0_1612493120070/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp/6.2.0_1612493120070/plan.json
@@ -1,0 +1,145 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, ID BIGINT, NAME STRING, TIME STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `TIME` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TS AS SELECT\n  TEST.K K,\n  TEST.ID ID,\n  PARSE_TIMESTAMP(TEST.TIME, 'yyyy-MM-dd''T''HH:mm:ss') TS\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TS",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `TS` TIMESTAMP",
+      "topicName" : "TS",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TS",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TS"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `TIME` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "ID AS ID", "PARSE_TIMESTAMP(TIME, 'yyyy-MM-dd''T''HH:mm:ss') AS TS" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "TS"
+      },
+      "queryId" : "CSAS_TS_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp/6.2.0_1612493120070/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp/6.2.0_1612493120070/spec.json
@@ -1,0 +1,108 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1612493120070,
+  "path" : "query-validation-tests/stringtimestamp.json",
+  "schemas" : {
+    "CSAS_TS_0.TS" : {
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `TS` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_TS_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `TIME` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "format timestamp",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "0",
+      "value" : "0,zero,2018-05-11T21:58:33"
+    }, {
+      "topic" : "test_topic",
+      "key" : "0",
+      "value" : "0,zero,2019-05-11T21:58:33"
+    }, {
+      "topic" : "test_topic",
+      "key" : "0",
+      "value" : "0,zero,2020-05-11T21:58:33"
+    } ],
+    "outputs" : [ {
+      "topic" : "TS",
+      "key" : "0",
+      "value" : "0,1526075913000"
+    }, {
+      "topic" : "TS",
+      "key" : "0",
+      "value" : "0,1557611913000"
+    }, {
+      "topic" : "TS",
+      "key" : "0",
+      "value" : "0,1589234313000"
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "TS",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, time varchar) WITH (kafka_topic='test_topic', value_format='DELIMITED');", "CREATE STREAM TS AS select K, id, parse_timestamp(time, 'yyyy-MM-dd''T''HH:mm:ss') as ts from test;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `TIME` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TS",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `ID` BIGINT, `TS` TIMESTAMP",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TS",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp/6.2.0_1612493120070/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp/6.2.0_1612493120070/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp_with_time_zone/6.2.0_1612493120113/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp_with_time_zone/6.2.0_1612493120113/plan.json
@@ -1,0 +1,145 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, ID BIGINT, NAME STRING, TIME STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `TIME` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TS AS SELECT\n  TEST.K K,\n  TEST.ID ID,\n  PARSE_TIMESTAMP(TEST.TIME, 'yyyy-MM-dd''T''HH:mm:ss zzz') TS\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TS",
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `TS` TIMESTAMP",
+      "topicName" : "TS",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TS",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TS"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `TIME` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "ID AS ID", "PARSE_TIMESTAMP(TIME, 'yyyy-MM-dd''T''HH:mm:ss zzz') AS TS" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "TS"
+      },
+      "queryId" : "CSAS_TS_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp_with_time_zone/6.2.0_1612493120113/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp_with_time_zone/6.2.0_1612493120113/spec.json
@@ -1,0 +1,108 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1612493120113,
+  "path" : "query-validation-tests/stringtimestamp.json",
+  "schemas" : {
+    "CSAS_TS_0.TS" : {
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `TS` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_TS_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `TIME` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "format timestamp with time zone",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "0",
+      "value" : "0,zero,2018-05-11T21:58:33 PST"
+    }, {
+      "topic" : "test_topic",
+      "key" : "0",
+      "value" : "0,zero,2019-05-11T21:58:33 PST"
+    }, {
+      "topic" : "test_topic",
+      "key" : "0",
+      "value" : "0,zero,2020-05-11T21:58:33 PST"
+    } ],
+    "outputs" : [ {
+      "topic" : "TS",
+      "key" : "0",
+      "value" : "0,1526101113000"
+    }, {
+      "topic" : "TS",
+      "key" : "0",
+      "value" : "0,1557637113000"
+    }, {
+      "topic" : "TS",
+      "key" : "0",
+      "value" : "0,1589259513000"
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "TS",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, time varchar) WITH (kafka_topic='test_topic', value_format='DELIMITED');", "CREATE STREAM TS AS select K, id, parse_timestamp(time, 'yyyy-MM-dd''T''HH:mm:ss zzz') as ts from test;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `ID` BIGINT, `NAME` STRING, `TIME` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TS",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `ID` BIGINT, `TS` TIMESTAMP",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TS",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp_with_time_zone/6.2.0_1612493120113/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/stringtimestamp_-_format_timestamp_with_time_zone/6.2.0_1612493120113/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/timestamp-to-string_-_timestamp_to_string_without_a_time_zone/6.2.0_1612493125106/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/timestamp-to-string_-_timestamp_to_string_without_a_time_zone/6.2.0_1612493125106/plan.json
@@ -1,0 +1,145 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, TIME TIMESTAMP) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `TIME` TIMESTAMP",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.K K,\n  FORMAT_TIMESTAMP(INPUT.TIME, 'yyyy-MM-dd HH:mm:ss') KSQL_COL_0\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `KSQL_COL_0` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `TIME` TIMESTAMP"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "FORMAT_TIMESTAMP(TIME, 'yyyy-MM-dd HH:mm:ss') AS KSQL_COL_0" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "false",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/timestamp-to-string_-_timestamp_to_string_without_a_time_zone/6.2.0_1612493125106/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/timestamp-to-string_-_timestamp_to_string_without_a_time_zone/6.2.0_1612493125106/spec.json
@@ -1,0 +1,98 @@
+{
+  "version" : "6.2.0",
+  "timestamp" : 1612493125106,
+  "path" : "query-validation-tests/timestamp-to-string.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `TIME` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `KSQL_COL_0` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "timestamp to string without a time zone",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "time" : 1526075913000
+      },
+      "timestamp" : 1526075913000
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "KSQL_COL_0" : "2018-05-11 21:58:33"
+      },
+      "timestamp" : 1526075913000
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (K STRING KEY, TIME TIMESTAMP) WITH (kafka_topic='input', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, FORMAT_TIMESTAMP(TIME, 'yyyy-MM-dd HH:mm:ss') FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `TIME` TIMESTAMP",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `KSQL_COL_0` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/timestamp-to-string_-_timestamp_to_string_without_a_time_zone/6.2.0_1612493125106/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/timestamp-to-string_-_timestamp_to_string_without_a_time_zone/6.2.0_1612493125106/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/stringtimestamp.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/stringtimestamp.json
@@ -24,17 +24,34 @@
       "name": "format timestamp",
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, time varchar) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
-        "CREATE STREAM TS AS select K, id, parse_timestamp(time, 'yyyy-MM-dd''T''HH:mm:ssX') as ts from test;"
+        "CREATE STREAM TS AS select K, id, parse_timestamp(time, 'yyyy-MM-dd''T''HH:mm:ss') as ts from test;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": "0", "value": "0,zero,2018-05-11T21:58:33Z"},
-        {"topic": "test_topic", "key": "0", "value": "0,zero,2019-05-11T21:58:33Z"},
-        {"topic": "test_topic", "key": "0", "value": "0,zero,2020-05-11T21:58:33Z"}
+        {"topic": "test_topic", "key": "0", "value": "0,zero,2018-05-11T21:58:33"},
+        {"topic": "test_topic", "key": "0", "value": "0,zero,2019-05-11T21:58:33"},
+        {"topic": "test_topic", "key": "0", "value": "0,zero,2020-05-11T21:58:33"}
       ],
       "outputs": [
         {"topic": "TS", "key": "0", "value": "0,1526075913000"},
         {"topic": "TS", "key": "0", "value": "0,1557611913000"},
         {"topic": "TS", "key": "0", "value": "0,1589234313000"}
+      ]
+    },
+    {
+      "name": "format timestamp with time zone",
+      "statements": [
+        "CREATE STREAM TEST (K STRING KEY, ID bigint, NAME varchar, time varchar) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM TS AS select K, id, parse_timestamp(time, 'yyyy-MM-dd''T''HH:mm:ss zzz') as ts from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "0", "value": "0,zero,2018-05-11T21:58:33 PST"},
+        {"topic": "test_topic", "key": "0", "value": "0,zero,2019-05-11T21:58:33 PST"},
+        {"topic": "test_topic", "key": "0", "value": "0,zero,2020-05-11T21:58:33 PST"}
+      ],
+      "outputs": [
+        {"topic": "TS", "key": "0", "value": "0,1526101113000"},
+        {"topic": "TS", "key": "0", "value": "0,1557637113000"},
+        {"topic": "TS", "key": "0", "value": "0,1589259513000"}
       ]
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/timestamp-to-string.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/timestamp-to-string.json
@@ -43,6 +43,19 @@
       "outputs": [
         {"topic": "OUTPUT", "value": {"KSQL_COL_0":"2018-05-11 14:58:33 PDT"}, "timestamp": 1526075913000}
       ]
+    },
+    {
+      "name": "timestamp to string without a time zone",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, TIME TIMESTAMP) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, FORMAT_TIMESTAMP(TIME, 'yyyy-MM-dd HH:mm:ss') FROM input;"
+      ],
+      "inputs": [
+        {"topic": "input", "value": {"time": 1526075913000}, "timestamp": 1526075913000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"KSQL_COL_0":"2018-05-11 21:58:33"}, "timestamp": 1526075913000}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 
Fixes #6943 

Makes format_timestamp and parse_timestamp assume UTC by default. Previously, they used local time by default.

### Testing done
Updated QTT and unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

