### PR TITLE
chore: close KafkaStreams applications created by sandbox execution in tests

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/AppInfo.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/AppInfo.java
@@ -42,9 +42,7 @@ public final class AppInfo {
       final Properties props = new Properties();
       try (InputStream resourceAsStream = AppInfo.class.getResourceAsStream(
           "/git.properties")) {
-        if (resourceAsStream != null) {
-          props.load(resourceAsStream);
-        }
+        props.load(resourceAsStream);
       }
       commitId = props.getProperty("git.commit.id", commitId).trim();
     } catch (final Exception e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
@@ -131,12 +131,16 @@ public class KsqlContext implements AutoCloseable {
     final KsqlExecutionContext sandbox = ksqlEngine.createSandbox(ksqlEngine.getServiceContext());
     final Map<String, Object> validationOverrides = new HashMap<>(overriddenProperties);
     for (final ParsedStatement stmt : statements) {
-      execute(
+      final ExecuteResult result = execute(
           sandbox,
           stmt,
           ksqlConfig,
           validationOverrides,
-          injectorFactory.apply(sandbox, sandbox.getServiceContext()));
+          injectorFactory.apply(sandbox, sandbox.getServiceContext())
+      );
+      if (result != null) {
+        result.getQuery().ifPresent(QueryMetadata::close);
+      }
     }
 
     final List<QueryMetadata> queries = new ArrayList<>();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -719,7 +719,7 @@ public class KsqlEngineTest {
         () -> sandbox.execute(
             sandboxServiceContext,
             ConfiguredStatement.of(prepared, SessionConfig.of(KSQL_CONFIG, Collections.emptyMap()))
-        )
+        ).getQuery().ifPresent(QueryMetadata::close)
     );
 
     // Then:
@@ -780,7 +780,7 @@ public class KsqlEngineTest {
         () -> sandbox.execute(
             sandboxServiceContext,
             ConfiguredStatement.of(statement, SessionConfig.of(KSQL_CONFIG, ImmutableMap.of()))
-        )
+        ).getQuery().ifPresent(QueryMetadata::close)
     );
 
     // Then:
@@ -1454,7 +1454,7 @@ public class KsqlEngineTest {
             serviceContext,
             ConfiguredStatement
                 .of(statement, SessionConfig.of(KSQL_CONFIG, new HashMap<>()))
-        )
+        ).getQuery().ifPresent(QueryMetadata::close)
     );
 
     // Then:
@@ -1478,7 +1478,7 @@ public class KsqlEngineTest {
             serviceContext,
             ConfiguredStatement
                 .of(statement, SessionConfig.of(KSQL_CONFIG, new HashMap<>()))
-        )
+        ).getQuery().ifPresent(QueryMetadata::close)
     );
 
     // Then:
@@ -1549,7 +1549,7 @@ public class KsqlEngineTest {
             sandboxServiceContext,
             ConfiguredStatement
                 .of(sandbox.prepare(stmt), SessionConfig.of(KSQL_CONFIG, new HashMap<>())
-                )));
+                )).getQuery().ifPresent(QueryMetadata::close));
 
     // Then:
     assertThat(metaStore.getSource(SourceName.of("TEST3")), is(notNullValue()));
@@ -1576,7 +1576,7 @@ public class KsqlEngineTest {
             sandboxServiceContext,
             ConfiguredStatement
                 .of(sandbox.prepare(stmt), SessionConfig.of(KSQL_CONFIG, new HashMap<>())
-                ))
+                )).getQuery().ifPresent(QueryMetadata::close)
     );
 
     // Then:
@@ -1595,7 +1595,7 @@ public class KsqlEngineTest {
         sandboxServiceContext,
         ConfiguredStatement
             .of(statement, SessionConfig.of(KSQL_CONFIG, new HashMap<>()))
-    );
+    ).getQuery().ifPresent(QueryMetadata::close);
 
     // Then:
     final List<QueryMetadata> queries = KsqlEngineTestUtil
@@ -1620,7 +1620,7 @@ public class KsqlEngineTest {
         sandboxServiceContext,
         ConfiguredStatement
             .of(prepared, SessionConfig.of(KSQL_CONFIG, new HashMap<>()))
-    );
+    ).getQuery().ifPresent(QueryMetadata::close);
 
     // Then:
     verify(schemaRegistryClient, never()).register(any(), any(AvroSchema.class));
@@ -1667,6 +1667,7 @@ public class KsqlEngineTest {
         is(not(Optional.empty())));
     assertThat(ksqlEngine.getPersistentQuery(getQueryId(result.getQuery().get())),
         is(Optional.empty()));
+    result.getQuery().ifPresent(QueryMetadata::close);
   }
 
   @Test
@@ -1726,6 +1727,7 @@ public class KsqlEngineTest {
         ConfiguredStatement
             .of(statement, SessionConfig.of(KSQL_CONFIG, new HashMap<>()))
     );
+    result.getQuery().ifPresent(QueryMetadata::close);
 
     // Then:
     assertThat(result.getCommandResult(), is(Optional.of("Stream created")));


### PR DESCRIPTION
### Description 
We weren't properly closing some KafkaStreams apps that were created when executing using a SandBox engine. This caused tests to fail since we were locking state directories and then never unlocking them (since close()) was never called.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

