### PR TITLE
docs: correct examples on /query endpoint docs (MINOR)

### DIFF
--- a/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
@@ -55,7 +55,7 @@ Response JSON Object:
 curl -X "POST" "http://<ksqldb-host-name>:8088/query" \
      -H "Accept: application/vnd.ksql.v1+json" \
      -d $'{
-  "ksql": "SELECT * FROM USERS;",
+  "ksql": "SELECT * FROM USERS EMIT CHANGES;",
   "streamsProperties": {}
 }'
 
@@ -69,7 +69,7 @@ Accept: application/vnd.ksql.v1+json
 Content-Type: application/vnd.ksql.v1+json
 
 {
-  "sql": "SELECT * FROM pageviews;",
+  "ksql": "SELECT * FROM pageviews EMIT CHANGES;",
   "streamsProperties": {
     "ksql.streams.auto.offset.reset": "earliest"
   }


### PR DESCRIPTION
### Description 

Two minor fixes to the /query endpoint docs:
- request field is named "ksql" not "sql"
- push queries require `EMIT CHANGES` syntax

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

