### PR TITLE
docs: replace release sitevar with ksqldbversion (DOCS-3260)

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -54,7 +54,7 @@ Start by creating a `pom.xml` for your Java application:
     <properties>
         <!-- Keep versions as properties to allow easy modification -->
         <java.version>8</java.version>
-        <ksqldb.version>{{ site.release }}</ksqldb.version>
+        <ksqldb.version>{{ site.ksqldbversion }}</ksqldb.version>
         <!-- Maven properties for compilation -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/docs/developer-guide/ksqldb-rest-api/info-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/info-endpoint.md
@@ -19,7 +19,7 @@ Your output should resemble:
 ```json
 {
   "KsqlServerInfo": {
-    "version": "{{ site.release }}",
+    "version": "{{ site.ksqldbversion }}",
     "kafkaClusterId": "j3tOi6E_RtO_TMH3gBmK7A",
     "ksqlServiceId": "default_"
   }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -294,7 +294,7 @@ ps -aux | grep ksql
 Your output should resemble:
 
 ```
-jim       2540  5.2  2.3 8923244 387388 tty2   Sl   07:48   0:33 /usr/lib/jvm/java-8-oracle/bin/java -cp /home/jim/confluent-{{ site.release }}/share/java/monitoring-interceptors/* ...
+jim       2540  5.2  2.3 8923244 387388 tty2   Sl   07:48   0:33 /usr/lib/jvm/java-8-oracle/bin/java -cp /home/jim/confluent-{{ site.ksqldbversion }}/share/java/monitoring-interceptors/* ...
 ```
 
 If the process status of the JVM isn't `Sl` or `Ssl`, the ksqlDB Server

--- a/docs/operate-and-deploy/installation/check-ksqldb-server-health.md
+++ b/docs/operate-and-deploy/installation/check-ksqldb-server-health.md
@@ -35,7 +35,7 @@ ps -aux | grep ksql
 Your output should resemble:
 
 ```
-jim       2540  5.2  2.3 8923244 387388 tty2   Sl   07:48   0:33 /usr/lib/jvm/java-8-oracle/bin/java -cp /home/jim/confluent-{{ site.release }}/share/java/monitoring-interceptors/* ...
+jim       2540  5.2  2.3 8923244 387388 tty2   Sl   07:48   0:33 /usr/lib/jvm/java-8-oracle/bin/java -cp /home/jim/confluent-{{ site.ksqldbversion }}/share/java/monitoring-interceptors/* ...
 ```
 
 If the process status of the JVM isn't `Sl` or `Ssl`, the ksqlDB server

--- a/docs/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -65,7 +65,7 @@ docker run -d \
   -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KSQL_LISTENERS=http://0.0.0.0:8088/ \
   -e KSQL_KSQL_SERVICE_ID=ksql_service_2_ \
-  confluentinc/ksqldb-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.ksqldbversion }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -103,7 +103,7 @@ docker run -d \
   -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KSQL_KSQL_SERVICE_ID=ksql_standalone_1_ \
   -e KSQL_KSQL_QUERIES_FILE=/path/in/container/queries.sql \
-  confluentinc/ksqldb-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.ksqldbversion }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -140,7 +140,7 @@ docker run -d \
   -e KSQL_SECURITY_PROTOCOL=SASL_SSL \
   -e KSQL_SASL_MECHANISM=PLAIN \
   -e KSQL_SASL_JAAS_CONFIG="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"<username>\" password=\"<strong-password>\";" \
-  confluentinc/ksqldb-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.ksqldbversion }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -207,7 +207,7 @@ docker run -d \
   -v /path/on/host:/path/in/container/ \
   -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KSQL_OPTS="-Dksql.service.id=ksql_service_3_  -Dksql.queries.file=/path/in/container/queries.sql" \
-  confluentinc/ksqldb-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.ksqldbversion }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -281,7 +281,7 @@ that's running in a different container.
 docker run -d -p 10.0.0.11:8088:8088 \
   -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KSQL_OPTS="-Dksql.service.id=ksql_service_3_  -Dlisteners=http://0.0.0.0:8088/" \  
-  confluentinc/ksqldb-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.ksqldbversion }}
 
 # Connect the ksqlDB CLI to the server.
 docker run -it confluentinc/ksqldb-cli ksql http://10.0.0.11:8088 
@@ -312,7 +312,7 @@ ls /path/on/host/ksql-cli.properties
 
 docker run -it \
   -v /path/on/host/:/path/in/container  \
-  confluentinc/ksqldb-cli:{{ site.release }} ksql http://10.0.0.11:8088 \
+  confluentinc/ksqldb-cli:{{ site.ksqldbversion }} ksql http://10.0.0.11:8088 \
   --config-file /path/in/container/ksql-cli.properties
 ```
 
@@ -322,7 +322,7 @@ Run a ksqlDB CLI instance in a container and connect to a remote ksqlDB
 Server host:
 
 ```bash
-docker run -it confluentinc/ksqldb-cli:{{ site.release }} ksql \
+docker run -it confluentinc/ksqldb-cli:{{ site.ksqldbversion }} ksql \
   http://ec2-blah.us-blah.compute.amazonaws.com:8080
 ```
 
@@ -332,7 +332,7 @@ Your output should resemble:
 ... 
 Copyright 2017-2020 Confluent Inc.
 
-CLI v{{ site.release }}, Server v{{ site.release }} located at http://ec2-blah.us-blah.compute.amazonaws.com:8080
+CLI v{{ site.ksqldbversion }}, Server v{{ site.ksqldbversion }} located at http://ec2-blah.us-blah.compute.amazonaws.com:8080
 
 Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!
 
@@ -409,8 +409,8 @@ Discover the default command that the container runs when it launches,
 which is either `Entrypoint` or `Cmd`:
 
 ```bash
-docker inspect --format={% raw %}'{{.Config.Entrypoint}}'{% endraw %} confluentinc/ksqldb-server:{{ site.release }}
-docker inspect --format={% raw %}'{{.Config.Cmd}}'{% endraw %} confluentinc/ksqldb-server:{{ site.release }}
+docker inspect --format={% raw %}'{{.Config.Entrypoint}}'{% endraw %} confluentinc/ksqldb-server:{{ site.ksqldbversion }}
+docker inspect --format={% raw %}'{{.Config.Cmd}}'{% endraw %} confluentinc/ksqldb-server:{{ site.ksqldbversion }}
 ```
 
 Your output should resemble:
@@ -431,7 +431,7 @@ a directory and downloads a tar archive into it.
 
 ```yaml
 ksql-server:
-  image: confluentinc/ksqldb-server:{{ site.release }}
+  image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
   depends_on:
     - kafka
   environment:
@@ -466,7 +466,7 @@ the environment to a desired state.
 
 ```yaml
 ksql-cli:
-  image: confluentinc/ksqldb-cli:{{ site.release }}
+  image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
   depends_on:
     - ksql-server
   volumes:

--- a/docs/operate-and-deploy/installation/installing.md
+++ b/docs/operate-and-deploy/installation/installing.md
@@ -374,9 +374,9 @@ You can use ksqlDB with compatible {{ site.aktm }} and {{ site.cp }}
 versions.
 
 |    ksqlDB version       | {{ site.ksqldbversion }} |
-| ----------------------- | ------------------ |
-| {{ site.aktm }} version | 0.11.0 and later   |
-| {{ site.cp }} version   | 5.5.0 and later    |
+| ----------------------- | ------------------------ |
+| {{ site.aktm }} version | 0.11.0 and later         |
+| {{ site.cp }} version   | 5.5.0 and later          |
 
 Scale your ksqlDB Server deployment
 -----------------------------------

--- a/docs/operate-and-deploy/installation/installing.md
+++ b/docs/operate-and-deploy/installation/installing.md
@@ -167,7 +167,7 @@ cd ksql
 Switch to the correct ksqlDB release branch.
 
 ```bash
-git checkout {{ site.releasepostbranch }}
+git checkout {{ site.ksqldbversionpostbranch }}
 ```
 
 ### 3. Start the stack
@@ -245,7 +245,7 @@ After the ksqlDB CLI starts, your terminal should resemble the following.
 
 Copyright 2017-2020 Confluent Inc.
 
-CLI v{{ site.release }}, Server v{{ site.release }} located at http://primary-ksql-server:8088
+CLI v{{ site.ksqldbversion }}, Server v{{ site.ksqldbversion }} located at http://primary-ksql-server:8088
 
 Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!
 
@@ -373,7 +373,7 @@ Supported versions and interoperability
 You can use ksqlDB with compatible {{ site.aktm }} and {{ site.cp }}
 versions.
 
-|    ksqlDB version       | {{ site.release }} |
+|    ksqlDB version       | {{ site.ksqldbversion }} |
 | ----------------------- | ------------------ |
 | {{ site.aktm }} version | 0.11.0 and later   |
 | {{ site.cp }} version   | 5.5.0 and later    |

--- a/docs/operate-and-deploy/monitoring.md
+++ b/docs/operate-and-deploy/monitoring.md
@@ -21,7 +21,7 @@ complete setup in the [quickstart](https://ksqldb.io/quickstart.html).
 
 ```yaml
 ksqldb-server:
-  image: confluentinc/ksqldb-server:{{ site.release }}
+  image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
   hostname: ksqldb-server
   container_name: ksqldb-server
   depends_on:

--- a/docs/troubleshoot-ksqldb.md
+++ b/docs/troubleshoot-ksqldb.md
@@ -243,7 +243,7 @@ ksqlDB doesn't clean up internal topics
 
 Make sure that your Kafka cluster is configured with
 `delete.topic.enable=true`. See
-[deleteTopics](https://docs.confluent.io/{{ site.release }}/clients/javadocs/org/apache/kafka/clients/admin/AdminClient.html)
+[deleteTopics](https://docs.confluent.io/{{ site.ksqldbversion }}/clients/javadocs/org/apache/kafka/clients/admin/AdminClient.html)
 for more information.
 
 Replicated topic with Avro schema causes errors

--- a/docs/tutorials/etl.md
+++ b/docs/tutorials/etl.md
@@ -154,7 +154,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:{{ site.release }}
+    image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -184,7 +184,7 @@ services:
       KSQL_CONNECT_PLUGIN_PATH: "/usr/share/kafka/plugins"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:{{ site.release }}
+    image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/docs/tutorials/event-driven-microservice.md
+++ b/docs/tutorials/event-driven-microservice.md
@@ -73,7 +73,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:{{ site.release }}
+    image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -102,7 +102,7 @@ services:
       KSQL_CONNECT_PLUGIN_PATH: "/usr/share/kafka/plugins"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:{{ site.release }}
+    image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/docs/tutorials/materialized.md
+++ b/docs/tutorials/materialized.md
@@ -124,7 +124,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
 
   ksqldb-server:
-    image: confluentinc/ksqldb-server:{{ site.release }}
+    image: confluentinc/ksqldb-server:{{ site.ksqldbversion }}
     hostname: ksqldb-server
     container_name: ksqldb-server
     depends_on:
@@ -155,7 +155,7 @@ services:
       KSQL_CONNECT_PLUGIN_PATH: "/usr/share/kafka/plugins"
 
   ksqldb-cli:
-    image: confluentinc/ksqldb-cli:{{ site.release }}
+    image: confluentinc/ksqldb-cli:{{ site.ksqldbversion }}
     container_name: ksqldb-cli
     depends_on:
       - broker

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,7 +241,6 @@ extra:
         kafkaversion: 2.7
         ksqldbversion: 0.16.0
         kstreamsbetatag: 6.2.0-beta210122194818
-        release: 0.16.0
         cprelease: 6.2.0
         releasepostbranch: 6.2.0-post
         scalaversion: 2.13


### PR DESCRIPTION
Replace redundant `release` sitevar with equivalent `ksqldbversion`.