### PR TITLE
fix: Append state.dir directive to ksql-server.properties

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -79,3 +79,4 @@ compression.type=snappy
 
 # Uncomment and complete the following to enable KSQL's integration to the Confluent Schema Registry:
 # ksql.schema.registry.url=http://localhost:8081
+

--- a/debian/confluent-ksqldb.spec.in
+++ b/debian/confluent-ksqldb.spec.in
@@ -26,14 +26,6 @@ getent group $_group 2>&1 >/dev/null || groupadd -r $_group
 getent passwd $_user 2>&1 >/dev/null || \
     useradd -r -g $_group --home-dir /tmp --no-create-home -s /sbin/nologin -c "Confluent KSQL" $_user
     
-# Set explicit kafka-streams directory if not set
-ksqldb_config=/etc/ksqldb/ksql-server.properties
-if [ -f $ksqldb_config ]; then
-  if ! grep '^state.dir=' $ksqldb_config >/dev/null 2>&1; then
-    echo "state.dir=/var/lib/kafka-streams" >> $ksqldb_config
-  fi
-fi    
-
 _permwarn=
 for dir in /var/log/confluent /var/lib/kafka-streams ; do
     # Confluent log and kafka-streams directories should be writable by group
@@ -58,6 +50,13 @@ if [ -n "$_permwarn" ]; then
 fi
 
 %post
+# Set explicit kafka-streams directory if not set
+ksqldb_config=/etc/ksqldb/ksql-server.properties
+if [ -f $ksqldb_config ]; then
+  if ! grep '^state.dir=' $ksqldb_config >/dev/null 2>&1; then
+    echo "state.dir=/var/lib/kafka-streams" >> $ksqldb_config
+  fi
+fi
 
 %preun
 

--- a/ksqldb-examples/src/main/resources/ksql-server.properties
+++ b/ksqldb-examples/src/main/resources/ksql-server.properties
@@ -22,3 +22,4 @@ num.stream.threads=4
 commit.interval.ms=2000
 cache.max.bytes.buffering=2000000
 listeners=http://0.0.0.0:8088
+


### PR DESCRIPTION
- Moved RPM scriptlet that appends state.dir to %post
- Appended newline to config/ksql-server.properties so the append above
doesn't wind up on the same line as another directive

### Description 
The debian packages' `/etc/ksqldb/ksql-server.properties` had this line incorrectly appended

```
# ksql.schema.registry.url=http://localhost:8081state.dir=/var/lib/kafka-streams
```

TO remedy that, I added an extra newline to `config/ksql-server.properties` where I believe this file is sourced from.

And the RPMs `/etc/ksqldb/ksql-server.properties` didn't have this at all. RPM didn't because the script (that I moved) Was running before the package was even installed, so the file `-f` check failed. I moved this check to %post so that the check/append occurs when the package & file are actually installed.

### Testing done 
Non-code change. Nightly builds will pick this change up where we can verify the change is present in the OS packages.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

