### PR TITLE
refactor: use SqlArgument wrapper to look up functions

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.types.ParamTypes;
 import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlConstants;
@@ -59,7 +60,7 @@ public abstract class AggregateFunctionFactory {
   }
 
   public abstract KsqlAggregateFunction<?, ?, ?> createAggregateFunction(
-      List<SqlType> argTypeList, AggregateFunctionInitArguments initArgs);
+      List<SqlArgument> argTypeList, AggregateFunctionInitArguments initArgs);
 
   protected abstract List<List<ParamType>> supportedArgs();
 
@@ -77,6 +78,7 @@ public abstract class AggregateFunctionFactory {
         .map(args -> args
             .stream()
             .map(AggregateFunctionFactory::getSampleSqlType)
+            .map(arg -> SqlArgument.of(arg))
             .collect(Collectors.toList()))
         .forEach(args -> consumer.accept(createAggregateFunction(args, getDefaultArguments())));
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function;
 
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.testing.EffectivelyImmutable;
@@ -114,7 +115,7 @@ public interface FunctionRegistry {
    * @return the function instance.
    * @throws KsqlException on unknown table function, or on unsupported {@code argumentType}.
    */
-  KsqlTableFunction getTableFunction(FunctionName functionName, List<SqlType> argumentTypes);
+  KsqlTableFunction getTableFunction(FunctionName functionName, List<SqlArgument> argumentTypes);
 
   /**
    * @return all UDF factories.

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/GenericsUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/GenericsUtil.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.function.types.MapType;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.types.StructType;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlStruct.Builder;
@@ -145,7 +146,7 @@ public final class GenericsUtil {
    */
   public static Map<GenericType, SqlType> resolveGenerics(
       final ParamType schema,
-      final SqlType instance
+      final SqlArgument instance
   ) {
     final List<Entry<GenericType, SqlType>> genericMapping = new ArrayList<>();
     final boolean success = resolveGenerics(genericMapping, schema, instance);
@@ -172,11 +173,15 @@ public final class GenericsUtil {
     return ImmutableMap.copyOf(mapping);
   }
 
+  // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   private static boolean resolveGenerics(
       final List<Entry<GenericType, SqlType>> mapping,
       final ParamType schema,
-      final SqlType instance
+      final SqlArgument instance
   ) {
+    final SqlType sqlType = instance.getSqlType();
+
+    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     if (!isGeneric(schema) && !matches(schema, instance)) {
       // cannot identify from type mismatch
       return false;
@@ -191,19 +196,20 @@ public final class GenericsUtil {
             + schema + " vs. " + instance);
 
     if (isGeneric(schema)) {
-      mapping.add(new HashMap.SimpleEntry<>((GenericType) schema, instance));
+      mapping.add(new HashMap.SimpleEntry<>((GenericType) schema, sqlType));
     }
 
     if (schema instanceof ArrayType) {
+      final SqlArray sqlArray = (SqlArray) sqlType;
       return resolveGenerics(
-          mapping, ((ArrayType) schema).element(), ((SqlArray) instance).getItemType());
+          mapping, ((ArrayType) schema).element(), SqlArgument.of(sqlArray.getItemType()));
     }
 
     if (schema instanceof MapType) {
-      final SqlMap sqlMap = (SqlMap) instance;
+      final SqlMap sqlMap = (SqlMap) sqlType;
       final MapType mapType = (MapType) schema;
-      return resolveGenerics(mapping, mapType.key(), sqlMap.getKeyType())
-          && resolveGenerics(mapping, mapType.value(), sqlMap.getValueType());
+      return resolveGenerics(mapping, mapType.key(), SqlArgument.of(sqlMap.getKeyType()))
+          && resolveGenerics(mapping, mapType.value(), SqlArgument.of(sqlMap.getValueType()));
     }
 
     if (schema instanceof StructType) {
@@ -213,9 +219,9 @@ public final class GenericsUtil {
     return true;
   }
 
-  private static boolean matches(final ParamType schema, final SqlType instance) {
+  private static boolean matches(final ParamType schema, final SqlArgument instance) {
     final ParamType instanceParamType = SchemaConverters
-        .sqlToFunctionConverter().toFunctionType(instance);
+        .sqlToFunctionConverter().toFunctionType(instance.getSqlType());
     return schema.getClass() == instanceParamType.getClass();
   }
 
@@ -224,7 +230,7 @@ public final class GenericsUtil {
    * @param instance  a schema without generics
    * @return whether {@code instance} conforms to the structure of {@code schema}
    */
-  public static boolean instanceOf(final ParamType schema, final SqlType instance) {
+  public static boolean instanceOf(final ParamType schema, final SqlArgument instance) {
     final List<Entry<GenericType, SqlType>> mappings = new ArrayList<>();
 
     if (!resolveGenerics(mappings, schema, instance)) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/GenericsUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/GenericsUtil.java
@@ -179,9 +179,9 @@ public final class GenericsUtil {
       final ParamType schema,
       final SqlArgument instance
   ) {
+    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     final SqlType sqlType = instance.getSqlType();
 
-    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     if (!isGeneric(schema) && !matches(schema, instance)) {
       // cannot identify from type mismatch
       return false;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
@@ -21,6 +21,7 @@ import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.function.types.ArrayType;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.testing.EffectivelyImmutable;
 import java.util.List;
@@ -75,7 +76,7 @@ public class KsqlFunction implements FunctionSignature {
     }
   }
 
-  public SqlType getReturnType(final List<SqlType> arguments) {
+  public SqlType getReturnType(final List<SqlArgument> arguments) {
     return returnSchemaProvider.resolve(parameters(), arguments);
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/SchemaProvider.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/SchemaProvider.java
@@ -16,12 +16,13 @@
 package io.confluent.ksql.function;
 
 import io.confluent.ksql.function.types.ParamType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import java.util.List;
 
 @FunctionalInterface
 public interface SchemaProvider {
 
-  SqlType resolve(List<ParamType> parameters, List<SqlType> arguments);
+  SqlType resolve(List<ParamType> parameters, List<SqlArgument> arguments);
 
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/TableFunctionFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/TableFunctionFactory.java
@@ -17,7 +17,8 @@ package io.confluent.ksql.function;
 
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.udf.UdfMetadata;
-import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -46,7 +47,7 @@ public class TableFunctionFactory {
     udtfIndex.values().forEach(consumer);
   }
 
-  public synchronized KsqlTableFunction createTableFunction(final List<SqlType> argTypes) {
+  public synchronized KsqlTableFunction createTableFunction(final List<SqlArgument> argTypes) {
     return udtfIndex.getFunction(argTypes);
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.function;
 
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.function.udf.UdfMetadata;
-import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Objects;
@@ -79,7 +79,7 @@ public class UdfFactory {
         + '}';
   }
 
-  public synchronized KsqlScalarFunction getFunction(final List<SqlType> argTypes) {
+  public synchronized KsqlScalarFunction getFunction(final List<SqlArgument> argTypes) {
     return udfIndex.getFunction(argTypes);
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.function.types.ArrayType;
 import io.confluent.ksql.function.types.GenericType;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.types.ParamTypes;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.KsqlException;
@@ -142,7 +143,7 @@ public class UdfIndex<T extends FunctionSignature> {
     curr.update(function, order);
   }
 
-  T getFunction(final List<SqlType> arguments) {
+  T getFunction(final List<SqlArgument> arguments) {
     final List<Node> candidates = new ArrayList<>();
 
     // first try to get the candidates without any implicit casting
@@ -169,7 +170,7 @@ public class UdfIndex<T extends FunctionSignature> {
   }
 
   private void getCandidates(
-      final List<SqlType> arguments,
+      final List<SqlArgument> arguments,
       final int argIndex,
       final Node current,
       final List<Node> candidates,
@@ -183,7 +184,7 @@ public class UdfIndex<T extends FunctionSignature> {
       return;
     }
 
-    final SqlType arg = arguments.get(argIndex);
+    final SqlArgument arg = arguments.get(argIndex);
     for (final Entry<Parameter, Node> candidate : current.children.entrySet()) {
       final Map<GenericType, SqlType> reservedCopy = new HashMap<>(reservedGenerics);
       if (candidate.getKey().accepts(arg, reservedCopy, allowCasts)) {
@@ -193,11 +194,11 @@ public class UdfIndex<T extends FunctionSignature> {
     }
   }
 
-  private KsqlException createNoMatchingFunctionException(final List<SqlType> paramTypes) {
+  private KsqlException createNoMatchingFunctionException(final List<SqlArgument> paramTypes) {
     LOG.debug("Current UdfIndex:\n{}", describe());
 
     final String requiredTypes = paramTypes.stream()
-        .map(type -> type == null ? "null" : type.toString(FormatOptions.noEscape()))
+        .map(type -> type == null ? "null" : type.getSqlType().toString(FormatOptions.noEscape()))
         .collect(Collectors.joining(", ", "(", ")"));
 
     final String acceptedTypes = allFunctions.values().stream()
@@ -348,9 +349,9 @@ public class UdfIndex<T extends FunctionSignature> {
      *         this parameter
      */
     // CHECKSTYLE_RULES.OFF: BooleanExpressionComplexity
-    boolean accepts(final SqlType argument, final Map<GenericType, SqlType> reservedGenerics,
+    boolean accepts(final SqlArgument argument, final Map<GenericType, SqlType> reservedGenerics,
         final boolean allowCasts) {
-      if (argument == null) {
+      if (argument == null || argument.getSqlType() == null) {
         return true;
       }
 
@@ -364,7 +365,7 @@ public class UdfIndex<T extends FunctionSignature> {
 
     private static boolean reserveGenerics(
         final ParamType schema,
-        final SqlType argument,
+        final SqlArgument argument,
         final Map<GenericType, SqlType> reservedGenerics
     ) {
       if (!GenericsUtil.instanceOf(schema, argument)) {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.function.types.ParamTypes;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import org.apache.kafka.common.KafkaException;
 import org.junit.Test;
 
@@ -42,7 +43,7 @@ public class UdfFactoryTest {
     // When:
     final Exception e = assertThrows(
         KafkaException.class,
-        () -> factory.getFunction(of(STRING, BIGINT))
+        () -> factory.getFunction(of(SqlArgument.of(STRING), SqlArgument.of(BIGINT)))
     );
 
     // Then:

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.function.types.ParamTypes;
 import io.confluent.ksql.function.types.StructType;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -103,7 +104,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -117,7 +118,7 @@ public class UdfIndexTest {
     Arrays.stream(functions).forEach(udfIndex::addFunction);
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.INTEGER)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -134,7 +135,7 @@ public class UdfIndexTest {
     Arrays.stream(functions).forEach(udfIndex::addFunction);
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.INTEGER)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -149,7 +150,7 @@ public class UdfIndexTest {
 
     // When:
     final KsqlScalarFunction fun = udfIndex
-        .getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.INTEGER));
+        .getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.INTEGER)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -164,7 +165,7 @@ public class UdfIndexTest {
 
     // When:
     final KsqlScalarFunction fun = udfIndex
-        .getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
+        .getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -179,7 +180,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -194,7 +195,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -209,7 +210,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(STRUCT1_ARG));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(STRUCT1_ARG)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -224,7 +225,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(MAP1_ARG));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(MAP1_ARG)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -238,7 +239,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(DECIMAL1_ARG));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(DECIMAL1_ARG)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -266,7 +267,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -281,7 +282,7 @@ public class UdfIndexTest {
 
     // When:
     final KsqlScalarFunction fun = udfIndex
-        .getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
+        .getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -295,7 +296,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(STRUCT1_ARG, STRUCT1_ARG));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(STRUCT1_ARG), SqlArgument.of(STRUCT1_ARG)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -310,7 +311,7 @@ public class UdfIndexTest {
 
     // When:
     final KsqlScalarFunction fun = udfIndex
-        .getFunction(ImmutableList.of(SqlArray.of(SqlTypes.STRING)));
+        .getFunction(ImmutableList.of(SqlArgument.of(SqlArray.of(SqlTypes.STRING))));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -325,7 +326,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -341,7 +342,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -357,7 +358,7 @@ public class UdfIndexTest {
 
     // When:
     final KsqlScalarFunction fun = udfIndex
-        .getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING));
+        .getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -385,7 +386,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(null, SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(null, SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -414,7 +415,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(new SqlType[]{null}));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(new SqlArgument[]{null}));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -428,7 +429,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(null, SqlTypes.STRING, null));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(null, SqlArgument.of(SqlTypes.STRING), null));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -458,7 +459,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(new SqlType[]{null, null}));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(SqlArgument.of(null), SqlArgument.of(null)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -473,7 +474,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(new SqlType[]{null, null}));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(SqlArgument.of(null), SqlArgument.of(null)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -488,7 +489,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(SqlTypes.STRING, null));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(SqlArgument.of(SqlTypes.STRING), null));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -506,7 +507,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(SqlTypes.STRING, SqlTypes.INTEGER, null, SqlTypes.INTEGER));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(INTEGER), null, SqlArgument.of(INTEGER)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -520,7 +521,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(SqlArray.of(SqlTypes.INTEGER)));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(SqlArgument.of(SqlArray.of(SqlTypes.INTEGER))));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -534,7 +535,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(SqlArray.of(SqlTypes.STRING)));
+    final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(SqlArgument.of(SqlArray.of(SqlTypes.STRING))));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -549,7 +550,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER, SqlTypes.INTEGER));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(INTEGER), SqlArgument.of(INTEGER)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -565,7 +566,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER, SqlTypes.STRING));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(INTEGER), SqlArgument.of(SqlTypes.STRING)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -580,7 +581,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArray.of(SqlTypes.INTEGER), SqlArray.of(SqlTypes.INTEGER)));
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlArray.of(SqlTypes.INTEGER)), SqlArgument.of(SqlArray.of(SqlTypes.INTEGER))));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -596,7 +597,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.STRING))
+        () -> udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.STRING)))
     );
 
     // Then:
@@ -614,7 +615,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER))
+        () -> udfIndex.getFunction(ImmutableList.of(SqlArgument.of(INTEGER)))
     );
 
     // Then:
@@ -632,7 +633,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> udfIndex.getFunction(Arrays.asList(SqlTypes.INTEGER, null))
+        () -> udfIndex.getFunction(Arrays.asList(SqlArgument.of(INTEGER), null))
     );
 
     // Then:
@@ -651,7 +652,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.INTEGER, SqlTypes.STRING))
+        () -> udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(INTEGER), SqlArgument.of(SqlTypes.STRING)))
     );
 
     // Then:
@@ -669,7 +670,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> udfIndex.getFunction(Arrays.asList(SqlTypes.STRING, null))
+        () -> udfIndex.getFunction(Arrays.asList(SqlArgument.of(SqlTypes.STRING), null))
     );
 
     // Then:
@@ -687,7 +688,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> udfIndex.getFunction(ImmutableList.of(STRUCT1_ARG, STRUCT2_ARG))
+        () -> udfIndex.getFunction(ImmutableList.of(SqlArgument.of(STRUCT1_ARG), SqlArgument.of(STRUCT2_ARG)))
     );
 
     // Then:
@@ -706,7 +707,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER, SqlTypes.STRING))
+        () -> udfIndex.getFunction(ImmutableList.of(SqlArgument.of(INTEGER), SqlArgument.of(SqlTypes.STRING)))
     );
 
     // Then:
@@ -726,7 +727,7 @@ public class UdfIndexTest {
     final Exception e = assertThrows(
         KsqlException.class,
         () -> udfIndex
-            .getFunction(ImmutableList.of(SqlArray.of(SqlTypes.INTEGER), SqlArray.of(SqlTypes.STRING)))
+            .getFunction(ImmutableList.of(SqlArgument.of(SqlArray.of(SqlTypes.INTEGER)), SqlArgument.of(SqlArray.of(SqlTypes.STRING))))
     );
 
     // Then:
@@ -747,7 +748,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
         Exception.class,
-        () -> udfIndex.getFunction(ImmutableList.of(SqlTypes.STRING, INTEGER, SqlTypes.STRING))
+        () -> udfIndex.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(INTEGER), SqlArgument.of(SqlTypes.STRING)))
     );
 
     // Then:
@@ -768,7 +769,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final KsqlFunction fun = udfIndex.getFunction(ImmutableList.of(INTEGER));
+    final KsqlFunction fun = udfIndex.getFunction(ImmutableList.of(SqlArgument.of(INTEGER)));
 
     // Then:
     assertThat(fun.name(), equalTo(EXPECTED));
@@ -785,7 +786,7 @@ public class UdfIndexTest {
     // When:
     final Exception e = assertThrows(
             KsqlException.class,
-            () -> udfIndex.getFunction(ImmutableList.of(SqlTypes.INTEGER))
+            () -> udfIndex.getFunction(ImmutableList.of(SqlArgument.of(INTEGER)))
     );
 
     // Then:

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/types/ParamTypesTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/types/ParamTypesTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.types;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import org.junit.Test;
 
@@ -71,23 +72,23 @@ public class ParamTypesTest {
 
   @Test
   public void shouldPassCompatibleSchemasWithImplicitCasting() {
-    assertThat(ParamTypes.areCompatible(SqlTypes.INTEGER, ParamTypes.LONG, true), is(true));
-    assertThat(ParamTypes.areCompatible(SqlTypes.INTEGER, ParamTypes.DOUBLE, true), is(true));
-    assertThat(ParamTypes.areCompatible(SqlTypes.INTEGER, ParamTypes.DECIMAL, true), is(true));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.INTEGER), ParamTypes.LONG, true), is(true));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.INTEGER), ParamTypes.DOUBLE, true), is(true));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.INTEGER), ParamTypes.DECIMAL, true), is(true));
 
-    assertThat(ParamTypes.areCompatible(SqlTypes.BIGINT, ParamTypes.DOUBLE, true), is(true));
-    assertThat(ParamTypes.areCompatible(SqlTypes.BIGINT, ParamTypes.DECIMAL, true), is(true));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.BIGINT), ParamTypes.DOUBLE, true), is(true));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.BIGINT), ParamTypes.DECIMAL, true), is(true));
 
-    assertThat(ParamTypes.areCompatible(SqlTypes.decimal(2, 1), ParamTypes.DOUBLE, true), is(true));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.decimal(2, 1)), ParamTypes.DOUBLE, true), is(true));
   }
 
   @Test
   public void shouldNotPassInCompatibleSchemasWithImplicitCasting() {
-    assertThat(ParamTypes.areCompatible(SqlTypes.BIGINT, ParamTypes.INTEGER, true), is(false));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.BIGINT), ParamTypes.INTEGER, true), is(false));
 
-    assertThat(ParamTypes.areCompatible(SqlTypes.DOUBLE, ParamTypes.LONG, true), is(false));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.DOUBLE), ParamTypes.LONG, true), is(false));
 
-    assertThat(ParamTypes.areCompatible(SqlTypes.DOUBLE, ParamTypes.DECIMAL, true), is(false));
+    assertThat(ParamTypes.areCompatible(SqlArgument.of(SqlTypes.DOUBLE), ParamTypes.DECIMAL, true), is(false));
   }
 }
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/GenericsUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/GenericsUtilTest.java
@@ -29,7 +29,7 @@ import io.confluent.ksql.function.types.MapType;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.types.ParamTypes;
 import io.confluent.ksql.function.types.StructType;
-import io.confluent.ksql.schema.ksql.types.SqlArray;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Map;
@@ -142,7 +142,7 @@ public class GenericsUtilTest {
   public void shouldIdentifyGeneric() {
     // Given:
     final GenericType a = GenericType.of("A");
-    final SqlType instance = SqlTypes.STRING;
+    final SqlArgument instance = SqlArgument.of(SqlTypes.STRING);
 
     // When:
     final Map<GenericType, SqlType> mapping = GenericsUtil.resolveGenerics(a, instance);
@@ -155,7 +155,7 @@ public class GenericsUtilTest {
   public void shouldIdentifyArrayGeneric() {
     // Given:
     final ArrayType a = ArrayType.of(GenericType.of("A"));
-    final SqlType instance = SqlTypes.array(SqlTypes.STRING);
+    final SqlArgument instance = SqlArgument.of(SqlTypes.array(SqlTypes.STRING));
 
     // When:
     final Map<GenericType, SqlType> mapping = GenericsUtil.resolveGenerics(a, instance);
@@ -168,7 +168,7 @@ public class GenericsUtilTest {
   public void shouldIdentifyMapGeneric() {
     // Given:
     final MapType a = MapType.of(GenericType.of("A"), GenericType.of("B"));
-    final SqlType instance = SqlTypes.map(SqlTypes.DOUBLE, SqlTypes.BIGINT);
+    final SqlArgument instance = SqlArgument.of(SqlTypes.map(SqlTypes.DOUBLE, SqlTypes.BIGINT));
 
     // When:
     final Map<GenericType, SqlType> mapping = GenericsUtil.resolveGenerics(a, instance);
@@ -182,7 +182,7 @@ public class GenericsUtilTest {
   public void shouldNotIdentifyInstanceOfTypeMismatch() {
     // Given:
     final MapType map = MapType.of(GenericType.of("A"), GenericType.of("B"));
-    final SqlType instance = SqlTypes.array(SqlTypes.STRING);
+    final SqlArgument instance = SqlArgument.of(SqlTypes.array(SqlTypes.STRING));
 
     // When:
     final boolean isInstance = GenericsUtil.instanceOf(map, instance);
@@ -205,7 +205,7 @@ public class GenericsUtilTest {
   public void shouldFailIdentifyMismatchStructureGeneric() {
     // Given:
     final MapType a = MapType.of(GenericType.of("A"), GenericType.of("B"));
-    final SqlArray instance = SqlTypes.array(SqlTypes.STRING);
+    final SqlArgument instance = SqlArgument.of(SqlTypes.array(SqlTypes.STRING));
 
     // When:
     GenericsUtil.resolveGenerics(a, instance);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.function.udaf.sum.SumAggFunctionFactory;
 import io.confluent.ksql.function.udaf.topk.TopKAggregateFunctionFactory;
 import io.confluent.ksql.function.udaf.topkdistinct.TopkDistinctAggFunctionFactory;
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.ParserKeywordValidatorUtil;
@@ -122,7 +123,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
       throw new KsqlException("No aggregate function with name " + functionName + " exists!");
     }
     return udafFactory.createAggregateFunction(
-        Collections.singletonList(argumentType),
+        Collections.singletonList(SqlArgument.of(argumentType)),
         initArgs
     );
   }
@@ -130,7 +131,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
   @Override
   public synchronized KsqlTableFunction getTableFunction(
       final FunctionName functionName,
-      final List<SqlType> argumentTypes
+      final List<SqlArgument> argumentTypes
   ) {
     final TableFunctionFactory udtfFactory = udtfs.get(functionName.text().toUpperCase());
     if (udtfFactory == null) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -51,15 +52,16 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
 
   @Override
   public synchronized KsqlAggregateFunction<?, ?, ?> createAggregateFunction(
-      final List<SqlType> argTypeList,
+      final List<SqlArgument> argTypeList,
       final AggregateFunctionInitArguments initArgs
   ) {
-    final List<SqlType> allParams = buildAllParams(argTypeList, initArgs);
+    final List<SqlArgument> allParams = buildAllParams(argTypeList, initArgs);
     final UdafFactoryInvoker creator = udfIndex.getFunction(allParams);
     if (creator == null) {
       throw new KsqlException("There is no aggregate function with name='" + getName()
           + "' that has arguments of type="
           + allParams.stream()
+          .map(SqlArgument::getSqlType)
           .map(SqlType::baseType)
           .map(Objects::toString)
           .collect(Collectors.joining(",")));
@@ -75,15 +77,16 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
         .collect(Collectors.toList());
   }
 
-  private List<SqlType> buildAllParams(
-      final List<SqlType> argTypeList,
+  private List<SqlArgument> buildAllParams(
+      final List<SqlArgument> argTypeList,
       final AggregateFunctionInitArguments initArgs
   ) {
     if (initArgs.args().isEmpty()) {
       return argTypeList;
     }
 
-    final List<SqlType> allParams = new ArrayList<>(argTypeList.size() + initArgs.args().size());
+    final List<SqlArgument> allParams =
+        new ArrayList<>(argTypeList.size() + initArgs.args().size());
     allParams.addAll(argTypeList);
 
     for (final Object arg : initArgs.args()) {
@@ -97,7 +100,7 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
       try {
         // Only primitive types currently supported:
         final SqlPrimitiveType primitiveType = SqlPrimitiveType.of(baseType);
-        allParams.add(primitiveType);
+        allParams.add(SqlArgument.of(primitiveType));
       } catch (final Exception e) {
         throw new KsqlFunctionException("Only primitive init arguments are supported by UDAF "
             + getName() + ", but got " + arg, e);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
@@ -20,7 +20,7 @@ import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.types.ParamType;
-import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import java.util.List;
 
 public class CountAggFunctionFactory extends AggregateFunctionFactory {
@@ -33,7 +33,7 @@ public class CountAggFunctionFactory extends AggregateFunctionFactory {
 
   @Override
   public KsqlAggregateFunction createAggregateFunction(
-      final List<SqlType> argTypeList,
+      final List<SqlArgument> argTypeList,
       final AggregateFunctionInitArguments initArgs
   ) {
     return new CountKudaf(FUNCTION_NAME, initArgs.udafIndex());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.types.ParamType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlPreconditions;
@@ -34,14 +35,14 @@ public class MaxAggFunctionFactory extends AggregateFunctionFactory {
 
   @Override
   public KsqlAggregateFunction createAggregateFunction(
-      final List<SqlType> argTypeList,
+      final List<SqlArgument> argTypeList,
       final AggregateFunctionInitArguments initArgs
   ) {
     KsqlPreconditions.checkArgument(
         argTypeList.size() == 1,
         "expected exactly one argument to aggregate MAX function");
 
-    final SqlType argSchema = argTypeList.get(0);
+    final SqlType argSchema = argTypeList.get(0).getSqlType();
     switch (argSchema.baseType()) {
       case INTEGER:
         return new IntegerMaxKudaf(FUNCTION_NAME, initArgs.udafIndex());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.types.ParamType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlPreconditions;
@@ -34,13 +35,13 @@ public class MinAggFunctionFactory extends AggregateFunctionFactory {
 
   @Override
   public KsqlAggregateFunction createAggregateFunction(
-      final List<SqlType> argTypeList,
+      final List<SqlArgument> argTypeList,
       final AggregateFunctionInitArguments initArgs) {
     KsqlPreconditions.checkArgument(
         argTypeList.size() == 1,
         "expected exactly one argument to aggregate MAX function");
 
-    final SqlType argSchema = argTypeList.get(0);
+    final SqlType argSchema = argTypeList.get(0).getSqlType();
     switch (argSchema.baseType()) {
       case INTEGER:
         return new IntegerMinKudaf(FUNCTION_NAME, initArgs.udafIndex());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.types.ParamType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
@@ -35,14 +36,14 @@ public class SumAggFunctionFactory extends AggregateFunctionFactory {
 
   @Override
   public KsqlAggregateFunction createAggregateFunction(
-      final List<SqlType> argTypeList,
+      final List<SqlArgument> argTypeList,
       final AggregateFunctionInitArguments initArgs
   ) {
     KsqlPreconditions.checkArgument(
         argTypeList.size() == 1,
         "expected exactly one argument to aggregate MAX function");
 
-    final SqlType argSchema = argTypeList.get(0);
+    final SqlType argSchema = argTypeList.get(0).getSqlType();
     switch (argSchema.baseType()) {
       case INTEGER:
         return new IntegerSumKudaf(FUNCTION_NAME, initArgs.udafIndex());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.types.ParamTypes;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
@@ -48,14 +49,14 @@ public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
 
   @Override
   public KsqlAggregateFunction createAggregateFunction(
-      final List<SqlType> argumentType,
+      final List<SqlArgument> argumentType,
       final AggregateFunctionInitArguments initArgs
   ) {
     if (argumentType.isEmpty()) {
       throw new KsqlException("TOPK function should have two arguments.");
     }
     final int tkValFromArg = (Integer)(initArgs.arg(0));
-    final SqlType argSchema = argumentType.get(0);
+    final SqlType argSchema = argumentType.get(0).getSqlType();
     switch (argSchema.baseType()) {
       case INTEGER:
         return new TopkKudaf<>(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.types.ParamTypes;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
@@ -49,13 +50,13 @@ public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
   @SuppressWarnings("unchecked")
   @Override
   public KsqlAggregateFunction createAggregateFunction(
-      final List<SqlType> argTypeList,
+      final List<SqlArgument> argTypeList,
       final AggregateFunctionInitArguments initArgs) {
     if (argTypeList.isEmpty()) {
       throw new KsqlException("TOPKDISTINCT function should have two arguments.");
     }
     final int tkValFromArg = (Integer)(initArgs.arg(0));
-    final SqlType argSchema = argTypeList.get(0);
+    final SqlType argSchema = argTypeList.get(0).getSqlType();
     switch (argSchema.baseType()) {
       case INTEGER:
       case BIGINT:

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Abs.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Abs.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlConstants;
@@ -61,8 +62,8 @@ public class Abs {
   }
 
   @UdfSchemaProvider
-  public SqlType absDecimalProvider(final List<SqlType> params) {
-    final SqlType s = params.get(0);
+  public SqlType absDecimalProvider(final List<SqlArgument> params) {
+    final SqlType s = params.get(0).getSqlType();
     if (s.baseType() != SqlBaseType.DECIMAL) {
       throw new KsqlException("The schema provider method for Abs expects a BigDecimal parameter"
           + "type");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Ceil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Ceil.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlConstants;
@@ -62,8 +63,8 @@ public class Ceil {
   }
 
   @UdfSchemaProvider
-  public SqlType ceilDecimalProvider(final List<SqlType> params) {
-    final SqlType s = params.get(0);
+  public SqlType ceilDecimalProvider(final List<SqlArgument> params) {
+    final SqlType s = params.get(0).getSqlType();
     if (s.baseType() != SqlBaseType.DECIMAL) {
       throw new KsqlException("The schema provider method for Ceil expects a BigDecimal parameter"
           + "type");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Floor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Floor.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlConstants;
@@ -63,8 +64,8 @@ public class Floor {
   }
 
   @UdfSchemaProvider
-  public SqlType floorDecimalProvider(final List<SqlType> params) {
-    final SqlType s = params.get(0);
+  public SqlType floorDecimalProvider(final List<SqlArgument> params) {
+    final SqlType s = params.get(0).getSqlType();
     if (s.baseType() != SqlBaseType.DECIMAL) {
       throw new KsqlException("The schema provider method for Floor expects a BigDecimal parameter"
           + "type");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Round.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Round.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -122,13 +123,13 @@ public class Round {
 
   @SuppressWarnings("unused") // Invoked via reflection
   @UdfSchemaProvider
-  public static SqlType provideDecimalSchemaWithDecimalPlaces(final List<SqlType> params) {
-    final SqlType s0 = params.get(0);
+  public static SqlType provideDecimalSchemaWithDecimalPlaces(final List<SqlArgument> params) {
+    final SqlType s0 = params.get(0).getSqlType();
     if (s0.baseType() != SqlBaseType.DECIMAL) {
       throw new KsqlException("The schema provider method for round expects a BigDecimal parameter"
           + "type as first parameter.");
     }
-    final SqlType s1 = params.get(1);
+    final SqlType s1 = params.get(1).getSqlType();
     if (s1.baseType() != SqlBaseType.INTEGER) {
       throw new KsqlException("The schema provider method for round expects an Integer parameter"
           + "type as second parameter.");
@@ -141,8 +142,8 @@ public class Round {
 
   @SuppressWarnings("unused") // Invoked via reflection
   @UdfSchemaProvider
-  public static SqlType provideDecimalSchema(final List<SqlType> params) {
-    final SqlType s0 = params.get(0);
+  public static SqlType provideDecimalSchema(final List<SqlArgument> params) {
+    final SqlType s0 = params.get(0).getSqlType();
     if (s0.baseType() != SqlBaseType.DECIMAL) {
       throw new KsqlException("The schema provider method for round expects a BigDecimal parameter"
           + "type as a parameter.");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udtf/array/Explode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udtf/array/Explode.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
 import io.confluent.ksql.function.udtf.Udtf;
 import io.confluent.ksql.function.udtf.UdtfDescription;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlConstants;
@@ -51,8 +52,8 @@ public class Explode {
   }
 
   @UdfSchemaProvider
-  public SqlType provideSchema(final List<SqlType> params) {
-    final SqlType argType = params.get(0);
+  public SqlType provideSchema(final List<SqlArgument> params) {
+    final SqlType argType = params.get(0).getSqlType();
     if (!(argType instanceof SqlArray)) {
       throw new KsqlException("explode should be provided with an ARRAY");
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -38,7 +38,7 @@ import io.confluent.ksql.function.types.ParamTypes;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.name.FunctionName;
-import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Arrays;
@@ -264,7 +264,7 @@ public class InternalFunctionRegistryTest {
   public void shouldAddTableFunction() {
     functionRegistry.addTableFunctionFactory(createTableFunctionFactory());
     assertThat(functionRegistry.getTableFunction(FunctionName.of("my_tablefunction"),
-        ImmutableList.of(SqlTypes.INTEGER)
+        ImmutableList.of(SqlArgument.of(SqlTypes.INTEGER))
     ), not(nullValue()));
   }
 
@@ -302,7 +302,7 @@ public class InternalFunctionRegistryTest {
 
     // Then:
     assertThat(functionRegistry.getUdfFactory(FunctionName.of("func"))
-        .getFunction(Collections.singletonList(SqlTypes.BIGINT)), equalTo(func2));
+        .getFunction(Collections.singletonList(SqlArgument.of(SqlTypes.BIGINT))), equalTo(func2));
     assertThat(functionRegistry.getUdfFactory(FunctionName.of("func"))
         .getFunction(Collections.emptyList()), equalTo(func));
   }
@@ -386,7 +386,7 @@ public class InternalFunctionRegistryTest {
   private AggregateFunctionFactory createAggregateFunctionFactory() {
     return new AggregateFunctionFactory("my_aggregate") {
       @Override
-      public KsqlAggregateFunction createAggregateFunction(final List<SqlType> argTypeList,
+      public KsqlAggregateFunction createAggregateFunction(final List<SqlArgument> argTypeList,
                                                            final AggregateFunctionInitArguments initArgs) {
         return mockAggFun;
       }
@@ -402,7 +402,7 @@ public class InternalFunctionRegistryTest {
     return new TableFunctionFactory(new UdfMetadata("my_tablefunction",
         "", "", "", FunctionCategory.OTHER, "")) {
       @Override
-      public KsqlTableFunction createTableFunction(final List<SqlType> argTypeList) {
+      public KsqlTableFunction createTableFunction(final List<SqlArgument> argTypeList) {
         return tableFunction;
       }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafAggregateFunctionFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdafAggregateFunctionFactoryTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.function.udf.UdfMetadata;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -58,31 +59,31 @@ public class UdafAggregateFunctionFactoryTest {
   public void shouldAppendInitParamTypesWhenLookingUpFunction() {
     // When:
     functionFactory.createAggregateFunction(
-        ImmutableList.of(SqlTypes.STRING),
+        ImmutableList.of(SqlArgument.of(SqlTypes.STRING)),
         new AggregateFunctionInitArguments(0, ImmutableMap.of(), ImmutableList.of(1))
     );
 
     // Then:
-    verify(functionIndex).getFunction(ImmutableList.of(SqlTypes.STRING, SqlTypes.INTEGER));
+    verify(functionIndex).getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING), (SqlArgument.of(SqlTypes.INTEGER))));
   }
 
   @Test
   public void shouldHandleNullLiteralParams() {
     // When:
     functionFactory.createAggregateFunction(
-        ImmutableList.of(SqlTypes.STRING),
+        ImmutableList.of(SqlArgument.of(SqlTypes.STRING)),
         new AggregateFunctionInitArguments(0, ImmutableMap.of(), Arrays.asList(null, 5L))
     );
 
     // Then:
-    verify(functionIndex).getFunction(Arrays.asList(SqlTypes.STRING, null, SqlTypes.BIGINT));
+    verify(functionIndex).getFunction(Arrays.asList(SqlArgument.of(SqlTypes.STRING), null, SqlArgument.of(SqlTypes.BIGINT)));
   }
 
   @Test
   public void shouldHandleInitParamsOfAllPrimitiveTypes() {
     // When:
     functionFactory.createAggregateFunction(
-        ImmutableList.of(SqlTypes.STRING),
+        ImmutableList.of(SqlArgument.of(SqlTypes.STRING)),
         new AggregateFunctionInitArguments(0, ImmutableMap.of(), ImmutableList.of(true, 1, 1L, 1.0d, "s"))
     );
 
@@ -94,7 +95,7 @@ public class UdafAggregateFunctionFactoryTest {
     // When:
     final Exception e = assertThrows(KsqlFunctionException.class,
         () -> functionFactory.createAggregateFunction(
-            ImmutableList.of(SqlTypes.STRING),
+            ImmutableList.of(SqlArgument.of(SqlTypes.STRING)),
             new AggregateFunctionInitArguments(0, ImmutableMap.of(), ImmutableList.of(BigDecimal.ONE))
         )
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
@@ -123,11 +124,11 @@ public class UdfLoaderTest {
     assertThat(function, not(nullValue()));
 
     final Kudf substring1 = function.getFunction(
-        Arrays.asList(SqlTypes.STRING, SqlTypes.INTEGER)).newInstance(ksqlConfig);
+        Arrays.asList(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.INTEGER))).newInstance(ksqlConfig);
     assertThat(substring1.evaluate("foo", 2), equalTo("oo"));
 
     final Kudf substring2 = function.getFunction(
-        Arrays.asList(SqlTypes.STRING, SqlTypes.INTEGER, SqlTypes.INTEGER)).newInstance(ksqlConfig);
+        Arrays.asList(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.INTEGER), SqlArgument.of(SqlTypes.INTEGER))).newInstance(ksqlConfig);
     assertThat(substring2.evaluate("foo", 2, 1), equalTo("o"));
   }
 
@@ -180,7 +181,7 @@ public class UdfLoaderTest {
 
     // When:
     final KsqlScalarFunction fun = FUNC_REG.getUdfFactory(FunctionName.of("floor"))
-        .getFunction(ImmutableList.of(schema));
+        .getFunction(ImmutableList.of(SqlArgument.of(schema)));
 
     // Then:
     assertThat(fun.name().text(), equalToIgnoringCase("floor"));
@@ -200,7 +201,7 @@ public class UdfLoaderTest {
     final UdfFactory toList = FUNC_REG.getUdfFactory(FunctionName.of("tolist"));
 
     // When:
-    final List<SqlType> args = Collections.singletonList(SqlTypes.STRING);
+    final List<SqlArgument> args = Collections.singletonList(SqlArgument.of(SqlTypes.STRING));
     final KsqlScalarFunction function
         = toList.getFunction(args);
 
@@ -215,7 +216,7 @@ public class UdfLoaderTest {
     final UdfFactory toMap = FUNC_REG.getUdfFactory(FunctionName.of("tomap"));
 
     // When:
-    final List<SqlType> args = Collections.singletonList(SqlTypes.STRING);
+    final List<SqlArgument> args = Collections.singletonList(SqlArgument.of(SqlTypes.STRING));
     final KsqlScalarFunction function
         = toMap.getFunction(args);
 
@@ -232,7 +233,7 @@ public class UdfLoaderTest {
     final UdfFactory toStruct = FUNC_REG.getUdfFactory(FunctionName.of("tostruct"));
 
     // When:
-    final List<SqlType> args = Collections.singletonList(SqlTypes.STRING);
+    final List<SqlArgument> args = Collections.singletonList(SqlArgument.of(SqlTypes.STRING));
     final KsqlScalarFunction function
         = toStruct.getFunction(args);
 
@@ -250,7 +251,7 @@ public class UdfLoaderTest {
 
     // When:
     final SqlDecimal decimal = SqlTypes.decimal(2, 1);
-    final List<SqlType> args = Collections.singletonList(decimal);
+    final List<SqlArgument> args = Collections.singletonList(SqlArgument.of(decimal));
     final KsqlScalarFunction function = returnDecimal.getFunction(args);
 
     // Then:
@@ -263,7 +264,7 @@ public class UdfLoaderTest {
     final UdfFactory returnDecimal = FUNC_REG.getUdfFactory(FunctionName.of("KsqlStructUdf"));
 
     // When:
-    final List<SqlType> args = ImmutableList.of();
+    final List<SqlArgument> args = ImmutableList.of();
     final KsqlScalarFunction function = returnDecimal.getFunction(args);
 
     // Then:
@@ -291,7 +292,7 @@ public class UdfLoaderTest {
     final UdfFactory returnIncompatible = FUNC_REG
         .getUdfFactory(of("returnincompatible"));
     final SqlDecimal decimal = decimal(2, 1);
-    final List<SqlType> args = singletonList(decimal);
+    final List<SqlArgument> args = singletonList(SqlArgument.of(decimal));
     final KsqlScalarFunction function = returnIncompatible.getFunction(args);
 
     // When:
@@ -398,11 +399,11 @@ public class UdfLoaderTest {
     final UdfFactory toString = FUNC_REG.getUdfFactory(FunctionName.of("tostring"));
     final UdfFactory multiply = FUNC_REG.getUdfFactory(FunctionName.of("multiply"));
 
-    final Kudf toStringUdf = toString.getFunction(ImmutableList.of(SqlTypes.STRING))
+    final Kudf toStringUdf = toString.getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)))
         .newInstance(ksqlConfig);
 
     final Kudf multiplyUdf = multiply.getFunction(
-        Arrays.asList(SqlTypes.INTEGER, SqlTypes.INTEGER))
+        Arrays.asList(SqlArgument.of(SqlTypes.INTEGER), SqlArgument.of(SqlTypes.INTEGER)))
         .newInstance(ksqlConfig);
 
     final ClassLoader multiplyLoader = getActualUdfClassLoader(multiplyUdf);
@@ -433,11 +434,13 @@ public class UdfLoaderTest {
     final UdfFactory multiply = functionRegistry.getUdfFactory(FunctionName.of("multiply"));
     final UdfFactory multiply2 = functionRegistry.getUdfFactory(FunctionName.of("multiply2"));
 
-    final Kudf multiplyUdf = multiply.getFunction(Arrays.asList(SqlTypes.INTEGER, SqlTypes.INTEGER))
-        .newInstance(ksqlConfig);
+    final Kudf multiplyUdf = multiply.getFunction(Arrays.asList(SqlArgument.of(
+        SqlTypes.INTEGER),
+        SqlArgument.of(SqlTypes.INTEGER))
+    ).newInstance(ksqlConfig);
 
     final Kudf multiply2Udf = multiply2
-        .getFunction(Arrays.asList(SqlTypes.INTEGER, SqlTypes.INTEGER))
+        .getFunction(Arrays.asList(SqlArgument.of(SqlTypes.INTEGER), SqlArgument.of(SqlTypes.INTEGER)))
         .newInstance(ksqlConfig);
 
     assertThat(multiplyUdf.evaluate(2, 2), equalTo(4L));
@@ -464,9 +467,9 @@ public class UdfLoaderTest {
     final UdfFactory substring = FUNC_REG.getUdfFactory(FunctionName.of("somefunction"));
     final KsqlScalarFunction function = substring.getFunction(
         ImmutableList.of(
-            SqlTypes.STRING,
-            SqlTypes.STRING,
-            SqlTypes.STRING));
+            SqlArgument.of(SqlTypes.STRING),
+            SqlArgument.of(SqlTypes.STRING),
+            SqlArgument.of(SqlTypes.STRING)));
 
     final List<ParameterInfo> arguments = function.parameterInfo();
 
@@ -484,7 +487,7 @@ public class UdfLoaderTest {
   public void shouldPutKsqlFunctionsInParentClassLoader() throws Exception {
     final UdfFactory substring = FUNC_REG.getUdfFactory(FunctionName.of("substring"));
     final Kudf kudf = substring.getFunction(
-        Arrays.asList(SqlTypes.STRING, SqlTypes.INTEGER))
+        Arrays.asList(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.INTEGER)))
         .newInstance(ksqlConfig);
     assertThat(getActualUdfClassLoader(kudf), equalTo(PARENT_CLASS_LOADER));
   }
@@ -539,10 +542,10 @@ public class UdfLoaderTest {
         SqlTypeParser.create(TypeRegistry.EMPTY),
         true
     );
-    final ImmutableList<SqlType> args = ImmutableList.of(
-        SqlTypes.STRING,
-        SqlTypes.STRING,
-        SqlTypes.STRING);
+    final ImmutableList<SqlArgument> args = ImmutableList.of(
+        SqlArgument.of(SqlTypes.STRING),
+        SqlArgument.of(SqlTypes.STRING),
+        SqlArgument.of(SqlTypes.STRING));
 
     // When:
     udfLoader.loadUdfFromClass(UdfLoaderTest.SomeFunctionUdf.class);
@@ -560,7 +563,7 @@ public class UdfLoaderTest {
     // Given:
     final UdfFactory substring = FUNC_REG_WITH_METRICS.getUdfFactory(FunctionName.of("substring"));
     final KsqlScalarFunction function = substring
-        .getFunction(Arrays.asList(SqlTypes.STRING, SqlTypes.INTEGER));
+        .getFunction(Arrays.asList(SqlArgument.of(SqlTypes.STRING), SqlArgument.of(SqlTypes.INTEGER)));
 
     // When:
     final Kudf kudf = function.newInstance(ksqlConfig);
@@ -615,7 +618,7 @@ public class UdfLoaderTest {
     ));
 
     final KsqlScalarFunction udf = FUNC_REG.getUdfFactory(FunctionName.of("ConfigurableUdf"))
-        .getFunction(ImmutableList.of(SqlTypes.INTEGER));
+        .getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.INTEGER)));
 
     // When:
     udf.newInstance(ksqlConfig);
@@ -631,7 +634,7 @@ public class UdfLoaderTest {
 
   @Test
   public void shouldEnsureFunctionReturnTypeIsDeepOptional() {
-    final List<SqlType> args = Collections.singletonList(SqlTypes.STRING);
+    final List<SqlArgument> args = Collections.singletonList(SqlArgument.of(SqlTypes.STRING));
     final KsqlScalarFunction complexFunction = FUNC_REG
         .getUdfFactory(FunctionName.of("ComplexFunction"))
         .getFunction(args);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udtf.Udtf;
 import io.confluent.ksql.function.udtf.UdtfDescription;
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -52,14 +53,14 @@ public class UdtfLoaderTest {
   public void shouldLoadSimpleParams() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(
-        SqlTypes.INTEGER,
-        SqlTypes.BIGINT,
-        SqlTypes.DOUBLE,
-        SqlTypes.BOOLEAN,
-        SqlTypes.STRING,
-        DECIMAL_SCHEMA,
-        STRUCT_SCHEMA
+    final List<SqlArgument> args = ImmutableList.of(
+        SqlArgument.of(SqlTypes.INTEGER),
+        SqlArgument.of(SqlTypes.BIGINT),
+        SqlArgument.of(SqlTypes.DOUBLE),
+        SqlArgument.of( SqlTypes.BOOLEAN),
+        SqlArgument.of(SqlTypes.STRING),
+        SqlArgument.of( DECIMAL_SCHEMA),
+        SqlArgument.of( STRUCT_SCHEMA)
     );
 
     // When:
@@ -74,14 +75,14 @@ public class UdtfLoaderTest {
   public void shouldLoadParameterizedListParams() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(
-        SqlTypes.array(SqlTypes.INTEGER),
-        SqlTypes.array(SqlTypes.BIGINT),
-        SqlTypes.array(SqlTypes.DOUBLE),
-        SqlTypes.array(SqlTypes.BOOLEAN),
-        SqlTypes.array(SqlTypes.STRING),
-        SqlTypes.array(DECIMAL_SCHEMA),
-        SqlTypes.array(STRUCT_SCHEMA)
+    final List<SqlArgument> args = ImmutableList.of(
+        SqlArgument.of(SqlTypes.array(SqlTypes.INTEGER)),
+        SqlArgument.of(SqlTypes.array(SqlTypes.BIGINT)),
+        SqlArgument.of(SqlTypes.array(SqlTypes.DOUBLE)),
+        SqlArgument.of(SqlTypes.array(SqlTypes.BOOLEAN)),
+        SqlArgument.of(SqlTypes.array(SqlTypes.STRING)),
+        SqlArgument.of(SqlTypes.array(DECIMAL_SCHEMA)),
+        SqlArgument.of(SqlTypes.array(STRUCT_SCHEMA))
     );
 
     // When:
@@ -96,14 +97,14 @@ public class UdtfLoaderTest {
   public void shouldLoadParameterizedMapParams() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(
-        SqlTypes.map(SqlTypes.BIGINT, SqlTypes.INTEGER),
-        SqlTypes.map(SqlTypes.STRING, SqlTypes.BIGINT),
-        SqlTypes.map(SqlTypes.STRING, SqlTypes.DOUBLE),
-        SqlTypes.map(SqlTypes.STRING, SqlTypes.BOOLEAN),
-        SqlTypes.map(SqlTypes.STRING, SqlTypes.STRING),
-        SqlTypes.map(SqlTypes.STRING, DECIMAL_SCHEMA),
-        SqlTypes.map(SqlTypes.STRING, STRUCT_SCHEMA)
+    final List<SqlArgument> args = ImmutableList.of(
+        SqlArgument.of(SqlTypes.map(SqlTypes.BIGINT, SqlTypes.INTEGER)),
+        SqlArgument.of(SqlTypes.map(SqlTypes.STRING, SqlTypes.BIGINT)),
+        SqlArgument.of( SqlTypes.map(SqlTypes.STRING, SqlTypes.DOUBLE)),
+        SqlArgument.of(SqlTypes.map(SqlTypes.STRING, SqlTypes.BOOLEAN)),
+        SqlArgument.of(SqlTypes.map(SqlTypes.STRING, SqlTypes.STRING)),
+        SqlArgument.of(SqlTypes.map(SqlTypes.STRING, DECIMAL_SCHEMA)),
+        SqlArgument.of(SqlTypes.map(SqlTypes.STRING, STRUCT_SCHEMA))
     );
 
     // When:
@@ -118,7 +119,7 @@ public class UdtfLoaderTest {
   public void shouldLoadListIntReturn() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(SqlTypes.INTEGER);
+    final List<SqlArgument> args = ImmutableList.of(SqlArgument.of(SqlTypes.INTEGER));
 
     // When:
     final KsqlTableFunction function = FUNC_REG
@@ -132,7 +133,7 @@ public class UdtfLoaderTest {
   public void shouldLoadListLongReturn() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(SqlTypes.BIGINT);
+    final List<SqlArgument> args = ImmutableList.of(SqlArgument.of(SqlTypes.BIGINT));
 
     // When:
     final KsqlTableFunction function = FUNC_REG
@@ -146,7 +147,7 @@ public class UdtfLoaderTest {
   public void shouldLoadListDoubleReturn() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(SqlTypes.DOUBLE);
+    final List<SqlArgument> args = ImmutableList.of(SqlArgument.of(SqlTypes.DOUBLE));
 
     // When:
     final KsqlTableFunction function = FUNC_REG
@@ -160,7 +161,7 @@ public class UdtfLoaderTest {
   public void shouldLoadListBooleanReturn() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(SqlTypes.BOOLEAN);
+    final List<SqlArgument> args = ImmutableList.of(SqlArgument.of(SqlTypes.BOOLEAN));
 
     // When:
     final KsqlTableFunction function = FUNC_REG
@@ -174,7 +175,7 @@ public class UdtfLoaderTest {
   public void shouldLoadListStringReturn() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(SqlTypes.STRING);
+    final List<SqlArgument> args = ImmutableList.of(SqlArgument.of(SqlTypes.STRING));
 
     // When:
     final KsqlTableFunction function = FUNC_REG
@@ -188,7 +189,7 @@ public class UdtfLoaderTest {
   public void shouldLoadListBigDecimalReturnWithSchemaProvider() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(DECIMAL_SCHEMA);
+    final List<SqlArgument> args = ImmutableList.of(SqlArgument.of(DECIMAL_SCHEMA));
 
     // When:
     final KsqlTableFunction function = FUNC_REG
@@ -202,7 +203,7 @@ public class UdtfLoaderTest {
   public void shouldLoadListStructReturnWithSchemaAnnotation() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(STRUCT_SCHEMA);
+    final List<SqlArgument> args = ImmutableList.of(SqlArgument.of(STRUCT_SCHEMA));
 
     // When:
     final KsqlTableFunction function = FUNC_REG
@@ -216,7 +217,7 @@ public class UdtfLoaderTest {
   public void shouldLoadVarArgsMethod() {
 
     // Given:
-    final List<SqlType> args = ImmutableList.of(STRUCT_SCHEMA);
+    final List<SqlArgument> args = ImmutableList.of(SqlArgument.of(STRUCT_SCHEMA));
 
     // When:
     final KsqlTableFunction function = FUNC_REG

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/count/CountKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/count/CountKudafTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import org.junit.Test;
@@ -89,7 +90,7 @@ public class CountKudafTest {
 
   private CountKudaf getDoubleCountKudaf() {
     final KsqlAggregateFunction aggregateFunction = new CountAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.DOUBLE),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(CountKudaf.class));
     return  (CountKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DecimalMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DecimalMaxKudafTest.java
@@ -23,10 +23,12 @@ import static org.hamcrest.Matchers.is;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Collections;
+
 import org.apache.kafka.streams.kstream.Merger;
 import org.junit.Test;
 
@@ -79,7 +81,7 @@ public class DecimalMaxKudafTest {
 
   private DecimalMaxKudaf getDecimalMaxKudaf(final int precision) {
     final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlDecimal.of(precision, 1))
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlDecimal.of(precision, 1)))
             , AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DecimalMaxKudaf.class));
     return  (DecimalMaxKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import org.apache.kafka.streams.kstream.Merger;
@@ -75,7 +76,7 @@ public class DoubleMaxKudafTest {
 
   private DoubleMaxKudaf getDoubleMaxKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.DOUBLE),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DoubleMaxKudaf.class));
     return  (DoubleMaxKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import org.apache.kafka.streams.kstream.Merger;
@@ -76,7 +77,7 @@ public class IntegerMaxKudafTest {
 
   private IntegerMaxKudaf getIntegerMaxKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.INTEGER),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(IntegerMaxKudaf.class));
     return  (IntegerMaxKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import org.apache.kafka.streams.kstream.Merger;
@@ -76,7 +77,7 @@ public class LongMaxKudafTest {
 
   private LongMaxKudaf getLongMaxKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.BIGINT),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.BIGINT)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(LongMaxKudaf.class));
     return  (LongMaxKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DecimalMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DecimalMinKudafTest.java
@@ -23,10 +23,12 @@ import static org.hamcrest.Matchers.is;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Collections;
+
 import org.apache.kafka.streams.kstream.Merger;
 import org.junit.Test;
 
@@ -79,7 +81,7 @@ public class DecimalMinKudafTest {
 
   private DecimalMinKudaf getDecimalMinKudaf(final int precision) {
     final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlDecimal.of(precision, 1)),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlDecimal.of(precision, 1))),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DecimalMinKudaf.class));
     return  (DecimalMinKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import org.apache.kafka.streams.kstream.Merger;
@@ -77,7 +78,7 @@ public class DoubleMinKudafTest {
 
   private DoubleMinKudaf getDoubleMinKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.DOUBLE),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DoubleMinKudaf.class));
     return  (DoubleMinKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import org.apache.kafka.streams.kstream.Merger;
@@ -77,7 +78,7 @@ public class IntegerMinKudafTest {
 
   private IntegerMinKudaf getIntegerMinKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.INTEGER),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(IntegerMinKudaf.class));
     return  (IntegerMinKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import org.apache.kafka.streams.kstream.Merger;
@@ -77,7 +78,7 @@ public class LongMinKudafTest {
 
   private LongMinKudaf getLongMinKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.BIGINT),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.BIGINT)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(LongMinKudaf.class));
     return  (LongMinKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DecimalSumKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DecimalSumKudafTest.java
@@ -20,7 +20,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
+
 import java.math.BigDecimal;
 import java.util.Collections;
 
@@ -32,7 +34,7 @@ public class DecimalSumKudafTest extends BaseSumKudafTest<BigDecimal, DecimalSum
 
   protected DecimalSumKudaf getSumKudaf() {
     final KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlDecimal.of(4, 2)),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlDecimal.of(4, 2))),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DecimalSumKudaf.class));
     return (DecimalSumKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 
@@ -30,7 +31,7 @@ public class DoubleSumKudafTest extends BaseSumKudafTest<Double, DoubleSumKudaf>
 
   protected DoubleSumKudaf getSumKudaf() {
     final KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.DOUBLE),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DoubleSumKudaf.class));
     return  (DoubleSumKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 
@@ -30,7 +31,7 @@ public class IntegerSumKudafTest extends BaseSumKudafTest<Integer, IntegerSumKud
 
   protected IntegerSumKudaf getSumKudaf() {
     final KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.INTEGER),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(IntegerSumKudaf.class));
     return  (IntegerSumKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 
@@ -30,7 +31,7 @@ public class LongSumKudafTest extends BaseSumKudafTest<Long, LongSumKudaf> {
 
   protected LongSumKudaf getSumKudaf() {
     final KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.BIGINT),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.BIGINT)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(LongSumKudaf.class));
     return  (LongSumKudaf) aggregateFunction;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,7 +34,7 @@ public class DoubleTopkKudafTest {
   private final List<Double> valuesArray = ImmutableList.of(10.0, 30.0, 45.0, 10.0, 50.0, 60.0, 20.0, 60.0, 80.0, 35.0,
       25.0);
   private TopKAggregateFunctionFactory topKFactory;
-  private List<SqlType> argumentType;
+  private List<SqlArgument> argumentType;
 
   private final AggregateFunctionInitArguments args =
       new AggregateFunctionInitArguments(0, 3);
@@ -42,7 +42,7 @@ public class DoubleTopkKudafTest {
   @Before
   public void setup() {
     topKFactory = new TopKAggregateFunctionFactory();
-    argumentType = Collections.singletonList(SqlTypes.DOUBLE);
+    argumentType = Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +47,7 @@ public class IntTopkKudafTest {
   @Before
   public void setup() {
     topkKudaf = new TopKAggregateFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.INTEGER),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             createArgs(3));
   }
 
@@ -109,7 +110,7 @@ public class IntTopkKudafTest {
     // Given:
     final int topKSize = 300;
     topkKudaf = new TopKAggregateFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.INTEGER),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             createArgs(topKSize));
     final List<Integer> initialAggregate = IntStream.range(0, topKSize)
             .boxed().sorted(Comparator.reverseOrder()).collect(Collectors.toList());
@@ -129,7 +130,7 @@ public class IntTopkKudafTest {
   public void shouldBeThreadSafe() {
     // Given:
     topkKudaf = new TopKAggregateFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.INTEGER),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             createArgs(12));
 
     final List<Integer> values = ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 70, 80, 35, 25);
@@ -158,7 +159,7 @@ public class IntTopkKudafTest {
     final int iterations = 1_000_000_000;
     final int topX = 10;
     topkKudaf = new TopKAggregateFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.INTEGER),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             createArgs(topX));
     final List<Integer> aggregate = new ArrayList<>();
     final long start = System.currentTimeMillis();
@@ -177,7 +178,7 @@ public class IntTopkKudafTest {
     final int iterations = 1_000_000_000;
     final int topX = 10;
     topkKudaf = new TopKAggregateFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlTypes.INTEGER),
+        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             createArgs(topX));
 
     final List<Integer> aggregate1 = IntStream.range(0, topX)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,14 +34,14 @@ public class LongTopkKudafTest {
   private final List<Long> valuesArray = ImmutableList.of(10L, 30L, 10L, 45L, 50L, 60L, 20L, 60L, 80L, 35L,
       25L);
   private TopKAggregateFunctionFactory topKFactory;
-  private List<SqlType> argumentType;
+  private List<SqlArgument> argumentType;
   private final AggregateFunctionInitArguments args =
       new AggregateFunctionInitArguments(0, 3);
       
   @Before
   public void setup() {
     topKFactory = new TopKAggregateFunctionFactory();
-    argumentType = Collections.singletonList(SqlTypes.BIGINT);
+    argumentType = Collections.singletonList(SqlArgument.of(SqlTypes.BIGINT));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,7 +34,7 @@ public class StringTopkKudafTest {
   private final List<String> valueArray = ImmutableList.of("10", "ab", "cde", "efg", "aa", "32", "why", "How are you",
       "Test", "123", "432");
   private TopKAggregateFunctionFactory topKFactory;
-  private List<SqlType> argumentType;
+  private List<SqlArgument> argumentType;
 
   private final AggregateFunctionInitArguments args =
       new AggregateFunctionInitArguments(0, 3);
@@ -42,7 +42,7 @@ public class StringTopkKudafTest {
   @Before
   public void setup() {
     topKFactory = new TopKAggregateFunctionFactory();
-    argumentType = Collections.singletonList(SqlTypes.STRING);
+    argumentType = Collections.singletonList(SqlArgument.of(SqlTypes.STRING));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.function.udaf.topkdistinct;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
-
 import java.util.Collections;
 
 public class TopKDistinctTestUtils {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
@@ -16,7 +16,9 @@
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+
 import java.util.Collections;
 
 public class TopKDistinctTestUtils {
@@ -25,7 +27,7 @@ public class TopKDistinctTestUtils {
       final int topk, final SqlType schema) {
     return (TopkDistinctKudaf<T>) new TopkDistinctAggFunctionFactory()
         .createAggregateFunction(
-            Collections.singletonList(schema),
+            Collections.singletonList(SqlArgument.of(schema)),
             new AggregateFunctionInitArguments(0, topk));
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -39,6 +39,7 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SchemaConverters.SqlToJavaTypeConverter;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -181,11 +182,13 @@ public class CodeGenRunner {
 
     @Override
     public Void visitFunctionCall(final FunctionCall node, final TypeContext context) {
-      final List<SqlType> argumentTypes = new ArrayList<>();
+      final List<SqlArgument> argumentTypes = new ArrayList<>();
       final FunctionName functionName = node.getName();
       for (final Expression argExpr : node.getArguments()) {
         process(argExpr, null);
-        argumentTypes.add(expressionTypeManager.getExpressionSqlType(argExpr));
+        argumentTypes.add(SqlArgument.of(
+            expressionTypeManager.getExpressionSqlType(argExpr)
+        ));
       }
 
       final UdfFactory holder = functionRegistry.getUdfFactory(functionName);

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -104,7 +104,6 @@ import io.confluent.ksql.util.Pair;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -434,11 +433,10 @@ public class SqlToJavaVisitor {
       final String instanceName = funNameToCodeName.apply(functionName);
 
       final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName());
-      final List<SqlArgument> argumentSchemas = new ArrayList<>();
-      for (final Expression argExpr : node.getArguments()) {
-        final SqlType newSqlType = expressionTypeManager.getExpressionSqlType(argExpr);
-        argumentSchemas.add(SqlArgument.of(newSqlType));
-      }
+      final List<SqlArgument> argumentSchemas = node.getArguments().stream()
+          .map(expressionTypeManager::getExpressionSqlType)
+          .map(SqlArgument::of)
+          .collect(Collectors.toList());
 
       final KsqlFunction function = udfFactory.getFunction(argumentSchemas);
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/TypeContext.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/TypeContext.java
@@ -24,8 +24,8 @@ import java.util.Map;
 
 public class TypeContext {
   private SqlType sqlType;
-  private final List<SqlType> inputTypes = new ArrayList<>();
-  private final Map<String, SqlType> lambdaTypeMapping = new HashMap<>();
+  private final List<SqlType> lambdaInputTypes = new ArrayList<>();
+  private final Map<String, SqlType> lambdaInputTypeMapping = new HashMap<>();
 
   public SqlType getSqlType() {
     return sqlType;
@@ -35,33 +35,33 @@ public class TypeContext {
     this.sqlType = sqlType;
   }
 
-  public List<SqlType> getInputTypes() {
-    return inputTypes;
+  public List<SqlType> getLambdaInputTypes() {
+    return lambdaInputTypes;
   }
 
-  public void addInputType(final SqlType inputType) {
-    this.inputTypes.add(inputType);
+  public void addLambdaInputType(final SqlType inputType) {
+    this.lambdaInputTypes.add(inputType);
   }
 
-  public void mapInputTypes(final List<String> argumentList) {
-    if (inputTypes.size() != argumentList.size()) {
+  public void mapLambdaInputTypes(final List<String> argumentList) {
+    if (lambdaInputTypes.size() != argumentList.size()) {
       throw new IllegalArgumentException("Was expecting "
-          + inputTypes.size()
+          + lambdaInputTypes.size()
           + " arguments but found "
           + argumentList.size() + ", "
           + argumentList
           + ". Check your lambda statement.");
     }
     for (int i = 0; i < argumentList.size(); i++) {
-      this.lambdaTypeMapping.putIfAbsent(argumentList.get(i), inputTypes.get(i));
+      this.lambdaInputTypeMapping.putIfAbsent(argumentList.get(i), lambdaInputTypes.get(i));
     }
   }
 
   public SqlType getLambdaType(final String name) {
-    return lambdaTypeMapping.get(name);
+    return lambdaInputTypeMapping.get(name);
   }
 
   public boolean notAllInputsSeen() {
-    return lambdaTypeMapping.size() != inputTypes.size() || inputTypes.size() == 0;
+    return lambdaInputTypeMapping.size() != lambdaInputTypes.size() || lambdaInputTypes.size() == 0;
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/UdtfUtil.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/UdtfUtil.java
@@ -24,8 +24,8 @@ import io.confluent.ksql.function.KsqlTableFunction;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlArgument;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class UdtfUtil {
 
@@ -43,11 +43,12 @@ public final class UdtfUtil {
     final List<Expression> functionArgs = functionCall.getArguments();
 
     final List<SqlArgument> argTypes = functionArgs.isEmpty()
-        ? ImmutableList.of(SqlArgument.of(FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA))
-        : new ArrayList<>();
-    for (final Expression e : functionArgs) {
-      argTypes.add(SqlArgument.of(expressionTypeManager.getExpressionSqlType(e)));
-    }
+        ? ImmutableList.of(
+            SqlArgument.of(FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA))
+        : functionArgs.stream()
+            .map(expressionTypeManager::getExpressionSqlType)
+            .map(SqlArgument::of)
+            .collect(Collectors.toList());
 
     return functionRegistry.getTableFunction(
         functionCall.getName(),

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/UdtfUtil.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/UdtfUtil.java
@@ -22,9 +22,10 @@ import io.confluent.ksql.execution.util.ExpressionTypeManager;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlTableFunction;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.SqlArgument;
+
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public final class UdtfUtil {
 
@@ -41,10 +42,12 @@ public final class UdtfUtil {
 
     final List<Expression> functionArgs = functionCall.getArguments();
 
-    final List<SqlType> argTypes = functionArgs.isEmpty()
-        ? ImmutableList.of(FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA)
-        : functionArgs.stream().map(expressionTypeManager::getExpressionSqlType)
-            .collect(Collectors.toList());
+    final List<SqlArgument> argTypes = functionArgs.isEmpty()
+        ? ImmutableList.of(SqlArgument.of(FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA))
+        : new ArrayList<>();
+    for (final Expression e : functionArgs) {
+      argTypes.add(SqlArgument.of(expressionTypeManager.getExpressionSqlType(e)));
+    }
 
     return functionRegistry.getTableFunction(
         functionCall.getName(),

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -80,6 +80,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class ExpressionTypeManager {
 
@@ -448,10 +449,11 @@ public class ExpressionTypeManager {
         final List<SqlArgument> argumentTypes = node.getArguments().isEmpty()
             ? ImmutableList.of(
                 SqlArgument.of(FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA))
-            : new ArrayList<>();
-        for (final Expression e : node.getArguments()) {
-          argumentTypes.add(SqlArgument.of(getExpressionSqlType(e)));
-        }
+            : node.getArguments()
+                .stream()
+                .map(ExpressionTypeManager.this::getExpressionSqlType)
+                .map(SqlArgument::of)
+                .collect(Collectors.toList());
 
         final KsqlTableFunction tableFunction = functionRegistry
             .getTableFunction(node.getName(), argumentTypes);

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/TypeContextTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/TypeContextTest.java
@@ -30,12 +30,12 @@ public class TypeContextTest {
   public void shouldThrowOnLambdaMismatch() {
     // Given
     TypeContext context = new TypeContext();
-    context.addInputType(SqlTypes.STRING);
-    context.addInputType(SqlTypes.STRING);
+    context.addLambdaInputType(SqlTypes.STRING);
+    context.addLambdaInputType(SqlTypes.STRING);
 
     // When
     final Exception e =
-        assertThrows(IllegalArgumentException.class, () -> context.mapInputTypes(ImmutableList.of("x", "y", "z")));
+        assertThrows(IllegalArgumentException.class, () -> context.mapLambdaInputTypes(ImmutableList.of("x", "y", "z")));
 
     // Then
     assertThat(e.getMessage(),
@@ -46,11 +46,11 @@ public class TypeContextTest {
   public void shouldMapLambdaTypes() {
     // Given
     TypeContext context = new TypeContext();
-    context.addInputType(SqlTypes.STRING);
-    context.addInputType(SqlTypes.BIGINT);
+    context.addLambdaInputType(SqlTypes.STRING);
+    context.addLambdaInputType(SqlTypes.BIGINT);
 
     // When
-    context.mapInputTypes(ImmutableList.of("x", "y"));
+    context.mapLambdaInputTypes(ImmutableList.of("x", "y"));
 
     // Then
     assertThat(context.getLambdaType("x"), is(SqlTypes.STRING));

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -59,7 +59,6 @@ import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
-import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
 import io.confluent.ksql.execution.testutil.TestExpressions;
@@ -72,12 +71,12 @@ import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.Operator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
-import java.sql.Timestamp;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
@@ -302,8 +301,8 @@ public class ExpressionTypeManagerTest {
 
     // Then:
     assertThat(exprType, is(SqlTypes.DOUBLE));
-    verify(udfFactory).getFunction(ImmutableList.of(SqlTypes.DOUBLE));
-    verify(function).getReturnType(ImmutableList.of(SqlTypes.DOUBLE));
+    verify(udfFactory).getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.DOUBLE)));
+    verify(function).getReturnType(ImmutableList.of(SqlArgument.of(SqlTypes.DOUBLE)));
   }
 
   @Test
@@ -318,8 +317,8 @@ public class ExpressionTypeManagerTest {
 
     // Then:
     assertThat(exprType, is(SqlTypes.STRING));
-    verify(udfFactory).getFunction(ImmutableList.of(SqlTypes.STRING));
-    verify(function).getReturnType(ImmutableList.of(SqlTypes.STRING));
+    verify(udfFactory).getFunction(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)));
+    verify(function).getReturnType(ImmutableList.of(SqlArgument.of(SqlTypes.STRING)));
   }
 
   @Test

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlReferentialIntegrityException;
@@ -233,7 +234,7 @@ public final class MetaStoreImpl implements MutableMetaStore {
 
   public KsqlTableFunction getTableFunction(
       final FunctionName functionName,
-      final List<SqlType> argumentTypes
+      final List<SqlArgument> argumentTypes
   ) {
     return functionRegistry.getTableFunction(functionName, argumentTypes);
   }

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/SqlArgument.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/SqlArgument.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import java.util.Objects;
+
+/**
+ * A wrapper class to bundle SqlTypes for UDF functions.
+ */
+public class SqlArgument {
+
+  private final SqlType sqlType;
+
+  public SqlArgument(final SqlType type) {
+    sqlType = type;
+  }
+
+  public static SqlArgument of(final SqlType type) {
+    return new SqlArgument(type);
+  }
+
+  public SqlType getSqlType() {
+    return sqlType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(sqlType);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final SqlArgument that = (SqlArgument) o;
+    return that.sqlType == this.sqlType;
+  }
+}


### PR DESCRIPTION
### Description 
Uses SqlArgument wrapper when looking up functions. This allows us in future PR's to handle non SqlType function arguments (such as lambdas)

PR looks large, but it's mainly just replacing instances of SqlType with SqlArgument in UDF lookup code.

### Testing done 
Updated unit tests, non functional change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

