### PR TITLE
docs: fix beta tag for 0.15

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -69,7 +69,7 @@ Start by creating a `pom.xml` for your Java application:
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/1/maven/</url>
+            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/{{ site.kstreamsbetabuild }}/maven/</url>
         </repository>
     </repositories>
 
@@ -80,7 +80,7 @@ Start by creating a `pom.xml` for your Java application:
         </pluginRepository>
         <pluginRepository>
             <id>confluent</id>
-            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/1/maven/</url>
+            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/{{ site.kstreamsbetabuild }}/maven/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,7 +239,8 @@ extra:
         # Build-related string tokens
         kafkaversion: 2.7
         ksqldbversion: 0.15.0
-        kstreamsbetatag: 6.2.0-beta201122193350
+        kstreamsbetatag: 6.2.0-beta201122193350-cp5
+        kstreamsbetabuild: 3
         release: 0.15.0
         cprelease: 6.1.0
         releasepostbranch: 6.1.0-post


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/7021.

The beta tag for the 0.15 release is `6.2.0-beta201122193350-cp5`, rather than `6.2.0-beta201122193350`. This PR fixes the docs accordingly.

This fix needs to be cherry-picked to 0.15.0-ksqldb as well.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

