### PR TITLE
docs: make beta build number a docs var (MINOR)

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -69,7 +69,7 @@ Start by creating a `pom.xml` for your Java application:
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/1/maven/</url>
+            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/{{ site.kstreamsbetabuild }}/maven/</url>
         </repository>
     </repositories>
 
@@ -80,7 +80,7 @@ Start by creating a `pom.xml` for your Java application:
         </pluginRepository>
         <pluginRepository>
             <id>confluent</id>
-            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/1/maven/</url>
+            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/{{ site.kstreamsbetabuild }}/maven/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,6 +241,7 @@ extra:
         kafkaversion: 2.7
         ksqldbversion: 0.16.0
         kstreamsbetatag: 6.2.0-beta210122194818
+        kstreamsbetabuild: 1
         cprelease: 6.2.0
         releasepostbranch: 6.2.0-post
         scalaversion: 2.13


### PR DESCRIPTION
### Description 

Updates the beta build number (for release dependencies) to be a variable in the docs, as it may vary from release to release. See https://github.com/confluentinc/ksql/pull/7024 for an example.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

