### PR TITLE
chore: adjust default jmh settings for benchmarks (MINOR)

### DIFF
--- a/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -73,8 +73,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 6, time = 30)
-@Measurement(iterations = 3, time = 60)
+@Warmup(iterations = 3, time = 10)
+@Measurement(iterations = 3, time = 10)
 @Threads(4)
 @Fork(3)
 public class SerdeBenchmark {

--- a/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/UdfInvokerBenchmark.java
+++ b/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/UdfInvokerBenchmark.java
@@ -39,8 +39,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 4, time = 10)
-@Measurement(iterations = 4, time = 10)
+@Warmup(iterations = 6, time = 10)
+@Measurement(iterations = 3, time = 10)
 @Threads(4)
 @Fork(3)
 public class UdfInvokerBenchmark {


### PR DESCRIPTION
### Description 

This PR decreases the default configs for the serde JMH benchmarks so they take about an hour to run, rather than 6.5 hours. Comparing results from the new defaults to the old defaults, I don't see any systematic differences (larger times or variances, etc). (When I tried decreasing the iteration times further, I did start to see variances rise.)

New default configs:
```
Benchmark                                (params)  Mode  Cnt   Score   Error  Units
SerdeBenchmark.deserialize   single-key/Delimited  avgt    9   5.002 ± 0.045  us/op
SerdeBenchmark.deserialize       single-key/Kafka  avgt    9   0.090 ± 0.021  us/op
SerdeBenchmark.deserialize        single-key/JSON  avgt    9   0.476 ± 0.031  us/op
SerdeBenchmark.deserialize        single-key/Avro  avgt    9   1.305 ± 0.161  us/op
SerdeBenchmark.deserialize  impressions/Delimited  avgt    9   5.047 ± 0.045  us/op
SerdeBenchmark.deserialize   impressions/Protobuf  avgt    9   4.161 ± 0.179  us/op
SerdeBenchmark.deserialize       impressions/JSON  avgt    9   3.070 ± 0.175  us/op
SerdeBenchmark.deserialize       impressions/Avro  avgt    9   3.566 ± 0.107  us/op
SerdeBenchmark.deserialize       metrics/Protobuf  avgt    9  12.743 ± 0.329  us/op
SerdeBenchmark.deserialize           metrics/JSON  avgt    9  14.819 ± 0.202  us/op
SerdeBenchmark.deserialize           metrics/Avro  avgt    9  11.639 ± 0.665  us/op
SerdeBenchmark.serialize     single-key/Delimited  avgt    9   0.385 ± 0.006  us/op
SerdeBenchmark.serialize         single-key/Kafka  avgt    9   0.031 ± 0.001  us/op
SerdeBenchmark.serialize          single-key/JSON  avgt    9   0.435 ± 0.090  us/op
SerdeBenchmark.serialize          single-key/Avro  avgt    9   0.565 ± 0.028  us/op
SerdeBenchmark.serialize    impressions/Delimited  avgt    9   1.034 ± 0.031  us/op
SerdeBenchmark.serialize     impressions/Protobuf  avgt    9   3.129 ± 0.234  us/op
SerdeBenchmark.serialize         impressions/JSON  avgt    9   1.875 ± 0.030  us/op
SerdeBenchmark.serialize         impressions/Avro  avgt    9   2.816 ± 0.157  us/op
SerdeBenchmark.serialize         metrics/Protobuf  avgt    9  14.004 ± 0.567  us/op
SerdeBenchmark.serialize             metrics/JSON  avgt    9   8.228 ± 0.368  us/op
SerdeBenchmark.serialize             metrics/Avro  avgt    9  10.561 ± 0.200  us/op
```

Original default configs:
```
Benchmark                                             (params)  Mode  Cnt   Score    Error  Units
SerdeBenchmark.deserialize                single-key/Delimited  avgt    9   5.021 ±  0.047  us/op
SerdeBenchmark.deserialize                    single-key/Kafka  avgt    9   0.107 ±  0.029  us/op
SerdeBenchmark.deserialize                     single-key/JSON  avgt    9   0.452 ±  0.097  us/op
SerdeBenchmark.deserialize                     single-key/Avro  avgt    9   1.345 ±  0.066  us/op
SerdeBenchmark.deserialize               impressions/Delimited  avgt    9   5.055 ±  0.092  us/op
SerdeBenchmark.deserialize                impressions/Protobuf  avgt    9   4.167 ±  0.090  us/op
SerdeBenchmark.deserialize                    impressions/JSON  avgt    9   3.016 ±  0.115  us/op
SerdeBenchmark.deserialize                    impressions/Avro  avgt    9   3.555 ±  0.031  us/op
SerdeBenchmark.deserialize                    metrics/Protobuf  avgt    9  12.928 ±  0.233  us/op
SerdeBenchmark.deserialize                        metrics/JSON  avgt    9  14.921 ±  0.377  us/op
SerdeBenchmark.deserialize                        metrics/Avro  avgt    9  11.467 ±  0.076  us/op
SerdeBenchmark.serialize                  single-key/Delimited  avgt    9   0.388 ±  0.008  us/op
SerdeBenchmark.serialize                      single-key/Kafka  avgt    9   0.031 ±  0.001  us/op
SerdeBenchmark.serialize                       single-key/JSON  avgt    9   0.453 ±  0.062  us/op
SerdeBenchmark.serialize                       single-key/Avro  avgt    9   0.557 ±  0.035  us/op
SerdeBenchmark.serialize                 impressions/Delimited  avgt    9   1.006 ±  0.044  us/op
SerdeBenchmark.serialize                  impressions/Protobuf  avgt    9   3.032 ±  0.151  us/op
SerdeBenchmark.serialize                      impressions/JSON  avgt    9   1.941 ±  0.036  us/op
SerdeBenchmark.serialize                      impressions/Avro  avgt    9   2.765 ±  0.083  us/op
SerdeBenchmark.serialize                      metrics/Protobuf  avgt    9  13.912 ±  0.383  us/op
SerdeBenchmark.serialize                          metrics/JSON  avgt    9   8.116 ±  0.178  us/op
SerdeBenchmark.serialize                          metrics/Avro  avgt    9  10.693 ±  0.150  us/op
```

This PR also increases the number of warmup iterations for the UdfInvoker benchmarks since I noticed that for some of the runs, the first measurement iteration result was noticeably higher than the rest. 

### Testing done 

Non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

