### PR TITLE
docs: cherry-pick: makes the docs card titles clickable (DOCS-7153)

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -10,19 +10,19 @@ Learn the core concepts that ksqlDB is built around.
 
 <div class="cards">
   <div class="card concepts">
-    <strong>Events</strong>
+    <a href="/concepts/events"><strong>Events</strong></a>
     <p class="card-body"><small>An event is the fundamental unit of data in stream processing.</small></p>
     <span><a href="/concepts/events">Learn →</a></span>
   </div>
 
   <div class="card concepts">
-    <strong>Stream processing</strong>
+    <a href="/concepts/stream-processing"><strong>Stream processing</strong></a>
     <p class="card-body"><small>Stream processing is a way to write programs computing over unbounded streams of events.</small></p>
     <span><a href="/concepts/stream-processing">Learn →</a></span>
   </div>
 
   <div class="card concepts">
-    <strong>Materialized views</strong>
+    <a href="/concepts/materialized-views"><strong>Materialized views</strong></a>
     <p class="card-body"><small>Materialized views precompute the results of queries at write-time so reads become predictably fast.</small></p>
     <span><a href="/concepts/materialized-views">Learn →</a></span>
   </div>
@@ -30,19 +30,19 @@ Learn the core concepts that ksqlDB is built around.
 
 <div class="cards">
   <div class="card concepts">
-    <strong>Streams</strong>
+    <a href="/concepts/streams"><strong>Streams</strong></a>
     <p class="card-body"><small>A stream is an immutable, append-only collection of events that represents a series of historical facts.</small></p>
     <span><a href="/concepts/streams">Learn →</a></span>
   </div>
 
   <div class="card concepts">
-    <strong>Tables</strong>
+    <a href="/concepts/tables"><strong>Tables</strong></a>
     <p class="card-body"><small>A table is a mutable collection of events that models change over time.</small></p>
     <span><a href="/concepts/tables">Learn →</a></span>
   </div>
 
   <div class="card concepts">
-    <strong>Queries</strong>
+    <a href="/concepts/queries"><strong>Queries</strong></a>
     <p class="card-body"><small>Queries are how you process events and retrieve computed results.</small></p>
     <span><a href="/concepts/queries">Learn →</a></span>
   </div>
@@ -50,34 +50,33 @@ Learn the core concepts that ksqlDB is built around.
 
 <div class="cards">
   <div class="card concepts">
-    <strong>Joins</strong>
+    <a href="/developer-guide/joins"><strong>Joins</strong></a>
     <p class="card-body"><small>Joins are how to combine data from many streams and tables into one.</small></p>
     <span><a href="/developer-guide/joins">Learn →</a></span>
   </div>
 
   <div class="card concepts">
-    <strong>Time and windows</strong>
+    <a href="/concepts/time-and-windows-in-ksqldb-queries"><strong>Time and windows</strong></a>
     <p class="card-body"><small>Windows help you bound a continuous stream of events into distinct time intervals.</small></p>
     <span><a href="/concepts/time-and-windows-in-ksqldb-queries">Learn →</a></span>
   </div>
 
   <div class="card concepts">
-    <strong>User-defined functions</strong>
+    <a href="/concepts/functions"><strong>User-defined functions</strong></a>
     <p class="card-body"><small>Extend ksqlDB to invoke custom code written in Java.</small></p>
     <span><a href="/concepts/functions">Learn →</a></span>
   </div>
 </div>
 
-
 <div class="cards">
   <div class="card concepts">
-    <strong>Connectors</strong>
+    <a href="/concepts/connectors"><strong>Connectors</strong></a>
     <p class="card-body"><small>Connectors source and sink data from external systems.</small></p>
     <span><a href="/concepts/connectors">Learn →</a></span>
   </div>
 
   <div class="card concepts">
-    <strong>Apache Kafka primer</strong>
+    <a href="/overview/apache-kafka-primer"><strong>Apache Kafka primer</strong></a>
     <p class="card-body"><small>None of this making sense? Take a step back and learn the basics of Kafka first.</small></p>
     <span><a href="/overview/apache-kafka-primer">Learn →</a></span>
   </div>

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -2,19 +2,19 @@ Follow compact lessons that help you work with common ksqlDB functionality.
 
 <div class="cards">
   <div class="card how-to-guide">
-    <strong>Query structured data</strong>
+    <a href="/how-to-guides/query-structured-data"><strong>Query structured data</strong></a>
     <p class="card-body"><small>Process and query structured data types like structs, maps, and arrays.</small></p>
     <span><a href="/how-to-guides/query-structured-data">Learn →</a></span>
   </div>
 
   <div class="card how-to-guide">
-    <strong>Convert a changelog to a table</strong>
+    <a href="/how-to-guides/convert-changelog-to-table"><strong>Convert a changelog to a table</strong></a>
     <p class="card-body"><small>Create a table representing the latest values in a stream.</small></p>
     <span><a href="/how-to-guides/convert-changelog-to-table">Learn →</a></span>
   </div>
 
   <div class="card how-to-guide">
-    <strong>Use connector management</strong>
+    <a href="/how-to-guides/use-connector-management"><strong>Use connector management</strong></a>
     <p class="card-body"><small>Source and sink data from external systems.</small></p>
     <span><a href="/how-to-guides/use-connector-management">Learn →</a></span>
   </div>
@@ -22,19 +22,19 @@ Follow compact lessons that help you work with common ksqlDB functionality.
 
 <div class="cards">
   <div class="card how-to-guide">
-    <strong>Update a running persistent query</strong>
+    <a href="/how-to-guides/update-a-running-persistent-query"><strong>Update a running persistent query</strong></a>
     <p class="card-body"><small>Change a running persistent query with no downtime.</small></p>
     <span><a href="/how-to-guides/update-a-running-persistent-query">Learn →</a></span>
   </div>
 
   <div class="card how-to-guide">
-    <strong>Create a user-defined function</strong>
+    <a href="/how-to-guides/create-a-user-defined-function"><strong>Create a user-defined function</strong></a>
     <p class="card-body"><small>Extend ksqlDB and invoke code that you wrote.</small></p>
     <span><a href="/how-to-guides/create-a-user-defined-function">Learn →</a></span>
   </div>
 
   <div class="card how-to-guide">
-    <strong>Control the case of identifiers</strong>
+    <a href="/how-to-guides/control-the-case-of-identifiers"><strong>Control the case of identifiers</strong></a>
     <p class="card-body"><small>Specify the exact capitalization of object names.</small></p>
     <span><a href="/how-to-guides/control-the-case-of-identifiers">Learn →</a></span>
   </div>
@@ -42,19 +42,19 @@ Follow compact lessons that help you work with common ksqlDB functionality.
 
 <div class="cards">
   <div class="card how-to-guide">
-    <strong>Use a custom timestamp column</strong>
+    <a href="/how-to-guides/use-a-custom-timestamp-column"><strong>Use a custom timestamp column</strong></a>
     <p class="card-body"><small>Perform time-based operations using a timestamp in each record.</small></p>
     <span><a href="/how-to-guides/use-a-custom-timestamp-column">Learn →</a></span>
   </div>
 
   <div class="card how-to-guide">
-    <strong>Test an application</strong>
+    <a href="/how-to-guides/test-an-app"><strong>Test an application</strong></a>
     <p class="card-body"><small>Build test suites to assert correct program behavior.</small></p>
     <span><a href="/how-to-guides/test-an-app">Learn →</a></span>
   </div>
 
   <div class="card how-to-guide">
-    <strong>Substitute variables</strong>
+    <a href="/how-to-guides/substitute-variables"><strong>Substitute variables</strong></a>
     <p class="card-body"><small>Change the content of a query based on variables.</small></p>
     <span><a href="/how-to-guides/substitute-variables">Learn →</a></span>
   </div>
@@ -62,7 +62,7 @@ Follow compact lessons that help you work with common ksqlDB functionality.
 
 <div class="cards">
   <div class="card how-to-guide contribute">
-    <strong>Help us write another?</strong>
+    <a href="https://github.com/confluentinc/ksql"><strong>Help us write another?</strong></a>
     <p class="card-body"><small>We're always looking for more guides. Just send a pull request!</small></p>
     <span><a href="https://github.com/confluentinc/ksql">Contribute →</a></span>
   </div>

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,76 +10,87 @@ Look up critical information quickly as you use the project.
 
 <div class="cards">
   <div class="card reference">
-    <strong>The SQL language</strong>
+    <a href="/reference/sql/syntax/lexical-structure"><strong>The SQL language</strong></a>
     <p class="card-body"><small>Learn the make-up of the SQL languge to write programs.</small></p>
-    <a href="/reference/sql/syntax/lexical-structure">Read →</a>
+
+    <span><a href="/reference/sql/syntax/lexical-structure">Read →</a></span>
   </div>
 
   <div class="card reference">
-    <strong>Built-in functions</strong>
+    <a href="/developer-guide/ksqldb-reference/functions"><strong>Built-in functions</strong></a>
     <p class="card-body"><small>Invoke built-in functions shipped with ksqlDB.</small></p>
-    <a href="/developer-guide/ksqldb-reference/functions">Read →</a>
+
+    <span><a href="/developer-guide/ksqldb-reference/functions">Read →</a></span>
   </div>
 
   <div class="card reference">
-    <strong>Operators</strong>
+    <a href="/developer-guide/ksqldb-reference/operators"><strong>Operators</strong></a>
     <p class="card-body"><small>Call operators built into the language.</small></p>
-    <a href="/developer-guide/ksqldb-reference/operators">Read →</a>
+
+    <span><a href="/developer-guide/ksqldb-reference/operators">Read →</a></span>
   </div>
 </div>
 
 <div class="cards">
   <div class="card reference">
-    <strong>Server configuration</strong>
+    <a href="/reference/server-configuration"><strong>Server configuration</strong></a>
     <p class="card-body"><small>Control how ksqlDB server behaves.</small></p>
-    <a href="/reference/server-configuration">Read →</a>
+
+    <span><a href="/reference/server-configuration">Read →</a></span>
   </div>
 
   <div class="card reference">
-    <strong>Metrics</strong>
+    <a href="/reference/metrics"><strong>Metrics</strong></a>
     <p class="card-body"><small>Observe how your cluster is behaving over time.</small></p>
-    <a href="/reference/metrics">Read →</a>
+
+    <span><a href="/reference/metrics">Read →</a></span>
   </div>
 </div>
 
 <div class="cards">
   <div class="card reference">
-    <strong>User-defined functions</strong>
+    <a href="/reference/user-defined-functions"><strong>User-defined functions</strong></a>
     <p class="card-body"><small>Extend ksqlDB to invoke custom code written in Java.</small></p>
-    <a href="/reference/user-defined-functions">Read →</a>
+
+    <span><a href="/reference/user-defined-functions">Read →</a></span>
   </div>
 
   <div class="card reference">
-    <strong>Processing log</strong>
+    <a href="/reference/processing-log"><strong>Processing log</strong></a>
     <p class="card-body"><small>Log internal events that arise when processing rows.</small></p>
-    <a href="/reference/processing-log">Read →</a>
+
+    <span><a href="/reference/processing-log">Read →</a></span>
   </div>
 </div>
 
 <div class="cards">
   <div class="card reference">
-    <strong>Serialization</strong>
+    <a href="/reference/serialization"><strong>Serialization</strong></a>
     <p class="card-body"><small>Control the format of how data is read and written.</small></p>
-    <a href="/reference/serialization">Read →</a>
+
+    <span><a href="/reference/serialization">Read →</a></span>
   </div>
 
   <div class="card reference">
-    <strong>Clients</strong>
+    <a href="/developer-guide/ksqldb-clients"><strong>Clients</strong></a>
     <p class="card-body"><small>Talk to ksqlDB using your favorite programming language.</small></p>
-    <a href="/developer-guide/ksqldb-clients">Read →</a>
+
+    <span><a href="/developer-guide/ksqldb-clients">Read →</a></span>
   </div>
 
   <div class="card reference">
-    <strong>REST API</strong>
+    <a href="/developer-guide/api"><strong>REST API</strong></a>
     <p class="card-body"><small>Communicate with ksqlDB over an HTTP REST API.</small></p>
-    <a href="/developer-guide/api">Read →</a>
+
+    <span><a href="/developer-guide/api">Read →</a></span>
   </div>
 </div>
 
 <div class="cards">
   <div class="card reference">
-    <strong>Appendix</strong>
+    <a href="/developer-guide/ksqldb-reference/quick-reference/"><strong>Appendix</strong></a>
     <p class="card-body"><small>Quickly reference the elements of the language.</small></p>
-    <a href="/developer-guide/ksqldb-reference/quick-reference/">Read →</a>
+
+    <span><a href="/developer-guide/ksqldb-reference/quick-reference/">Read →</a></span>
   </div>
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -90,6 +90,11 @@ select.version::-ms-expand {
     margin: 5px;
 }
 
+.card > a {
+    color: inherit;
+    text-decoration: underline;
+}
+
 ul.card-items {
     margin-left: 0;
     list-style-type: none;
@@ -106,17 +111,6 @@ ul.card-items li {
 
 .card-more {
     align-self: flex-start;
-}
-
-.tutorial-begin {
-    display: flex;
-    flex-flow: row nowrap;
-}
-
-.tutorial-begin a {
-    align-self: center;
-    margin: auto;
-    transform: translateX(-20px);
 }
 
 .card.tutorial {

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -10,32 +10,22 @@ Get up and running by trying these end-to-end examples of specific use cases.
 
 <div class="cards">
   <div class="card tutorial">
-    <strong>Materialized cache</strong>
+    <a href="/tutorials/materialized"><strong>Materialized cache</strong></a>
     <p class="card-body"><small>Build and serve incrementally-updated stateful views.</small></p>
-
-    <div class="tutorial-begin">
-      <img src="../img/materialized-views.svg"/>
-      <a href="/tutorials/materialized">Begin →</a>
-    </div>
+    <span><a href="/tutorials/materialized">Begin →</a></span>
   </div>
 
   <div class="card tutorial">
-    <strong>Streaming ETL pipeline</strong>
+    <a href="/tutorials/etl"><strong>Streaming ETL pipeline</strong></a>
     <p class="card-body"><small>Manipulate in-flight data to connect arbitrary sources and sinks.</small></p>
 
-    <div class="tutorial-begin">
-      <img src="../img/streaming-etl.svg"/>
-      <a href="/tutorials/etl">Begin →</a>
-    </div>
+    <span><a href="/tutorials/etl">Begin →</a></span>
   </div>
 
   <div class="card tutorial">
-    <strong>Event-driven microservice</strong>
+    <a href="/tutorials/event-driven-microservice"><strong>Event-driven microservice</strong></a>
     <p class="card-body"><small>Trigger changes based on observed patterns of events in a stream.</small></p>
 
-    <div class="tutorial-begin">
-      <img src="../img/microservices.svg"/>
-      <a href="/tutorials/event-driven-microservice">Begin →</a>
-    </div>
+    <span><a href="/tutorials/event-driven-microservice">Begin →</a></span>
   </div>
 </div>


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/7033.

* docs: make card titles clickable

* docs: rewrap ref links in spans
