### PR TITLE
chore: refactor migrations commands to not call exit from within command

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.tools.migrations;
 import com.github.rvesse.airline.Cli;
 import com.github.rvesse.airline.help.Help;
 import io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand;
+import io.confluent.ksql.tools.migrations.commands.BaseCommand;
 import io.confluent.ksql.tools.migrations.commands.CleanMigrationsCommand;
 import io.confluent.ksql.tools.migrations.commands.CreateMigrationCommand;
 import io.confluent.ksql.tools.migrations.commands.InitializeMigrationCommand;
@@ -52,10 +53,10 @@ public final class Migrations {
   private Migrations() {}
 
   public static void main(final String[] args) {
-    // all Migrations commands must implement Runnable, so we
+    // all Migrations commands must implement BaseCommand, so we
     // are safe to assume that the type returned is Cli<Runnable>
-    final Cli<Runnable> cli = new Cli<>(Migrations.class);
-    cli.parse(args).run();
+    final Cli<BaseCommand> cli = new Cli<>(Migrations.class);
+    System.exit(cli.parse(args).run());
   }
 
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
@@ -54,7 +54,7 @@ public final class Migrations {
 
   public static void main(final String[] args) {
     // all Migrations commands must implement BaseCommand, so we
-    // are safe to assume that the type returned is Cli<Runnable>
+    // are safe to assume that the type returned is Cli<BaseCommand>
     final Cli<BaseCommand> cli = new Cli<>(Migrations.class);
     System.exit(cli.parse(args).run());
   }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -55,7 +55,7 @@ public class ApplyMigrationCommand extends BaseCommand {
   private int version;
 
   @Override
-  protected void command() {
+  protected int command() {
     throw new UnsupportedOperationException();
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
     value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
     justification = "code is skeleton only at the moment, used to generate HELP message"
 )
-public abstract class BaseCommand implements Runnable {
+public abstract class BaseCommand {
 
   @Option(
       name = {"-c", "--config-file"},
@@ -46,15 +46,19 @@ public abstract class BaseCommand implements Runnable {
   )
   protected boolean dryRun = false;
 
-  @Override
-  @SuppressFBWarnings("DM_EXIT")
-  public void run() {
+  /**
+   * @return exit status of the command
+   */
+  public int run() {
     final long startTime = System.nanoTime();
     final int status = command();
     getLogger().info("Execution time: " + (System.nanoTime() - startTime) / 1000000000);
-    System.exit(status);
+    return status;
   }
 
+  /**
+   * @return exit status of the command
+   */
   protected abstract int command();
 
   protected abstract Logger getLogger();

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -47,6 +47,7 @@ public abstract class BaseCommand implements Runnable {
   protected boolean dryRun = false;
 
   @Override
+  @SuppressFBWarnings("DM_EXIT")
   public void run() {
     final long startTime = System.nanoTime();
     final int status = command();

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -49,11 +49,12 @@ public abstract class BaseCommand implements Runnable {
   @Override
   public void run() {
     final long startTime = System.nanoTime();
-    command();
+    final int status = command();
     getLogger().info("Execution time: " + (System.nanoTime() - startTime) / 1000000000);
+    System.exit(status);
   }
 
-  protected abstract void command();
+  protected abstract int command();
 
   protected abstract Logger getLogger();
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
@@ -28,7 +28,7 @@ public class CleanMigrationsCommand extends BaseCommand {
   private static final Logger LOGGER = LoggerFactory.getLogger(CleanMigrationsCommand.class);
 
   @Override
-  protected void command() {
+  protected int command() {
     throw new UnsupportedOperationException();
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -52,7 +52,7 @@ public class CreateMigrationCommand extends BaseCommand {
   private String description;
 
   @Override
-  protected void command() {
+  protected int command() {
     throw new UnsupportedOperationException();
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.tools.migrations.commands;
 
 import com.github.rvesse.airline.annotations.Command;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.MigrationException;
@@ -70,8 +69,7 @@ public class InitializeMigrationCommand extends BaseCommand {
   }
 
   @Override
-  @SuppressFBWarnings("DM_EXIT")
-  protected void command() {
+  protected int command() {
     final MigrationConfig properties = MigrationConfig.load();
     final String streamName = properties.getString(MigrationConfig.KSQL_MIGRATIONS_STREAM_NAME);
     final String tableName = properties.getString(MigrationConfig.KSQL_MIGRATIONS_TABLE_NAME);
@@ -91,8 +89,7 @@ public class InitializeMigrationCommand extends BaseCommand {
       ksqlClient = MigrationsUtil.getKsqlClient(ksqlServerUrl);
     } catch (MigrationException e) {
       LOGGER.error(e.getMessage());
-      System.exit(1);
-      return;
+      return 1;
     }
 
     if (tryCreate(ksqlClient, eventStreamCommand, streamName, true)
@@ -101,8 +98,10 @@ public class InitializeMigrationCommand extends BaseCommand {
       ksqlClient.close();
     } else {
       ksqlClient.close();
-      System.exit(1);
+      return 1;
     }
+
+    return 0;
   }
 
   private boolean tryCreate(

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommand.java
@@ -28,7 +28,7 @@ public class MigrationInfoCommand extends BaseCommand {
   private static final Logger LOGGER = LoggerFactory.getLogger(MigrationInfoCommand.class);
 
   @Override
-  protected void command() {
+  protected int command() {
     throw new UnsupportedOperationException();
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.tools.migrations.commands;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.restrictions.Required;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystemException;
@@ -40,14 +39,14 @@ public class NewMigrationCommand extends BaseCommand {
   private String projectPath;
 
   @Override
-  @SuppressFBWarnings("DM_EXIT")
-  protected void command() {
+  protected int command() {
     if (tryCreateDirectory(projectPath)
         && tryCreateDirectory(projectPath + "/migrations")
         && tryCreatePropertiesFile(projectPath + "/ksql-migrations.properties")) {
       LOGGER.info("Migrations project directory created successfully");
+      return 0;
     } else {
-      System.exit(1);
+      return 1;
     }
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
@@ -36,7 +36,7 @@ public class ValidateMigrationsCommand extends BaseCommand {
   private static final Logger LOGGER = LoggerFactory.getLogger(ValidateMigrationsCommand.class);
 
   @Override
-  protected void command() {
+  protected int command() {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
### Description 

BaseCommand should handle returning the appropriate exit code after printing the execution time, rather than exiting from within the commands themselves.

### Testing done 

Minor refactor, more thorough testing (in general) coming in a later PR.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

