### PR TITLE
fix: incompatible schema causing KsqlEngineTest.shouldNotFailIfAvroSchemaEvolvable failure

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -636,7 +636,7 @@ public class KsqlEngineTest {
   public void shouldNotFailIfAvroSchemaEvolvable() {
     // Given:
     final Schema evolvableSchema = SchemaBuilder
-        .record("Test").fields()
+        .record("KsqlDataSourceSchema").fields()
         .nullableInt("f1", 1)
         .endRecord();
 


### PR DESCRIPTION
Test was relying on an incompatible schema due to the `Record` names differing. Need to rename this field from `Test` to `KsqlDataSourceSchema`

Issue surfaced after tightening up the compatibility check in https://github.com/confluentinc/schema-registry/pull/1775