### PR TITLE
test(migrations): add integration test for migrations tool

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -1243,7 +1243,7 @@ public class ClientIntegrationTest {
       @Override
       public void describeTo(final Description description) {
         description.appendText(String.format(
-            "tableName: %s. topicName: %s. keyFormat: %s. valueFormat: %s. isWindowed: %s",
+            "streamName: %s. topicName: %s. keyFormat: %s. valueFormat: %s. isWindowed: %s",
             streamName, topicName, keyFormat, valueFormat, isWindowed));
       }
     };

--- a/ksqldb-tools/pom.xml
+++ b/ksqldb-tools/pom.xml
@@ -52,6 +52,21 @@
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksqldb-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksqldb-rest-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksqldb-api-client</artifactId>
+        </dependency>
+
         <!-- Required for running tests -->
 
         <dependency>
@@ -60,16 +75,29 @@
             <version>${io.confluent.ksql.version}</version>
             <scope>test</scope>
         </dependency>
-      <dependency>
-        <groupId>io.confluent.ksql</groupId>
-        <artifactId>ksqldb-common</artifactId>
-      </dependency>
-      <dependency>
-          <groupId>io.confluent.ksql</groupId>
-          <artifactId>ksqldb-api-client</artifactId>
-          <version>${io.confluent.ksql.version}</version>
-          <scope>compile</scope>
-      </dependency>
+
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksqldb-rest-app</artifactId>
+            <version>${io.confluent.ksql.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksqldb-rest-app</artifactId>
+            <version>${io.confluent.ksql.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksqldb-engine</artifactId>
+            <version>${io.confluent.ksql.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
@@ -34,7 +34,7 @@ public final class MigrationConfig extends AbstractConfig {
   public static final String KSQL_MIGRATIONS_STREAM_NAME = "ksql.migrations.stream.name";
   public static final String KSQL_MIGRATIONS_STREAM_NAME_DEFAULT = "migration_events";
   public static final String KSQL_MIGRATIONS_TABLE_NAME = "ksql.migrations.table.name";
-  public static final String KSQL_MIGRATIONS_TABLE_NAME_DEFAULT = "schema_version";
+  public static final String KSQL_MIGRATIONS_TABLE_NAME_DEFAULT = "migration_schema_versions";
   public static final String KSQL_MIGRATIONS_STREAM_TOPIC_NAME =
       "ksql.migrations.stream.topic.name";
   public static final String KSQL_MIGRATIONS_TABLE_TOPIC_NAME = "ksql.migrations.table.topic.name";

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
@@ -41,9 +41,9 @@ public final class MigrationConfig extends AbstractConfig {
   public static final String KSQL_MIGRATIONS_TOPIC_REPLICAS = "ksql.migrations.topic.replicas";
   public static final int KSQL_MIGRATIONS_TOPIC_REPLICAS_DEFAULT = 1;
 
-  public static MigrationConfig load() {
+  public static MigrationConfig load(final String configFile) {
     final Map<String, String> configsMap =
-        PropertiesUtil.loadProperties(new File(MigrationsUtil.MIGRATIONS_CONFIG_FILE));
+        PropertiesUtil.loadProperties(new File(configFile));
     return new MigrationConfig(configsMap, getServiceId(configsMap));
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -30,8 +30,11 @@ import org.slf4j.Logger;
 )
 public abstract class BaseCommand {
 
+  private static final String CONFIG_FILE_OPTION = "--config-file";
+  private static final String CONFIG_FILE_OPTION_SHORT = "-c";
+
   @Option(
-      name = {"-c", "--config-file"},
+      name = {CONFIG_FILE_OPTION_SHORT, CONFIG_FILE_OPTION},
       title = "config-file",
       description = "Specifies a configuration file",
       type = OptionType.GLOBAL
@@ -62,4 +65,14 @@ public abstract class BaseCommand {
   protected abstract int command();
 
   protected abstract Logger getLogger();
+
+  protected boolean validateConfigFilePresent() {
+    if (configFile == null || configFile.equals("")) {
+      getLogger().error("Migrations config file required but not specified. "
+          + "Specify with {} (or, equivalently, {}).",
+          CONFIG_FILE_OPTION, CONFIG_FILE_OPTION_SHORT);
+      return false;
+    }
+    return true;
+  }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
@@ -73,9 +73,13 @@ public class InitializeMigrationCommand extends BaseCommand {
 
   @Override
   protected int command() {
+    if (!validateConfigFilePresent()) {
+      return 1;
+    }
+
     final MigrationConfig config;
     try {
-      config = MigrationConfig.load();
+      config = MigrationConfig.load(configFile);
     } catch (KsqlException | MigrationException e) {
       LOGGER.error(e.getMessage());
       return 1;

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -68,12 +68,15 @@ public class MigrationsTest {
 
   private static final Cli<BaseCommand> MIGRATIONS_CLI = new Cli<>(Migrations.class);
 
+  private static String configFilePath;
+
   @BeforeClass
   public static void setUpClass() {
     final String testDir = Paths.get(TestUtils.tempDirectory().getAbsolutePath(), "migrations_integ_test").toString();
     createAndVerifyDirectoryStructure(testDir);
 
-    initializeAndVerifyMetadataStreamAndTable();
+    configFilePath = Paths.get(testDir, MigrationsUtil.MIGRATIONS_CONFIG_FILE).toString();
+    initializeAndVerifyMetadataStreamAndTable(configFilePath);
   }
 
   @AfterClass
@@ -107,9 +110,9 @@ public class MigrationsTest {
     assertThat(configFile.isDirectory(), is(false));
   }
 
-  private static void initializeAndVerifyMetadataStreamAndTable() {
+  private static void initializeAndVerifyMetadataStreamAndTable(final String configFile) {
     // use `initialize` to create metadata stream and table
-    final int status = MIGRATIONS_CLI.parse("initialize").run();
+    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "initialize").run();
     assertThat(status, is(0));
 
     // verify metadata stream

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.tools.migrations.commands.BaseCommand;
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -71,7 +72,7 @@ public class MigrationsTest {
   private static String configFilePath;
 
   @BeforeClass
-  public static void setUpClass() {
+  public static void setUpClass() throws Exception {
     final String testDir = Paths.get(TestUtils.tempDirectory().getAbsolutePath(), "migrations_integ_test").toString();
     createAndVerifyDirectoryStructure(testDir);
 
@@ -89,7 +90,7 @@ public class MigrationsTest {
     // placeholder until additional functionality (beyond initialization) is added
   }
 
-  private static void createAndVerifyDirectoryStructure(final String testDir) {
+  private static void createAndVerifyDirectoryStructure(final String testDir) throws Exception {
     // use `new` to create directory structure
     final int status = MIGRATIONS_CLI.parse("new", testDir, REST_APP.getHttpListener().toString()).run();
     assertThat(status, is(0));
@@ -108,6 +109,11 @@ public class MigrationsTest {
     final File configFile = new File(Paths.get(testDir, MigrationsUtil.MIGRATIONS_CONFIG_FILE).toString());
     assertThat(configFile.exists(), is(true));
     assertThat(configFile.isDirectory(), is(false));
+
+    // verify config file contents
+    final List<String> lines = Files.readAllLines(configFile.toPath());
+    assertThat(lines, hasSize(1));
+    assertThat(lines.get(0), is(MigrationConfig.KSQL_SERVER_URL + "=" + REST_APP.getHttpListener().toString()));
   }
 
   private static void initializeAndVerifyMetadataStreamAndTable(final String configFile) {

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations;
+
+import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import com.github.rvesse.airline.Cli;
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.integration.Retry;
+import io.confluent.ksql.rest.entity.FieldInfo;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.SourceDescription;
+import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
+import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
+import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.tools.migrations.commands.BaseCommand;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.test.TestUtils;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+
+@Category({IntegrationTest.class})
+public class MigrationsTest {
+
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+
+  private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
+      .build();
+
+  @ClassRule
+  public static final RuleChain CHAIN = RuleChain
+      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .around(TEST_HARNESS)
+      .around(REST_APP);
+
+  private static final Cli<BaseCommand> MIGRATIONS_CLI = new Cli<>(Migrations.class);
+
+  @BeforeClass
+  public static void setUpClass() {
+    final String testDir = Paths.get(TestUtils.tempDirectory().getAbsolutePath(), "migrations_integ_test").toString();
+    createAndVerifyDirectoryStructure(testDir);
+
+    initializeAndVerifyMetadataStreamAndTable();
+  }
+
+  @AfterClass
+  public static void classTearDown() {
+    REST_APP.getPersistentQueries().forEach(str -> makeKsqlRequest("TERMINATE " + str + ";"));
+  }
+
+  @Test
+  public void dummy() {
+    // TODO
+  }
+
+  private static void createAndVerifyDirectoryStructure(final String testDir) {
+    // use `new` to create directory structure
+    final int status = MIGRATIONS_CLI.parse("new", testDir, REST_APP.getHttpListener().toString()).run();
+    assertThat(status, is(0));
+
+    // verify root directory
+    final File rootDir = new File(testDir);
+    assertThat(rootDir.exists(), is(true));
+    assertThat(rootDir.isDirectory(), is(true));
+
+    // verify migrations directory
+    final File migrationsDir = new File(Paths.get(testDir, MigrationsUtil.MIGRATIONS_DIR).toString());
+    assertThat(migrationsDir.exists(), is(true));
+    assertThat(migrationsDir.isDirectory(), is(true));
+
+    // verify config file
+    final File configFile = new File(Paths.get(testDir, MigrationsUtil.MIGRATIONS_CONFIG_FILE).toString());
+    assertThat(configFile.exists(), is(true));
+    assertThat(configFile.isDirectory(), is(false));
+  }
+
+  private static void initializeAndVerifyMetadataStreamAndTable() {
+    // use `initialize` to create metadata stream and table
+    final int status = MIGRATIONS_CLI.parse("initialize").run();
+    assertThat(status, is(0));
+
+    // verify metadata stream
+    final SourceDescription streamDesc = describeSource("migration_events");
+    assertThat(streamDesc.getType(), is("STREAM"));
+    assertThat(streamDesc.getTopic(), is("default_ksql_migration_events"));
+    assertThat(streamDesc.getKeyFormat(), is("KAFKA"));
+    assertThat(streamDesc.getValueFormat(), is("JSON"));
+    assertThat(streamDesc.getPartitions(), is(1));
+    assertThat(streamDesc.getReplication(), is(1));
+    assertThat(streamDesc.getFields(), containsInAnyOrder(
+        fieldInfo("version_key", "STRING", true),
+        fieldInfo("version", "STRING", false),
+        fieldInfo("name", "STRING", false),
+        fieldInfo("state", "STRING", false),
+        fieldInfo("checksum", "STRING", false),
+        fieldInfo("started_on", "STRING", false),
+        fieldInfo("completed_on", "STRING", false),
+        fieldInfo("previous", "STRING", false)
+    ));
+
+    // verify metadata table
+    final SourceDescription tableDesc = describeSource("migration_schema_versions");
+    assertThat(tableDesc.getType(), is("TABLE"));
+    assertThat(tableDesc.getTopic(), is("default_ksql_migration_schema_versions"));
+    assertThat(tableDesc.getKeyFormat(), is("KAFKA"));
+    assertThat(tableDesc.getValueFormat(), is("JSON"));
+    assertThat(tableDesc.getPartitions(), is(1));
+    assertThat(tableDesc.getReplication(), is(1));
+    assertThat(tableDesc.getFields(), containsInAnyOrder(
+        fieldInfo("version_key", "STRING", true),
+        fieldInfo("version", "STRING", false),
+        fieldInfo("name", "STRING", false),
+        fieldInfo("state", "STRING", false),
+        fieldInfo("checksum", "STRING", false),
+        fieldInfo("started_on", "STRING", false),
+        fieldInfo("completed_on", "STRING", false),
+        fieldInfo("previous", "STRING", false)
+    ));
+  }
+
+  private static SourceDescription describeSource(final String name) {
+    final List<KsqlEntity> entities = makeKsqlRequest("DESCRIBE " + name + ";");
+
+    assertThat(entities, hasSize(1));
+    assertThat(entities.get(0), instanceOf(SourceDescriptionEntity.class));
+    SourceDescriptionEntity entity = (SourceDescriptionEntity) entities.get(0);
+
+    return entity.getSourceDescription();
+  }
+
+  private static List<KsqlEntity> makeKsqlRequest(final String sql) {
+    return RestIntegrationTestUtil.makeKsqlRequest(REST_APP, sql);
+  }
+
+  private static Matcher<? super FieldInfo> fieldInfo(
+      final String name,
+      final String type,
+      final boolean isKey
+  ) {
+    return new TypeSafeDiagnosingMatcher<FieldInfo>() {
+      @Override
+      protected boolean matchesSafely(
+          final FieldInfo actual,
+          final Description mismatchDescription) {
+        if (!name.equals(actual.getName())) {
+          return false;
+        }
+        if (!type.equals(actual.getSchema().getTypeName())) {
+          return false;
+        }
+        return isKey == isKey(actual);
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText(String.format(
+            "name: %s. type: %s. isKey: %s",
+            name, type, isKey));
+      }
+
+      private boolean isKey(final FieldInfo fieldInfo) {
+        if (!fieldInfo.getType().isPresent()) {
+          return false;
+        }
+        return fieldInfo.getType().get().equals(FieldInfo.FieldType.KEY);
+      }
+    };
+  }
+}

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -86,7 +86,7 @@ public class MigrationsTest {
 
   @Test
   public void dummy() {
-    // TODO
+    // placeholder until additional functionality (beyond initialization) is added
   }
 
   private static void createAndVerifyDirectoryStructure(final String testDir) {
@@ -124,14 +124,14 @@ public class MigrationsTest {
     assertThat(streamDesc.getPartitions(), is(1));
     assertThat(streamDesc.getReplication(), is(1));
     assertThat(streamDesc.getFields(), containsInAnyOrder(
-        fieldInfo("version_key", "STRING", true),
-        fieldInfo("version", "STRING", false),
-        fieldInfo("name", "STRING", false),
-        fieldInfo("state", "STRING", false),
-        fieldInfo("checksum", "STRING", false),
-        fieldInfo("started_on", "STRING", false),
-        fieldInfo("completed_on", "STRING", false),
-        fieldInfo("previous", "STRING", false)
+        fieldInfo("VERSION_KEY", "STRING", true),
+        fieldInfo("VERSION", "STRING", false),
+        fieldInfo("NAME", "STRING", false),
+        fieldInfo("STATE", "STRING", false),
+        fieldInfo("CHECKSUM", "STRING", false),
+        fieldInfo("STARTED_ON", "STRING", false),
+        fieldInfo("COMPLETED_ON", "STRING", false),
+        fieldInfo("PREVIOUS", "STRING", false)
     ));
 
     // verify metadata table
@@ -143,14 +143,14 @@ public class MigrationsTest {
     assertThat(tableDesc.getPartitions(), is(1));
     assertThat(tableDesc.getReplication(), is(1));
     assertThat(tableDesc.getFields(), containsInAnyOrder(
-        fieldInfo("version_key", "STRING", true),
-        fieldInfo("version", "STRING", false),
-        fieldInfo("name", "STRING", false),
-        fieldInfo("state", "STRING", false),
-        fieldInfo("checksum", "STRING", false),
-        fieldInfo("started_on", "STRING", false),
-        fieldInfo("completed_on", "STRING", false),
-        fieldInfo("previous", "STRING", false)
+        fieldInfo("VERSION_KEY", "STRING", true),
+        fieldInfo("VERSION", "STRING", false),
+        fieldInfo("NAME", "STRING", false),
+        fieldInfo("STATE", "STRING", false),
+        fieldInfo("CHECKSUM", "STRING", false),
+        fieldInfo("STARTED_ON", "STRING", false),
+        fieldInfo("COMPLETED_ON", "STRING", false),
+        fieldInfo("PREVIOUS", "STRING", false)
     ));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,12 @@
                 <artifactId>ksqldb-api-reactive-streams-tck</artifactId>
                 <version>${io.confluent.ksql.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>io.confluent.ksql</groupId>
+                <artifactId>ksqldb-api-client</artifactId>
+                <version>${io.confluent.ksql.version}</version>
+            </dependency>
             <!-- End cross-submodule dependencies -->
 
             <!-- Confluent dependencies -->


### PR DESCRIPTION
### Description 

This PR is stacked on https://github.com/confluentinc/ksql/pull/7053 and https://github.com/confluentinc/ksql/pull/7059. Only the commits starting from `test(migrations): integration test for migrations tool (wip)` need to be reviewed.

This PR sets up an integration test for the migrations tool, and tests both of the commands that have already been implemented (`new` and `initialize`). This PR also fixes a bug in the usage of the `--config-file` option, in order to properly load the specified config file in `initialize`. Also some other minor changes (cleaning up the module's pom, changing the default migrations table name from `schema_version` to `migration_schema_versions`, etc).

### Testing done 

The newly added integration test verifies that `new` and `initialize` work as expected, including verifying the directory structure created by `new` and the schema of the metadata stream and table created by `initialize`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

