### PR TITLE
chore(migrations): require server url as argument to `new` command

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.tools.migrations.commands.ValidateMigrationsCommand;
  * to the "help" message.
  */
 @com.github.rvesse.airline.annotations.Cli(
-    name = "ksql-migrations",
+    name = MigrationsUtil.MIGRATIONS_COMMAND,
     description = "This tool provides easy and automated schema migrations for "
         + "ksqlDB environments. This allows control over ksqlDB schemas, recreate schemas "
         + "from scratch and migrations for current schemas to newer versions.",

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationsUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationsUtil.java
@@ -25,6 +25,8 @@ public final class MigrationsUtil {
   private MigrationsUtil() {
   }
 
+  public static final String MIGRATIONS_COMMAND = "ksql-migrations";
+
   public static final String MIGRATIONS_DIR = "migrations";
   public static final String MIGRATIONS_CONFIG_FILE = "ksql-migrations.properties";
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -27,6 +27,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -119,9 +121,9 @@ public class NewMigrationCommand extends BaseCommand {
 
     final String initialConfig = MigrationConfig.KSQL_SERVER_URL + "=" + ksqlServerUrl;
     LOGGER.info("Writing to config file: " + initialConfig);
-    try (PrintWriter out = new PrintWriter(path)) {
+    try (PrintWriter out = new PrintWriter(path, Charset.defaultCharset().name())) {
       out.println(initialConfig);
-    } catch (FileNotFoundException e) {
+    } catch (FileNotFoundException | UnsupportedEncodingException e) {
       LOGGER.error(String.format("Failed to write to config file %s: %s", path, e.getMessage()));
       return false;
     }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -21,31 +21,55 @@ import static io.confluent.ksql.tools.migrations.MigrationsUtil.MIGRATIONS_DIR;
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.restrictions.Required;
+import io.confluent.ksql.tools.migrations.MigrationConfig;
+import io.confluent.ksql.tools.migrations.MigrationsUtil;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Command(
-    name = "new",
+    name = NewMigrationCommand.NEW_COMMAND_NAME,
     description = "Creates a new migrations project, directory structure and config file."
 )
 public class NewMigrationCommand extends BaseCommand {
 
+  static final String NEW_COMMAND_NAME = "new";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(NewMigrationCommand.class);
 
   @Required
-  @Arguments(description = "the project path to create the directory", title = "project-path")
-  private String projectPath;
+  @Arguments(
+      description = "project-path: the project path to create the directory\n"
+          + "ksql-server-url: the address of the ksqlDB server to connect to",
+      title = {"project-path", "ksql-server-url"})
+  private List<String> args;
 
   @Override
   protected int command() {
+    if (args.size() != 2) {
+      LOGGER.error(
+          "Unexpected number of arguments to `{} {}}`. Expected: 2. Got: {}. "
+              + "See `{} help {}` for usage.",
+          MigrationsUtil.MIGRATIONS_COMMAND, NEW_COMMAND_NAME, args.size(),
+          MigrationsUtil.MIGRATIONS_COMMAND, NEW_COMMAND_NAME);
+      return 1;
+    }
+
+    final String projectPath = args.get(0);
+    final String ksqlServerUrl = args.get(1);
     if (tryCreateDirectory(projectPath)
         && tryCreateDirectory(Paths.get(projectPath, MIGRATIONS_DIR).toString())
-        && tryCreatePropertiesFile(Paths.get(projectPath, MIGRATIONS_CONFIG_FILE).toString())) {
+        && tryCreatePropertiesFile(
+            Paths.get(projectPath, MIGRATIONS_CONFIG_FILE).toString(),
+            ksqlServerUrl)
+    ) {
       LOGGER.info("Migrations project directory created successfully");
       return 0;
     } else {
@@ -82,7 +106,7 @@ public class NewMigrationCommand extends BaseCommand {
     return true;
   }
 
-  private boolean tryCreatePropertiesFile(final String path) {
+  private boolean tryCreatePropertiesFile(final String path, final String ksqlServerUrl) {
     try {
       LOGGER.info("Creating file: " + path);
       if (!new File(path).createNewFile()) {
@@ -92,6 +116,16 @@ public class NewMigrationCommand extends BaseCommand {
       LOGGER.error(String.format("Failed to create file %s: %s", path, e.getMessage()));
       return false;
     }
+
+    final String initialConfig = MigrationConfig.KSQL_SERVER_URL + "=" + ksqlServerUrl;
+    LOGGER.info("Writing to config file: " + initialConfig);
+    try (PrintWriter out = new PrintWriter(path)) {
+      out.println(initialConfig);
+    } catch (FileNotFoundException e) {
+      LOGGER.error(String.format("Failed to write to config file %s: %s", path, e.getMessage()));
+      return false;
+    }
+
     return true;
   }
 }


### PR DESCRIPTION
### Description 

This PR is stacked on https://github.com/confluentinc/ksql/pull/7053. Only the commits starting from `chore(migrations): require server url as argument to command` need to be reviewed.

The `ksql-migrations new` command now requires two arguments, the migrations directory and the ksqlDB server URL, which is used to initialize the migrations config file (the server URL is a required config). This means `initialize` may now be called immediately after `new`. 

In a future PR we can consider initializing the config file with other configs (set to their default values) and helpful comments for how to use them.

### Testing done 

Updated unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

