### PR TITLE
fix: quick fix for appender

### DIFF
--- a/config/log4j-rolling.properties
+++ b/config/log4j-rolling.properties
@@ -44,6 +44,8 @@ log4j.appender.kafka_appender=org.apache.kafka.log4jappender.KafkaLog4jAppender
 log4j.appender.kafka_appender.layout=io.confluent.common.logging.log4j.StructuredJsonLayout
 log4j.appender.kafka_appender.BrokerList=localhost:9092
 log4j.appender.kafka_appender.Topic=default_ksql_processing_log
+log4j.appender.kafka_appender.SyncSend=true
+log4j.appender.kafka_appender.ignoreExceptions=false
 
 # loggers
 

--- a/config/log4j-rolling.properties
+++ b/config/log4j-rolling.properties
@@ -45,7 +45,7 @@ log4j.appender.kafka_appender.layout=io.confluent.common.logging.log4j.Structure
 log4j.appender.kafka_appender.BrokerList=localhost:9092
 log4j.appender.kafka_appender.Topic=default_ksql_processing_log
 log4j.appender.kafka_appender.SyncSend=true
-log4j.appender.kafka_appender.ignoreExceptions=false
+log4j.appender.kafka_appender.IgnoreExceptions=false
 
 # loggers
 


### PR DESCRIPTION
update the default for the kafka log appender to the producer send buffer does not fill up on a bad configuration

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

