### PR TITLE
feat: Introduce materialization support for tables using CTAS to make tables queryable

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/PullQueryExecutionUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/PullQueryExecutionUtil.java
@@ -110,8 +110,4 @@ public final class PullQueryExecutionUtil {
                     + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
     );
   }
-
-
-
-
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/PullQueryExecutionUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/PullQueryExecutionUtil.java
@@ -101,12 +101,12 @@ public final class PullQueryExecutionUtil {
   private static KsqlException notMaterializedException(final SourceName sourceTable) {
     final String tableName = sourceTable.toString().replaceAll("`", "");
     return new KsqlException(
-            "The " + sourceTable + " table isn't queriable. To derive a queriable table, "
-                    + "you can do 'CREATE TABLE QUERIABLE_"
+            "The " + sourceTable + " table isn't queryable. To derive a queryable table, "
+                    + "you can do 'CREATE TABLE QUERYABLE_"
                     + tableName
                     + " AS SELECT * FROM "
                     + tableName
-                    + "."
+                    + "'."
                     + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/PullQueryExecutionUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/PullQueryExecutionUtil.java
@@ -99,11 +99,18 @@ public final class PullQueryExecutionUtil {
   }
 
   private static KsqlException notMaterializedException(final SourceName sourceTable) {
+    final String tableName = sourceTable.toString().replaceAll("`", "");
     return new KsqlException(
-        "Can't pull from " + sourceTable + " as it's not a materialized table."
-            + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
+            "The " + sourceTable + " table isn't queriable. To derive a queriable table, "
+                    + "you can do 'CREATE TABLE QUERIABLE_"
+                    + tableName
+                    + " AS SELECT * FROM "
+                    + tableName
+                    + "."
+                    + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
     );
   }
+
 
 
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
@@ -203,14 +203,14 @@ public class PullPhysicalPlanBuilder {
   }
 
   private KsqlException notMaterializedException(final SourceName sourceTable) {
-    final String tableName = sourceTable.toString().replaceAll("`", "");
+    final String tableName = sourceTable.text();
     return new KsqlException(
-        "The " + sourceTable + " table isn't queriable. To derive a queriable table, "
-                + "you can do 'CREATE TABLE QUERIABLE_"
+        "The " + sourceTable + " table isn't queryable. To derive a queryable table, "
+                + "you can do 'CREATE TABLE QUERYABLE_"
                 + tableName
                 + " AS SELECT * FROM "
                 + tableName
-                + "."
+                + "'."
                 + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
@@ -203,9 +203,15 @@ public class PullPhysicalPlanBuilder {
   }
 
   private KsqlException notMaterializedException(final SourceName sourceTable) {
+    final String tableName = sourceTable.toString().replaceAll("`", "");
     return new KsqlException(
-        "Can't pull from " + sourceTable + " as it's not a materialized table."
-            + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
+        "The " + sourceTable + " table isn't queriable. To derive a queriable table, "
+                + "you can do 'CREATE TABLE QUERIABLE_"
+                + tableName
+                + " AS SELECT * FROM "
+                + tableName
+                + "."
+                + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -178,21 +178,6 @@ public class KsMaterializationFunctionalTest {
   }
 
   @Test
-  public void shouldReturnEmptyIfNotMaterializedTable() {
-    // Given:
-    final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT * FROM " + USER_TABLE + ";"
-    );
-
-    // When:
-    final Optional<Materialization> result = query.getMaterialization(queryId, contextStacker);
-
-    // Then:
-    assertThat(result, is(Optional.empty()));
-  }
-
-  @Test
   public void shouldReturnEmptyIfNotMaterializedStream() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -178,22 +178,6 @@ public class KsMaterializationFunctionalTest {
   }
 
   @Test
-  public void shouldReturnEmptyIfNotMaterializedTable() {
-    // Given:
-    final List<QueryMetadata> list = ksqlContext.sql("CREATE TABLE USERS_TABLE_CT"
-            + " (ID BIGINT PRIMARY KEY,"
-            + " usertimestamp BIGINT,"
-            + " gender VARCHAR,"
-            + " region_id VARCHAR"
-            + " ) WITH (kafka_topic='users_topic_ct',"
-            + " VALUE_FORMAT = 'JSON',"
-            + " PARTITIONS=1);");
-
-    // Then:
-    assertThat(list.size(), is(0));
-  }
-
-  @Test
   public void shouldReturnEmptyIfNotMaterializedStream() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -180,16 +180,17 @@ public class KsMaterializationFunctionalTest {
   @Test
   public void shouldReturnEmptyIfNotMaterializedTable() {
     // Given:
-    final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT * FROM " + USER_TABLE + ";"
-    );
-
-    // When:
-    final Optional<Materialization> result = query.getMaterialization(queryId, contextStacker);
+    final List<QueryMetadata> list = ksqlContext.sql("CREATE TABLE USERS_TABLE_CT"
+            + " (ID BIGINT PRIMARY KEY,"
+            + " usertimestamp BIGINT,"
+            + " gender VARCHAR,"
+            + " region_id VARCHAR"
+            + " ) WITH (kafka_topic='users_topic_ct',"
+            + " VALUE_FORMAT = 'JSON',"
+            + " PARTITIONS=1);");
 
     // Then:
-    assertThat(result, is(Optional.empty()));
+    assertThat(list.size(), is(0));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -180,17 +180,16 @@ public class KsMaterializationFunctionalTest {
   @Test
   public void shouldReturnEmptyIfNotMaterializedTable() {
     // Given:
-    final List<QueryMetadata> list = ksqlContext.sql("CREATE TABLE USERS_TABLE_CT"
-            + " (ID BIGINT PRIMARY KEY,"
-            + " usertimestamp BIGINT,"
-            + " gender VARCHAR,"
-            + " region_id VARCHAR"
-            + " ) WITH (kafka_topic='users_topic_ct',"
-            + " VALUE_FORMAT = 'JSON',"
-            + " PARTITIONS=1);");
+    final PersistentQueryMetadata query = executeQuery(
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT * FROM " + USER_TABLE + ";"
+    );
+
+    // When:
+    final Optional<Materialization> result = query.getMaterialization(queryId, contextStacker);
 
     // Then:
-    assertThat(list.size(), is(0));
+    assertThat(result, is(Optional.empty()));
   }
 
   @Test
@@ -806,3 +805,4 @@ public class KsMaterializationFunctionalTest {
     return assertThatEventually(supplier, is(notNullValue()), RetryOnException);
   }
 }
+

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -106,31 +106,31 @@ public class KsMaterializationFunctionalTest {
   private static final Duration WINDOW_SEGMENT_DURATION = Duration.ofSeconds(60);
   private static final int NUM_WINDOWS = 4;
   private static final List<Instant> WINDOW_START_INSTANTS = LongStream.range(1, NUM_WINDOWS + 1)
-          // records have to be apart by at-least a segment for retention to enforced
-          .mapToObj(i -> Instant.ofEpochMilli(i * WINDOW_SEGMENT_DURATION.toMillis()))
-          .collect(Collectors.toList());
+      // records have to be apart by at-least a segment for retention to enforced
+      .mapToObj(i -> Instant.ofEpochMilli(i * WINDOW_SEGMENT_DURATION.toMillis()))
+      .collect(Collectors.toList());
 
   private static final Deserializer<String> STRING_DESERIALIZER = new StringDeserializer();
   private static final Deserializer<Windowed<String>> TIME_WINDOWED_DESERIALIZER =
-          WindowedSerdes
-                  .timeWindowedSerdeFrom(String.class, WINDOW_SIZE.toMillis())
-                  .deserializer();
+      WindowedSerdes
+          .timeWindowedSerdeFrom(String.class, WINDOW_SIZE.toMillis())
+          .deserializer();
   private static final Deserializer<Windowed<String>> SESSION_WINDOWED_DESERIALIZER =
-          WindowedSerdes
-                  .sessionWindowedSerdeFrom(String.class)
-                  .deserializer();
+      WindowedSerdes
+          .sessionWindowedSerdeFrom(String.class)
+          .deserializer();
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-          .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
-          .around(TEST_HARNESS);
+      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .around(TEST_HARNESS);
 
   @Rule
   public final TestKsqlContext ksqlContext = TEST_HARNESS.ksqlContextBuilder()
-          .withAdditionalConfig(StreamsConfig.APPLICATION_SERVER_CONFIG, "https://localhost:34")
-          .build();
+      .withAdditionalConfig(StreamsConfig.APPLICATION_SERVER_CONFIG, "https://localhost:34")
+      .build();
 
   @Rule
   public final Timeout timeout = Timeout.seconds(120);
@@ -146,19 +146,19 @@ public class KsMaterializationFunctionalTest {
     TEST_HARNESS.ensureTopics(USERS_TOPIC, PAGE_VIEWS_TOPIC);
 
     TEST_HARNESS.produceRows(
-            USERS_TOPIC,
-            USER_DATA_PROVIDER,
-            KEY_FORMAT,
-            VALUE_FORMAT
+        USERS_TOPIC,
+        USER_DATA_PROVIDER,
+        KEY_FORMAT,
+        VALUE_FORMAT
     );
 
     for (final Instant windowTime : WINDOW_START_INSTANTS) {
       TEST_HARNESS.produceRows(
-              PAGE_VIEWS_TOPIC,
-              PAGE_VIEW_DATA_PROVIDER,
-              KEY_FORMAT,
-              VALUE_FORMAT,
-              windowTime::toEpochMilli
+          PAGE_VIEWS_TOPIC,
+          PAGE_VIEW_DATA_PROVIDER,
+          KEY_FORMAT,
+          VALUE_FORMAT,
+          windowTime::toEpochMilli
       );
     }
   }
@@ -181,8 +181,8 @@ public class KsMaterializationFunctionalTest {
   public void shouldReturnEmptyIfNotMaterializedTable() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT * FROM " + USER_TABLE + ";"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT * FROM " + USER_TABLE + ";"
     );
 
     // When:
@@ -196,8 +196,8 @@ public class KsMaterializationFunctionalTest {
   public void shouldReturnEmptyIfNotMaterializedStream() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE STREAM " + output + " AS"
-                    + " SELECT * FROM " + USER_STREAM + ";"
+        "CREATE STREAM " + output + " AS"
+            + " SELECT * FROM " + USER_STREAM + ";"
     );
 
     // When:
@@ -214,10 +214,10 @@ public class KsMaterializationFunctionalTest {
       initializeKsql(ksqlNoAppServer);
 
       final PersistentQueryMetadata query = executeQuery(
-              ksqlNoAppServer,
-              "CREATE TABLE " + output + " AS"
-                      + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
-                      + " GROUP BY USERID;"
+          ksqlNoAppServer,
+          "CREATE TABLE " + output + " AS"
+              + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
+              + " GROUP BY USERID;"
       );
 
       // When:
@@ -232,9 +232,9 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForAggregatedTable() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) FROM " + USER_TABLE
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) FROM " + USER_TABLE
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("KSQL_COL_0", SqlTypes.BIGINT);
@@ -266,9 +266,9 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForAggregatedStream() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
@@ -300,16 +300,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForTumblingWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-                    + " WINDOW TUMBLING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS)"
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+            + " WINDOW TUMBLING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS)"
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-            waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
+        waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -324,7 +324,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -333,18 +333,18 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-                      Range.all())));
+          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+              Range.all())));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
       assertThat("past start", resultPast, is(empty())
       );
     });
@@ -354,17 +354,17 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForHoppingWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-                    + " WINDOW HOPPING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS,"
-                    + " ADVANCE BY " + WINDOW_SIZE.getSeconds() + " SECONDS)"
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+            + " WINDOW HOPPING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS,"
+            + " ADVANCE BY " + WINDOW_SIZE.getSeconds() + " SECONDS)"
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-            waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
+        waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -379,7 +379,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -388,18 +388,18 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
 
       assertThat("past start", resultPast, is(empty()));
     });
@@ -409,16 +409,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForSessionWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-                    + " WINDOW SESSION (" + WINDOW_SIZE.getSeconds() + " SECONDS)"
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+            + " WINDOW SESSION (" + WINDOW_SIZE.getSeconds() + " SECONDS)"
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-            waitForUniqueUserRows(SESSION_WINDOWED_DESERIALIZER, schema);
+        waitForUniqueUserRows(SESSION_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -433,7 +433,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -442,17 +442,17 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
       assertThat("past start", resultPast, is(empty()));
     });
   }
@@ -472,16 +472,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryTumblingWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-                    + " WINDOW TUMBLING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-                    + " RETENTION " + (WINDOW_SEGMENT_DURATION.getSeconds() * 2) + " SECONDS,"
-                    + " GRACE PERIOD 0 SECONDS)"
-                    + " GROUP BY PAGEID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+            + " WINDOW TUMBLING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+            + " RETENTION " + (WINDOW_SEGMENT_DURATION.getSeconds() * 2) + " SECONDS,"
+            + " GRACE PERIOD 0 SECONDS)"
+            + " GROUP BY PAGEID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-            waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+        waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -490,9 +490,9 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.TUMBLING)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-            Window.of(WINDOW_START_INSTANTS.get(1), WINDOW_START_INSTANTS.get(1).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
+        Window.of(WINDOW_START_INSTANTS.get(1), WINDOW_START_INSTANTS.get(1).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -501,17 +501,17 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryHoppingWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-                    + " WINDOW HOPPING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-                    + " ADVANCE BY " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS, "
-                    + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-                    + " GRACE PERIOD 0 SECONDS"
-                    + ") GROUP BY PAGEID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+            + " WINDOW HOPPING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+            + " ADVANCE BY " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS, "
+            + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+            + " GRACE PERIOD 0 SECONDS"
+            + ") GROUP BY PAGEID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-            waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+        waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -520,8 +520,8 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.HOPPING)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
+        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -530,16 +530,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQuerySessionWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-                    + " WINDOW SESSION (" + WINDOW_SEGMENT_DURATION.getSeconds()/2 + " SECONDS,"
-                    + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-                    + " GRACE PERIOD 0 SECONDS"
-                    + ") GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+            + " WINDOW SESSION (" + WINDOW_SEGMENT_DURATION.getSeconds()/2 + " SECONDS,"
+            + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+            + " GRACE PERIOD 0 SECONDS"
+            + ") GROUP BY USERID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-            waitForPageViewRows(SESSION_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+        waitForPageViewRows(SESSION_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -548,8 +548,8 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.SESSION)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2)),
-            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3))
+        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2)),
+        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -558,14 +558,14 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableWithKeyFieldsInProjection() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*), AS_VALUE(USERID) AS USERID_2 FROM " + USER_TABLE
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*), AS_VALUE(USERID) AS USERID_2 FROM " + USER_TABLE
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema(
-            "KSQL_COL_0", SqlTypes.BIGINT,
-            "USERID_2", SqlTypes.STRING
+        "KSQL_COL_0", SqlTypes.BIGINT,
+        "USERID_2", SqlTypes.STRING
     );
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(STRING_DESERIALIZER, schema);
@@ -593,14 +593,14 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableWithMultipleAggregationColumns() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(1) AS COUNT, SUM(REGISTERTIME) AS SUM FROM " + USER_TABLE
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(1) AS COUNT, SUM(REGISTERTIME) AS SUM FROM " + USER_TABLE
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema(
-            "COUNT", SqlTypes.BIGINT,
-            "SUM", SqlTypes.BIGINT
+        "COUNT", SqlTypes.BIGINT,
+        "SUM", SqlTypes.BIGINT
     );
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(STRING_DESERIALIZER, schema);
@@ -630,17 +630,17 @@ public class KsMaterializationFunctionalTest {
 
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
-                    + " GROUP BY USERID"
-                    + " HAVING SUM(REGISTERTIME) > 2;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
+            + " GROUP BY USERID"
+            + " HAVING SUM(REGISTERTIME) > 2;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final int matches = (int) USER_DATA_PROVIDER.data().values().stream()
-            .filter(row -> ((Long) row.get(0)) > 2)
-            .count();
+        .filter(row -> ((Long) row.get(0)) > 2)
+        .count();
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(matches, STRING_DESERIALIZER, schema);
 
@@ -661,68 +661,68 @@ public class KsMaterializationFunctionalTest {
     });
 
     USER_DATA_PROVIDER.data().entries().stream()
-            .filter(e -> !rows.containsKey(e.getKey().get(0)))
-            .forEach(e -> {
-              // Rows filtered by the HAVING clause:
-              final Optional<Row> row = withRetry(() -> table.get(e.getKey(), PARTITION));
-              assertThat(row, is(Optional.empty()));
-            });
+        .filter(e -> !rows.containsKey(e.getKey().get(0)))
+        .forEach(e -> {
+          // Rows filtered by the HAVING clause:
+          final Optional<Row> row = withRetry(() -> table.get(e.getKey(), PARTITION));
+          assertThat(row, is(Optional.empty()));
+        });
   }
 
   private static void verifyRetainedWindows(
-          final List<ConsumerRecord<Windowed<String>, GenericRow>> rows,
-          final MaterializedWindowedTable table,
-          final Set<Optional<Window>> expectedWindows
+      final List<ConsumerRecord<Windowed<String>, GenericRow>> rows,
+      final MaterializedWindowedTable table,
+      final Set<Optional<Window>> expectedWindows
   ) {
     rows.forEach(record -> {
       final GenericKey key = genericKey(record.key().key());
       final List<WindowedRow> resultAtWindowStart =
-              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.all()));
+          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.all()));
 
       assertThat("Should have fewer windows retained",
-              resultAtWindowStart,
-              hasSize(expectedWindows.size()));
+          resultAtWindowStart,
+          hasSize(expectedWindows.size()));
       final Set<Optional<Window>> actualWindows = resultAtWindowStart.stream()
-              .map(WindowedRow::window)
-              .collect(Collectors.toSet());
+          .map(WindowedRow::window)
+          .collect(Collectors.toSet());
       assertThat("Should retain the latest windows", actualWindows, equalTo(expectedWindows));
     });
   }
 
   private <T> Map<T, GenericRow> waitForUniqueUserRows(
-          final Deserializer<T> keyDeserializer,
-          final LogicalSchema aggregateSchema
+      final Deserializer<T> keyDeserializer,
+      final LogicalSchema aggregateSchema
   ) {
     return waitForUniqueUserRows(
-            USER_DATA_PROVIDER.data().size(),
-            keyDeserializer,
-            aggregateSchema
+        USER_DATA_PROVIDER.data().size(),
+        keyDeserializer,
+        aggregateSchema
     );
   }
 
   private <T> Map<T, GenericRow> waitForUniqueUserRows(
-          final int count,
-          final Deserializer<T> keyDeserializer,
-          final LogicalSchema aggregateSchema
+      final int count,
+      final Deserializer<T> keyDeserializer,
+      final LogicalSchema aggregateSchema
   ) {
     return TEST_HARNESS.verifyAvailableUniqueRows(
-            output.toUpperCase(),
-            count,
-            VALUE_FORMAT,
-            PhysicalSchema.from(aggregateSchema, SerdeFeatures.of(), SerdeFeatures.of()),
-            keyDeserializer
+        output.toUpperCase(),
+        count,
+        VALUE_FORMAT,
+        PhysicalSchema.from(aggregateSchema, SerdeFeatures.of(), SerdeFeatures.of()),
+        keyDeserializer
     );
   }
 
   private <T> List<ConsumerRecord<T, GenericRow>> waitForPageViewRows(
-          final Deserializer<T> keyDeserializer,
-          final PhysicalSchema aggregateSchema) {
+      final Deserializer<T> keyDeserializer,
+      final PhysicalSchema aggregateSchema) {
     return TEST_HARNESS.verifyAvailableRows(
-            output.toUpperCase(),
-            hasSize(PAGE_VIEW_DATA_PROVIDER.data().size() * NUM_WINDOWS),
-            VALUE_FORMAT,
-            aggregateSchema,
-            keyDeserializer
+        output.toUpperCase(),
+        hasSize(PAGE_VIEW_DATA_PROVIDER.data().size() * NUM_WINDOWS),
+        VALUE_FORMAT,
+        aggregateSchema,
+        keyDeserializer
     );
   }
 
@@ -731,8 +731,8 @@ public class KsMaterializationFunctionalTest {
   }
 
   private PersistentQueryMetadata executeQuery(
-          final TestKsqlContext ksqlContext,
-          final String statement
+      final TestKsqlContext ksqlContext,
+      final String statement
   ) {
     final List<QueryMetadata> queries = ksqlContext.sql(statement);
 
@@ -748,52 +748,52 @@ public class KsMaterializationFunctionalTest {
 
   @SuppressWarnings("SameParameterValue")
   private static LogicalSchema schema(
-          final String columnName0,
-          final SqlType columnType0
+      final String columnName0,
+      final SqlType columnType0
   ) {
     return LogicalSchema.builder()
-            .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
-            .valueColumn(ColumnName.of(columnName0), columnType0)
-            .build();
+        .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of(columnName0), columnType0)
+        .build();
   }
 
   @SuppressWarnings("SameParameterValue")
   private static LogicalSchema schema(
-          final String columnName0, final SqlType columnType0,
-          final String columnName1, final SqlType columnType1
+      final String columnName0, final SqlType columnType0,
+      final String columnName1, final SqlType columnType1
   ) {
     return LogicalSchema.builder()
-            .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
-            .valueColumn(ColumnName.of(columnName0), columnType0)
-            .valueColumn(ColumnName.of(columnName1), columnType1)
-            .build();
+        .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of(columnName0), columnType0)
+        .valueColumn(ColumnName.of(columnName1), columnType1)
+        .build();
   }
 
   private static void initializeKsql(final TestKsqlContext ksqlContext) {
     ksqlContext.ensureStarted();
 
     ksqlContext.sql("CREATE TABLE " + USER_TABLE
-            + " (" + USER_DATA_PROVIDER.ksqlSchemaString(true) + ")"
-            + " WITH ("
-            + "    kafka_topic='" + USERS_TOPIC + "', "
-            + "    value_format='" + VALUE_FORMAT.name() + "'"
-            + ");"
+        + " (" + USER_DATA_PROVIDER.ksqlSchemaString(true) + ")"
+        + " WITH ("
+        + "    kafka_topic='" + USERS_TOPIC + "', "
+        + "    value_format='" + VALUE_FORMAT.name() + "'"
+        + ");"
     );
 
     ksqlContext.sql("CREATE STREAM " + USER_STREAM + " "
-            + " (" + USER_DATA_PROVIDER.ksqlSchemaString(false) + ")"
-            + " WITH ("
-            + "    kafka_topic='" + USERS_TOPIC + "', "
-            + "    value_format='" + VALUE_FORMAT.name() + "'"
-            + ");"
+        + " (" + USER_DATA_PROVIDER.ksqlSchemaString(false) + ")"
+        + " WITH ("
+        + "    kafka_topic='" + USERS_TOPIC + "', "
+        + "    value_format='" + VALUE_FORMAT.name() + "'"
+        + ");"
     );
 
     ksqlContext.sql("CREATE STREAM " + PAGE_VIEWS_STREAM + " "
-            + " (" + PAGE_VIEW_DATA_PROVIDER.ksqlSchemaString(false) + ")"
-            + " WITH ("
-            + "    kafka_topic='" + PAGE_VIEWS_TOPIC + "', "
-            + "    value_format='" + VALUE_FORMAT.name() + "'"
-            + ");"
+        + " (" + PAGE_VIEW_DATA_PROVIDER.ksqlSchemaString(false) + ")"
+        + " WITH ("
+        + "    kafka_topic='" + PAGE_VIEWS_TOPIC + "', "
+        + "    value_format='" + VALUE_FORMAT.name() + "'"
+        + ");"
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -106,31 +106,31 @@ public class KsMaterializationFunctionalTest {
   private static final Duration WINDOW_SEGMENT_DURATION = Duration.ofSeconds(60);
   private static final int NUM_WINDOWS = 4;
   private static final List<Instant> WINDOW_START_INSTANTS = LongStream.range(1, NUM_WINDOWS + 1)
-      // records have to be apart by at-least a segment for retention to enforced
-      .mapToObj(i -> Instant.ofEpochMilli(i * WINDOW_SEGMENT_DURATION.toMillis()))
-      .collect(Collectors.toList());
+          // records have to be apart by at-least a segment for retention to enforced
+          .mapToObj(i -> Instant.ofEpochMilli(i * WINDOW_SEGMENT_DURATION.toMillis()))
+          .collect(Collectors.toList());
 
   private static final Deserializer<String> STRING_DESERIALIZER = new StringDeserializer();
   private static final Deserializer<Windowed<String>> TIME_WINDOWED_DESERIALIZER =
-      WindowedSerdes
-          .timeWindowedSerdeFrom(String.class, WINDOW_SIZE.toMillis())
-          .deserializer();
+          WindowedSerdes
+                  .timeWindowedSerdeFrom(String.class, WINDOW_SIZE.toMillis())
+                  .deserializer();
   private static final Deserializer<Windowed<String>> SESSION_WINDOWED_DESERIALIZER =
-      WindowedSerdes
-          .sessionWindowedSerdeFrom(String.class)
-          .deserializer();
+          WindowedSerdes
+                  .sessionWindowedSerdeFrom(String.class)
+                  .deserializer();
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
-      .around(TEST_HARNESS);
+          .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+          .around(TEST_HARNESS);
 
   @Rule
   public final TestKsqlContext ksqlContext = TEST_HARNESS.ksqlContextBuilder()
-      .withAdditionalConfig(StreamsConfig.APPLICATION_SERVER_CONFIG, "https://localhost:34")
-      .build();
+          .withAdditionalConfig(StreamsConfig.APPLICATION_SERVER_CONFIG, "https://localhost:34")
+          .build();
 
   @Rule
   public final Timeout timeout = Timeout.seconds(120);
@@ -146,19 +146,19 @@ public class KsMaterializationFunctionalTest {
     TEST_HARNESS.ensureTopics(USERS_TOPIC, PAGE_VIEWS_TOPIC);
 
     TEST_HARNESS.produceRows(
-        USERS_TOPIC,
-        USER_DATA_PROVIDER,
-        KEY_FORMAT,
-        VALUE_FORMAT
+            USERS_TOPIC,
+            USER_DATA_PROVIDER,
+            KEY_FORMAT,
+            VALUE_FORMAT
     );
 
     for (final Instant windowTime : WINDOW_START_INSTANTS) {
       TEST_HARNESS.produceRows(
-          PAGE_VIEWS_TOPIC,
-          PAGE_VIEW_DATA_PROVIDER,
-          KEY_FORMAT,
-          VALUE_FORMAT,
-          windowTime::toEpochMilli
+              PAGE_VIEWS_TOPIC,
+              PAGE_VIEW_DATA_PROVIDER,
+              KEY_FORMAT,
+              VALUE_FORMAT,
+              windowTime::toEpochMilli
       );
     }
   }
@@ -181,8 +181,8 @@ public class KsMaterializationFunctionalTest {
   public void shouldReturnEmptyIfNotMaterializedTable() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT * FROM " + USER_TABLE + ";"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT * FROM " + USER_TABLE + ";"
     );
 
     // When:
@@ -196,8 +196,8 @@ public class KsMaterializationFunctionalTest {
   public void shouldReturnEmptyIfNotMaterializedStream() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE STREAM " + output + " AS"
-            + " SELECT * FROM " + USER_STREAM + ";"
+            "CREATE STREAM " + output + " AS"
+                    + " SELECT * FROM " + USER_STREAM + ";"
     );
 
     // When:
@@ -214,10 +214,10 @@ public class KsMaterializationFunctionalTest {
       initializeKsql(ksqlNoAppServer);
 
       final PersistentQueryMetadata query = executeQuery(
-          ksqlNoAppServer,
-          "CREATE TABLE " + output + " AS"
-              + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
-              + " GROUP BY USERID;"
+              ksqlNoAppServer,
+              "CREATE TABLE " + output + " AS"
+                      + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
+                      + " GROUP BY USERID;"
       );
 
       // When:
@@ -232,9 +232,9 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForAggregatedTable() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(*) FROM " + USER_TABLE
-            + " GROUP BY USERID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(*) FROM " + USER_TABLE
+                    + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("KSQL_COL_0", SqlTypes.BIGINT);
@@ -266,9 +266,9 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForAggregatedStream() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-            + " GROUP BY USERID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+                    + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
@@ -300,16 +300,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForTumblingWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-            + " WINDOW TUMBLING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS)"
-            + " GROUP BY USERID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+                    + " WINDOW TUMBLING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS)"
+                    + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-        waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
+            waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -324,7 +324,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -333,18 +333,18 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> withRetry(() -> table
-          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all())));
+              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+                      Range.all())));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+                      Range.all()));
       assertThat("past start", resultPast, is(empty())
       );
     });
@@ -354,17 +354,17 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForHoppingWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-            + " WINDOW HOPPING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS,"
-            + " ADVANCE BY " + WINDOW_SIZE.getSeconds() + " SECONDS)"
-            + " GROUP BY USERID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+                    + " WINDOW HOPPING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS,"
+                    + " ADVANCE BY " + WINDOW_SIZE.getSeconds() + " SECONDS)"
+                    + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-        waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
+            waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -379,7 +379,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -388,18 +388,18 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> table
-          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+                      Range.all()));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+                      Range.all()));
 
       assertThat("past start", resultPast, is(empty()));
     });
@@ -409,16 +409,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForSessionWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-            + " WINDOW SESSION (" + WINDOW_SIZE.getSeconds() + " SECONDS)"
-            + " GROUP BY USERID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+                    + " WINDOW SESSION (" + WINDOW_SIZE.getSeconds() + " SECONDS)"
+                    + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-        waitForUniqueUserRows(SESSION_WINDOWED_DESERIALIZER, schema);
+            waitForUniqueUserRows(SESSION_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -433,7 +433,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -442,17 +442,17 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> table
-          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+                      Range.all()));
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+                      Range.all()));
       assertThat("past start", resultPast, is(empty()));
     });
   }
@@ -472,16 +472,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryTumblingWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-            + " WINDOW TUMBLING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-            + " RETENTION " + (WINDOW_SEGMENT_DURATION.getSeconds() * 2) + " SECONDS,"
-            + " GRACE PERIOD 0 SECONDS)"
-            + " GROUP BY PAGEID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+                    + " WINDOW TUMBLING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+                    + " RETENTION " + (WINDOW_SEGMENT_DURATION.getSeconds() * 2) + " SECONDS,"
+                    + " GRACE PERIOD 0 SECONDS)"
+                    + " GROUP BY PAGEID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-        waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+            waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -490,9 +490,9 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.TUMBLING)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-        Window.of(WINDOW_START_INSTANTS.get(1), WINDOW_START_INSTANTS.get(1).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
+            Window.of(WINDOW_START_INSTANTS.get(1), WINDOW_START_INSTANTS.get(1).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -501,17 +501,17 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryHoppingWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-            + " WINDOW HOPPING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-            + " ADVANCE BY " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS, "
-            + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-            + " GRACE PERIOD 0 SECONDS"
-            + ") GROUP BY PAGEID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+                    + " WINDOW HOPPING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+                    + " ADVANCE BY " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS, "
+                    + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+                    + " GRACE PERIOD 0 SECONDS"
+                    + ") GROUP BY PAGEID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-        waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+            waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -520,8 +520,8 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.HOPPING)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
+            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -530,16 +530,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQuerySessionWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-            + " WINDOW SESSION (" + WINDOW_SEGMENT_DURATION.getSeconds()/2 + " SECONDS,"
-            + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-            + " GRACE PERIOD 0 SECONDS"
-            + ") GROUP BY USERID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+                    + " WINDOW SESSION (" + WINDOW_SEGMENT_DURATION.getSeconds()/2 + " SECONDS,"
+                    + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+                    + " GRACE PERIOD 0 SECONDS"
+                    + ") GROUP BY USERID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-        waitForPageViewRows(SESSION_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+            waitForPageViewRows(SESSION_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -548,8 +548,8 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.SESSION)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2)),
-        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3))
+            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2)),
+            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -558,14 +558,14 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableWithKeyFieldsInProjection() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(*), AS_VALUE(USERID) AS USERID_2 FROM " + USER_TABLE
-            + " GROUP BY USERID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(*), AS_VALUE(USERID) AS USERID_2 FROM " + USER_TABLE
+                    + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema(
-        "KSQL_COL_0", SqlTypes.BIGINT,
-        "USERID_2", SqlTypes.STRING
+            "KSQL_COL_0", SqlTypes.BIGINT,
+            "USERID_2", SqlTypes.STRING
     );
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(STRING_DESERIALIZER, schema);
@@ -593,14 +593,14 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableWithMultipleAggregationColumns() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(1) AS COUNT, SUM(REGISTERTIME) AS SUM FROM " + USER_TABLE
-            + " GROUP BY USERID;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(1) AS COUNT, SUM(REGISTERTIME) AS SUM FROM " + USER_TABLE
+                    + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema(
-        "COUNT", SqlTypes.BIGINT,
-        "SUM", SqlTypes.BIGINT
+            "COUNT", SqlTypes.BIGINT,
+            "SUM", SqlTypes.BIGINT
     );
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(STRING_DESERIALIZER, schema);
@@ -630,17 +630,17 @@ public class KsMaterializationFunctionalTest {
 
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-        "CREATE TABLE " + output + " AS"
-            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
-            + " GROUP BY USERID"
-            + " HAVING SUM(REGISTERTIME) > 2;"
+            "CREATE TABLE " + output + " AS"
+                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
+                    + " GROUP BY USERID"
+                    + " HAVING SUM(REGISTERTIME) > 2;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final int matches = (int) USER_DATA_PROVIDER.data().values().stream()
-        .filter(row -> ((Long) row.get(0)) > 2)
-        .count();
+            .filter(row -> ((Long) row.get(0)) > 2)
+            .count();
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(matches, STRING_DESERIALIZER, schema);
 
@@ -661,68 +661,68 @@ public class KsMaterializationFunctionalTest {
     });
 
     USER_DATA_PROVIDER.data().entries().stream()
-        .filter(e -> !rows.containsKey(e.getKey().get(0)))
-        .forEach(e -> {
-          // Rows filtered by the HAVING clause:
-          final Optional<Row> row = withRetry(() -> table.get(e.getKey(), PARTITION));
-          assertThat(row, is(Optional.empty()));
-        });
+            .filter(e -> !rows.containsKey(e.getKey().get(0)))
+            .forEach(e -> {
+              // Rows filtered by the HAVING clause:
+              final Optional<Row> row = withRetry(() -> table.get(e.getKey(), PARTITION));
+              assertThat(row, is(Optional.empty()));
+            });
   }
 
   private static void verifyRetainedWindows(
-      final List<ConsumerRecord<Windowed<String>, GenericRow>> rows,
-      final MaterializedWindowedTable table,
-      final Set<Optional<Window>> expectedWindows
+          final List<ConsumerRecord<Windowed<String>, GenericRow>> rows,
+          final MaterializedWindowedTable table,
+          final Set<Optional<Window>> expectedWindows
   ) {
     rows.forEach(record -> {
       final GenericKey key = genericKey(record.key().key());
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.all()));
+              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.all()));
 
       assertThat("Should have fewer windows retained",
-          resultAtWindowStart,
-          hasSize(expectedWindows.size()));
+              resultAtWindowStart,
+              hasSize(expectedWindows.size()));
       final Set<Optional<Window>> actualWindows = resultAtWindowStart.stream()
-          .map(WindowedRow::window)
-          .collect(Collectors.toSet());
+              .map(WindowedRow::window)
+              .collect(Collectors.toSet());
       assertThat("Should retain the latest windows", actualWindows, equalTo(expectedWindows));
     });
   }
 
   private <T> Map<T, GenericRow> waitForUniqueUserRows(
-      final Deserializer<T> keyDeserializer,
-      final LogicalSchema aggregateSchema
+          final Deserializer<T> keyDeserializer,
+          final LogicalSchema aggregateSchema
   ) {
     return waitForUniqueUserRows(
-        USER_DATA_PROVIDER.data().size(),
-        keyDeserializer,
-        aggregateSchema
+            USER_DATA_PROVIDER.data().size(),
+            keyDeserializer,
+            aggregateSchema
     );
   }
 
   private <T> Map<T, GenericRow> waitForUniqueUserRows(
-      final int count,
-      final Deserializer<T> keyDeserializer,
-      final LogicalSchema aggregateSchema
+          final int count,
+          final Deserializer<T> keyDeserializer,
+          final LogicalSchema aggregateSchema
   ) {
     return TEST_HARNESS.verifyAvailableUniqueRows(
-        output.toUpperCase(),
-        count,
-        VALUE_FORMAT,
-        PhysicalSchema.from(aggregateSchema, SerdeFeatures.of(), SerdeFeatures.of()),
-        keyDeserializer
+            output.toUpperCase(),
+            count,
+            VALUE_FORMAT,
+            PhysicalSchema.from(aggregateSchema, SerdeFeatures.of(), SerdeFeatures.of()),
+            keyDeserializer
     );
   }
 
   private <T> List<ConsumerRecord<T, GenericRow>> waitForPageViewRows(
-      final Deserializer<T> keyDeserializer,
-      final PhysicalSchema aggregateSchema) {
+          final Deserializer<T> keyDeserializer,
+          final PhysicalSchema aggregateSchema) {
     return TEST_HARNESS.verifyAvailableRows(
-        output.toUpperCase(),
-        hasSize(PAGE_VIEW_DATA_PROVIDER.data().size() * NUM_WINDOWS),
-        VALUE_FORMAT,
-        aggregateSchema,
-        keyDeserializer
+            output.toUpperCase(),
+            hasSize(PAGE_VIEW_DATA_PROVIDER.data().size() * NUM_WINDOWS),
+            VALUE_FORMAT,
+            aggregateSchema,
+            keyDeserializer
     );
   }
 
@@ -731,8 +731,8 @@ public class KsMaterializationFunctionalTest {
   }
 
   private PersistentQueryMetadata executeQuery(
-      final TestKsqlContext ksqlContext,
-      final String statement
+          final TestKsqlContext ksqlContext,
+          final String statement
   ) {
     final List<QueryMetadata> queries = ksqlContext.sql(statement);
 
@@ -748,52 +748,52 @@ public class KsMaterializationFunctionalTest {
 
   @SuppressWarnings("SameParameterValue")
   private static LogicalSchema schema(
-      final String columnName0,
-      final SqlType columnType0
+          final String columnName0,
+          final SqlType columnType0
   ) {
     return LogicalSchema.builder()
-        .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of(columnName0), columnType0)
-        .build();
+            .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
+            .valueColumn(ColumnName.of(columnName0), columnType0)
+            .build();
   }
 
   @SuppressWarnings("SameParameterValue")
   private static LogicalSchema schema(
-      final String columnName0, final SqlType columnType0,
-      final String columnName1, final SqlType columnType1
+          final String columnName0, final SqlType columnType0,
+          final String columnName1, final SqlType columnType1
   ) {
     return LogicalSchema.builder()
-        .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of(columnName0), columnType0)
-        .valueColumn(ColumnName.of(columnName1), columnType1)
-        .build();
+            .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
+            .valueColumn(ColumnName.of(columnName0), columnType0)
+            .valueColumn(ColumnName.of(columnName1), columnType1)
+            .build();
   }
 
   private static void initializeKsql(final TestKsqlContext ksqlContext) {
     ksqlContext.ensureStarted();
 
     ksqlContext.sql("CREATE TABLE " + USER_TABLE
-        + " (" + USER_DATA_PROVIDER.ksqlSchemaString(true) + ")"
-        + " WITH ("
-        + "    kafka_topic='" + USERS_TOPIC + "', "
-        + "    value_format='" + VALUE_FORMAT.name() + "'"
-        + ");"
+            + " (" + USER_DATA_PROVIDER.ksqlSchemaString(true) + ")"
+            + " WITH ("
+            + "    kafka_topic='" + USERS_TOPIC + "', "
+            + "    value_format='" + VALUE_FORMAT.name() + "'"
+            + ");"
     );
 
     ksqlContext.sql("CREATE STREAM " + USER_STREAM + " "
-        + " (" + USER_DATA_PROVIDER.ksqlSchemaString(false) + ")"
-        + " WITH ("
-        + "    kafka_topic='" + USERS_TOPIC + "', "
-        + "    value_format='" + VALUE_FORMAT.name() + "'"
-        + ");"
+            + " (" + USER_DATA_PROVIDER.ksqlSchemaString(false) + ")"
+            + " WITH ("
+            + "    kafka_topic='" + USERS_TOPIC + "', "
+            + "    value_format='" + VALUE_FORMAT.name() + "'"
+            + ");"
     );
 
     ksqlContext.sql("CREATE STREAM " + PAGE_VIEWS_STREAM + " "
-        + " (" + PAGE_VIEW_DATA_PROVIDER.ksqlSchemaString(false) + ")"
-        + " WITH ("
-        + "    kafka_topic='" + PAGE_VIEWS_TOPIC + "', "
-        + "    value_format='" + VALUE_FORMAT.name() + "'"
-        + ");"
+            + " (" + PAGE_VIEW_DATA_PROVIDER.ksqlSchemaString(false) + ")"
+            + " WITH ("
+            + "    kafka_topic='" + PAGE_VIEWS_TOPIC + "', "
+            + "    value_format='" + VALUE_FORMAT.name() + "'"
+            + ");"
     );
   }
 
@@ -805,4 +805,3 @@ public class KsMaterializationFunctionalTest {
     return assertThatEventually(supplier, is(notNullValue()), RetryOnException);
   }
 }
-

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -106,31 +106,31 @@ public class KsMaterializationFunctionalTest {
   private static final Duration WINDOW_SEGMENT_DURATION = Duration.ofSeconds(60);
   private static final int NUM_WINDOWS = 4;
   private static final List<Instant> WINDOW_START_INSTANTS = LongStream.range(1, NUM_WINDOWS + 1)
-          // records have to be apart by at-least a segment for retention to enforced
-          .mapToObj(i -> Instant.ofEpochMilli(i * WINDOW_SEGMENT_DURATION.toMillis()))
-          .collect(Collectors.toList());
+      // records have to be apart by at-least a segment for retention to enforced
+      .mapToObj(i -> Instant.ofEpochMilli(i * WINDOW_SEGMENT_DURATION.toMillis()))
+      .collect(Collectors.toList());
 
   private static final Deserializer<String> STRING_DESERIALIZER = new StringDeserializer();
   private static final Deserializer<Windowed<String>> TIME_WINDOWED_DESERIALIZER =
-          WindowedSerdes
-                  .timeWindowedSerdeFrom(String.class, WINDOW_SIZE.toMillis())
-                  .deserializer();
+      WindowedSerdes
+          .timeWindowedSerdeFrom(String.class, WINDOW_SIZE.toMillis())
+          .deserializer();
   private static final Deserializer<Windowed<String>> SESSION_WINDOWED_DESERIALIZER =
-          WindowedSerdes
-                  .sessionWindowedSerdeFrom(String.class)
-                  .deserializer();
+      WindowedSerdes
+          .sessionWindowedSerdeFrom(String.class)
+          .deserializer();
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
   @ClassRule
   public static final RuleChain CLUSTER_WITH_RETRY = RuleChain
-          .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
-          .around(TEST_HARNESS);
+      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .around(TEST_HARNESS);
 
   @Rule
   public final TestKsqlContext ksqlContext = TEST_HARNESS.ksqlContextBuilder()
-          .withAdditionalConfig(StreamsConfig.APPLICATION_SERVER_CONFIG, "https://localhost:34")
-          .build();
+      .withAdditionalConfig(StreamsConfig.APPLICATION_SERVER_CONFIG, "https://localhost:34")
+      .build();
 
   @Rule
   public final Timeout timeout = Timeout.seconds(120);
@@ -146,19 +146,19 @@ public class KsMaterializationFunctionalTest {
     TEST_HARNESS.ensureTopics(USERS_TOPIC, PAGE_VIEWS_TOPIC);
 
     TEST_HARNESS.produceRows(
-            USERS_TOPIC,
-            USER_DATA_PROVIDER,
-            KEY_FORMAT,
-            VALUE_FORMAT
+        USERS_TOPIC,
+        USER_DATA_PROVIDER,
+        KEY_FORMAT,
+        VALUE_FORMAT
     );
 
     for (final Instant windowTime : WINDOW_START_INSTANTS) {
       TEST_HARNESS.produceRows(
-              PAGE_VIEWS_TOPIC,
-              PAGE_VIEW_DATA_PROVIDER,
-              KEY_FORMAT,
-              VALUE_FORMAT,
-              windowTime::toEpochMilli
+          PAGE_VIEWS_TOPIC,
+          PAGE_VIEW_DATA_PROVIDER,
+          KEY_FORMAT,
+          VALUE_FORMAT,
+          windowTime::toEpochMilli
       );
     }
   }
@@ -181,8 +181,8 @@ public class KsMaterializationFunctionalTest {
   public void shouldReturnEmptyIfNotMaterializedTable() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT * FROM " + USER_TABLE + ";"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT * FROM " + USER_TABLE + ";"
     );
 
     // When:
@@ -196,8 +196,8 @@ public class KsMaterializationFunctionalTest {
   public void shouldReturnEmptyIfNotMaterializedStream() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE STREAM " + output + " AS"
-                    + " SELECT * FROM " + USER_STREAM + ";"
+        "CREATE STREAM " + output + " AS"
+            + " SELECT * FROM " + USER_STREAM + ";"
     );
 
     // When:
@@ -214,10 +214,10 @@ public class KsMaterializationFunctionalTest {
       initializeKsql(ksqlNoAppServer);
 
       final PersistentQueryMetadata query = executeQuery(
-              ksqlNoAppServer,
-              "CREATE TABLE " + output + " AS"
-                      + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
-                      + " GROUP BY USERID;"
+          ksqlNoAppServer,
+          "CREATE TABLE " + output + " AS"
+              + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
+              + " GROUP BY USERID;"
       );
 
       // When:
@@ -232,9 +232,9 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForAggregatedTable() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) FROM " + USER_TABLE
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) FROM " + USER_TABLE
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("KSQL_COL_0", SqlTypes.BIGINT);
@@ -266,9 +266,9 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForAggregatedStream() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
@@ -300,16 +300,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForTumblingWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-                    + " WINDOW TUMBLING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS)"
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+            + " WINDOW TUMBLING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS)"
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-            waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
+        waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -324,7 +324,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -333,18 +333,18 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-                      Range.all())));
+          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+              Range.all())));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
       assertThat("past start", resultPast, is(empty())
       );
     });
@@ -354,17 +354,17 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForHoppingWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-                    + " WINDOW HOPPING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS,"
-                    + " ADVANCE BY " + WINDOW_SIZE.getSeconds() + " SECONDS)"
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+            + " WINDOW HOPPING (SIZE " + WINDOW_SIZE.getSeconds() + " SECONDS,"
+            + " ADVANCE BY " + WINDOW_SIZE.getSeconds() + " SECONDS)"
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-            waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
+        waitForUniqueUserRows(TIME_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -379,7 +379,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -388,18 +388,18 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
 
       assertThat("past start", resultPast, is(empty()));
     });
@@ -409,16 +409,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableForSessionWindowed() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
-                    + " WINDOW SESSION (" + WINDOW_SIZE.getSeconds() + " SECONDS)"
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_STREAM
+            + " WINDOW SESSION (" + WINDOW_SIZE.getSeconds() + " SECONDS)"
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final Map<Windowed<String>, GenericRow> rows =
-            waitForUniqueUserRows(SESSION_WINDOWED_DESERIALIZER, schema);
+        waitForUniqueUserRows(SESSION_WINDOWED_DESERIALIZER, schema);
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -433,7 +433,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-              withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -442,17 +442,17 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> table
-              .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-                      Range.all()));
+          .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
+              Range.all()));
       assertThat("past start", resultPast, is(empty()));
     });
   }
@@ -472,16 +472,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryTumblingWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-                    + " WINDOW TUMBLING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-                    + " RETENTION " + (WINDOW_SEGMENT_DURATION.getSeconds() * 2) + " SECONDS,"
-                    + " GRACE PERIOD 0 SECONDS)"
-                    + " GROUP BY PAGEID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+            + " WINDOW TUMBLING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+            + " RETENTION " + (WINDOW_SEGMENT_DURATION.getSeconds() * 2) + " SECONDS,"
+            + " GRACE PERIOD 0 SECONDS)"
+            + " GROUP BY PAGEID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-            waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+        waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -490,9 +490,9 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.TUMBLING)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-            Window.of(WINDOW_START_INSTANTS.get(1), WINDOW_START_INSTANTS.get(1).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
+        Window.of(WINDOW_START_INSTANTS.get(1), WINDOW_START_INSTANTS.get(1).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -501,17 +501,17 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryHoppingWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-                    + " WINDOW HOPPING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-                    + " ADVANCE BY " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS, "
-                    + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-                    + " GRACE PERIOD 0 SECONDS"
-                    + ") GROUP BY PAGEID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT PAGEID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+            + " WINDOW HOPPING (SIZE " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+            + " ADVANCE BY " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS, "
+            + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+            + " GRACE PERIOD 0 SECONDS"
+            + ") GROUP BY PAGEID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-            waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+        waitForPageViewRows(TIME_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -520,8 +520,8 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.HOPPING)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
-            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
+        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds())),
+        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3).plusSeconds(WINDOW_SEGMENT_DURATION.getSeconds()))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -530,16 +530,16 @@ public class KsMaterializationFunctionalTest {
   public void shouldQuerySessionWindowMaterializedTableWithRetention() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
-                    + " WINDOW SESSION (" + WINDOW_SEGMENT_DURATION.getSeconds()/2 + " SECONDS,"
-                    + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
-                    + " GRACE PERIOD 0 SECONDS"
-                    + ") GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + PAGE_VIEWS_STREAM
+            + " WINDOW SESSION (" + WINDOW_SEGMENT_DURATION.getSeconds()/2 + " SECONDS,"
+            + " RETENTION " + WINDOW_SEGMENT_DURATION.getSeconds() + " SECONDS,"
+            + " GRACE PERIOD 0 SECONDS"
+            + ") GROUP BY USERID;"
     );
 
     final List<ConsumerRecord<Windowed<String>, GenericRow>> rows =
-            waitForPageViewRows(SESSION_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
+        waitForPageViewRows(SESSION_WINDOWED_DESERIALIZER, query.getPhysicalSchema());
 
     // When:
     final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
@@ -548,8 +548,8 @@ public class KsMaterializationFunctionalTest {
     assertThat(materialization.windowType(), is(Optional.of(WindowType.SESSION)));
     final MaterializedWindowedTable table = materialization.windowed();
     final Set<Optional<Window>> expectedWindows = Stream.of(
-            Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2)),
-            Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3))
+        Window.of(WINDOW_START_INSTANTS.get(2), WINDOW_START_INSTANTS.get(2)),
+        Window.of(WINDOW_START_INSTANTS.get(3), WINDOW_START_INSTANTS.get(3))
     ).map(Optional::of).collect(Collectors.toSet());
     verifyRetainedWindows(rows, table, expectedWindows);
   }
@@ -558,14 +558,14 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableWithKeyFieldsInProjection() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*), AS_VALUE(USERID) AS USERID_2 FROM " + USER_TABLE
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*), AS_VALUE(USERID) AS USERID_2 FROM " + USER_TABLE
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema(
-            "KSQL_COL_0", SqlTypes.BIGINT,
-            "USERID_2", SqlTypes.STRING
+        "KSQL_COL_0", SqlTypes.BIGINT,
+        "USERID_2", SqlTypes.STRING
     );
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(STRING_DESERIALIZER, schema);
@@ -593,14 +593,14 @@ public class KsMaterializationFunctionalTest {
   public void shouldQueryMaterializedTableWithMultipleAggregationColumns() {
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(1) AS COUNT, SUM(REGISTERTIME) AS SUM FROM " + USER_TABLE
-                    + " GROUP BY USERID;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(1) AS COUNT, SUM(REGISTERTIME) AS SUM FROM " + USER_TABLE
+            + " GROUP BY USERID;"
     );
 
     final LogicalSchema schema = schema(
-            "COUNT", SqlTypes.BIGINT,
-            "SUM", SqlTypes.BIGINT
+        "COUNT", SqlTypes.BIGINT,
+        "SUM", SqlTypes.BIGINT
     );
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(STRING_DESERIALIZER, schema);
@@ -630,17 +630,17 @@ public class KsMaterializationFunctionalTest {
 
     // Given:
     final PersistentQueryMetadata query = executeQuery(
-            "CREATE TABLE " + output + " AS"
-                    + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
-                    + " GROUP BY USERID"
-                    + " HAVING SUM(REGISTERTIME) > 2;"
+        "CREATE TABLE " + output + " AS"
+            + " SELECT USERID, COUNT(*) AS COUNT FROM " + USER_TABLE
+            + " GROUP BY USERID"
+            + " HAVING SUM(REGISTERTIME) > 2;"
     );
 
     final LogicalSchema schema = schema("COUNT", SqlTypes.BIGINT);
 
     final int matches = (int) USER_DATA_PROVIDER.data().values().stream()
-            .filter(row -> ((Long) row.get(0)) > 2)
-            .count();
+        .filter(row -> ((Long) row.get(0)) > 2)
+        .count();
 
     final Map<String, GenericRow> rows = waitForUniqueUserRows(matches, STRING_DESERIALIZER, schema);
 
@@ -661,68 +661,68 @@ public class KsMaterializationFunctionalTest {
     });
 
     USER_DATA_PROVIDER.data().entries().stream()
-            .filter(e -> !rows.containsKey(e.getKey().get(0)))
-            .forEach(e -> {
-              // Rows filtered by the HAVING clause:
-              final Optional<Row> row = withRetry(() -> table.get(e.getKey(), PARTITION));
-              assertThat(row, is(Optional.empty()));
-            });
+        .filter(e -> !rows.containsKey(e.getKey().get(0)))
+        .forEach(e -> {
+          // Rows filtered by the HAVING clause:
+          final Optional<Row> row = withRetry(() -> table.get(e.getKey(), PARTITION));
+          assertThat(row, is(Optional.empty()));
+        });
   }
 
   private static void verifyRetainedWindows(
-          final List<ConsumerRecord<Windowed<String>, GenericRow>> rows,
-          final MaterializedWindowedTable table,
-          final Set<Optional<Window>> expectedWindows
+      final List<ConsumerRecord<Windowed<String>, GenericRow>> rows,
+      final MaterializedWindowedTable table,
+      final Set<Optional<Window>> expectedWindows
   ) {
     rows.forEach(record -> {
       final GenericKey key = genericKey(record.key().key());
       final List<WindowedRow> resultAtWindowStart =
-              withRetry(() -> table.get(key, PARTITION, Range.all(), Range.all()));
+          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.all()));
 
       assertThat("Should have fewer windows retained",
-              resultAtWindowStart,
-              hasSize(expectedWindows.size()));
+          resultAtWindowStart,
+          hasSize(expectedWindows.size()));
       final Set<Optional<Window>> actualWindows = resultAtWindowStart.stream()
-              .map(WindowedRow::window)
-              .collect(Collectors.toSet());
+          .map(WindowedRow::window)
+          .collect(Collectors.toSet());
       assertThat("Should retain the latest windows", actualWindows, equalTo(expectedWindows));
     });
   }
 
   private <T> Map<T, GenericRow> waitForUniqueUserRows(
-          final Deserializer<T> keyDeserializer,
-          final LogicalSchema aggregateSchema
+      final Deserializer<T> keyDeserializer,
+      final LogicalSchema aggregateSchema
   ) {
     return waitForUniqueUserRows(
-            USER_DATA_PROVIDER.data().size(),
-            keyDeserializer,
-            aggregateSchema
+        USER_DATA_PROVIDER.data().size(),
+        keyDeserializer,
+        aggregateSchema
     );
   }
 
   private <T> Map<T, GenericRow> waitForUniqueUserRows(
-          final int count,
-          final Deserializer<T> keyDeserializer,
-          final LogicalSchema aggregateSchema
+      final int count,
+      final Deserializer<T> keyDeserializer,
+      final LogicalSchema aggregateSchema
   ) {
     return TEST_HARNESS.verifyAvailableUniqueRows(
-            output.toUpperCase(),
-            count,
-            VALUE_FORMAT,
-            PhysicalSchema.from(aggregateSchema, SerdeFeatures.of(), SerdeFeatures.of()),
-            keyDeserializer
+        output.toUpperCase(),
+        count,
+        VALUE_FORMAT,
+        PhysicalSchema.from(aggregateSchema, SerdeFeatures.of(), SerdeFeatures.of()),
+        keyDeserializer
     );
   }
 
   private <T> List<ConsumerRecord<T, GenericRow>> waitForPageViewRows(
-          final Deserializer<T> keyDeserializer,
-          final PhysicalSchema aggregateSchema) {
+      final Deserializer<T> keyDeserializer,
+      final PhysicalSchema aggregateSchema) {
     return TEST_HARNESS.verifyAvailableRows(
-            output.toUpperCase(),
-            hasSize(PAGE_VIEW_DATA_PROVIDER.data().size() * NUM_WINDOWS),
-            VALUE_FORMAT,
-            aggregateSchema,
-            keyDeserializer
+        output.toUpperCase(),
+        hasSize(PAGE_VIEW_DATA_PROVIDER.data().size() * NUM_WINDOWS),
+        VALUE_FORMAT,
+        aggregateSchema,
+        keyDeserializer
     );
   }
 
@@ -731,8 +731,8 @@ public class KsMaterializationFunctionalTest {
   }
 
   private PersistentQueryMetadata executeQuery(
-          final TestKsqlContext ksqlContext,
-          final String statement
+      final TestKsqlContext ksqlContext,
+      final String statement
   ) {
     final List<QueryMetadata> queries = ksqlContext.sql(statement);
 
@@ -748,52 +748,52 @@ public class KsMaterializationFunctionalTest {
 
   @SuppressWarnings("SameParameterValue")
   private static LogicalSchema schema(
-          final String columnName0,
-          final SqlType columnType0
+      final String columnName0,
+      final SqlType columnType0
   ) {
     return LogicalSchema.builder()
-            .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
-            .valueColumn(ColumnName.of(columnName0), columnType0)
-            .build();
+        .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of(columnName0), columnType0)
+        .build();
   }
 
   @SuppressWarnings("SameParameterValue")
   private static LogicalSchema schema(
-          final String columnName0, final SqlType columnType0,
-          final String columnName1, final SqlType columnType1
+      final String columnName0, final SqlType columnType0,
+      final String columnName1, final SqlType columnType1
   ) {
     return LogicalSchema.builder()
-            .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
-            .valueColumn(ColumnName.of(columnName0), columnType0)
-            .valueColumn(ColumnName.of(columnName1), columnType1)
-            .build();
+        .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of(columnName0), columnType0)
+        .valueColumn(ColumnName.of(columnName1), columnType1)
+        .build();
   }
 
   private static void initializeKsql(final TestKsqlContext ksqlContext) {
     ksqlContext.ensureStarted();
 
     ksqlContext.sql("CREATE TABLE " + USER_TABLE
-            + " (" + USER_DATA_PROVIDER.ksqlSchemaString(true) + ")"
-            + " WITH ("
-            + "    kafka_topic='" + USERS_TOPIC + "', "
-            + "    value_format='" + VALUE_FORMAT.name() + "'"
-            + ");"
+        + " (" + USER_DATA_PROVIDER.ksqlSchemaString(true) + ")"
+        + " WITH ("
+        + "    kafka_topic='" + USERS_TOPIC + "', "
+        + "    value_format='" + VALUE_FORMAT.name() + "'"
+        + ");"
     );
 
     ksqlContext.sql("CREATE STREAM " + USER_STREAM + " "
-            + " (" + USER_DATA_PROVIDER.ksqlSchemaString(false) + ")"
-            + " WITH ("
-            + "    kafka_topic='" + USERS_TOPIC + "', "
-            + "    value_format='" + VALUE_FORMAT.name() + "'"
-            + ");"
+        + " (" + USER_DATA_PROVIDER.ksqlSchemaString(false) + ")"
+        + " WITH ("
+        + "    kafka_topic='" + USERS_TOPIC + "', "
+        + "    value_format='" + VALUE_FORMAT.name() + "'"
+        + ");"
     );
 
     ksqlContext.sql("CREATE STREAM " + PAGE_VIEWS_STREAM + " "
-            + " (" + PAGE_VIEW_DATA_PROVIDER.ksqlSchemaString(false) + ")"
-            + " WITH ("
-            + "    kafka_topic='" + PAGE_VIEWS_TOPIC + "', "
-            + "    value_format='" + VALUE_FORMAT.name() + "'"
-            + ");"
+        + " (" + PAGE_VIEW_DATA_PROVIDER.ksqlSchemaString(false) + ")"
+        + " WITH ("
+        + "    kafka_topic='" + PAGE_VIEWS_TOPIC + "', "
+        + "    value_format='" + VALUE_FORMAT.name() + "'"
+        + ");"
     );
   }
 
@@ -805,3 +805,4 @@ public class KsMaterializationFunctionalTest {
     return assertThatEventually(supplier, is(notNullValue()), RetryOnException);
   }
 }
+

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -207,7 +207,7 @@ public class SchemaKTableTest {
   private ExecutionStep buildSourceStep(final LogicalSchema schema, final KTable kTable) {
     final ExecutionStep sourceStep = mock(ExecutionStep.class);
     when(sourceStep.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.unmaterialized(kTable, schema, executionKeyFactory));
+        KTableHolder.materialized(kTable, schema, executionKeyFactory, null));
     return sourceStep;
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.structured;
 
+import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -160,6 +161,8 @@ public class SchemaKTableTest {
   private KsqlTopic topic;
   @Mock
   private PlanInfo planInfo;
+  @Mock
+  private MaterializationInfo.Builder materializationBuilder;
 
   @Before
   public void init() {
@@ -207,7 +210,7 @@ public class SchemaKTableTest {
   private ExecutionStep buildSourceStep(final LogicalSchema schema, final KTable kTable) {
     final ExecutionStep sourceStep = mock(ExecutionStep.class);
     when(sourceStep.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.materialized(kTable, schema, executionKeyFactory, null));
+        KTableHolder.materialized(kTable, schema, executionKeyFactory, materializationBuilder));
     return sourceStep;
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/KTableHolder.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/KTableHolder.java
@@ -88,13 +88,6 @@ public final class KTableHolder<K> {
     return new KTableHolder<>(table, schema, executionKeyFactory, materializationBuilder);
   }
 
-  public KTableHolder<K> withTable(
-          final KTable<K, GenericRow> table,
-          final LogicalSchema schema,
-          final Optional<MaterializationInfo.Builder> builder) {
-    return new KTableHolder<>(table, schema, executionKeyFactory, builder);
-  }
-
   public KTableHolder<K> withMaterialization(final Optional<MaterializationInfo.Builder> builder) {
     return new KTableHolder<>(
         stream,

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/KTableHolder.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/KTableHolder.java
@@ -88,6 +88,13 @@ public final class KTableHolder<K> {
     return new KTableHolder<>(table, schema, executionKeyFactory, materializationBuilder);
   }
 
+  public KTableHolder<K> withTable(
+          final KTable<K, GenericRow> table,
+          final LogicalSchema schema,
+          final Optional<MaterializationInfo.Builder> builder) {
+    return new KTableHolder<>(table, schema, executionKeyFactory, builder);
+  }
+
   public KTableHolder<K> withMaterialization(final Optional<MaterializationInfo.Builder> builder) {
     return new KTableHolder<>(
         stream,

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -4,11 +4,11 @@
   ],
   "tests": [
     {
-      "name": "select * against mat table",
+      "name": "select * against mat table table scan",
       "statements": [
-        "CREATE TABLE users (id BIGINT PRIMARY KEY,usertimestamp BIGINT,gender VARCHAR,region_id VARCHAR) WITH (KAFKA_TOPIC = 'users_topic',VALUE_FORMAT = 'JSON',PARTITIONS=1);",
-        "CREATE TABLE queriable_users AS SELECT * from users;",
-        "SELECT * FROM queriable_users;"
+        "CREATE TABLE USERS (ID BIGINT PRIMARY KEY, USERTIMESTAMP BIGINT, GENDER VARCHAR, REGION_ID VARCHAR) WITH (KAFKA_TOPIC = 'users_topic',VALUE_FORMAT = 'JSON',PARTITIONS=1);",
+        "CREATE TABLE QUERYABLE_USERS AS SELECT * FROM USERS;",
+        "SELECT * FROM QUERYABLE_USERS;"
       ],
       "inputs": [
         {"topic": "users_topic", "timestamp": 12345, "key": 1, "value": {"usertimestamp": 1000, "gender":  "m", "region_id": "w"}},
@@ -29,9 +29,9 @@
     {
       "name": "select * against mat table key lookup",
       "statements": [
-        "CREATE TABLE users (id BIGINT PRIMARY KEY,usertimestamp BIGINT,gender VARCHAR,region_id VARCHAR) WITH (KAFKA_TOPIC = 'users_topic',VALUE_FORMAT = 'JSON',PARTITIONS=1);",
-        "CREATE TABLE queriable_users AS SELECT * from users;",
-        "SELECT * FROM queriable_users where id=2;"
+        "CREATE TABLE USERS (ID BIGINT PRIMARY KEY, USERTIMESTAMP BIGINT, GENDER VARCHAR, REGION_ID VARCHAR) WITH (KAFKA_TOPIC = 'users_topic',VALUE_FORMAT = 'JSON',PARTITIONS=1);",
+        "CREATE TABLE QUERYABLE_USERS AS SELECT * FROM USERS;",
+        "SELECT * FROM QUERYABLE_USERS WHERE ID=2;"
       ],
       "inputs": [
         {"topic": "users_topic", "timestamp": 12345, "key": 1, "value": {"usertimestamp": 1000, "gender":  "m", "region_id": "w"}},
@@ -48,7 +48,7 @@
       ]
     },
     {
-      "name": "select star with projection",
+      "name": "select * with projection table scan",
       "statements": [
         "CREATE TABLE INPUT (ID STRING PRIMARY KEY, GRADE STRING, RANK INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE NEW_INPUT AS SELECT ID, CONCAT(GRADE, '+'), RANK * 2 FROM INPUT;",
@@ -70,7 +70,7 @@
       ]
     },
     {
-      "name": "select star with projection and filter",
+      "name": "select star with projection key lookup",
       "statements": [
         "CREATE TABLE INPUT (ID STRING PRIMARY KEY, GRADE STRING, RANK INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE NEW_INPUT AS SELECT ID, CONCAT(GRADE, '+'), RANK * 2 FROM INPUT;",
@@ -120,7 +120,7 @@
       ]
     },
     {
-      "name": "select with projection and IN",
+      "name": "select with projection and IN clause",
       "statements": [
         "CREATE TABLE INPUT (ID STRING PRIMARY KEY, GRADE STRING, RANK INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE NEW_INPUT AS SELECT ID, CONCAT(GRADE, '+'), RANK * 2 AS DOUBLE_RANK FROM INPUT;",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -48,31 +48,6 @@
       ]
     },
     {
-      "name": "select * against mat table windowed table scan",
-      "statements": [
-        "CREATE TABLE users (ID BIGINT PRIMARY KEY, USERTIMESTAMP BIGINT,gender VARCHAR,region_id VARCHAR) WITH (KAFKA_TOPIC = 'users_topic',VALUE_FORMAT = 'JSON',PARTITIONS=1);",
-        "CREATE TABLE queriable_users AS SELECT ID, COUNT(*) AS COUNT from users GROUP BY ID;",
-        "SELECT * FROM queriable_users WHERE ID=2;",
-        "SELECT * FROM queriable_users WHERE ID=1234567;"
-      ],
-      "inputs": [
-        {"topic": "users_topic", "timestamp": 12345, "key": 1, "value": {"usertimestamp": 1000, "gender":  "m", "region_id": "w"}},
-        {"topic": "users_topic", "timestamp": 13345, "key": 2, "value": {"usertimestamp": 2000, "gender":  "f", "region_id": "e"}},
-        {"topic": "users_topic", "timestamp": 14345, "key": 3, "value": {"usertimestamp": 3000, "gender":  "f", "region_id": "n"}}
-      ],
-      "responses": [
-        {"admin": {"@type": "currentStatus"}},
-        {"admin": {"@type": "currentStatus"}},
-        {"query": [
-          {"header":{"schema":"`ID` BIGINT KEY, `COUNT` BIGINT"}},
-          {"row":{"columns":[2,1]}}
-        ]},
-        {"query": [
-          {"header":{"schema":"`ID` BIGINT KEY, `COUNT` BIGINT"}}
-        ]}
-      ]
-    },
-    {
       "name": "select star with projection",
       "statements": [
         "CREATE TABLE INPUT (ID STRING PRIMARY KEY, GRADE STRING, RANK INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -212,7 +187,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "The `INNER_JOIN` table isn't queriable. To derive a queriable table, you can do 'CREATE TABLE QUERIABLE_INNER_JOIN AS SELECT * FROM INNER_JOIN. See https://cnfl.io/queries for more info.",
+        "message": "The `INNER_JOIN` table isn't queryable. To derive a queryable table, you can do 'CREATE TABLE QUERYABLE_INNER_JOIN AS SELECT * FROM INNER_JOIN'. See https://cnfl.io/queries for more info.",
         "status": 400
       }
     },
@@ -227,7 +202,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "The `USERS` table isn't queriable. To derive a queriable table, you can do 'CREATE TABLE QUERIABLE_USERS AS SELECT * FROM USERS. See https://cnfl.io/queries for more info.",
+        "message": "The `USERS` table isn't queryable. To derive a queryable table, you can do 'CREATE TABLE QUERYABLE_USERS AS SELECT * FROM USERS'. See https://cnfl.io/queries for more info.",
         "status": 400
       }
     }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -198,7 +198,7 @@
       ]
     },
     {
-      "name": "pull query on `CREATE TABLE` table should fail",
+      "name": "pull query on `CREATE TABLE` table should fail ",
       "statements": [
         "CREATE TABLE USERS (id BIGINT PRIMARY KEY, USER_TIMESTAMP BIGINT, GENDER VARCHAR, REGION_ID VARCHAR) WITH (KAFKA_TOPIC = 'my-users-topic', VALUE_FORMAT = 'JSON', PARTITIONS=1);",
         "SELECT * FROM USERS;"

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -1,0 +1,148 @@
+  {
+  "comments": [
+    "Tests covering Pull queries of materialized using CTAS tables"
+  ],
+  "tests": [
+    {
+      "name": "select * against mat table",
+      "statements": [
+        "CREATE TABLE users (id BIGINT PRIMARY KEY,usertimestamp BIGINT,gender VARCHAR,region_id VARCHAR) WITH (KAFKA_TOPIC = 'users_topic',VALUE_FORMAT = 'JSON',PARTITIONS=1);",
+        "CREATE TABLE queriable_users AS SELECT * from users;",
+        "SELECT * FROM queriable_users;"
+      ],
+      "inputs": [
+        {"topic": "users_topic", "timestamp": 12345, "key": 1, "value": {"usertimestamp": 1000, "gender":  "m", "region_id": "w"}},
+        {"topic": "users_topic", "timestamp": 13345, "key": 2, "value": {"usertimestamp": 2000, "gender":  "f", "region_id": "e"}},
+        {"topic": "users_topic", "timestamp": 14345, "key": 3, "value": {"usertimestamp": 3000, "gender":  "f", "region_id": "n"}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` BIGINT KEY, `USERTIMESTAMP` BIGINT, `GENDER` STRING, `REGION_ID` STRING"}},
+          {"row":{"columns":[1,1000,"m","w"]}},
+          {"row":{"columns":[2,2000,"f","e"]}},
+          {"row":{"columns":[3,3000,"f","n"]}}
+        ]}
+      ]
+    },
+    {
+      "name": "select * against mat table key lookup",
+      "statements": [
+        "CREATE TABLE users (id BIGINT PRIMARY KEY,usertimestamp BIGINT,gender VARCHAR,region_id VARCHAR) WITH (KAFKA_TOPIC = 'users_topic',VALUE_FORMAT = 'JSON',PARTITIONS=1);",
+        "CREATE TABLE queriable_users AS SELECT * from users;",
+        "SELECT * FROM queriable_users where id=2;"
+      ],
+      "inputs": [
+        {"topic": "users_topic", "timestamp": 12345, "key": 1, "value": {"usertimestamp": 1000, "gender":  "m", "region_id": "w"}},
+        {"topic": "users_topic", "timestamp": 13345, "key": 2, "value": {"usertimestamp": 2000, "gender":  "f", "region_id": "e"}},
+        {"topic": "users_topic", "timestamp": 14345, "key": 3, "value": {"usertimestamp": 3000, "gender":  "f", "region_id": "n"}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` BIGINT KEY, `USERTIMESTAMP` BIGINT, `GENDER` STRING, `REGION_ID` STRING"}},
+          {"row":{"columns":[2,2000,"f","e"]}}
+        ]}
+      ]
+    },
+    {
+      "name": "select * against mat table windowed table scan",
+      "statements": [
+        "CREATE TABLE users (ID BIGINT PRIMARY KEY, USERTIMESTAMP BIGINT,gender VARCHAR,region_id VARCHAR) WITH (KAFKA_TOPIC = 'users_topic',VALUE_FORMAT = 'JSON',PARTITIONS=1);",
+        "CREATE TABLE queriable_users AS SELECT ID, COUNT(*) AS COUNT from users GROUP BY ID;",
+        "SELECT * FROM queriable_users WHERE ID=2;",
+        "SELECT * FROM queriable_users WHERE ID=1234567;"
+      ],
+      "inputs": [
+        {"topic": "users_topic", "timestamp": 12345, "key": 1, "value": {"usertimestamp": 1000, "gender":  "m", "region_id": "w"}},
+        {"topic": "users_topic", "timestamp": 13345, "key": 2, "value": {"usertimestamp": 2000, "gender":  "f", "region_id": "e"}},
+        {"topic": "users_topic", "timestamp": 14345, "key": 3, "value": {"usertimestamp": 3000, "gender":  "f", "region_id": "n"}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[2,1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` BIGINT KEY, `COUNT` BIGINT"}}
+        ]}
+      ]
+    },
+    {
+      "name": "select star with projection",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, GRADE STRING, RANK INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE NEW_INPUT AS SELECT ID, CONCAT(GRADE, '+'), RANK * 2 FROM INPUT;",
+        "SELECT * FROM NEW_INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12346, "key": "11", "value": {"GRADE": "A", "RANK": 1}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"GRADE": "B", "RANK": 2}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `KSQL_COL_0` STRING, `KSQL_COL_1` INTEGER"}},
+          {"row":{"columns":["11", "A+", 2]}},
+          {"row":{"columns":["10", "B+", 4]}}
+        ]}
+
+      ]
+    },
+    {
+      "name": "select star with projection and filter",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, GRADE STRING, RANK INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE NEW_INPUT AS SELECT ID, CONCAT(GRADE, '+'), RANK * 2 FROM INPUT;",
+        "SELECT * FROM NEW_INPUT WHERE ID='11';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12346, "key": "11", "value": {"GRADE": "A", "RANK": 1}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"GRADE": "B", "RANK": 2}},
+        {"topic": "test_topic", "timestamp": 12389, "key": "12", "value": {"GRADE": "C", "RANK": 3}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `KSQL_COL_0` STRING, `KSQL_COL_1` INTEGER"}},
+          {"row":{"columns":["11", "A+", 2]}}
+        ]}
+
+      ]
+    },
+    {
+      "name": "select with projection table scan and key lookup",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, GRADE STRING, RANK INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE NEW_INPUT AS SELECT ID, CONCAT(GRADE, '+'), RANK * 2 AS DOUBLE_RANK FROM INPUT;",
+        "SELECT ID, DOUBLE_RANK FROM NEW_INPUT;",
+        "SELECT ID, DOUBLE_RANK FROM NEW_INPUT WHERE ID='11';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12346, "key": "11", "value": {"GRADE": "A", "RANK": 1}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"GRADE": "B", "RANK": 2}},
+        {"topic": "test_topic", "timestamp": 12389, "key": "12", "value": {"GRADE": "C", "RANK": 3}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `DOUBLE_RANK` INTEGER"}},
+          {"row":{"columns":["11", 2]}},
+          {"row":{"columns":["10", 4]}},
+          {"row":{"columns":["12", 6]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `DOUBLE_RANK` INTEGER"}},
+          {"row":{"columns":["11", 2]}}
+        ]}
+      ]
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -212,7 +212,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Can't pull from `INNER_JOIN` as it's not a materialized table. See https://cnfl.io/queries for more info.",
+        "message": "The `INNER_JOIN` table isn't queriable. To derive a queriable table, you can do 'CREATE TABLE QUERIABLE_INNER_JOIN AS SELECT * FROM INNER_JOIN. See https://cnfl.io/queries for more info.",
         "status": 400
       }
     },
@@ -227,7 +227,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Can't pull from `USERS` as it's not a materialized table. See https://cnfl.io/queries for more info.",
+        "message": "The `USERS` table isn't queriable. To derive a queriable table, you can do 'CREATE TABLE QUERIABLE_USERS AS SELECT * FROM USERS. See https://cnfl.io/queries for more info.",
         "status": 400
       }
     }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -196,6 +196,21 @@
           {"row":{"columns":[90,"ninety",90,"a",10]}}
         ]}
       ]
+    },
+    {
+      "name": "pull query on `CREATE TABLE` table should fail",
+      "statements": [
+        "CREATE TABLE USERS (id BIGINT PRIMARY KEY, USER_TIMESTAMP BIGINT, GENDER VARCHAR, REGION_ID VARCHAR) WITH (KAFKA_TOPIC = 'my-users-topic', VALUE_FORMAT = 'JSON', PARTITIONS=1);",
+        "SELECT * FROM USERS;"
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}}
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Can't pull from `USERS` as it's not a materialized table. See https://cnfl.io/queries for more info.",
+        "status": 400
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -1,4 +1,4 @@
-  {
+{
   "comments": [
     "Tests covering Pull queries of materialized using CTAS tables"
   ],
@@ -141,6 +141,59 @@
         {"query": [
           {"header":{"schema":"`ID` STRING KEY, `DOUBLE_RANK` INTEGER"}},
           {"row":{"columns":["11", 2]}}
+        ]}
+      ]
+    },
+    {
+      "name": "select with projection and IN",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, GRADE STRING, RANK INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE NEW_INPUT AS SELECT ID, CONCAT(GRADE, '+'), RANK * 2 AS DOUBLE_RANK FROM INPUT;",
+        "SELECT ID, DOUBLE_RANK FROM NEW_INPUT WHERE ID IN ('11', '12');"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12346, "key": "11", "value": {"GRADE": "A", "RANK": 1}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"GRADE": "B", "RANK": 2}},
+        {"topic": "test_topic", "timestamp": 12389, "key": "12", "value": {"GRADE": "C", "RANK": 3}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `DOUBLE_RANK` INTEGER"}},
+          {"row":{"columns":["11", 2]}},
+          {"row":{"columns":["12", 6]}}
+        ]}
+      ]
+    },
+    {
+      "name": "table table inner join",
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='json');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='json');",
+        "CREATE TABLE INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;",
+        "CREATE TABLE INNER_JOIN_MAT AS SELECT * FROM INNER_JOIN;",
+        "SELECT * FROM INNER_JOIN_MAT;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "left_topic", "key": 90, "value": {"NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 100, "value": {"NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "right_topic", "key": 90, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"F1": "c", "F2": 20}, "timestamp": 15500},
+        {"topic": "right_topic", "key": 500, "value": {"F1": "D", "F2": 500}, "timestamp": 15555}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`T_ID` BIGINT KEY, `NAME` STRING, `VALUE` BIGINT, `F1` STRING, `F2` BIGINT"}},
+          {"row":{"columns":[100,"100",5,"c",20]}},
+          {"row":{"columns":[0,"zero",0,"blah",50]}},
+          {"row":{"columns":[90,"ninety",90,"a",10]}}
         ]}
       ]
     }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -198,7 +198,7 @@
       ]
     },
     {
-      "name": "table table inner join should fail",
+      "name": "table table inner join should fail as the join result is not materialized",
       "statements": [
         "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='json');",
         "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='json');",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-ctas-materialized.json
@@ -198,6 +198,25 @@
       ]
     },
     {
+      "name": "table table inner join should fail",
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='json');",
+        "CREATE TABLE TEST_TABLE (ID BIGINT PRIMARY KEY, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='json');",
+        "CREATE TABLE INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;",
+        "SELECT * FROM INNER_JOIN;"
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}}
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Can't pull from `INNER_JOIN` as it's not a materialized table. See https://cnfl.io/queries for more info.",
+        "status": 400
+      }
+    },
+    {
       "name": "pull query on `CREATE TABLE` table should fail ",
       "statements": [
         "CREATE TABLE USERS (id BIGINT PRIMARY KEY, USER_TIMESTAMP BIGINT, GENDER VARCHAR, REGION_ID VARCHAR) WITH (KAFKA_TOPIC = 'my-users-topic', VALUE_FORMAT = 'JSON', PARTITIONS=1);",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1088,7 +1088,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "The `X` table isn't queriable. To derive a queriable table, you can do 'CREATE TABLE QUERIABLE_X AS SELECT * FROM X. See https://cnfl.io/queries for more info.",
+        "message": "The `X` table isn't queryable. To derive a queryable table, you can do 'CREATE TABLE QUERYABLE_X AS SELECT * FROM X'. See https://cnfl.io/queries for more info.",
         "status": 400
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1088,7 +1088,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "The `X` table isn't queriable. To derive a queriable table, you can do 'CREATE TABLE QUERIABLE_X AS SELECT * FROM X. See https://cnfl.io/queries for more info.'t pull from `X` as it's not a materialized table.",
+        "message": "The `X` table isn't queriable. To derive a queriable table, you can do 'CREATE TABLE QUERIABLE_X AS SELECT * FROM X. See https://cnfl.io/queries for more info.",
         "status": 400
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2624,24 +2624,6 @@
           {"row":{"columns":[101, 3]}}
         ]}
       ]
-    },
-    {
-      "name": "should give good error message when querying a stream with multiple input queries",
-      "statements": [
-        "CREATE STREAM tweets_01 (id varchar key, contents varchar) with (kafka_topic='tweets', format='json', partitions=1);",
-        "CREATE STREAM tweets_02 (id varchar key, contents varchar) with (kafka_topic='tweets', format='json', partitions=1);",
-        "CREATE STREAM ALL_TWEETS WITH (KAFKA_TOPIC='ALL_TWEETS', PARTITIONS=1, REPLICAS=1) AS SELECT * FROM tweets_01;",
-        "INSERT INTO ALL_TWEETS SELECT * FROM TWEETS_02;",
-        "SELECT * FROM ALL_TWEETS WHERE ID = '10';"
-      ],
-      "properties": {
-        "ksql.query.pull.table.scan.enabled":  false
-      },
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Add EMIT CHANGES if you intended to issue a push query.",
-        "status": 400
-      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1088,7 +1088,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Can't pull from `X` as it's not a materialized table.",
+        "message": "The `X` table isn't queriable. To derive a queriable table, you can do 'CREATE TABLE QUERIABLE_X AS SELECT * FROM X. See https://cnfl.io/queries for more info.'t pull from `X` as it's not a materialized table.",
         "status": 400
       }
     },
@@ -2624,6 +2624,24 @@
           {"row":{"columns":[101, 3]}}
         ]}
       ]
+    },
+    {
+      "name": "should give good error message when querying a stream with multiple input queries",
+      "statements": [
+        "CREATE STREAM tweets_01 (id varchar key, contents varchar) with (kafka_topic='tweets', format='json', partitions=1);",
+        "CREATE STREAM tweets_02 (id varchar key, contents varchar) with (kafka_topic='tweets', format='json', partitions=1);",
+        "CREATE STREAM ALL_TWEETS WITH (KAFKA_TOPIC='ALL_TWEETS', PARTITIONS=1, REPLICAS=1) AS SELECT * FROM tweets_01;",
+        "INSERT INTO ALL_TWEETS SELECT * FROM TWEETS_02;",
+        "SELECT * FROM ALL_TWEETS WHERE ID = '10';"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Add EMIT CHANGES if you intended to issue a push query.",
+        "status": 400
+      }
     }
   ]
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -206,7 +206,7 @@ public final class SourceBuilder {
         ktable,
         buildSchema(source, false),
         ExecutionKeyFactory.unwindowed(buildContext),
-        MaterializationInfo.builder(stateStoreName, buildSchema(source, false))
+        MaterializationInfo.builder(stateStoreName, physicalSchema.logicalSchema())
     );
   }
 
@@ -261,7 +261,7 @@ public final class SourceBuilder {
         ktable,
         buildSchema(source, true),
         ExecutionKeyFactory.windowed(buildContext, windowInfo),
-        MaterializationInfo.builder(stateStoreName, buildSchema(source, true))
+        MaterializationInfo.builder(stateStoreName, physicalSchema.logicalSchema())
     );
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -14,12 +14,11 @@
 
 package io.confluent.ksql.execution.streams;
 
-import static java.util.Objects.requireNonNull;
-
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
+import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
 import io.confluent.ksql.execution.plan.KStreamHolder;
@@ -49,6 +48,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -201,10 +201,11 @@ public final class SourceBuilder {
         planInfo
     );
 
-    return KTableHolder.unmaterialized(
+    return KTableHolder.materialized(
         ktable,
         buildSchema(source, false),
-        ExecutionKeyFactory.unwindowed(buildContext)
+        ExecutionKeyFactory.unwindowed(buildContext),
+        MaterializationInfo.builder(stateStoreName, buildSchema(source, false))
     );
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.streams;
 
+import static java.util.Objects.requireNonNull;
+
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.context.QueryContext;
@@ -48,7 +50,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.kafka.clients.consumer.ConsumerConfig;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -256,10 +256,11 @@ public final class SourceBuilder {
         planInfo
     );
 
-    return KTableHolder.unmaterialized(
+    return KTableHolder.materialized(
         ktable,
         buildSchema(source, true),
-        ExecutionKeyFactory.windowed(buildContext, windowInfo)
+        ExecutionKeyFactory.windowed(buildContext, windowInfo),
+        MaterializationInfo.builder(stateStoreName, buildSchema(source, true))
     );
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import java.util.Optional;
 import org.apache.kafka.streams.kstream.KTable;
 
 public final class TableTableJoinBuilder {
@@ -53,6 +52,9 @@ public final class TableTableJoinBuilder {
         throw new IllegalStateException("invalid join type");
     }
 
-    return left.withTable(result, joinParams.getSchema(), Optional.empty());
+    return KTableHolder.unmaterialized(
+            result,
+            joinParams.getSchema(),
+            left.getExecutionKeyFactory());
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.Optional;
 import org.apache.kafka.streams.kstream.KTable;
 
 public final class TableTableJoinBuilder {
@@ -52,6 +53,6 @@ public final class TableTableJoinBuilder {
         throw new IllegalStateException("invalid join type");
     }
 
-    return left.withTable(result, joinParams.getSchema());
+    return left.withTable(result, joinParams.getSchema(), Optional.empty());
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -116,7 +116,7 @@ public class StreamTableJoinBuilderTest {
     when(left.build(any(), eq(planInfo))).thenReturn(
         new KStreamHolder<>(leftKStream, LEFT_SCHEMA, executionKeyFactory));
     when(right.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.unmaterialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory));
+        KTableHolder.materialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory, null));
 
     when(leftKStream.leftJoin(any(KTable.class), any(), any())).thenReturn(resultStream);
     when(leftKStream.join(any(KTable.class), any(), any())).thenReturn(resultStream);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -1,5 +1,6 @@
 package io.confluent.ksql.execution.streams;
 
+import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import static io.confluent.ksql.execution.plan.StreamStreamJoin.LEGACY_KEY_COL;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWKEY_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -102,6 +103,8 @@ public class StreamTableJoinBuilderTest {
   private Serde<GenericRow> leftSerde;
   @Mock
   private PlanInfo planInfo;
+  @Mock
+  private MaterializationInfo.Builder materializationBuilder;
 
   private PlanBuilder planBuilder;
   private StreamTableJoin<Struct> join;
@@ -116,7 +119,7 @@ public class StreamTableJoinBuilderTest {
     when(left.build(any(), eq(planInfo))).thenReturn(
         new KStreamHolder<>(leftKStream, LEFT_SCHEMA, executionKeyFactory));
     when(right.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.materialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory, null));
+        KTableHolder.materialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory, materializationBuilder));
 
     when(leftKStream.leftJoin(any(KTable.class), any(), any())).thenReturn(resultStream);
     when(leftKStream.join(any(KTable.class), any(), any())).thenReturn(resultStream);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -79,9 +79,9 @@ public class TableTableJoinBuilderTest {
   @Before
   public void init() {
     when(left.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.unmaterialized(leftKTable, LEFT_SCHEMA, executionKeyFactory));
+        KTableHolder.materialized(leftKTable, LEFT_SCHEMA, executionKeyFactory, null));
     when(right.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.unmaterialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory));
+        KTableHolder.materialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory, null));
 
     when(leftKTable.leftJoin(any(KTable.class), any())).thenReturn(resultKTable);
     when(leftKTable.outerJoin(any(KTable.class), any())).thenReturn(resultKTable);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -1,5 +1,6 @@
 package io.confluent.ksql.execution.streams;
 
+import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import static io.confluent.ksql.execution.plan.StreamStreamJoin.LEGACY_KEY_COL;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWKEY_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,6 +72,8 @@ public class TableTableJoinBuilderTest {
   private ExecutionKeyFactory<Struct> executionKeyFactory;
   @Mock
   private PlanInfo planInfo;
+  @Mock
+  private MaterializationInfo.Builder materializationBuilder;
 
   private PlanBuilder planBuilder;
   private TableTableJoin<Struct> join;
@@ -79,9 +82,9 @@ public class TableTableJoinBuilderTest {
   @Before
   public void init() {
     when(left.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.materialized(leftKTable, LEFT_SCHEMA, executionKeyFactory, null));
+        KTableHolder.materialized(leftKTable, LEFT_SCHEMA, executionKeyFactory, materializationBuilder));
     when(right.build(any(), eq(planInfo))).thenReturn(
-        KTableHolder.materialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory, null));
+        KTableHolder.materialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory, materializationBuilder));
 
     when(leftKTable.leftJoin(any(KTable.class), any())).thenReturn(resultKTable);
     when(leftKTable.outerJoin(any(KTable.class), any())).thenReturn(resultKTable);


### PR DESCRIPTION
### Description 
Introduces materialization support for tables using CTAS to make tables queryable. 
We can make tables queryable by using:
`CREATE TABLE QUERYABLE_TABLE AS SELECT...`

This would help fix #4614 by adding a more helpful error message as well.

### Testing done 
- Unit tests
- Query translation tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

