### PR TITLE
fix: Table Scan: Filters out StreamsMetadata for wrong subtopology

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/MaterializationProviderBuilderFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/MaterializationProviderBuilderFactory.java
@@ -31,14 +31,15 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
 
 public final class MaterializationProviderBuilderFactory {
   // Interface used for Function alias
   public interface MaterializationProviderBuilder
-      extends Function<KafkaStreams, Optional<MaterializationProvider>> {
+      extends BiFunction<KafkaStreams, Topology, Optional<MaterializationProvider>> {
   }
 
   private final KsqlConfig ksqlConfig;
@@ -67,8 +68,9 @@ public final class MaterializationProviderBuilderFactory {
       final Map<String, Object> streamsProperties,
       final String applicationId
   ) {
-    return (kafkaStreams) -> buildMaterializationProvider(
+    return (kafkaStreams, topology) -> buildMaterializationProvider(
         kafkaStreams,
+        topology,
         materializationInfo,
         querySchema,
         keyFormat,
@@ -79,6 +81,7 @@ public final class MaterializationProviderBuilderFactory {
 
   private Optional<MaterializationProvider> buildMaterializationProvider(
       final KafkaStreams kafkaStreams,
+      final Topology topology,
       final MaterializationInfo materializationInfo,
       final PhysicalSchema schema,
       final KeyFormat keyFormat,
@@ -99,6 +102,7 @@ public final class MaterializationProviderBuilderFactory {
         .create(
             materializationInfo.stateStoreName(),
             kafkaStreams,
+            topology,
             materializationInfo.getStateStoreSchema(),
             keySerializer,
             keyFormat.getWindowInfo(),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -126,7 +126,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
     setUncaughtExceptionHandler(this::uncaughtHandler);
 
     this.materializationProvider = materializationProviderBuilder
-        .flatMap(builder -> builder.apply(getKafkaStreams()));
+        .flatMap(builder -> builder.apply(getKafkaStreams(), getTopology()));
   }
 
   @Override
@@ -193,7 +193,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
 
     final KafkaStreams newKafkaStreams = buildKafkaStreams();
     materializationProvider = materializationProviderBuilder.flatMap(
-        builder -> builder.apply(newKafkaStreams));
+        builder -> builder.apply(newKafkaStreams, getTopology()));
 
     resetKafkaStreams(newKafkaStreams);
     start();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -196,7 +196,8 @@ public class QueryExecutorTest {
     when(materializationBuilder.build()).thenReturn(materializationInfo);
     when(materializationInfo.getStateStoreSchema()).thenReturn(aggregationSchema);
     when(materializationInfo.stateStoreName()).thenReturn(STORE_NAME);
-    when(ksMaterializationFactory.create(any(), any(), any(), any(), any(), any(), any(), any()))
+    when(ksMaterializationFactory.create(any(), any(), any(), any(), any(), any(), any(), any(),
+        any()))
         .thenReturn(Optional.of(ksMaterialization));
     when(ksqlMaterializationFactory.create(any(), any(), any(), any())).thenReturn(materialization);
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
@@ -346,6 +347,7 @@ public class QueryExecutorTest {
     verify(ksMaterializationFactory).create(
         eq(STORE_NAME),
         same(kafkaStreams),
+        same(topology),
         same(aggregationSchema),
         any(),
         eq(Optional.empty()),

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -95,7 +95,7 @@ public class PersistentQueryMetadataTest {
   public void setUp()  {
     when(kafkaStreamsBuilder.build(any(), any())).thenReturn(kafkaStreams);
     when(physicalSchema.logicalSchema()).thenReturn(mock(LogicalSchema.class));
-    when(materializationProviderBuilder.apply(kafkaStreams))
+    when(materializationProviderBuilder.apply(kafkaStreams, topology))
         .thenReturn(Optional.of(materializationProvider));
 
     query = new PersistentQueryMetadata(
@@ -142,7 +142,7 @@ public class PersistentQueryMetadataTest {
 
     // Given:
     when(kafkaStreamsBuilder.build(any(), any())).thenReturn(newKafkaStreams);
-    when(materializationProviderBuilder.apply(newKafkaStreams))
+    when(materializationProviderBuilder.apply(newKafkaStreams, topology))
         .thenReturn(Optional.of(newMaterializationProvider));
 
     // When:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataTest.java
@@ -89,7 +89,7 @@ public class SandboxedPersistentQueryMetadataTest {
   public void setUp() {
     when(kafkaStreamsBuilder.build(any(), any())).thenReturn(kafkaStreams);
     when(physicalSchema.logicalSchema()).thenReturn(mock(LogicalSchema.class));
-    when(materializationProviderBuilder.apply(kafkaStreams))
+    when(materializationProviderBuilder.apply(kafkaStreams, topology))
         .thenReturn(Optional.of(materializationProvider));
 
     query = new PersistentQueryMetadata(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -350,7 +350,8 @@ public class PullQueryFunctionalTest {
   @Test
   public void shouldDoTableScanBothNodes_multipleSubtopologies() {
     // Given:
-    // The 'a-' prefix creates a repartition and and therefore 2 subtopologies
+    // The 'a-' prefix creates a repartition and and therefore 2 subtopologies.  This is important
+    // to exercise the logic that filters source topics by subtopology for table scans.
     makeAdminRequest(
         "CREATE TABLE " + output + " AS"
             + " SELECT 'a-' + " + USER_PROVIDER.key() + " AS USERID, COUNT(1) AS COUNT FROM "

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -129,6 +129,7 @@ public class PullQueryFunctionalTest {
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + "num.standby.replicas", 1)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + "cache.max.bytes.buffering", 10000)
+      .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)
       .build();
 
   private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
@@ -141,6 +142,7 @@ public class PullQueryFunctionalTest {
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + "num.standby.replicas", 1)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + "cache.max.bytes.buffering", 10000)
+      .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)
       .build();
 
   @ClassRule
@@ -343,6 +345,117 @@ public class PullQueryFunctionalTest {
             BASE_TIME + ONE_SECOND, // WINDOWEND
             1                       // COUNT
         )));
+  }
+
+  @Test
+  public void shouldDoTableScanBothNodes_multipleSubtopologies() {
+    // Given:
+    // The 'a-' prefix creates a repartition and and therefore 2 subtopologies
+    makeAdminRequest(
+        "CREATE TABLE " + output + " AS"
+            + " SELECT 'a-' + " + USER_PROVIDER.key() + " AS USERID, COUNT(1) AS COUNT FROM "
+            + USERS_STREAM
+            + " GROUP BY 'a-' + " + USER_PROVIDER.key() + ";"
+    );
+
+    waitForTableRows();
+
+    final String sql = "SELECT * FROM " + output + ";";
+
+    // When:
+    final List<StreamedRow> rows_0 = makePullQueryRequest(REST_APP_0, sql);
+    final List<StreamedRow> rows_1 = makePullQueryRequest(REST_APP_1, sql);
+
+    // Then:
+    assertThat(rows_0, hasSize(HEADER + 5));
+    assertThat(rows_1, is(matchersRowsAnyOrder(rows_0)));
+    assertThat(rows_0.get(1).getRow(), is(not(Optional.empty())));
+    Set<String> hosts1 = rows_0.subList(1, rows_0.size()).stream()
+        .map(sr -> sr.getSourceHost().map(KsqlHostInfoEntity::toString).orElse("unknown"))
+        .collect(Collectors.toSet());
+    assertThat(hosts1, containsInAnyOrder("localhost:8188", "localhost:8189"));
+    Set<String> hosts2 = rows_0.subList(1, rows_0.size()).stream()
+        .map(sr -> sr.getSourceHost().map(KsqlHostInfoEntity::toString).orElse("unknown"))
+        .collect(Collectors.toSet());
+    assertThat(hosts2, containsInAnyOrder("localhost:8188", "localhost:8189"));
+
+    List<List<?>> rows = rows_0.subList(1, rows_0.size()).stream()
+        .map(sr -> sr.getRow().get().getColumns())
+        .collect(Collectors.toList());
+    assertThat(rows, containsInAnyOrder(
+        ImmutableList.of("a-" + USER_PROVIDER.getStringKey(0), 1),
+        ImmutableList.of("a-" + USER_PROVIDER.getStringKey(1), 1),
+        ImmutableList.of("a-" + USER_PROVIDER.getStringKey(2), 1),
+        ImmutableList.of("a-" + USER_PROVIDER.getStringKey(3), 1),
+        ImmutableList.of("a-" + USER_PROVIDER.getStringKey(4), 1)));
+  }
+
+  @Test
+  public void shouldDoTableScanWindowedBothNodes() {
+    // Given:
+    makeAdminRequest(
+        "CREATE TABLE " + output + " AS"
+            + " SELECT " +  USER_PROVIDER.key() + ", COUNT(1) AS COUNT FROM " + USERS_STREAM
+            + " WINDOW TUMBLING (SIZE 1 SECOND)"
+            + " GROUP BY " + USER_PROVIDER.key() + ";"
+    );
+
+    waitForTableRows();
+
+    final String sql = "SELECT * FROM " + output + ";";
+
+    // When:
+    final List<StreamedRow> rows_0 = makePullQueryRequest(REST_APP_0, sql);
+    final List<StreamedRow> rows_1 = makePullQueryRequest(REST_APP_1, sql);
+
+    // Then:
+    assertThat(rows_0, hasSize(HEADER + 5));
+    assertThat(rows_1, is(matchersRowsAnyOrder(rows_0)));
+    assertThat(rows_0.get(1).getRow(), is(not(Optional.empty())));
+    Set<String> hosts1 = rows_0.subList(1, rows_0.size()).stream()
+        .map(sr -> sr.getSourceHost().map(KsqlHostInfoEntity::toString).orElse("unknown"))
+        .collect(Collectors.toSet());
+    assertThat(hosts1, containsInAnyOrder("localhost:8188", "localhost:8189"));
+    Set<String> hosts2 = rows_0.subList(1, rows_0.size()).stream()
+        .map(sr -> sr.getSourceHost().map(KsqlHostInfoEntity::toString).orElse("unknown"))
+        .collect(Collectors.toSet());
+    assertThat(hosts2, containsInAnyOrder("localhost:8188", "localhost:8189"));
+
+    List<List<?>> rows = rows_0.subList(1, rows_0.size()).stream()
+        .map(sr -> sr.getRow().get().getColumns())
+        .collect(Collectors.toList());
+    assertThat(rows, containsInAnyOrder(
+        ImmutableList.of(
+            USER_PROVIDER.getStringKey(0),  // USERID
+            BASE_TIME,                      // WINDOWSTART
+            BASE_TIME + ONE_SECOND,         // WINDOWEND
+            1                               // COUNT
+        ),
+        ImmutableList.of(
+            USER_PROVIDER.getStringKey(1),  // USERID
+            BASE_TIME,                      // WINDOWSTART
+            BASE_TIME + ONE_SECOND,         // WINDOWEND
+            1                               // COUNT
+        ),
+        ImmutableList.of(
+            USER_PROVIDER.getStringKey(2),  // USERID
+            BASE_TIME,                      // WINDOWSTART
+            BASE_TIME + ONE_SECOND,         // WINDOWEND
+            1                               // COUNT
+        ),
+        ImmutableList.of(
+            USER_PROVIDER.getStringKey(3),  // USERID
+            BASE_TIME,                      // WINDOWSTART
+            BASE_TIME + ONE_SECOND,         // WINDOWEND
+            1                               // COUNT
+        ),
+        ImmutableList.of(
+            USER_PROVIDER.getStringKey(4),  // USERID
+            BASE_TIME,                      // WINDOWSTART
+            BASE_TIME + ONE_SECOND,         // WINDOWEND
+            1                               // COUNT
+        )
+    ));
   }
 
   private static List<StreamedRow> makePullQueryRequest(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -189,8 +189,6 @@ public final class KsLocator implements Locator {
       streamsMetadata.topicPartitions().forEach(
           tp -> {
             if (sourceTopics.contains(tp.topic())) {
-              LOG.info("Active: store: " + stateStoreName + " topic partition: " + tp + " host: "
-                  + streamsMetadata.hostInfo());
               activeHostByPartition.put(tp.partition(), streamsMetadata.hostInfo());
             }
           });
@@ -198,8 +196,6 @@ public final class KsLocator implements Locator {
       streamsMetadata.standbyTopicPartitions().forEach(
           tp -> {
             if (sourceTopics.contains(tp.topic())) {
-              LOG.info("Standby: store: " + stateStoreName + " topic partition: " + tp + " host: "
-                  + streamsMetadata.hostInfo());
               standbyHostsByPartition.computeIfAbsent(tp.partition(), p -> new HashSet<>());
               standbyHostsByPartition.get(tp.partition()).add(streamsMetadata.hostInfo());
             }
@@ -222,10 +218,6 @@ public final class KsLocator implements Locator {
           Collections.emptySet());
       metadataList.add(
           new PartitionMetadata(activeHost, standbyHosts, partition, Optional.empty()));
-    }
-
-    for (PartitionMetadata pm : metadataList) {
-      LOG.info("Got metadata partition: " + pm.getPartition() + " active: " + pm.getActiveHost() + " standbys: " + pm.getStandbyHosts());
     }
     return metadataList;
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -81,7 +81,7 @@ public final class KsLocator implements Locator {
       final String applicationId
   ) {
     this.kafkaStreams = requireNonNull(kafkaStreams, "kafkaStreams");
-    this.topology = topology;
+    this.topology = requireNonNull(topology, "topology");
     this.keySerializer = requireNonNull(keySerializer, "keySerializer");
     this.stateStoreName = requireNonNull(stateStoreName, "stateStoreName");
     this.localHost = requireNonNull(localHost, "localHost");

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -207,6 +207,8 @@ public final class KsLocator implements Locator {
 
       streamsMetadata.standbyTopicPartitions().forEach(
           tp -> {
+            // Ideally, we'd also throw an exception if we found a mis-mapping for the standbys, but
+            // with multiple per partition, we can't easy sanity check.
             if (sourceTopicSuffixes.stream().anyMatch(suffix -> tp.topic().endsWith(suffix))) {
               standbyHostsByPartition.computeIfAbsent(tp.partition(), p -> new HashSet<>());
               standbyHostsByPartition.get(tp.partition()).add(streamsMetadata.hostInfo());

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -196,7 +196,12 @@ public final class KsLocator implements Locator {
       streamsMetadata.topicPartitions().forEach(
           tp -> {
             if (sourceTopicSuffixes.stream().anyMatch(suffix -> tp.topic().endsWith(suffix))) {
-              activeHostByPartition.put(tp.partition(), streamsMetadata.hostInfo());
+              activeHostByPartition.compute(tp.partition(), (partition, hostInfo) -> {
+                if (hostInfo != null && !streamsMetadata.hostInfo().equals(hostInfo)) {
+                  throw new IllegalStateException("Should only be one active host per partition");
+                }
+                return streamsMetadata.hostInfo();
+              });
             }
           });
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactory.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
 
 /**
  * Factory class for {@link KsMaterialization}.
@@ -72,6 +73,7 @@ public final class KsMaterializationFactory {
   public Optional<KsMaterialization> create(
       final String stateStoreName,
       final KafkaStreams kafkaStreams,
+      final Topology topology,
       final LogicalSchema schema,
       final Serializer<GenericKey> keySerializer,
       final Optional<WindowInfo> windowInfo,
@@ -89,6 +91,7 @@ public final class KsMaterializationFactory {
     final KsLocator locator = locatorFactory.create(
         stateStoreName,
         kafkaStreams,
+        topology,
         keySerializer,
         localHost,
         applicationId
@@ -128,6 +131,7 @@ public final class KsMaterializationFactory {
     KsLocator create(
         String stateStoreName,
         KafkaStreams kafkaStreams,
+        Topology topology,
         Serializer<GenericKey> keySerializer,
         URL localHost,
         String applicationId

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -54,6 +54,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyDescription.Subtopology;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.StreamsMetadata;
 import org.junit.Before;
@@ -83,18 +85,27 @@ public class KsLocatorTest {
   private static final HostInfo ACTIVE_HOST_INFO = new HostInfo("remoteHost", 2345);
   private static final HostInfo STANDBY_HOST_INFO1 = new HostInfo("standby1", 1234);
   private static final HostInfo STANDBY_HOST_INFO2 = new HostInfo("standby2", 5678);
-  private static final TopicPartition TOPIC_PARTITION1 = new TopicPartition("foo", 0);
-  private static final TopicPartition TOPIC_PARTITION2 = new TopicPartition("foo", 1);
-  private static final TopicPartition TOPIC_PARTITION3 = new TopicPartition("foo", 2);
+  private static final String TOPIC_NAME = "foo";
+  private static final String FULL_TOPIC_NAME = APPLICATION_ID + "-" + TOPIC_NAME;
+  private static final String BAD_TOPIC_NAME = "bar";
+  private static final TopicPartition TOPIC_PARTITION1 = new TopicPartition(FULL_TOPIC_NAME, 0);
+  private static final TopicPartition TOPIC_PARTITION2 = new TopicPartition(FULL_TOPIC_NAME, 1);
+  private static final TopicPartition TOPIC_PARTITION3 = new TopicPartition(FULL_TOPIC_NAME, 2);
+  private static final TopicPartition BAD_TOPIC_PARTITION1 = new TopicPartition(BAD_TOPIC_NAME, 0);
+  private static final TopicPartition BAD_TOPIC_PARTITION2 = new TopicPartition(BAD_TOPIC_NAME, 1);
+  private static final TopicPartition BAD_TOPIC_PARTITION3 = new TopicPartition(BAD_TOPIC_NAME, 2);
   private static final StreamsMetadata HOST1_STREAMS_MD1 = new StreamsMetadata(ACTIVE_HOST_INFO,
-      ImmutableSet.of("state_store"), ImmutableSet.of(TOPIC_PARTITION1),
-      ImmutableSet.of("state_store"), ImmutableSet.of(TOPIC_PARTITION2, TOPIC_PARTITION3));
+      ImmutableSet.of(STORE_NAME), ImmutableSet.of(TOPIC_PARTITION1, BAD_TOPIC_PARTITION3),
+      ImmutableSet.of(STORE_NAME), ImmutableSet.of(TOPIC_PARTITION2, TOPIC_PARTITION3,
+      BAD_TOPIC_PARTITION1, BAD_TOPIC_PARTITION2));
   private static final StreamsMetadata HOST1_STREAMS_MD2 = new StreamsMetadata(STANDBY_HOST_INFO1,
-      ImmutableSet.of("state_store"), ImmutableSet.of(TOPIC_PARTITION2),
-      ImmutableSet.of("state_store"), ImmutableSet.of(TOPIC_PARTITION1, TOPIC_PARTITION3));
+      ImmutableSet.of(STORE_NAME), ImmutableSet.of(TOPIC_PARTITION2, BAD_TOPIC_PARTITION1),
+      ImmutableSet.of(STORE_NAME), ImmutableSet.of(TOPIC_PARTITION1, TOPIC_PARTITION3,
+      BAD_TOPIC_PARTITION2, BAD_TOPIC_PARTITION3));
   private static final StreamsMetadata HOST1_STREAMS_MD3 = new StreamsMetadata(STANDBY_HOST_INFO2,
-      ImmutableSet.of("state_store"), ImmutableSet.of(TOPIC_PARTITION3),
-      ImmutableSet.of("state_store"), ImmutableSet.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+      ImmutableSet.of(STORE_NAME), ImmutableSet.of(TOPIC_PARTITION3, BAD_TOPIC_PARTITION2),
+      ImmutableSet.of(STORE_NAME), ImmutableSet.of(TOPIC_PARTITION1, TOPIC_PARTITION2,
+      BAD_TOPIC_PARTITION1, BAD_TOPIC_PARTITION3));
 
   @Mock
   private KafkaStreams kafkaStreams;
@@ -110,6 +121,14 @@ public class KsLocatorTest {
   private RoutingFilter activeFilter;
   @Mock
   private RoutingOptions routingOptions;
+  @Mock
+  private TopologyDescription description;
+  @Mock
+  private Subtopology sub1;
+  @Mock
+  private TopologyDescription.Source source;
+  @Mock
+  private TopologyDescription.Processor processor;
 
   private KsLocator locator;
   private KsqlNode activeNode;
@@ -403,9 +422,13 @@ public class KsLocatorTest {
   @Test
   public void shouldFindAllPartitionsWhenNoKeys() {
     // Given:
+    when(topology.describe()).thenReturn(description);
+    when(description.subtopologies()).thenReturn(ImmutableSet.of(sub1));
+    when(sub1.nodes()).thenReturn(ImmutableSet.of(source, processor));
+    when(source.topicSet()).thenReturn(ImmutableSet.of(TOPIC_NAME));
+    when(processor.stores()).thenReturn(ImmutableSet.of(STORE_NAME));
     when(kafkaStreams.allMetadataForStore(any()))
         .thenReturn(ImmutableList.of(HOST1_STREAMS_MD1, HOST1_STREAMS_MD2, HOST1_STREAMS_MD3));
-    getActiveStandbyMetadata(SOME_KEY, 0, ACTIVE_HOST_INFO, STANDBY_HOST_INFO1);
 
     // When:
     final List<KsqlPartitionLocation> result = locator.locate(

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -53,6 +53,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.StreamsMetadata;
 import org.junit.Before;
@@ -98,6 +99,8 @@ public class KsLocatorTest {
   @Mock
   private KafkaStreams kafkaStreams;
   @Mock
+  private Topology topology;
+  @Mock
   private KeyQueryMetadata keyQueryMetadata;
   @Mock
   private Serializer<GenericKey> keySerializer;
@@ -121,7 +124,7 @@ public class KsLocatorTest {
 
   @Before
   public void setUp() {
-    locator = new KsLocator(STORE_NAME, kafkaStreams, keySerializer, LOCAL_HOST_URL,
+    locator = new KsLocator(STORE_NAME, kafkaStreams, topology, keySerializer, LOCAL_HOST_URL,
         APPLICATION_ID);
 
     activeNode = locator.asNode(ACTIVE_HOST);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactoryTest.java
@@ -41,6 +41,7 @@ import java.util.Optional;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,6 +62,8 @@ public class KsMaterializationFactoryTest {
 
   @Mock
   private KafkaStreams kafkaStreams;
+  @Mock
+  private Topology topology;
   @Mock
   private Serializer<GenericKey> keySerializer;
 
@@ -89,7 +92,7 @@ public class KsMaterializationFactoryTest {
         materializationFactory
     );
 
-    when(locatorFactory.create(any(), any(), any(), any(), any())).thenReturn(locator);
+    when(locatorFactory.create(any(), any(), any(), any(), any(), any())).thenReturn(locator);
     when(storeFactory.create(any(), any(), any(), any())).thenReturn(stateStore);
     when(materializationFactory.create(any(), any(), any())).thenReturn(materialization);
 
@@ -113,8 +116,8 @@ public class KsMaterializationFactoryTest {
 
     // When:
     final Optional<KsMaterialization> result = factory
-        .create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties,
-            ksqlConfig, APPLICATION_ID);
+        .create(STORE_NAME, kafkaStreams, topology, SCHEMA, keySerializer, Optional.empty(),
+            streamsProperties, ksqlConfig, APPLICATION_ID);
 
     // Then:
     assertThat(result, is(Optional.empty()));
@@ -123,13 +126,14 @@ public class KsMaterializationFactoryTest {
   @Test
   public void shouldBuildLocatorWithCorrectParams() {
     // When:
-    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties,
-        ksqlConfig, APPLICATION_ID);
+    factory.create(STORE_NAME, kafkaStreams, topology, SCHEMA, keySerializer, Optional.empty(),
+        streamsProperties, ksqlConfig, APPLICATION_ID);
 
     // Then:
     verify(locatorFactory).create(
         STORE_NAME,
         kafkaStreams,
+        topology,
         keySerializer,
         DEFAULT_APP_SERVER,
         APPLICATION_ID
@@ -139,8 +143,8 @@ public class KsMaterializationFactoryTest {
   @Test
   public void shouldBuildStateStoreWithCorrectParams() {
     // When:
-    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties,
-        ksqlConfig, APPLICATION_ID);
+    factory.create(STORE_NAME, kafkaStreams, topology, SCHEMA, keySerializer, Optional.empty(),
+        streamsProperties, ksqlConfig, APPLICATION_ID);
 
     // Then:
     verify(storeFactory).create(
@@ -158,8 +162,8 @@ public class KsMaterializationFactoryTest {
         Optional.of(WindowInfo.of(WindowType.SESSION, Optional.empty()));
 
     // When:
-    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, windowInfo, streamsProperties,
-        ksqlConfig, APPLICATION_ID);
+    factory.create(STORE_NAME, kafkaStreams, topology, SCHEMA, keySerializer, windowInfo,
+        streamsProperties, ksqlConfig, APPLICATION_ID);
 
     // Then:
     verify(materializationFactory).create(
@@ -173,8 +177,8 @@ public class KsMaterializationFactoryTest {
   public void shouldReturnMaterialization() {
     // When:
     final Optional<KsMaterialization> result = factory
-        .create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties,
-            ksqlConfig, APPLICATION_ID);
+        .create(STORE_NAME, kafkaStreams, topology, SCHEMA, keySerializer, Optional.empty(),
+            streamsProperties, ksqlConfig, APPLICATION_ID);
 
     // Then:
     assertThat(result,  is(Optional.of(materialization)));


### PR DESCRIPTION
### Description 
The call to `kafkaStreams.allMetadataForStore(stateStoreName)` returns metadata for all subtopologies associated with the store, including ones which don't actually contain the store.  The calling code assumed that it was for just one subtopology, so this resulted in a bug where TopicPartitions from the wrong subtopology could overwrite the intended one.

### Testing done 
Unit tests and manual testing with table scans in a multi node environment.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

