### PR TITLE
feat(migrations): implement `validate` command

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.tools.migrations.commands;
 
-import static io.confluent.ksql.tools.migrations.util.MigrationsUtil.MIGRATIONS_CONFIG_FILE;
-import static io.confluent.ksql.tools.migrations.util.MigrationsUtil.MIGRATIONS_DIR;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.MIGRATIONS_CONFIG_FILE;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.MIGRATIONS_DIR;
 
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
@@ -17,6 +17,21 @@ package io.confluent.ksql.tools.migrations.commands;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.help.Discussion;
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.api.client.BatchedQueryResult;
+import io.confluent.ksql.api.client.Client;
+import io.confluent.ksql.api.client.Row;
+import io.confluent.ksql.tools.migrations.MigrationConfig;
+import io.confluent.ksql.tools.migrations.MigrationException;
+import io.confluent.ksql.tools.migrations.MigrationsUtil;
+import io.confluent.ksql.util.KsqlException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +52,51 @@ public class ValidateMigrationsCommand extends BaseCommand {
 
   @Override
   protected int command() {
-    throw new UnsupportedOperationException();
+    if (!validateConfigFilePresent()) {
+      return 1;
+    }
+
+    final MigrationConfig config;
+    try {
+      config = MigrationConfig.load(configFile);
+    } catch (KsqlException | MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return 1;
+    }
+
+    return command(config, MigrationsUtil::getKsqlClient);
+  }
+
+  @VisibleForTesting
+  int command(
+      final MigrationConfig config,
+      final Function<MigrationConfig, Client> clientSupplier
+  ) {
+    final Client ksqlClient;
+    try {
+      ksqlClient = clientSupplier.apply(config);
+    } catch (MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return 1;
+    }
+
+    final boolean success;
+    try {
+      success = validate(config, ksqlClient);
+    } catch (MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return 1;
+    }
+
+    if (success) {
+      LOGGER.info("Successfully validated checksums for migrations that have already been applied");
+      ksqlClient.close();
+    } else {
+      ksqlClient.close();
+      return 1;
+    }
+
+    return 0;
   }
 
   @Override
@@ -45,4 +104,65 @@ public class ValidateMigrationsCommand extends BaseCommand {
     return null;
   }
 
+  /**
+   * @return true if validation passes, else false.
+   */
+  static boolean validate(final MigrationConfig config, final Client ksqlClient) {
+    String version = MetadataUtil.getCurrentVersion(config);
+    while (!version.equals(NONE_VERSION)) {
+      // TODO: combine with util helper to de-dup code?
+      final String migrationTableName = config
+          .getString(MigrationConfig.KSQL_MIGRATIONS_TABLE_NAME);
+      final BatchedQueryResult result = ksqlClient.executeQuery(
+          "SELECT checksum, previous FROM " + migrationTableName
+              + " WHERE version_key = 'CURRENT';");
+      final String expectedHash;
+      final String prevVersion;
+      try {
+        final List<Row> resultRows = result.get();
+        if (resultRows.size() == 0) {
+          throw new MigrationException(
+              "Failed to query state for migration with version " + version
+                  + ": no such migration is present in the migrations metadata table");
+        }
+        expectedHash = resultRows.get(0).getString(0);
+        prevVersion = resultRows.get(0).getString(1);
+      } catch (InterruptedException | ExecutionException e) {
+        throw new MigrationException(String.format(
+            "Failed to query state for migration with version %s: %s", version, e.getMessage()));
+      }
+
+      final String filename;
+      try {
+        filename = getFileNameForVersion(version);
+      } catch (MigrationException e) {
+        LOGGER.error("No migrations file found for version with status {}. Version: {}", MIGRATED,
+            version);
+        return false;
+      }
+      final String hash = computeHash(filename);
+      if (!expectedHash.equals(hash)) {
+        LOGGER.error("Migrations file found for version {} does not match the checksum saved "
+                + "for this version. Expected checksum: {}. Actual checksum: {}. File name: {}",
+            version, expectedHash, hash, filename);
+        return false;
+      }
+
+      version = prevVersion;
+    }
+
+    return true;
+  }
+
+  // TODO: move to util
+  public static String computeHash(final String filename) {
+    try {
+      final byte[] bytes = Files.readAllBytes( // TODO: replace with helper method
+          Paths.get(filename));
+      return new String(MessageDigest.getInstance("MD5").digest(bytes));
+    } catch (NoSuchAlgorithmException e) {
+      throw new MigrationException(String.format(
+          "Could not compute hash for file '%s': %s", filename, e.getMessage()));
+    }
+  }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.api.client.Row;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.MigrationException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 public final class MetadataUtil {
@@ -52,6 +53,107 @@ public final class MetadataUtil {
     } catch (InterruptedException | ExecutionException e) {
       throw new MigrationException(
           String.format("Could not query %s: %s", migrationTableName, e.getMessage()));
+    }
+  }
+
+  public static String getLatestMigratedVersion(
+      final MigrationConfig config,
+      final Client ksqlClient
+  ) {
+    final String currentVersion = MetadataUtil.getCurrentVersion(config, ksqlClient);
+    if (currentVersion.equals(MetadataUtil.NONE_VERSION)) {
+      return currentVersion;
+    }
+
+    final VersionInfo currentVersionInfo = getInfoForVersion(currentVersion, config, ksqlClient);
+    if (currentVersionInfo.state == MigrationState.MIGRATED) {
+      return currentVersion;
+    }
+
+    if (currentVersionInfo.prevVersion.equals(MetadataUtil.NONE_VERSION)) {
+      return MetadataUtil.NONE_VERSION;
+    }
+
+    final VersionInfo prevVersionInfo = getInfoForVersion(
+        currentVersionInfo.prevVersion,
+        config,
+        ksqlClient
+    );
+    validateVersionIsMigrated(currentVersionInfo.prevVersion, prevVersionInfo, currentVersion);
+
+    return currentVersionInfo.prevVersion;
+  }
+
+  public static void validateVersionIsMigrated(
+      final String version,
+      final VersionInfo versionInfo,
+      final String nextVersion
+  ) {
+    if (versionInfo.state != MigrationState.MIGRATED) {
+      throw new MigrationException(String.format(
+          "Discovered version with previous version that does not have status {}. "
+              + "Version: {}. Previous version: {}. Previous version status: {}",
+          MigrationState.MIGRATED,
+          nextVersion,
+          version,
+          versionInfo.state
+      ));
+    }
+  }
+
+  public static VersionInfo getInfoForVersion(
+      final String version,
+      final MigrationConfig config,
+      final Client ksqlClient
+  ) {
+    final String migrationTableName = config
+        .getString(MigrationConfig.KSQL_MIGRATIONS_TABLE_NAME);
+    final BatchedQueryResult result = ksqlClient.executeQuery(
+        "SELECT checksum, previous, state FROM " + migrationTableName
+            + " WHERE version_key = '" + version + "';");
+
+    final String expectedHash;
+    final String prevVersion;
+    final String state;
+    try {
+      final List<Row> resultRows = result.get();
+      if (resultRows.size() == 0) {
+        throw new MigrationException(
+            "Failed to query state for migration with version " + version
+                + ": no such migration is present in the migrations metadata table");
+      }
+      expectedHash = resultRows.get(0).getString(0);
+      prevVersion = resultRows.get(0).getString(1);
+      state = resultRows.get(0).getString(2);
+    } catch (InterruptedException | ExecutionException e) {
+      throw new MigrationException(String.format(
+          "Failed to query state for migration with version %s: %s", version, e.getMessage()));
+    }
+
+    return new VersionInfo(expectedHash, prevVersion, state);
+  }
+
+  public static class VersionInfo {
+    private final String expectedHash;
+    private final String prevVersion;
+    private final MigrationState state;
+
+    VersionInfo(final String expectedHash, final String prevVersion, final String state) {
+      this.expectedHash = Objects.requireNonNull(expectedHash, "expectedHash");
+      this.prevVersion = Objects.requireNonNull(prevVersion, "prevVersion");
+      this.state = MigrationState.valueOf(Objects.requireNonNull(state, "state"));
+    }
+
+    public String getExpectedHash() {
+      return expectedHash;
+    }
+
+    public String getPrevVersion() {
+      return prevVersion;
+    }
+
+    public MigrationState getState() {
+      return state;
     }
   }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
@@ -28,6 +28,13 @@ public final class MetadataUtil {
   public static final String NONE_VERSION = "<none>";
   public static final String CURRENT_VERSION_KEY = "CURRENT";
 
+  public enum MigrationState {
+    PENDING,
+    RUNNING,
+    MIGRATED,
+    ERROR
+  }
+
   private MetadataUtil() {
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -38,7 +39,12 @@ public final class MigrationsDirectoryUtil {
   }
 
   public static String getMigrationsDirFromConfigFile(final String configFilePath) {
-    return Paths.get(configFilePath).getParent().resolve(MIGRATIONS_DIR).toString();
+    final Path parentDir = Paths.get(configFilePath).getParent();
+    if (parentDir == null) {
+      throw new MigrationException("Could not find parent directory for config file '"
+          + configFilePath + "': no parent dir exists.");
+    }
+    return parentDir.resolve(MIGRATIONS_DIR).toString();
   }
 
   public static Optional<String> getFilePathForVersion(
@@ -87,7 +93,7 @@ public final class MigrationsDirectoryUtil {
   public static String computeHashForFile(final String filename) {
     try {
       final byte[] bytes = Files.readAllBytes(Paths.get(filename));
-      return new String(MessageDigest.getInstance("MD5").digest(bytes));
+      return new String(MessageDigest.getInstance("MD5").digest(bytes), StandardCharsets.UTF_8);
     } catch (NoSuchAlgorithmException | IOException e) {
       throw new MigrationException(String.format(
           "Could not compute hash for file '%s': %s", filename, e.getMessage()));

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
@@ -20,11 +20,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 public final class MigrationsDirectoryUtil {
@@ -39,29 +41,36 @@ public final class MigrationsDirectoryUtil {
     return Paths.get(configFilePath).getParent().resolve(MIGRATIONS_DIR).toString();
   }
 
-  public static Optional<String> getFileNameForVersion(
+  public static Optional<String> getFilePathForVersion(
       final String version,
       final String migrationsDir
   ) {
     final String prefix = "V" + StringUtils.leftPad(version, 6, "0");
+
     final File directory = new File(migrationsDir);
     if (!directory.isDirectory()) {
       throw new MigrationException(migrationsDir + " is not a directory.");
     }
+
     final String[] names = directory.list();
     if (names == null) {
       throw new MigrationException("Failed to retrieve files from " + migrationsDir);
     }
-    for (String name : names) {
-      if (name.startsWith(prefix)) {
-        return Optional.of(name);
-      }
+
+    final List<String> matches = Arrays.stream(names)
+        .filter(name -> name.startsWith(prefix))
+        .collect(Collectors.toList());
+    if (matches.size() == 1) {
+      return Optional.of(Paths.get(migrationsDir, matches.get(0)).toString());
+    } else if (matches.size() == 0) {
+      return Optional.empty();
+    } else {
+      throw new MigrationException("Found multiple migration files for version " + version);
     }
-    return Optional.empty();
   }
 
   public static String getFileContentsForVersion(final String version, final String migrationsDir) {
-    final Optional<String> filename = getFileNameForVersion(version, migrationsDir);
+    final Optional<String> filename = getFilePathForVersion(version, migrationsDir);
     if (!filename.isPresent()) {
       throw new MigrationException("Cannot find migration file with version "
           + version + " in " + migrationsDir);

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
@@ -20,12 +20,23 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 public final class MigrationsDirectoryUtil {
+
+  public static final String MIGRATIONS_DIR = "migrations";
+  public static final String MIGRATIONS_CONFIG_FILE = "ksql-migrations.properties";
+
   private MigrationsDirectoryUtil() {
+  }
+
+  public static String getMigrationsDirFromConfigFile(final String configFilePath) {
+    return Paths.get(configFilePath).getParent().resolve(MIGRATIONS_DIR).toString();
   }
 
   public static Optional<String> getFileNameForVersion(
@@ -61,6 +72,16 @@ public final class MigrationsDirectoryUtil {
     } catch (IOException e) {
       throw new MigrationException(
           String.format("Failed to read %s: %s", filepath, e.getMessage()));
+    }
+  }
+
+  public static String computeHashForFile(final String filename) {
+    try {
+      final byte[] bytes = Files.readAllBytes(Paths.get(filename));
+      return new String(MessageDigest.getInstance("MD5").digest(bytes));
+    } catch (NoSuchAlgorithmException | IOException e) {
+      throw new MigrationException(String.format(
+          "Could not compute hash for file '%s': %s", filename, e.getMessage()));
     }
   }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
@@ -29,9 +29,6 @@ public final class MigrationsUtil {
 
   public static final String MIGRATIONS_COMMAND = "ksql-migrations";
 
-  public static final String MIGRATIONS_DIR = "migrations";
-  public static final String MIGRATIONS_CONFIG_FILE = "ksql-migrations.properties";
-
   public static Client getKsqlClient(final MigrationConfig config) throws MigrationException {
     final String ksqlServerUrl = config.getString(MigrationConfig.KSQL_SERVER_URL);
     return getKsqlClient(ksqlServerUrl);

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
 import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.tools.migrations.commands.BaseCommand;
+import io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil;
 import io.confluent.ksql.tools.migrations.util.MigrationsUtil;
 import java.io.File;
 import java.nio.file.Files;
@@ -77,7 +78,7 @@ public class MigrationsTest {
     final String testDir = Paths.get(TestUtils.tempDirectory().getAbsolutePath(), "migrations_integ_test").toString();
     createAndVerifyDirectoryStructure(testDir);
 
-    configFilePath = Paths.get(testDir, MigrationsUtil.MIGRATIONS_CONFIG_FILE).toString();
+    configFilePath = Paths.get(testDir, MigrationsDirectoryUtil.MIGRATIONS_CONFIG_FILE).toString();
     initializeAndVerifyMetadataStreamAndTable(configFilePath);
   }
 
@@ -102,12 +103,12 @@ public class MigrationsTest {
     assertThat(rootDir.isDirectory(), is(true));
 
     // verify migrations directory
-    final File migrationsDir = new File(Paths.get(testDir, MigrationsUtil.MIGRATIONS_DIR).toString());
+    final File migrationsDir = new File(Paths.get(testDir, MigrationsDirectoryUtil.MIGRATIONS_DIR).toString());
     assertThat(migrationsDir.exists(), is(true));
     assertThat(migrationsDir.isDirectory(), is(true));
 
     // verify config file
-    final File configFile = new File(Paths.get(testDir, MigrationsUtil.MIGRATIONS_CONFIG_FILE).toString());
+    final File configFile = new File(Paths.get(testDir, MigrationsDirectoryUtil.MIGRATIONS_CONFIG_FILE).toString());
     assertThat(configFile.exists(), is(true));
     assertThat(configFile.isDirectory(), is(false));
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.tools.migrations.commands;
 
-import static io.confluent.ksql.tools.migrations.util.MigrationsUtil.MIGRATIONS_CONFIG_FILE;
-import static io.confluent.ksql.tools.migrations.util.MigrationsUtil.MIGRATIONS_DIR;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.MIGRATIONS_CONFIG_FILE;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.MIGRATIONS_DIR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import com.github.rvesse.airline.SingleCommand;
+import io.confluent.ksql.api.client.Client;
+import io.confluent.ksql.tools.migrations.MigrationConfig;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ValidateMigrationsCommandTest {
+
+  private static final SingleCommand<ValidateMigrationsCommand> PARSER =
+      SingleCommand.singleCommand(ValidateMigrationsCommand.class);
+
+  @Mock
+  private MigrationConfig config;
+  @Mock
+  private Client ksqlClient;
+
+  private ValidateMigrationsCommand command;
+
+  @Before
+  public void setUp() {
+
+  }
+
+}

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
@@ -33,7 +33,9 @@ import io.confluent.ksql.tools.migrations.util.MetadataUtil;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil.MigrationState;
 import io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -209,7 +211,7 @@ public class ValidateMigrationsCommandTest {
 
       try (PrintWriter out = new PrintWriter(filename, Charset.defaultCharset().name())) {
         out.println(fileContents);
-      } catch (Exception e) {
+      } catch (FileNotFoundException | UnsupportedEncodingException e) {
         Assert.fail("Failed to write test file: " + filename);
       }
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
@@ -15,10 +15,32 @@
 
 package io.confluent.ksql.tools.migrations.commands;
 
+import static io.confluent.ksql.tools.migrations.util.MetadataUtil.CURRENT_VERSION_KEY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.github.rvesse.airline.SingleCommand;
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.api.client.BatchedQueryResult;
 import io.confluent.ksql.api.client.Client;
+import io.confluent.ksql.api.client.Row;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
+import io.confluent.ksql.tools.migrations.util.MetadataUtil;
+import io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil;
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -29,16 +51,136 @@ public class ValidateMigrationsCommandTest {
   private static final SingleCommand<ValidateMigrationsCommand> PARSER =
       SingleCommand.singleCommand(ValidateMigrationsCommand.class);
 
+  private static final String MIGRATIONS_TABLE = "migrations_table";
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
   @Mock
   private MigrationConfig config;
   @Mock
   private Client ksqlClient;
 
+  private String migrationsDir;
   private ValidateMigrationsCommand command;
 
   @Before
   public void setUp() {
+    when(config.getString(MigrationConfig.KSQL_MIGRATIONS_TABLE_NAME)).thenReturn(MIGRATIONS_TABLE);
 
+    migrationsDir = folder.getRoot().getPath();
+    command = PARSER.parse();
+  }
+
+  @Test
+  public void shouldValidateSingleMigration() throws Exception {
+    // Given:
+    final List<String> versions = ImmutableList.of("1");
+    final List<String> checksums = givenExistingMigrationFiles(versions);
+    givenAppliedMigrations(versions, checksums);
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir);
+
+    // Then:
+    assertThat(result, is(0));
+
+    verifyClientCallsForVersions(versions);
+  }
+
+  /**
+   * @param versions versions, in the order they were applied
+   * @param checksums corresponding checksums (ordered according to {@code versions})
+   */
+  private void givenAppliedMigrations(final List<String> versions, final List<String> checksums) throws Exception {
+    String version = versions.get(versions.size() - 1);
+
+    Row row = mock(Row.class);
+    BatchedQueryResult queryResult = mock(BatchedQueryResult.class);
+    when(ksqlClient.executeQuery("SELECT VERSION FROM " + MIGRATIONS_TABLE
+        + " WHERE version_key = '" + CURRENT_VERSION_KEY + "';"))
+        .thenReturn(queryResult);
+    when(queryResult.get()).thenReturn(ImmutableList.of(row));
+    when(row.getString("VERSION")).thenReturn(version);
+
+    for (int i = versions.size() - 1; i >= 0; i--) {
+      version = versions.get(i);
+      String prevVersion = i > 0 ? versions.get(i-1) : MetadataUtil.NONE_VERSION;
+
+      row = mock(Row.class);
+      queryResult = mock(BatchedQueryResult.class);
+      when(ksqlClient.executeQuery("SELECT checksum, previous FROM " + MIGRATIONS_TABLE
+          + " WHERE version_key = '" + version + "';"))
+          .thenReturn(queryResult);
+      when(queryResult.get()).thenReturn(ImmutableList.of(row));
+      when(row.getString(0)).thenReturn(checksums.get(i));
+      when(row.getString(1)).thenReturn(prevVersion);
+    }
+  }
+
+  /**
+   * @param versions versions, in the order they were applied
+   */
+  private void verifyClientCallsForVersions(final List<String> versions) {
+    // TODO
+  }
+
+  @Test
+  public void shouldValidateMultipleMigrations() throws Exception {
+
+  }
+
+  @Test
+  public void shouldValidateNoMigrations() throws Exception {
+
+  }
+
+  @Test
+  public void shouldValidateWithExtraMigrations() throws Exception {
+
+  }
+
+  @Test
+  public void shouldFailOnMissingMigrationFile() throws Exception {
+
+  }
+
+  @Test
+  public void shouldFailOnChecksumMismatch() throws Exception {
+
+  }
+
+  /**
+   * @return checksums for the supplied versions
+   */
+  private List<String> givenExistingMigrationFiles(final List<String> versions) throws Exception {
+    final List<String> checksums = new ArrayList<>();
+
+    for (final String version : versions) {
+      final String filename = filePathForVersion(version);
+      final String fileContents = fileContentsForVersion(version);
+
+      assertThat(new File(filename).createNewFile(), is(true));
+
+      try (PrintWriter out = new PrintWriter(filename, Charset.defaultCharset().name())) {
+        out.println(fileContents);
+      } catch (Exception e) {
+        Assert.fail("Failed to write test file: " + filename);
+      }
+
+      checksums.add(MigrationsDirectoryUtil.computeHashForFile(filename));
+    }
+
+    return checksums;
+  }
+
+  private String filePathForVersion(final String version) {
+    final String prefix = "V" + StringUtils.leftPad(version, 6, "0");
+    return Paths.get(migrationsDir, prefix + "_awesome_migration").toString();
+  }
+
+  private static String fileContentsForVersion(final String version) {
+    return "sql_" + version;
   }
 
 }


### PR DESCRIPTION
### Description 

The `validate` command of the migrations tool:
1. Finds the latest migrated version by querying the metadata table for the current version and following "previous" pointers until one with status MIGRATED is found. This should never involve more than one hop following pointers since the `apply` command should always use the latest MIGRATED version as "previous". Currently an error is thrown if this is not the case, but we can revisit when we introduce the `abort` command to get out of bad states due to race conditions.
2. Continuing to follow "previous" pointers, validating each file's checksum (and that each version has status MIGRATED) along the way.
3. The "previous" pointers eventually lead to the special `NONE_VERSION`, indicating the first migration version has been reached.

Once table scans are implemented, we can simplify the algorithm by simply doing a table scan and filtering for status MIGRATED.

### Testing done 

Lots of unit tests. Integration tests will be added with the `apply` implementation.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

