### PR TITLE
chore: remove unnecessary output schema in serde QTT

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/serdes.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/serdes.json
@@ -229,10 +229,6 @@
         {
           "name": "input_topic",
           "schema": {"type": "map", "values": ["null", "int"]}
-        },
-        {
-          "name": "OUTPUT",
-          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","int"],"default":null}]}}]}]}
         }
       ],
       "inputs": [
@@ -266,11 +262,6 @@
           "name": "input_topic",
           "schema": {"type": "map", "values": ["null", "int"]},
           "format": "AVRO"
-        },
-        {
-          "name": "OUTPUT",
-          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","string"],"default":null}]}}]}]},
-          "format": "AVRO"
         }
       ],
       "inputs": [
@@ -300,10 +291,6 @@
         {
           "name": "input_topic",
           "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type": "map", "values": ["null", "int"]}]}]}
-        },
-        {
-          "name": "OUTPUT",
-          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","int"],"default":null}]}}]}]}
         }
       ],
       "inputs": [
@@ -465,12 +452,6 @@
         "CREATE STREAM INPUT (foo BOOLEAN) WITH (kafka_topic='input_topic', value_format='{FORMAT}');",
         "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=true) AS SELECT * FROM INPUT;"
       ],
-      "topics": [
-        {
-          "name": "OUTPUT",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null","boolean"]}]}
-        }
-      ],
       "inputs": [
         {"topic": "input_topic", "value": {"FOO": true}},
         {"topic": "input_topic", "value": {"FOO": null}},
@@ -506,12 +487,6 @@
         "CREATE STREAM INPUT (foo ARRAY<BIGINT>) WITH (kafka_topic='input_topic', value_format='{FORMAT}');",
         "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT * FROM INPUT;"
       ],
-      "topics": [
-        {
-          "name": "OUTPUT",
-          "schema": {"type": "array", "items": ["null", "long"]}
-        }
-      ],
       "inputs": [
         {"topic": "input_topic", "value": {"FOO": [12, 34, 999]}},
         {"topic": "input_topic", "value": {"FOO": [12, 34, null]}},
@@ -531,12 +506,6 @@
       "statements": [
         "CREATE STREAM INPUT (foo ARRAY<BIGINT>) WITH (kafka_topic='input_topic', value_format='{FORMAT}');",
         "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=true) AS SELECT * FROM INPUT;"
-      ],
-      "topics": [
-        {
-          "name": "OUTPUT",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type": "array", "items": ["null", "long"]}]}]}
-        }
       ],
       "inputs": [
         {"topic": "input_topic", "value": {"FOO": [12, 34, 999]}},
@@ -575,12 +544,6 @@
         "CREATE STREAM INPUT (foo MAP<STRING, DOUBLE>) WITH (kafka_topic='input_topic', value_format='{FORMAT}');",
         "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT * FROM INPUT;"
       ],
-      "topics": [
-        {
-          "name": "OUTPUT",
-          "schema": {"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","double"],"default":null}]}}
-        }
-      ],
       "inputs": [
         {"topic": "input_topic", "value": {"FOO": {"a": 1.1, "b": 2.2, "c": 3.456}}},
         {"topic": "input_topic", "value": {"FOO": {"a": 1.1, "b": 2.2, "c": null}}},
@@ -600,12 +563,6 @@
       "statements": [
         "CREATE STREAM INPUT (foo MAP<STRING, DOUBLE>) WITH (kafka_topic='input_topic', value_format='{FORMAT}');",
         "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=true) AS SELECT * FROM INPUT;"
-      ],
-      "topics": [
-        {
-          "name": "OUTPUT",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","double"],"default":null}]}}]}]}
-        }
       ],
       "inputs": [
         {"topic": "input_topic", "value": {"FOO": {"a": 1.1, "b": 2.2, "c": 3.456}}},
@@ -644,12 +601,6 @@
         "CREATE STREAM INPUT (foo STRUCT<F0 INT>) WITH (kafka_topic='input_topic', value_format='{FORMAT}');",
         "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=false) AS SELECT * FROM INPUT;"
       ],
-      "topics": [
-        {
-          "name": "OUTPUT",
-          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "F0", "type": ["null", "int"]}]}
-        }
-      ],
       "inputs": [
         {"topic": "input_topic", "value": {"FOO": {"F0": 1}}},
         {"topic": "input_topic", "value": {"FOO": {"F0": null}}},
@@ -669,14 +620,6 @@
       "statements": [
         "CREATE STREAM INPUT (foo STRUCT<F0 INT>) WITH (kafka_topic='input_topic', value_format='{FORMAT}');",
         "CREATE STREAM OUTPUT WITH (WRAP_SINGLE_VALUE=true) AS SELECT * FROM INPUT;"
-      ],
-      "topics": [
-        {
-          "name": "OUTPUT",
-          "schema": {"name": "ignored", "type": "record", "fields": [
-            {"name": "FOO", "type": ["null", {"name": "ignored2", "type": "record", "fields": [{"name": "F0", "type": ["null", "int"]}]}]}
-          ]}
-        }
       ],
       "inputs": [
         {"topic": "input_topic", "value": {"FOO": {"F0": 1}}},


### PR DESCRIPTION
### Description 

https://github.com/confluentinc/schema-registry/pull/1775 exposed an issue in our test, we were "overwriting" schemas that we had registered under the output subject in our tests. Registering these are pointless, as up until now they haven't enforced any true compatibility and in future versions we have `PostTopicNode` to ensure that the generated schema is as intended 

see https://github.com/confluentinc/ksql/blob/d064342cc0224569fc400d02b113c6432ed63cb7/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java#L169

### Testing done 

Ran the test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

