### PR TITLE
feat(migrations): apply command

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -23,7 +23,6 @@ import static io.vertx.core.http.HttpVersion.HTTP_1_1;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.UrlEscapers;
-import io.confluent.ksql.api.utils.ReceiveStream;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.client.BasicCredentials;
 import io.confluent.ksql.rest.client.KsqlRestClient;
@@ -175,7 +174,7 @@ public final class RestIntegrationTestUtil {
     }
   }
 
-  static List<StreamedRow> makeQueryRequest(
+  public static List<StreamedRow> makeQueryRequest(
       final TestKsqlRestApp restApp,
       final String sql,
       final Optional<BasicCredentials> userCreds

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migration.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migration.java
@@ -20,37 +20,30 @@ import java.util.Objects;
 public class Migration {
   private final int version;
   private final String name;
-  private final String checksum;
-  private final String command;
+  private final String filepath;
 
   public Migration(
       final int version,
       final String name,
-      final String checksum,
-      final String command
+      final String filepath
   ) {
     if (version < 1) {
       throw new MigrationException("Version must be positive, received " + version);
     }
     this.version = version;
     this.name = Objects.requireNonNull(name);
-    this.checksum = Objects.requireNonNull(checksum);
-    this.command = Objects.requireNonNull(command);
+    this.filepath = Objects.requireNonNull(filepath);
   }
 
   public int getVersion() {
     return version;
   }
 
-  public String getChecksum() {
-    return checksum;
-  }
-
   public String getName() {
     return name;
   }
 
-  public String getCommand() {
-    return command;
+  public String getFilepath() {
+    return filepath;
   }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migration.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations;
+
+import io.confluent.ksql.tools.migrations.util.MetadataUtil;
+import java.util.Objects;
+
+public class Migration {
+  private final String version;
+  private final String name;
+  private final String checksum;
+  private final String previous;
+  private final String command;
+
+  public Migration(
+      final int version,
+      final String name,
+      final String checksum,
+      final String command
+  ) {
+    if (version < 1) {
+      throw new MigrationException("Version must be positive, received " + version);
+    }
+    this.version = Integer.toString(version);
+    this.name = Objects.requireNonNull(name);
+    this.checksum = Objects.requireNonNull(checksum);
+    this.previous = version == 1 ? MetadataUtil.NONE_VERSION : Integer.toString(version - 1);
+    this.command = Objects.requireNonNull(command);
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public String getChecksum() {
+    return checksum;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getCommand() {
+    return command;
+  }
+
+  public String getPrevious() {
+    return previous;
+  }
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migration.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migration.java
@@ -15,14 +15,12 @@
 
 package io.confluent.ksql.tools.migrations;
 
-import io.confluent.ksql.tools.migrations.util.MetadataUtil;
 import java.util.Objects;
 
 public class Migration {
-  private final String version;
+  private final int version;
   private final String name;
   private final String checksum;
-  private final String previous;
   private final String command;
 
   public Migration(
@@ -34,14 +32,13 @@ public class Migration {
     if (version < 1) {
       throw new MigrationException("Version must be positive, received " + version);
     }
-    this.version = Integer.toString(version);
+    this.version = version;
     this.name = Objects.requireNonNull(name);
     this.checksum = Objects.requireNonNull(checksum);
-    this.previous = version == 1 ? MetadataUtil.NONE_VERSION : Integer.toString(version - 1);
     this.command = Objects.requireNonNull(command);
   }
 
-  public String getVersion() {
+  public int getVersion() {
     return version;
   }
 
@@ -55,9 +52,5 @@ public class Migration {
 
   public String getCommand() {
     return command;
-  }
-
-  public String getPrevious() {
-    return previous;
   }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -261,6 +261,7 @@ public class ApplyMigrationCommand extends BaseCommand {
     final String executionEnd = (state == MigrationState.MIGRATED || state == MigrationState.ERROR)
         ? Long.toString(clock.millis())
         : "";
+    final String checksum = MigrationsDirectoryUtil.computeHashForFile(migration.getFilepath());
     try {
       MetadataUtil.writeRow(
           config,
@@ -270,7 +271,8 @@ public class ApplyMigrationCommand extends BaseCommand {
           executionStart,
           executionEnd,
           migration,
-          previous
+          previous,
+          checksum
       ).get();
       MetadataUtil.writeRow(
           config,
@@ -280,7 +282,8 @@ public class ApplyMigrationCommand extends BaseCommand {
           executionStart,
           executionEnd,
           migration,
-          previous
+          previous,
+          checksum
       ).get();
       return true;
     } catch (InterruptedException | ExecutionException e) {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -15,9 +15,28 @@
 
 package io.confluent.ksql.tools.migrations.commands;
 
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getMigrationsDirFromConfigFile;
+
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.MutuallyExclusiveWith;
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.api.client.Client;
+import io.confluent.ksql.tools.migrations.Migration;
+import io.confluent.ksql.tools.migrations.MigrationConfig;
+import io.confluent.ksql.tools.migrations.MigrationException;
+import io.confluent.ksql.tools.migrations.util.MetadataUtil;
+import io.confluent.ksql.tools.migrations.util.MetadataUtil.MigrationState;
+import io.confluent.ksql.tools.migrations.util.MetadataUtil.VersionInfo;
+import io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil;
+import io.confluent.ksql.tools.migrations.util.MigrationsUtil;
+import io.confluent.ksql.util.KsqlException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +47,8 @@ import org.slf4j.LoggerFactory;
 public class ApplyMigrationCommand extends BaseCommand {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ApplyMigrationCommand.class);
+
+  private static final int MAX_RETRIES = 10;
 
   @Option(
       title = "all",
@@ -56,7 +77,228 @@ public class ApplyMigrationCommand extends BaseCommand {
 
   @Override
   protected int command() {
-    throw new UnsupportedOperationException();
+    if (!validateConfigFilePresent()) {
+      return 1;
+    }
+
+    final MigrationConfig config;
+    try {
+      config = MigrationConfig.load(configFile);
+    } catch (KsqlException | MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return 1;
+    }
+
+    return command(
+        config,
+        MigrationsUtil::getKsqlClient,
+        getMigrationsDirFromConfigFile(configFile)
+    );
+  }
+
+  @VisibleForTesting
+  int command(
+      final MigrationConfig config,
+      final Function<MigrationConfig, Client> clientSupplier,
+      final String migrationsDir
+  ) {
+    final Client ksqlClient;
+    try {
+      ksqlClient = clientSupplier.apply(config);
+    } catch (MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return 1;
+    }
+
+    if (!ValidateMigrationsCommand.validate(config, migrationsDir, ksqlClient)) {
+      return 1;
+    }
+
+    final int startVersion = getStartVersion(config, ksqlClient);
+    final int endVersion;
+    try {
+      endVersion = getEndVersion(startVersion, migrationsDir);
+    } catch (MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return 1;
+    }
+
+    LOGGER.info("Loading migration files");
+
+    final List<Migration> migrations;
+    try {
+      migrations = loadMigrations(startVersion, endVersion, migrationsDir);
+    } catch (MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return 1;
+    }
+
+    for (Migration migration : migrations) {
+      if (!applyMigration(config, ksqlClient, migration)) {
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+  private List<Migration> loadMigrations(
+      final int start,
+      final int end,
+      final String migrationsDir
+  ) {
+    final List<Migration> migrations = new ArrayList<>();
+    for (int version = start; version <= end; version++) {
+      migrations.add(loadMigration(version, migrationsDir));
+    }
+    return migrations;
+  }
+
+  private Migration loadMigration(
+      final int version,
+      final String migrationsDir
+  ) {
+    final String versionString = Integer.toString(version);
+
+    final Optional<String> migrationFilePath =
+        MigrationsDirectoryUtil.getFilePathForVersion(versionString, migrationsDir);
+    if (!migrationFilePath.isPresent()) {
+      throw new MigrationException("Failed to find file for version " + versionString);
+    }
+
+    final String migrationCommand =
+        MigrationsDirectoryUtil.getFileContentsForVersion(versionString, migrationsDir);
+
+    LOGGER.info(migrationFilePath.get() + " loaded");
+    return new Migration(
+        version,
+        MigrationsDirectoryUtil.getNameFromMigrationFilePath(migrationFilePath.get()),
+        MigrationsDirectoryUtil.computeHashForFile(migrationFilePath.get()),
+        migrationCommand
+    );
+  }
+
+  private boolean applyMigration(
+      final MigrationConfig config,
+      final Client ksqlClient,
+      final Migration migration
+  ) {
+    LOGGER.info("Applying " + migration.getName() + " version " + migration.getVersion());
+    LOGGER.info(migration.getCommand());
+
+    if (dryRun) {
+      return true;
+    }
+
+    if (!verifyMigrated(config, ksqlClient, migration.getPrevious(), MAX_RETRIES)) {
+      LOGGER.error("Failed to verify status of version" + migration.getPrevious());
+      return false;
+    }
+
+    final String executionStart = Long.toString(System.nanoTime() / 1000000);
+
+    if (!updateState(config, ksqlClient, MigrationState.RUNNING, executionStart, migration)) {
+      return false;
+    }
+
+    try {
+      final List<String> commands = Arrays.asList(migration.getCommand().split(";"));
+      for (final String command : commands) {
+        ksqlClient.executeStatement(command + ";").get();
+      }
+    } catch (InterruptedException | ExecutionException e) {
+      LOGGER.error(e.getMessage());
+      updateState(config, ksqlClient, MigrationState.ERROR, executionStart, migration);
+      return false;
+    }
+    updateState(config, ksqlClient, MigrationState.MIGRATED, executionStart, migration);
+    LOGGER.info("Successfully migrated");
+    return true;
+  }
+
+  private int getStartVersion(final MigrationConfig config, final Client ksqlClient) {
+    final String latestMigratedVersion = MetadataUtil.getLatestMigratedVersion(config, ksqlClient);
+    if (latestMigratedVersion.equals(MetadataUtil.NONE_VERSION)) {
+      return 1;
+    } else {
+      return Integer.parseInt(latestMigratedVersion) + 1;
+    }
+  }
+
+  private int getEndVersion(final int startVersion, final String migrationsDir) {
+    if (next) {
+      return startVersion;
+    } else if (version >= startVersion) {
+      return version;
+    } else if (version > 0 && version < startVersion) {
+      throw new MigrationException("Specified version is lower than latest migrated version");
+    } else {
+      int endVersion = startVersion;
+      while (
+          MigrationsDirectoryUtil
+              .getFilePathForVersion(Integer.toString(endVersion), migrationsDir)
+              .isPresent()
+      ) {
+        endVersion++;
+      }
+      return endVersion - 1;
+    }
+  }
+
+  private boolean verifyMigrated(
+      final MigrationConfig config,
+      final Client ksqlClient,
+      final String version,
+      final int retries
+  ) {
+    if (version.equals(MetadataUtil.NONE_VERSION)) {
+      return true;
+    }
+    for (int i = 1; i <= retries; i++) {
+      final VersionInfo versionInfo = MetadataUtil.getInfoForVersion(version, config, ksqlClient);
+      if (versionInfo.getState().equals(MigrationState.MIGRATED)) {
+        return true;
+      } else {
+        LOGGER.info(String.format(
+            "Could not verify status of version %s. Retrying (%i/%i)", version, i, retries));
+      }
+    }
+    return false;
+  }
+
+  private boolean updateState(
+      final MigrationConfig config,
+      final Client ksqlClient,
+      final MigrationState state,
+      final String executionStart,
+      final Migration migration
+  ) {
+    final String executionEnd = (state == MigrationState.MIGRATED || state == MigrationState.ERROR)
+        ? Long.toString(System.nanoTime() / 1000000)
+        : "";
+    try {
+      MetadataUtil.writeRow(
+          config,
+          ksqlClient,
+          MetadataUtil.CURRENT_VERSION_KEY,
+          state.toString(),
+          executionStart,
+          executionEnd,
+          migration
+      ).get();
+      MetadataUtil.writeRow(
+          config,
+          ksqlClient,
+          migration.getVersion(),
+          state.toString(),
+          executionStart,
+          executionEnd,
+          migration
+      ).get();
+      return true;
+    } catch (InterruptedException | ExecutionException e) {
+      LOGGER.error(e.getMessage());
+      return false;
+    }
   }
 
   @Override

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
@@ -127,8 +127,8 @@ public final class MetadataUtil {
   ) {
     if (versionInfo.state != MigrationState.MIGRATED) {
       throw new MigrationException(String.format(
-          "Discovered version with previous version that does not have status {}. "
-              + "Version: {}. Previous version: {}. Previous version status: {}",
+          "Discovered version with previous version that does not have status %s. "
+              + "Version: %s. Previous version: %s. Previous version status: %s",
           MigrationState.MIGRATED,
           nextVersion,
           version,

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
@@ -73,7 +73,8 @@ public final class MetadataUtil {
       final String startOn,
       final String completedOn,
       final Migration migration,
-      final String previous
+      final String previous,
+      final String checksum
   ) {
     final String migrationStreamName =
         config.getString(MigrationConfig.KSQL_MIGRATIONS_STREAM_NAME);
@@ -82,7 +83,7 @@ public final class MetadataUtil {
         Integer.toString(migration.getVersion()),
         migration.getName(),
         state,
-        MigrationsDirectoryUtil.computeHashForFile(migration.getFilepath()),
+        checksum,
         startOn,
         completedOn,
         previous

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
@@ -72,19 +72,20 @@ public final class MetadataUtil {
       final String state,
       final String startOn,
       final String completedOn,
-      final Migration migration
+      final Migration migration,
+      final String previous
   ) {
     final String migrationStreamName =
         config.getString(MigrationConfig.KSQL_MIGRATIONS_STREAM_NAME);
     final List<String> values = ImmutableList.of(
         versionKey,
-        migration.getVersion(),
+        Integer.toString(migration.getVersion()),
         migration.getName(),
         state,
         migration.getChecksum(),
         startOn,
         completedOn,
-        migration.getPrevious()
+        previous
     );
     return client.insertInto(
         migrationStreamName,

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MetadataUtil.java
@@ -82,7 +82,7 @@ public final class MetadataUtil {
         Integer.toString(migration.getVersion()),
         migration.getName(),
         state,
-        migration.getChecksum(),
+        MigrationsDirectoryUtil.computeHashForFile(migration.getFilepath()),
         startOn,
         completedOn,
         previous

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
@@ -130,6 +130,7 @@ public final class MigrationsDirectoryUtil {
     }
 
     return Arrays.stream(names)
+        .sorted()
         .map(name -> new Migration(
             getVersionFromMigrationFilePath(name),
             getNameFromMigrationFilePath(name),

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
@@ -28,6 +28,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
@@ -102,7 +104,15 @@ public final class MigrationsDirectoryUtil {
   }
 
   public static int getVersionFromMigrationFilePath(final String filename) {
-    return Integer.parseInt(filename.substring(1, 7));
+    final Matcher matcher = Pattern.compile(".*V([0-9]{6}).*\\.sql").matcher(filename);
+    if (matcher.find()) {
+      return Integer.parseInt(matcher.group(1));
+    } else {
+
+      throw new MigrationException(
+          "File path does not match expected pattern path/to/file/V<six digit number>__<name>.sql: "
+              + filename);
+    }
   }
 
   public static List<Migration> getAllMigrations(final String migrationsDir) {
@@ -117,11 +127,10 @@ public final class MigrationsDirectoryUtil {
     }
 
     return Arrays.stream(names)
-        .map(name ->new Migration(
+        .map(name -> new Migration(
             getVersionFromMigrationFilePath(name),
             getNameFromMigrationFilePath(name),
-            computeHashForFile(migrationsDir + "/" + name),
-            getFileContentsForName(migrationsDir + "/" + name)))
+            migrationsDir + "/" + name))
         .collect(Collectors.toList());
   }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
@@ -81,12 +81,11 @@ public final class MigrationsDirectoryUtil {
       throw new MigrationException("Cannot find migration file with version "
           + version + " in " + migrationsDir);
     }
-    final String filepath = migrationsDir + "/" + filename.get();
     try {
-      return new String(Files.readAllBytes(Paths.get(filepath)), StandardCharsets.UTF_8);
+      return new String(Files.readAllBytes(Paths.get(filename.get())), StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new MigrationException(
-          String.format("Failed to read %s: %s", filepath, e.getMessage()));
+          String.format("Failed to read %s: %s", filename.get(), e.getMessage()));
     }
   }
 
@@ -98,5 +97,11 @@ public final class MigrationsDirectoryUtil {
       throw new MigrationException(String.format(
           "Could not compute hash for file '%s': %s", filename, e.getMessage()));
     }
+  }
+
+  public static String getNameFromMigrationFilePath(final String filename) {
+    return filename
+        .substring(filename.indexOf("__") + 2, filename.indexOf(".sql"))
+        .replace('_', ' ');
   }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
@@ -104,14 +104,17 @@ public final class MigrationsDirectoryUtil {
   }
 
   public static int getVersionFromMigrationFilePath(final String filename) {
-    final Matcher matcher = Pattern.compile(".*V([0-9]{6}).*\\.sql").matcher(filename);
+    final Matcher matcher = Pattern.compile("V([0-9]{6})__.*\\.sql").matcher(filename);
     if (matcher.find()) {
-      return Integer.parseInt(matcher.group(1));
+      final int version = Integer.parseInt(matcher.group(1));
+      if (version > 0) {
+        return version;
+      } else {
+        throw new MigrationException("Version number must be positive - found " + filename);
+      }
     } else {
-
       throw new MigrationException(
-          "File path does not match expected pattern path/to/file/V<six digit number>__<name>.sql: "
-              + filename);
+          "File path does not match expected pattern V<six digit number>__<name>.sql: " + filename);
     }
   }
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -277,7 +277,7 @@ public class MigrationsTest {
   ) throws IOException {
     final String filePath = migrationsDir
         + String.format("/V00000%d__%s.sql", version, name.replace(' ', '_'));
-    new File(filePath).createNewFile();
+    assertThat(new File(filePath).createNewFile(), is(true));
     PrintWriter out = new PrintWriter(filePath, Charset.defaultCharset().name());
     out.println(content);
     out.close();

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.tools.migrations;
 
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -106,6 +107,13 @@ public class MigrationsTest {
         MigrationsDirectoryUtil.getMigrationsDirFromConfigFile(configFilePath),
         "CREATE STREAM BAR (A STRING) WITH (KAFKA_TOPIC='BAR', PARTITIONS=1, VALUE_FORMAT='DELIMITED');"
     );
+
+    // This is needed to make sure that the table is fully done being created.
+    // It's a similar situation to https://github.com/confluentinc/ksql/issues/6249
+    assertThatEventually(
+        () -> makeKsqlQuery("SELECT * FROM migration_schema_versions WHERE VERSION_KEY='CURRENT';").size(),
+        is(1)
+    );
     final int status = MIGRATIONS_CLI.parse("--config-file", configFilePath, "apply").run();
     assertThat(status, is(0));
 
@@ -115,27 +123,27 @@ public class MigrationsTest {
 
     // verify current
     final List<StreamedRow> current = makeKsqlQuery("SELECT * FROM migration_schema_versions WHERE VERSION_KEY='CURRENT';");
-    assertThat(current.size(), is(2));
-    assertThat(current.get(1).getRow().get().getColumns().get(1), is("2"));
-    assertThat(current.get(1).getRow().get().getColumns().get(2), is("bar"));
-    assertThat(current.get(1).getRow().get().getColumns().get(3), is("MIGRATED"));
-    assertThat(current.get(1).getRow().get().getColumns().get(7), is("1"));
+    assertThatEventually(() -> current.size(), is(2));
+    assertThatEventually(() -> current.get(1).getRow().get().getColumns().get(1), is("2"));
+    assertThatEventually(() -> current.get(1).getRow().get().getColumns().get(2), is("bar"));
+    assertThatEventually(() -> current.get(1).getRow().get().getColumns().get(3), is("MIGRATED"));
+    assertThatEventually(() -> current.get(1).getRow().get().getColumns().get(7), is("1"));
 
     // verify version 1
     final List<StreamedRow> version1 = makeKsqlQuery("SELECT * FROM migration_schema_versions WHERE VERSION_KEY='1';");
-    assertThat(version1.size(), is(2));
-    assertThat(version1.get(1).getRow().get().getColumns().get(1), is("1"));
-    assertThat(version1.get(1).getRow().get().getColumns().get(2), is("foo"));
-    assertThat(version1.get(1).getRow().get().getColumns().get(3), is("MIGRATED"));
-    assertThat(version1.get(1).getRow().get().getColumns().get(7), is("<none>"));
+    assertThatEventually(() -> version1.size(), is(2));
+    assertThatEventually(() -> version1.get(1).getRow().get().getColumns().get(1), is("1"));
+    assertThatEventually(() -> version1.get(1).getRow().get().getColumns().get(2), is("foo"));
+    assertThatEventually(() -> version1.get(1).getRow().get().getColumns().get(3), is("MIGRATED"));
+    assertThatEventually(() -> version1.get(1).getRow().get().getColumns().get(7), is("<none>"));
 
     // verify version 2
     final List<StreamedRow> version2 = makeKsqlQuery("SELECT * FROM migration_schema_versions WHERE VERSION_KEY='CURRENT';");
-    assertThat(version2.size(), is(2));
-    assertThat(version2.get(1).getRow().get().getColumns().get(1), is("2"));
-    assertThat(version2.get(1).getRow().get().getColumns().get(2), is("bar"));
-    assertThat(version2.get(1).getRow().get().getColumns().get(3), is("MIGRATED"));
-    assertThat(version2.get(1).getRow().get().getColumns().get(7), is("1"));
+    assertThatEventually(() -> version2.size(), is(2));
+    assertThatEventually(() -> version2.get(1).getRow().get().getColumns().get(1), is("2"));
+    assertThatEventually(() -> version2.get(1).getRow().get().getColumns().get(2), is("bar"));
+    assertThatEventually(() -> version2.get(1).getRow().get().getColumns().get(3), is("MIGRATED"));
+    assertThatEventually(() -> version2.get(1).getRow().get().getColumns().get(7), is("1"));
   }
 
   private static void createAndVerifyDirectoryStructure(final String testDir) throws Exception {
@@ -171,13 +179,13 @@ public class MigrationsTest {
 
     // verify metadata stream
     final SourceDescription streamDesc = describeSource("migration_events");
-    assertThat(streamDesc.getType(), is("STREAM"));
-    assertThat(streamDesc.getTopic(), is("default_ksql_migration_events"));
-    assertThat(streamDesc.getKeyFormat(), is("KAFKA"));
-    assertThat(streamDesc.getValueFormat(), is("JSON"));
-    assertThat(streamDesc.getPartitions(), is(1));
-    assertThat(streamDesc.getReplication(), is(1));
-    assertThat(streamDesc.getFields(), containsInAnyOrder(
+    assertThatEventually(() -> streamDesc.getType(), is("STREAM"));
+    assertThatEventually(() -> streamDesc.getTopic(), is("default_ksql_migration_events"));
+    assertThatEventually(() -> streamDesc.getKeyFormat(), is("KAFKA"));
+    assertThatEventually(() -> streamDesc.getValueFormat(), is("JSON"));
+    assertThatEventually(() -> streamDesc.getPartitions(), is(1));
+    assertThatEventually(() -> streamDesc.getReplication(), is(1));
+    assertThatEventually(() -> streamDesc.getFields(), containsInAnyOrder(
         fieldInfo("VERSION_KEY", "STRING", true),
         fieldInfo("VERSION", "STRING", false),
         fieldInfo("NAME", "STRING", false),
@@ -190,13 +198,13 @@ public class MigrationsTest {
 
     // verify metadata table
     final SourceDescription tableDesc = describeSource("migration_schema_versions");
-    assertThat(tableDesc.getType(), is("TABLE"));
-    assertThat(tableDesc.getTopic(), is("default_ksql_migration_schema_versions"));
-    assertThat(tableDesc.getKeyFormat(), is("KAFKA"));
-    assertThat(tableDesc.getValueFormat(), is("JSON"));
-    assertThat(tableDesc.getPartitions(), is(1));
-    assertThat(tableDesc.getReplication(), is(1));
-    assertThat(tableDesc.getFields(), containsInAnyOrder(
+    assertThatEventually(() -> tableDesc.getType(), is("TABLE"));
+    assertThatEventually(() -> tableDesc.getTopic(), is("default_ksql_migration_schema_versions"));
+    assertThatEventually(() -> tableDesc.getKeyFormat(), is("KAFKA"));
+    assertThatEventually(() -> tableDesc.getValueFormat(), is("JSON"));
+    assertThatEventually(() -> tableDesc.getPartitions(), is(1));
+    assertThatEventually(() -> tableDesc.getReplication(), is(1));
+    assertThatEventually(() -> tableDesc.getFields(), containsInAnyOrder(
         fieldInfo("VERSION_KEY", "STRING", true),
         fieldInfo("VERSION", "STRING", false),
         fieldInfo("NAME", "STRING", false),
@@ -211,8 +219,8 @@ public class MigrationsTest {
   private static SourceDescription describeSource(final String name) {
     final List<KsqlEntity> entities = makeKsqlRequest("DESCRIBE " + name + ";");
 
-    assertThat(entities, hasSize(1));
-    assertThat(entities.get(0), instanceOf(SourceDescriptionEntity.class));
+    assertThatEventually(() -> entities, hasSize(1));
+    assertThatEventually(() -> entities.get(0), instanceOf(SourceDescriptionEntity.class));
     SourceDescriptionEntity entity = (SourceDescriptionEntity) entities.get(0);
 
     return entity.getSourceDescription();

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -255,7 +255,7 @@ public class ApplyMigrationCommandTest {
     // Given:
     command = PARSER.parse("-n");
     createMigrationFile(1, NAME, migrationsDir, COMMAND);
-    new File(migrationsDir + "/foo.sql").createNewFile();
+    assertThat(new File(migrationsDir + "/foo.sql").createNewFile(), is(true));
     when(versionQueryResult.get()).thenReturn(ImmutableList.of(createVersionRow("1")));
     when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.MIGRATED)));
 
@@ -274,7 +274,7 @@ public class ApplyMigrationCommandTest {
       final String content
   ) throws IOException {
     final String filePath = getMigrationFilePath(version, name, migrationsDir);
-    new File(filePath).createNewFile();
+    assertThat(new File(filePath).createNewFile(), is(true));
     PrintWriter out = new PrintWriter(filePath, Charset.defaultCharset().name());
     out.println(content);
     out.close();

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -251,10 +251,11 @@ public class ApplyMigrationCommandTest {
   }
 
   @Test
-  public void shouldFailIfUntilVersionLowerThanPreviousVersion() throws Exception {
+  public void shouldFailIfFileDoesntFitFormat() throws Exception {
     // Given:
-    command = PARSER.parse("-u", "1");
+    command = PARSER.parse("-n");
     createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    new File(migrationsDir + "/foo.sql").createNewFile();
     when(versionQueryResult.get()).thenReturn(ImmutableList.of(createVersionRow("1")));
     when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.MIGRATED)));
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+import com.github.rvesse.airline.SingleCommand;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.api.client.BatchedQueryResult;
+import io.confluent.ksql.api.client.Client;
+import io.confluent.ksql.api.client.ExecuteStatementResult;
+import io.confluent.ksql.api.client.KsqlArray;
+import io.confluent.ksql.api.client.KsqlObject;
+import io.confluent.ksql.api.client.Row;
+import io.confluent.ksql.api.client.impl.RowImpl;
+import io.confluent.ksql.api.client.util.RowUtil;
+import io.confluent.ksql.tools.migrations.MigrationConfig;
+import io.confluent.ksql.tools.migrations.util.MetadataUtil;
+import io.confluent.ksql.tools.migrations.util.MetadataUtil.MigrationState;
+import io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil;
+import io.vertx.core.json.JsonArray;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+
+public class ApplyMigrationCommandTest {
+
+  private static final SingleCommand<ApplyMigrationCommand> PARSER =
+      SingleCommand.singleCommand(ApplyMigrationCommand.class);
+
+  private static final String MIGRATIONS_TABLE = "migrations_table";
+  private static final String MIGRATIONS_STREAM = "migrations_stream";
+  private static final String NAME = "FOO";
+  private static final String COMMAND = "CREATE STREAM FOO (A STRING) WITH (KAFKA_TOPIC='FOO', PARTITIONS=1, VALUE_FORMAT='DELIMITED');";
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Mock
+  private MigrationConfig config;
+  @Mock
+  private Client ksqlClient;
+  @Mock
+  private BatchedQueryResult versionQueryResult;
+  @Mock
+  private BatchedQueryResult infoQueryResult;
+  @Mock
+  private CompletableFuture<Void> insertResult;
+  @Mock
+  private CompletableFuture<ExecuteStatementResult> statementResult;
+
+  private String migrationsDir;
+  private ApplyMigrationCommand command;
+
+  @Before
+  public void setUp() throws ExecutionException, InterruptedException {
+    when(config.getString(MigrationConfig.KSQL_MIGRATIONS_TABLE_NAME)).thenReturn(MIGRATIONS_TABLE);
+    when(config.getString(MigrationConfig.KSQL_MIGRATIONS_STREAM_NAME)).thenReturn(MIGRATIONS_STREAM);
+
+    when(ksqlClient.insertInto(any(), any())).thenReturn(insertResult);
+    when(ksqlClient.executeStatement(any())).thenReturn(statementResult);
+    when(ksqlClient.executeQuery("SELECT VERSION FROM " + MIGRATIONS_TABLE + " WHERE version_key = 'CURRENT';"))
+        .thenReturn(versionQueryResult);
+    when(ksqlClient.executeQuery("SELECT checksum, previous, state FROM " + MIGRATIONS_TABLE + " WHERE version_key = '1';"))
+        .thenReturn(infoQueryResult);
+    when(insertResult.get()).thenReturn(null);
+    when(statementResult.get()).thenReturn(null);
+
+    migrationsDir = folder.getRoot().getPath();
+  }
+
+  @Test
+  public void shouldApplyFirstMigration()
+      throws IOException, ExecutionException, InterruptedException {
+    // Given:
+    command = PARSER.parse("-n");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of());
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(0));
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(inOrder, 1, MigrationState.MIGRATED);
+    inOrder.verify(ksqlClient).close();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldApplySecondMigration()
+      throws IOException, ExecutionException, InterruptedException {
+    // Given:
+    command = PARSER.parse("-n");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    createMigrationFile(2, NAME, migrationsDir, COMMAND);
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of(createVersionRow("1")));
+    when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.MIGRATED)));
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(0));
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(inOrder, 2, MigrationState.MIGRATED);
+    inOrder.verify(ksqlClient).close();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldApplyMultipleMigrations()
+      throws IOException, ExecutionException, InterruptedException {
+    // Given:
+    command = PARSER.parse("-a");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    createMigrationFile(2, NAME, migrationsDir, COMMAND);
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of());
+    when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.MIGRATED)));
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(0));
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(inOrder, 1, MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 2, MigrationState.MIGRATED);
+    inOrder.verify(ksqlClient).close();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldNotApplyMigrationIfPreviousNotFinished()
+      throws IOException, ExecutionException, InterruptedException {
+    // Given:
+    command = PARSER.parse("-a");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    createMigrationFile(2, NAME, migrationsDir, COMMAND);
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of());
+    when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.RUNNING)));
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(1));
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(inOrder, 1, MigrationState.MIGRATED);
+    inOrder.verify(ksqlClient).close();
+    Mockito.verify(ksqlClient, Mockito.times(1)).executeStatement(COMMAND);
+  }
+
+  @Test
+  public void shouldLogErrorStateIfMigrationFails()
+      throws IOException, ExecutionException, InterruptedException {
+    // Given:
+    command = PARSER.parse("-n");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of());
+    when(statementResult.get()).thenThrow(new InterruptedException());
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(1));
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(inOrder, 1, MigrationState.ERROR);
+    inOrder.verify(ksqlClient).close();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldSkipApplyIfValidateFails()
+      throws IOException, ExecutionException, InterruptedException {
+    // Given:
+    command = PARSER.parse("-n");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    createMigrationFile(1, "anotherone", migrationsDir, COMMAND);
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of(createVersionRow("1")));
+    when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.MIGRATED)));
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(1));
+    Mockito.verify(ksqlClient, Mockito.times(3)).executeQuery(any());
+  }
+
+  @Test
+  public void shouldFailIfUntilVersionLowerThanNextPendingVersion()
+      throws IOException, ExecutionException, InterruptedException {
+    // Given:
+    command = PARSER.parse("-u", "1");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of(createVersionRow("1")));
+    when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.MIGRATED)));
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(1));
+  }
+
+  private void createMigrationFile(
+      final int version,
+      final String name,
+      final String migrationsDir,
+      final String content
+  ) throws IOException {
+    final String filePath = getMigrationFilePath(version, name, migrationsDir);
+    new File(filePath).createNewFile();
+    PrintWriter out = new PrintWriter(filePath, Charset.defaultCharset().name());
+    out.println(content);
+    out.close();
+  }
+
+  private String getMigrationFilePath(
+      final int version,
+      final String name,
+      final String migrationsDir
+  ) {
+    return migrationsDir
+        + String.format("/V00000%d__%s.sql", version, name.replace(' ', '_'));
+  }
+
+  private KsqlObject createKsqlObject(
+      final String versionKey,
+      final int version,
+      final String name,
+      final MigrationState state,
+      final String startOn,
+      final String completedOn
+  ) {
+    final List<String> KEYS = ImmutableList.of(
+        "VERSION_KEY", "VERSION", "NAME", "STATE",
+        "CHECKSUM", "STARTED_ON", "COMPLETED_ON", "PREVIOUS"
+    );
+
+    final List<String> values = ImmutableList.of(
+        versionKey,
+        Integer.toString(version),
+        name,
+        state.toString(),
+        MigrationsDirectoryUtil.computeHashForFile(getMigrationFilePath(version, name, migrationsDir)),
+        startOn,
+        completedOn,
+        version == 1 ? MetadataUtil.NONE_VERSION : Integer.toString(version - 1)
+    );
+
+    return KsqlObject.fromArray(KEYS, new KsqlArray(values));
+  }
+
+  private Row createVersionRow(final String version) {
+    return new RowImpl(
+        ImmutableList.of("VERSION"),
+        RowUtil.columnTypesFromStrings(ImmutableList.of("STRING")),
+        new JsonArray(ImmutableList.of(version)),
+        ImmutableMap.of("VERSION", 1)
+    );
+  }
+
+  private Row createInfoRow(final int version, final String name, final MigrationState state) {
+    final String checksum = MigrationsDirectoryUtil.computeHashForFile(getMigrationFilePath(version, name, migrationsDir));
+    final String previous = version == 1 ? MetadataUtil.NONE_VERSION : Integer.toString(version - 1);
+    return new RowImpl(
+        ImmutableList.of("CHECKSUM", "PREVIOUS", "STATE"),
+        RowUtil.columnTypesFromStrings(ImmutableList.of("STRING", "STRING", "STRING")),
+        new JsonArray(ImmutableList.of(checksum, previous, state.toString())),
+        ImmutableMap.of("CHECKSUM", 1, "PREVIOUS", 2, "STATE", 3)
+    );
+  }
+
+  private void verifyMigratedVersion(final InOrder inOrder, final int version, final MigrationState finalState) {
+    inOrder.verify(ksqlClient).insertInto(
+        MIGRATIONS_STREAM,
+        createKsqlObject(MetadataUtil.CURRENT_VERSION_KEY, version, NAME, MigrationState.RUNNING, "1000", "")
+    );
+    inOrder.verify(ksqlClient).insertInto(
+        MIGRATIONS_STREAM,
+        createKsqlObject(Integer.toString(version), version, NAME, MigrationState.RUNNING, "1000", "")
+    );
+    inOrder.verify(ksqlClient).executeStatement(COMMAND);
+    inOrder.verify(ksqlClient).insertInto(
+        MIGRATIONS_STREAM,
+        createKsqlObject(MetadataUtil.CURRENT_VERSION_KEY, version, NAME, finalState, "1000", "1000")
+    );
+    inOrder.verify(ksqlClient).insertInto(
+        MIGRATIONS_STREAM,
+        createKsqlObject(Integer.toString(version), version, NAME, finalState, "1000", "1000")
+    );
+  }
+}

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
@@ -268,9 +268,9 @@ public class ValidateMigrationsCommandTest {
           + " WHERE version_key = '" + version + "';"))
           .thenReturn(queryResult);
       when(queryResult.get()).thenReturn(ImmutableList.of(row));
-      when(row.getString(0)).thenReturn(checksums.get(i));
-      when(row.getString(1)).thenReturn(prevVersion);
-      when(row.getString(2)).thenReturn(states.get(i).toString());
+      when(row.getString(1)).thenReturn(checksums.get(i));
+      when(row.getString(2)).thenReturn(prevVersion);
+      when(row.getString(3)).thenReturn(states.get(i).toString());
     }
   }
 


### PR DESCRIPTION
### Description 
Migrations tool `apply` command. Follows the algorithm outlined [here](https://github.com/jzaralim/ksql/pull/new/metadata-util). Also includes helper functions for writing metadata, loading all migration files and extracting the name of the migration from the file name, and introduces a new class, `Migration`

### Testing done 
unit and integration tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

