### PR TITLE
feat: limit the number of active push queries everywhere using "ksql.max.push.queries" config

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.LocalCommands;
 import io.confluent.ksql.rest.server.resources.streaming.PullQueryConfigPlannerOptions;
 import io.confluent.ksql.rest.server.resources.streaming.PullQueryConfigRoutingOptions;
@@ -61,6 +62,7 @@ public class QueryEndpoint {
 
   private final KsqlEngine ksqlEngine;
   private final KsqlConfig ksqlConfig;
+  private final KsqlRestConfig ksqlRestConfig;
   private final RoutingFilterFactory routingFilterFactory;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RateLimiter rateLimiter;
@@ -78,6 +80,7 @@ public class QueryEndpoint {
   ) {
     this.ksqlEngine = ksqlEngine;
     this.ksqlConfig = ksqlConfig;
+    this.ksqlRestConfig = new KsqlRestConfig(ksqlConfig.originals());
     this.routingFilterFactory = routingFilterFactory;
     this.pullQueryMetrics = pullQueryMetrics;
     this.rateLimiter = rateLimiter;
@@ -114,10 +117,10 @@ public class QueryEndpoint {
   ) {
     final BlockingQueryPublisher publisher = new BlockingQueryPublisher(context, workerExecutor);
 
-    if (QueryCapacityUtil.exceedsPushQueryCapacity(ksqlEngine, ksqlConfig)) {
+    if (QueryCapacityUtil.exceedsPushQueryCapacity(ksqlEngine, ksqlRestConfig)) {
       QueryCapacityUtil.throwTooManyActivePushQueriesException(
               ksqlEngine,
-              ksqlConfig,
+              ksqlRestConfig,
               statement.getStatementText()
       );
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -72,6 +72,7 @@ public class QueryEndpoint {
   public QueryEndpoint(
       final KsqlEngine ksqlEngine,
       final KsqlConfig ksqlConfig,
+      final KsqlRestConfig ksqlRestConfig,
       final RoutingFilterFactory routingFilterFactory,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RateLimiter rateLimiter,
@@ -80,7 +81,7 @@ public class QueryEndpoint {
   ) {
     this.ksqlEngine = ksqlEngine;
     this.ksqlConfig = ksqlConfig;
-    this.ksqlRestConfig = new KsqlRestConfig(ksqlConfig.originals());
+    this.ksqlRestConfig = ksqlRestConfig;
     this.routingFilterFactory = routingFilterFactory;
     this.pullQueryMetrics = pullQueryMetrics;
     this.rateLimiter = rateLimiter;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -359,7 +359,7 @@ public final class KsqlRestApplication implements Executable {
       apiServer.start();
 
       final KsqlConfig ksqlConfigWithPort = buildConfigWithPort();
-      configurables.forEach(c -> c.configure(ksqlConfigWithPort, restConfig));
+      configurables.forEach(c -> c.configure(ksqlConfigWithPort));
 
       startKsql(ksqlConfigWithPort);
       final Properties metricsProperties = new Properties();
@@ -748,6 +748,7 @@ public final class KsqlRestApplication implements Executable {
 
     final StreamedQueryResource streamedQueryResource = new StreamedQueryResource(
         ksqlEngine,
+        restConfig,
         commandStore,
         Duration.ofMillis(
             restConfig.getLong(KsqlRestConfig.STREAMED_QUERY_DISCONNECT_CHECK_MS_CONFIG)),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -336,6 +336,7 @@ public final class KsqlRestApplication implements Executable {
       final Endpoints endpoints = new KsqlServerEndpoints(
           ksqlEngine,
           ksqlConfigNoPort,
+          restConfig,
           routingFilterFactory,
           ksqlSecurityContextProvider,
           ksqlResource,
@@ -358,7 +359,7 @@ public final class KsqlRestApplication implements Executable {
       apiServer.start();
 
       final KsqlConfig ksqlConfigWithPort = buildConfigWithPort();
-      configurables.forEach(c -> c.configure(ksqlConfigWithPort));
+      configurables.forEach(c -> c.configure(ksqlConfigWithPort, restConfig));
 
       startKsql(ksqlConfigWithPort);
       final Properties metricsProperties = new Properties();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -68,6 +68,7 @@ public class KsqlServerEndpoints implements Endpoints {
 
   private final KsqlEngine ksqlEngine;
   private final KsqlConfig ksqlConfig;
+  private final KsqlRestConfig ksqlRestConfig;
   private final RoutingFilterFactory routingFilterFactory;
   private final ReservedInternalTopics reservedInternalTopics;
   private final KsqlSecurityContextProvider ksqlSecurityContextProvider;
@@ -90,6 +91,7 @@ public class KsqlServerEndpoints implements Endpoints {
   public KsqlServerEndpoints(
       final KsqlEngine ksqlEngine,
       final KsqlConfig ksqlConfig,
+      final KsqlRestConfig ksqlRestConfig,
       final RoutingFilterFactory routingFilterFactory,
       final KsqlSecurityContextProvider ksqlSecurityContextProvider,
       final KsqlResource ksqlResource,
@@ -111,6 +113,7 @@ public class KsqlServerEndpoints implements Endpoints {
     // CHECKSTYLE_RULES.ON: ParameterNumber
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine);
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig);
+    this.ksqlRestConfig = Objects.requireNonNull(ksqlRestConfig);
     this.routingFilterFactory = Objects.requireNonNull(routingFilterFactory);
     this.reservedInternalTopics = new ReservedInternalTopics(ksqlConfig);
     this.ksqlSecurityContextProvider = Objects.requireNonNull(ksqlSecurityContextProvider);
@@ -141,8 +144,8 @@ public class KsqlServerEndpoints implements Endpoints {
     return executeOnWorker(() -> {
       try {
         return new QueryEndpoint(
-            ksqlEngine, ksqlConfig, routingFilterFactory, pullQueryMetrics, rateLimiter, routing,
-            localCommands)
+            ksqlEngine, ksqlConfig, ksqlRestConfig, routingFilterFactory, pullQueryMetrics,
+            rateLimiter, routing, localCommands)
             .createQueryPublisher(
                 sql,
                 properties,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlConfigurable.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlConfigurable.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.KsqlConfig;
 
 public interface KsqlConfigurable {
@@ -23,6 +24,7 @@ public interface KsqlConfigurable {
    * Called with the server config.
    *
    * @param config server config
+   * @param restConfig REST config
    */
-  void configure(KsqlConfig config);
+  void configure(KsqlConfig config, KsqlRestConfig restConfig);
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlConfigurable.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlConfigurable.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.server.resources;
 
-import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.KsqlConfig;
 
 public interface KsqlConfigurable {
@@ -24,7 +23,6 @@ public interface KsqlConfigurable {
    * Called with the server config.
    *
    * @param config server config
-   * @param restConfig REST config
    */
-  void configure(KsqlConfig config, KsqlRestConfig restConfig);
+  void configure(KsqlConfig config);
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -169,13 +169,13 @@ public class StreamedQueryResource implements KsqlConfigurable {
   }
 
   @Override
-  public void configure(final KsqlConfig config) {
+  public void configure(final KsqlConfig config, final KsqlRestConfig restConfig) {
     if (!config.getKsqlStreamConfigProps().containsKey(StreamsConfig.APPLICATION_SERVER_CONFIG)) {
       throw new IllegalArgumentException("Need KS application server set");
     }
 
     ksqlConfig = config;
-    ksqlRestConfig = new KsqlRestConfig(ksqlConfig.originals());
+    ksqlRestConfig = restConfig;
   }
 
   public EndpointResponse streamQuery(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -97,6 +97,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
   @SuppressWarnings("checkstyle:ParameterNumber")
   public StreamedQueryResource(
       final KsqlEngine ksqlEngine,
+      final KsqlRestConfig ksqlRestConfig,
       final CommandQueue commandQueue,
       final Duration disconnectCheckInterval,
       final Duration commandQueueCatchupTimeout,
@@ -112,6 +113,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
   ) {
     this(
         ksqlEngine,
+        ksqlRestConfig,
         new StatementParser(ksqlEngine),
         commandQueue,
         disconnectCheckInterval,
@@ -133,6 +135,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
   StreamedQueryResource(
       // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
       final KsqlEngine ksqlEngine,
+      final KsqlRestConfig ksqlRestConfig,
       final StatementParser statementParser,
       final CommandQueue commandQueue,
       final Duration disconnectCheckInterval,
@@ -148,6 +151,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final Optional<LocalCommands> localCommands
   ) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
+    this.ksqlRestConfig = Objects.requireNonNull(ksqlRestConfig, "ksqlRestConfig");
     this.statementParser = Objects.requireNonNull(statementParser, "statementParser");
     this.commandQueue = Objects.requireNonNull(commandQueue, "commandQueue");
     this.disconnectCheckInterval =
@@ -169,13 +173,12 @@ public class StreamedQueryResource implements KsqlConfigurable {
   }
 
   @Override
-  public void configure(final KsqlConfig config, final KsqlRestConfig restConfig) {
+  public void configure(final KsqlConfig config) {
     if (!config.getKsqlStreamConfigProps().containsKey(StreamsConfig.APPLICATION_SERVER_CONFIG)) {
       throw new IllegalArgumentException("Need KS application server set");
     }
 
     ksqlConfig = config;
-    ksqlRestConfig = restConfig;
   }
 
   public EndpointResponse streamQuery(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.LocalCommands;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
@@ -91,6 +92,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
   private final Optional<LocalCommands> localCommands;
 
   private KsqlConfig ksqlConfig;
+  private KsqlRestConfig ksqlRestConfig;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public StreamedQueryResource(
@@ -173,6 +175,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
     }
 
     ksqlConfig = config;
+    ksqlRestConfig = new KsqlRestConfig(ksqlConfig.originals());
   }
 
   public EndpointResponse streamQuery(
@@ -354,10 +357,10 @@ public class StreamedQueryResource implements KsqlConfigurable {
     final ConfiguredStatement<Query> configured = ConfiguredStatement
         .of(statement, SessionConfig.of(ksqlConfig, streamsProperties));
 
-    if (QueryCapacityUtil.exceedsPushQueryCapacity(ksqlEngine, ksqlConfig)) {
+    if (QueryCapacityUtil.exceedsPushQueryCapacity(ksqlEngine, ksqlRestConfig)) {
       QueryCapacityUtil.throwTooManyActivePushQueriesException(
               ksqlEngine,
-              ksqlConfig,
+              ksqlRestConfig,
               statement.getStatementText()
       );
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -354,12 +354,12 @@ public class StreamedQueryResource implements KsqlConfigurable {
     final ConfiguredStatement<Query> configured = ConfiguredStatement
         .of(statement, SessionConfig.of(ksqlConfig, streamsProperties));
 
-    final int numPushQueries = QueryCapacityUtil.getNumLivePushQueries(ksqlEngine);
-    final int pushQueryLimit = QueryCapacityUtil.getPushQueryLimit(ksqlConfig);
-
-    if (numPushQueries >= pushQueryLimit) {
-      QueryCapacityUtil.throwTooManyActivePushQueriesException(statement.getStatementText(),
-              numPushQueries, pushQueryLimit);
+    if (QueryCapacityUtil.exceedsPushQueryCapacity(ksqlEngine, ksqlConfig)) {
+      QueryCapacityUtil.throwTooManyActivePushQueriesException(
+              ksqlEngine,
+              ksqlConfig,
+              statement.getStatementText()
+      );
     }
 
     final TransientQueryMetadata query = ksqlEngine

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
@@ -57,14 +57,14 @@ public final class QueryCapacityUtil {
 
   public static boolean exceedsPushQueryCapacity(
           final KsqlExecutionContext executionContext,
-          final KsqlConfig ksqlConfig
+          final KsqlRestConfig ksqlRestConfig
   ) {
-    return getNumLivePushQueries(executionContext) > getPushQueryLimit(ksqlConfig);
+    return getNumLivePushQueries(executionContext) >= getPushQueryLimit(ksqlRestConfig);
   }
 
   public static void throwTooManyActivePushQueriesException(
           final KsqlExecutionContext executionContext,
-          final KsqlConfig ksqlConfig,
+          final KsqlRestConfig ksqlRestConfig,
           final String statementStr
   ) {
     throw new KsqlException(
@@ -77,7 +77,7 @@ public final class QueryCapacityUtil {
                     statementStr,
                     KsqlRestConfig.MAX_PUSH_QUERIES,
                     getNumLivePushQueries(executionContext),
-                    getPushQueryLimit(ksqlConfig)
+                    getPushQueryLimit(ksqlRestConfig)
             )
     );
   }
@@ -86,8 +86,7 @@ public final class QueryCapacityUtil {
     return ctx.getAllLiveQueries().size() - ctx.getPersistentQueries().size();
   }
 
-  private static int getPushQueryLimit(final KsqlConfig ksqlConfig) {
-    KsqlRestConfig ksqlRestConfig = new KsqlRestConfig(ksqlConfig.originals());
+  private static int getPushQueryLimit(final KsqlRestConfig ksqlRestConfig) {
     return ksqlRestConfig.getInt(KsqlRestConfig.MAX_PUSH_QUERIES);
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.util;
 
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 
@@ -53,4 +54,35 @@ public final class QueryCapacityUtil {
   private static int getQueryLimit(final KsqlConfig ksqlConfig) {
     return ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG);
   }
+
+  public static void throwTooManyActivePushQueriesException(
+          final String statementStr,
+          final int numPushQueries,
+          final int pushQueryLimit
+  ) {
+    throw new KsqlException(
+            String.format(
+                    "Not executing statement(s) '%s' as it would cause the number "
+                            + "of active, push queries to exceed the configured limit. "
+                            + "Terminate existing PUSH queries, "
+                            + "or increase the '%s' setting via the 'ksql-server.properties' file. "
+                            + "Current push query count: %d. Configured limit: %d.",
+                    statementStr,
+                    KsqlRestConfig.MAX_PUSH_QUERIES,
+                    numPushQueries,
+                    pushQueryLimit
+            )
+    );
+  }
+
+  public static int getNumLivePushQueries(final KsqlExecutionContext ctx) {
+    return ctx.getAllLiveQueries().size() - ctx.getPersistentQueries().size();
+  }
+
+  public static int getPushQueryLimit(final KsqlConfig ksqlConfig) {
+    return Integer.parseInt(ksqlConfig
+            .originals()
+            .get("ksql.max.push.queries").toString());
+  }
+
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
@@ -82,7 +82,8 @@ public final class QueryCapacityUtil {
   public static int getPushQueryLimit(final KsqlConfig ksqlConfig) {
     return Integer.parseInt(ksqlConfig
             .originals()
-            .get(KsqlRestConfig.MAX_PUSH_QUERIES).toString());
+            .getOrDefault(KsqlRestConfig.MAX_PUSH_QUERIES, String.valueOf(Integer.MAX_VALUE))
+            .toString());
   }
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
@@ -82,7 +82,7 @@ public final class QueryCapacityUtil {
   public static int getPushQueryLimit(final KsqlConfig ksqlConfig) {
     return Integer.parseInt(ksqlConfig
             .originals()
-            .get("ksql.max.push.queries").toString());
+            .get(KsqlRestConfig.MAX_PUSH_QUERIES).toString());
   }
 
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -22,6 +22,7 @@ import static io.confluent.ksql.rest.Errors.badRequest;
 import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorCode;
 import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorMessage;
 import static io.confluent.ksql.rest.entity.KsqlStatementErrorMessageMatchers.statement;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionErrorMessage;
 import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatementErrorMessage;
 import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatusCode;
@@ -187,6 +188,8 @@ public class StreamedQueryResourceTest {
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
+  private KsqlRestConfig ksqlRestConfig;
+  @Mock
   private PullQueryResult pullQueryResult;
   @Mock
   private LogicalSchema schema;
@@ -218,6 +221,7 @@ public class StreamedQueryResourceTest {
 
     testResource =  new StreamedQueryResource(
         mockKsqlEngine,
+        ksqlRestConfig,
         mockStatementParser,
         commandQueue,
         DISCONNECT_CHECK_INTERVAL,
@@ -301,6 +305,7 @@ public class StreamedQueryResourceTest {
 
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
+        ksqlRestConfig,
         mockStatementParser,
         commandQueue,
         DISCONNECT_CHECK_INTERVAL,
@@ -347,6 +352,7 @@ public class StreamedQueryResourceTest {
     // Given:
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
+        ksqlRestConfig,
         mockStatementParser,
         commandQueue,
         DISCONNECT_CHECK_INTERVAL,
@@ -512,6 +518,7 @@ public class StreamedQueryResourceTest {
     when(mockStatementParser.<Query>parseSingleStatement(PULL_QUERY_STRING)).thenReturn(query);
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
+        ksqlRestConfig,
         mockStatementParser,
         commandQueue,
         DISCONNECT_CHECK_INTERVAL,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -15,41 +15,12 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
-import static io.confluent.ksql.GenericRow.genericRow;
-import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_STATEMENT;
-import static io.confluent.ksql.rest.Errors.ERROR_CODE_FORBIDDEN_KAFKA_ACCESS;
-import static io.confluent.ksql.rest.Errors.badRequest;
-import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorCode;
-import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorMessage;
-import static io.confluent.ksql.rest.entity.KsqlStatementErrorMessageMatchers.statement;
-import io.confluent.ksql.rest.server.KsqlRestConfig;
-import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionErrorMessage;
-import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatementErrorMessage;
-import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatusCode;
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
-import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.GenericRow;
+import static io.confluent.ksql.GenericRow.genericRow;
 import io.confluent.ksql.api.server.StreamingOutput;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.engine.KsqlEngine;
@@ -72,17 +43,27 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_STATEMENT;
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_FORBIDDEN_KAFKA_ACCESS;
+import static io.confluent.ksql.rest.Errors.badRequest;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorCode;
+import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorMessage;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
+import static io.confluent.ksql.rest.entity.KsqlStatementErrorMessageMatchers.statement;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.StreamedRow.DataRow;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
+import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionErrorMessage;
+import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatementErrorMessage;
+import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatusCode;
 import io.confluent.ksql.rest.server.validation.CustomValidators;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -98,6 +79,9 @@ import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata.ResultType;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.PipedInputStream;
@@ -125,11 +109,26 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.codehaus.plexus.util.StringUtils;
 import org.hamcrest.CoreMatchers;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.hamcrest.Matchers;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mock;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -631,6 +630,8 @@ public class StreamedQueryResourceTest {
         ConfiguredStatement
             .of(query, SessionConfig.of(VALID_CONFIG, requestStreamsProperties)), false))
         .thenReturn(transientQueryMetadata);
+
+    when(ksqlRestConfig.getInt(KsqlRestConfig.MAX_PUSH_QUERIES)).thenReturn(Integer.MAX_VALUE);
 
     final EndpointResponse response =
         testResource.streamQuery(


### PR DESCRIPTION
### Description 
This PR limits the number of active push queries using the `ksql.max.push.queries` config.

### Testing done 
- Unit testing
- Manual Testing
- 
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

