### PR TITLE
build: add back maven settings file into release commit (MINOR)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,6 +253,7 @@ def job = {
                             withEnv(['MAVEN_OPTS=-XX:MaxPermSize=128M']) {
                                 sh """
                                 cp ${settingsFile} ~/.m2/settings.xml
+                                cp ${settingsFile} .
                                 ${env.WORKSPACE}/build-packages.sh --workspace . \
                                     --docker-registry ${config.dockerRegistry} \
                                     --project-version ${config.ksql_db_artifact_version} \
@@ -261,7 +262,6 @@ def job = {
                             }
                             step([$class: 'hudson.plugins.findbugs.FindBugsPublisher', pattern: '**/*bugsXml.xml'])
 
-                            sh "cp ${settingsFile} ."
                             if (!config.isPrJob) {
                                 def git_tag = "v${config.ksql_db_artifact_version}-ksqldb"
                                 sh "git tag ${git_tag}"

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -122,6 +122,7 @@ echo "Versioning Diff:"
 git diff | cat
 
 # Commit changes
+git add .
 git commit -a -m "build: Setting project version ${FULL_VERSION} and parent version ${UPSTREAM_VERSION}."
 
 # We run things through fakeroot, which causes issues with finding an .m2/repository location to write. We set the homedir where it does

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -122,7 +122,7 @@ echo "Versioning Diff:"
 git diff | cat
 
 # Commit changes
-git add .
+git add maven-settings.xml
 git commit -a -m "build: Setting project version ${FULL_VERSION} and parent version ${UPSTREAM_VERSION}."
 
 # We run things through fakeroot, which causes issues with finding an .m2/repository location to write. We set the homedir where it does


### PR DESCRIPTION
### Description 

After the recent refactoring to the build script, the maven-settings.xml file is no longer getting checked into the git tag, which means the release branches are no longer buildable. This PR adds back the file.

### Testing done 

Wasn't able to test this with jenkins replay since the fix requires changes to build-packages.sh which we can't edit in replay. @andrewegel do you know of a workaround for testing this?

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

