### PR TITLE
feat(migrations): implement `create` command

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -15,21 +15,33 @@
 
 package io.confluent.ksql.tools.migrations.commands;
 
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getAllVersions;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getFilePathForVersion;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getFilePrefixForVersion;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getMigrationsDirFromConfigFile;
+
 import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.help.Examples;
 import com.github.rvesse.airline.annotations.restrictions.Required;
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.tools.migrations.MigrationException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Command(
     name = "create",
-    description = "Create a migration file with <desc> as description, which will be used to "
-        + "apply the next schema version."
+    description = "Create a blank migration file with <description> as description, which "
+        + "can then be edited and applied as the next schema version."
 )
 @Examples(
-    examples = "$ ksql-migrations create add_users",
+    examples = "$ ksql-migrations create Add_users",
     descriptions = "Creates a new migrations file for adding a users table to ksqlDB "
         + "(e.g. V000002__Add_users.sql)"
 )
@@ -37,27 +49,120 @@ public class CreateMigrationCommand extends BaseCommand {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CreateMigrationCommand.class);
 
+  private static final String INVALID_FILENAME_CHARS_PATTERN = "\\s|/|\\\\|:|\\*|\\?|\"|<|>|\\|";
+
   @Option(
       name = {"-v", "--version"},
       description = "the schema version to initialize, defaults to the next"
-          + " schema version."
+          + " schema version based on existing migration files."
   )
   private int version;
 
   @Required
   @Arguments(
-      title = "desc",
+      title = "description",
       description = "The description for the migration."
   )
   private String description;
 
   @Override
   protected int command() {
-    throw new UnsupportedOperationException();
+    return command(getMigrationsDirFromConfigFile(configFile));
+  }
+
+  @VisibleForTesting
+  int command(final String migrationsDir) {
+    if (!validateVersionDoesNotAlreadyExist(migrationsDir) || !validateDescriptionNotEmpty()) {
+      return 1;
+    }
+
+    try {
+      final int newVersion = version != 0 ? version : getLatestVersion(migrationsDir) + 1;
+      createMigrationsFile(newVersion, migrationsDir);
+    } catch (MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return 1;
+    }
+
+    return 0;
   }
 
   @Override
   protected Logger getLogger() {
     return LOGGER;
+  }
+
+  /**
+   * @return true if validation succeeds, else false
+   */
+  private boolean validateVersionDoesNotAlreadyExist(final String migrationsDir) {
+    // no explicit version was specified, nothing to verify
+    // (airline actually can't distinguish between explicit 0 and nothing specified,
+    // but we won't worry about this edge case for now)
+    if (version == 0) {
+      return true;
+    }
+
+    final Optional<String> existingFile;
+    try {
+      existingFile = getFilePathForVersion(String.valueOf(version), migrationsDir);
+    } catch (MigrationException e) {
+      LOGGER.error(e.getMessage());
+      return false;
+    }
+
+    if (existingFile.isPresent()) {
+      LOGGER.error("Found existing migrations file for version {}: {}",
+          version, existingFile.get());
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * @return true if validation succeeds, else false
+   */
+  private boolean validateDescriptionNotEmpty() {
+    if (description.isEmpty()) {
+      LOGGER.error("Description cannot be empty.");
+      return false;
+    }
+    return true;
+  }
+
+  private void createMigrationsFile(final int newVersion, final String migrationsDir) {
+    if (newVersion <= 0) {
+      throw new MigrationException("Invalid version file version: " + newVersion
+          + ". Version must be a positive integer.");
+    }
+    if (newVersion > 999999) {
+      throw new MigrationException("Invalid version file version: " + newVersion
+          + ". Version must fit into a six-digit integer.");
+    }
+
+    final String filename = getNewFileName(newVersion, description);
+    final String filePath = Paths.get(migrationsDir, filename).toString();
+    try {
+      LOGGER.info("Creating file: " + filePath);
+      final boolean result = new File(filePath).createNewFile();
+      if (!result) {
+        throw new IllegalStateException("File should not exist");
+      }
+    } catch (IOException | IllegalStateException e) {
+      throw new MigrationException(String.format(
+          "Failed to create file %s: %s", filePath, e.getMessage()));
+    }
+  }
+
+  private static int getLatestVersion(final String migrationsDir) {
+    final List<Integer> allVersions = getAllVersions(migrationsDir);
+    return allVersions.size() != 0 ? allVersions.get(allVersions.size() - 1) : 0;
+  }
+
+  private static String getNewFileName(final int newVersion, final String description) {
+    final String versionPrefix = getFilePrefixForVersion(String.valueOf(newVersion));
+    final String descriptionSuffix = description.replaceAll(INVALID_FILENAME_CHARS_PATTERN, "_");
+    return versionPrefix + "__" + descriptionSuffix + ".sql";
   }
 }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommandTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getFilePrefixForVersion;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.github.rvesse.airline.SingleCommand;
+import com.github.rvesse.airline.parser.errors.ParseArgumentsMissingException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
+import java.nio.file.Paths;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CreateMigrationCommandTest {
+
+  private static final SingleCommand<CreateMigrationCommand> PARSER =
+      SingleCommand.singleCommand(CreateMigrationCommand.class);
+
+  private static final String DESCRIPTION = "migration file description";
+  private static final String EXPECTED_FILE_SUFFIX = "migration_file_description.sql";
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private String migrationsDir;
+  private CreateMigrationCommand command;
+
+  @Before
+  public void setUp() {
+    migrationsDir = folder.getRoot().getPath();
+  }
+
+  @Test
+  public void shouldCreateWithNoExplicitVersionAndNonEmptyMigrationsDir() throws Exception {
+    // Given:
+    givenVersionsExist("1", "2", "4");
+
+    command = PARSER.parse(DESCRIPTION);
+
+    // When:
+    final int result = command.command(migrationsDir);
+
+    // Then:
+    assertThat(result, is(0));
+
+    final File expectedFile = new File(Paths.get(migrationsDir, "V000005__" + EXPECTED_FILE_SUFFIX).toString());
+    assertThat(expectedFile.exists(), is(true));
+    assertThat(expectedFile.isDirectory(), is(false));
+  }
+
+  @Test
+  public void shouldCreateWithNoExplicitVersionAndEmptyMigrationsDir() {
+    // Given:
+    command = PARSER.parse(DESCRIPTION);
+
+    // When:
+    final int result = command.command(migrationsDir);
+
+    // Then:
+    assertThat(result, is(0));
+
+    final File expectedFile = new File(Paths.get(migrationsDir, "V000001__" + EXPECTED_FILE_SUFFIX).toString());
+    assertThat(expectedFile.exists(), is(true));
+    assertThat(expectedFile.isDirectory(), is(false));
+  }
+
+  @Test
+  public void shouldCreateWithExplicitVersion() {
+    // Given:
+    command = PARSER.parse(DESCRIPTION, "-v", "12");
+
+    // When:
+    final int result = command.command(migrationsDir);
+
+    // Then:
+    assertThat(result, is(0));
+
+    final File expectedFile = new File(Paths.get(migrationsDir, "V000012__" + EXPECTED_FILE_SUFFIX).toString());
+    assertThat(expectedFile.exists(), is(true));
+    assertThat(expectedFile.isDirectory(), is(false));
+  }
+
+  @Test
+  public void shouldFailIfVersionAlreadyExists() throws Exception {
+    // Given:
+    givenVersionsExist("12");
+
+    command = PARSER.parse(DESCRIPTION, "-v", "12");
+
+    // When:
+    final int result = command.command(migrationsDir);
+
+    // Then:
+    assertThat(result, is(1));
+  }
+
+  @Test
+  public void shouldFailOnNegativeVersion() {
+    // Given:
+    command = PARSER.parse(DESCRIPTION, "-v", "-1");
+
+    // When:
+    final int result = command.command(migrationsDir);
+
+    // Then:
+    assertThat(result, is(1));
+  }
+
+  @Test
+  public void shouldFailIfVersionTooLarge() {
+    // Given:
+    command = PARSER.parse(DESCRIPTION, "-v", "10000000");
+
+    // When:
+    final int result = command.command(migrationsDir);
+
+    // Then:
+    assertThat(result, is(1));
+  }
+
+  @Test
+  public void shouldFailOnMissingDescription() {
+    // When:
+    final Exception e = assertThrows(ParseArgumentsMissingException.class, () -> PARSER.parse());
+
+    // Then:
+    assertThat(e.getMessage(), is("Required arguments are missing: 'description'"));
+  }
+
+  @Test
+  public void shouldFailOnEmptyDescription() {
+    // Given:
+    command = PARSER.parse("");
+
+    // When:
+    final int result = command.command(migrationsDir);
+
+    // Then:
+    assertThat(result, is(1));
+  }
+
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+  private void givenVersionsExist(final String... versions) throws Exception {
+    for (final String version : versions) {
+      final String prefix = getFilePrefixForVersion(version);
+      new File(Paths.get(migrationsDir, prefix + "__some_desc_" + version + ".sql").toString()).createNewFile();
+    }
+  }
+}

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.tools.migrations.commands;
 
 import static io.confluent.ksql.tools.migrations.util.MetadataUtil.CURRENT_VERSION_KEY;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getFilePrefixForVersion;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.inOrder;
@@ -41,7 +42,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -313,7 +313,7 @@ public class ValidateMigrationsCommandTest {
   }
 
   private String filePathForVersion(final String version) {
-    final String prefix = "V" + StringUtils.leftPad(version, 6, "0");
+    final String prefix = getFilePrefixForVersion(version);
     return Paths.get(migrationsDir, prefix + "_awesome_migration").toString();
   }
 


### PR DESCRIPTION
### Description 

The `migrations create` command creates an empty migrations file, of the appropriate filename format.

### Testing done 

Unit + integration.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

