### PR TITLE
fix: script used in kci-170 is now exporting an array instead of string

### DIFF
--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/GrammarTokenExporter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/GrammarTokenExporter.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import scala.Console;
 
 public final class GrammarTokenExporter {
   private GrammarTokenExporter() {
@@ -30,7 +29,11 @@ public final class GrammarTokenExporter {
 
   public static void main(final String[] args) throws IOException {
     final List<String> tokens = GrammarTokenExporter.getTokens();
-    Console.println("'" + String.join(" ", tokens) + "'");
+    final List<String> tokensWithQuotes = new ArrayList<>();
+    for (String token:tokens) {
+      tokensWithQuotes.add("'" + token + "'");
+    }
+    System.out.println(tokensWithQuotes);
   }
 
   private static final Pattern pattern = Pattern.compile("(T__[0-9]|\\w+_\\w+|UNRECOGNIZED)");


### PR DESCRIPTION
Jira: [https://confluentinc.atlassian.net/browse/KCI-170](KCI-170)
This is closely related to the [https://github.com/confluentinc/ksql/pull/7118](7118) PR. I needed to edit the script because of changes in the UI counterpart. The script now exports an array instead of a string.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

