### PR TITLE
feat(migrations): add ability to apply specific migration version

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.tools.migrations.commands;
 
 import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getAllMigrations;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getMigrationForVersion;
 import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getMigrationsDirFromConfigFile;
 
 import com.github.rvesse.airline.annotations.Command;
@@ -36,6 +37,7 @@ import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -192,7 +194,12 @@ public class ApplyMigrationCommand extends BaseCommand {
       final int minimumVersion
   ) {
     if (version > 0) {
-      // TODO
+      final Optional<Migration> migration =
+          getMigrationForVersion(String.valueOf(version), migrationsDir);
+      if (!migration.isPresent()) {
+        throw new MigrationException("No migration file with version " + version + " exists.");
+      }
+      return Collections.singletonList(migration.get());
     }
 
     final List<Migration> migrations = getAllMigrations(migrationsDir).stream()

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -16,8 +16,8 @@
 package io.confluent.ksql.tools.migrations.commands;
 
 import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getAllVersions;
-import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getFilePathForVersion;
 import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getFilePrefixForVersion;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getMigrationForVersion;
 import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getMigrationsDirFromConfigFile;
 
 import com.github.rvesse.airline.annotations.Arguments;
@@ -26,6 +26,7 @@ import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.help.Examples;
 import com.github.rvesse.airline.annotations.restrictions.Required;
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.tools.migrations.Migration;
 import io.confluent.ksql.tools.migrations.MigrationException;
 import java.io.File;
 import java.io.IOException;
@@ -103,17 +104,17 @@ public class CreateMigrationCommand extends BaseCommand {
       return true;
     }
 
-    final Optional<String> existingFile;
+    final Optional<Migration> existingMigration;
     try {
-      existingFile = getFilePathForVersion(String.valueOf(version), migrationsDir);
+      existingMigration = getMigrationForVersion(String.valueOf(version), migrationsDir);
     } catch (MigrationException e) {
       LOGGER.error(e.getMessage());
       return false;
     }
 
-    if (existingFile.isPresent()) {
+    if (existingMigration.isPresent()) {
       LOGGER.error("Found existing migrations file for version {}: {}",
-          version, existingFile.get());
+          version, existingMigration.get().getFilepath());
       return false;
     }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
@@ -19,7 +19,7 @@ import static io.confluent.ksql.tools.migrations.util.MetadataUtil.getInfoForVer
 import static io.confluent.ksql.tools.migrations.util.MetadataUtil.getLatestMigratedVersion;
 import static io.confluent.ksql.tools.migrations.util.MetadataUtil.validateVersionIsMigrated;
 import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.computeHashForFile;
-import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getFilePathForVersion;
+import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getMigrationForVersion;
 import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.getMigrationsDirFromConfigFile;
 
 import com.github.rvesse.airline.annotations.Command;
@@ -134,7 +134,7 @@ public class ValidateMigrationsCommand extends BaseCommand {
 
       final String filename;
       try {
-        filename = getFilePathForVersion(version, migrationsDir).get();
+        filename = getMigrationForVersion(version, migrationsDir).get().getFilepath();
       } catch (MigrationException | NoSuchElementException e) {
         LOGGER.error("No migrations file found for version with status {}. Version: {}",
             MigrationState.MIGRATED, version);

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtil.java
@@ -165,6 +165,27 @@ public final class MigrationsDirectoryUtil {
       ));
     }
 
+    validateMigrationVersionsUnique(migrations);
+
     return migrations;
+  }
+
+  private static void validateMigrationVersionsUnique(final List<Migration> migrations) {
+    if (migrations.size() == 0) {
+      return;
+    }
+
+    Migration previous = migrations.get(0);
+    for (int i = 1; i < migrations.size(); i++) {
+      if (migrations.get(i).getVersion() == previous.getVersion()) {
+        throw new MigrationException(String.format(
+            "Found multiple migrations files with the same version. Version: %d. Files: '%s', '%s'",
+            migrations.get(i).getVersion(),
+            migrations.get(i).getFilepath(),
+            previous.getFilepath()
+        ));
+      }
+      previous = migrations.get(i);
+    }
   }
 }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -114,7 +114,7 @@ public class MigrationsTest {
         () -> makeKsqlQuery("SELECT * FROM migration_schema_versions WHERE VERSION_KEY='CURRENT';").size(),
         is(1)
     );
-    final int status = MIGRATIONS_CLI.parse("--config-file", configFilePath, "apply").run();
+    final int status = MIGRATIONS_CLI.parse("--config-file", configFilePath, "apply", "-a").run();
     assertThat(status, is(0));
 
     // verify FOO and BAR were registered

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -184,6 +184,8 @@ public class ApplyMigrationCommandTest {
     command = PARSER.parse("-u", "2");
     createMigrationFile(1, NAME, migrationsDir, COMMAND);
     createMigrationFile(2, NAME, migrationsDir, COMMAND);
+    // extra migration to ensure only the first two are applied
+    createMigrationFile(3, NAME, migrationsDir, COMMAND);
     when(versionQueryResult.get()).thenReturn(ImmutableList.of());
     when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.MIGRATED)));
 
@@ -196,6 +198,27 @@ public class ApplyMigrationCommandTest {
     final InOrder inOrder = inOrder(ksqlClient);
     verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
     verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED);
+    inOrder.verify(ksqlClient).close();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldApplySpecificMigration() throws Exception {
+    // Given:
+    command = PARSER.parse("-v", "3");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    createMigrationFile(3, NAME, migrationsDir, COMMAND);
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of(createVersionRow("1")));
+    when(infoQueryResult.get()).thenReturn(ImmutableList.of(createInfoRow(1, NAME, MigrationState.MIGRATED)));
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(0));
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -119,6 +119,8 @@ public class ApplyMigrationCommandTest {
     // Given:
     command = PARSER.parse("-n");
     createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    // extra migration to ensure only the first is applied
+    createMigrationFile(3, NAME, migrationsDir, COMMAND);
     when(versionQueryResult.get()).thenReturn(ImmutableList.of());
 
     // When:
@@ -286,7 +288,6 @@ public class ApplyMigrationCommandTest {
     // Given:
     command = PARSER.parse("-n");
     createMigrationFile(1, NAME, migrationsDir, COMMAND);
-    when(versionQueryResult.get()).thenReturn(ImmutableList.of());
 
     when(sourceDescriptionCf.get())
         .thenThrow(new ExecutionException("Source not found", new RuntimeException()));

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
@@ -343,7 +343,7 @@ public class ValidateMigrationsCommandTest {
 
   private String filePathForVersion(final String version) {
     final String prefix = getFilePrefixForVersion(version);
-    return Paths.get(migrationsDir, prefix + "_awesome_migration").toString();
+    return Paths.get(migrationsDir, prefix + "__awesome_migration.sql").toString();
   }
 
   private static String fileContentsForVersion(final String version) {


### PR DESCRIPTION
### Description 

Adds a new option to `migrations apply` for applying a specific migration version. Also addresses follow-ups in https://github.com/confluentinc/ksql/pull/7099 and https://github.com/confluentinc/ksql/pull/7133#discussion_r585921808, and fixes a few bugs along the way.

### Testing done 

Added unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

