### PR TITLE
chore(migrations): add script to run migration tool

### DIFF
--- a/bin/ksql-migrations
+++ b/bin/ksql-migrations
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# (Copyright) [2018 - 2018] Confluent, Inc.
+# (Copyright) [2021 - 2021] Confluent, Inc.
 
 : "${JAVA_HOME:=""}"
 
@@ -39,5 +39,9 @@ if [ -d "$DIR" ]; then
 fi
 
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
+: "${KSQL_LOG4J_OPTS:=""}"
+if [ -z "$KSQL_LOG4J_OPTS" ]; then
+  export KSQL_LOG4J_OPTS="$KSQL_CONFIG_DIR/log4j-console.properties"
+fi
 
-exec "$JAVA" -cp "$KSQL_CLASSPATH" io.confluent.ksql.tools.migrations.Migrations "$@"
+exec "$JAVA" -Dlog4j.configuration=file://"$KSQL_LOG4J_OPTS" -cp "$KSQL_CLASSPATH" io.confluent.ksql.tools.migrations.Migrations "$@"

--- a/bin/ksql-migrations
+++ b/bin/ksql-migrations
@@ -2,44 +2,10 @@
 
 # (Copyright) [2021 - 2021] Confluent, Inc.
 
-: "${JAVA_HOME:=""}"
-
-function find_java_home {
-  local system=$(uname -s)
-  if (( $system == "Darwin" )); then
-    echo $(/usr/libexec/java_home)
-  fi
-}
-
-# Which java to use
-if [ -z "$JAVA_HOME" ]; then
-  JAVA_HOME=$(find_java_home)
-fi
-
-if [ -z "$JAVA_HOME" ]; then
-  echo "Could not find java home. Please set JAVA_HOME to path to jdk installation directory"
-  exit 1
-fi
-
-KSQL_CLASSPATH="$JAVA_HOME/lib/*"
-JAVA="$JAVA_HOME/bin/java"
-
 base_dir=$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 
-for dir in "$base_dir/ksqldb-tools/target/ksqldb-tools"-*-development; do
-  KSQL_DIR="$dir/share/java/ksqldb-tools"
-  if [ -d $KSQL_DIR ]; then
-    KSQL_CLASSPATH="$KSQL_CLASSPATH:$KSQL_DIR/*"
-  fi
-done
-
-DIR="$base_dir/share/java/ksqldb"
-if [ -d "$DIR" ]; then
-  KSQL_CLASSPATH="$DIR/*:$KSQL_CLASSPATH"
-fi
-
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
-: "${KSQL_LOG4J_OPTS:=""}"
+
 if [ -z "$KSQL_LOG4J_OPTS" ]; then
   if [ -e "$base_dir/config/log4j-console.properties" ]; then # Dev environment
     KSQL_CONFIG_DIR="$base_dir/config"
@@ -48,7 +14,7 @@ if [ -z "$KSQL_LOG4J_OPTS" ]; then
   elif [ -e "/etc/ksqldb/log4j-console.properties" ]; then # Normal install layout
     KSQL_CONFIG_DIR="/etc/ksqldb"
   fi
-  export KSQL_LOG4J_OPTS="$KSQL_CONFIG_DIR/log4j-console.properties"
+  export KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$KSQL_CONFIG_DIR/log4j-console.properties"
 fi
 
-exec "$JAVA" -Dlog4j.configuration=file://"$KSQL_LOG4J_OPTS" -cp "$KSQL_CLASSPATH" io.confluent.ksql.tools.migrations.Migrations "$@"
+exec "$base_dir"/bin/ksql-run-class io.confluent.ksql.tools.migrations.Migrations "$@"

--- a/bin/ksql-migrations
+++ b/bin/ksql-migrations
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# (Copyright) [2018 - 2018] Confluent, Inc.
+
+: "${JAVA_HOME:=""}"
+
+function find_java_home {
+  local system=$(uname -s)
+  if (( $system == "Darwin" )); then
+    echo $(/usr/libexec/java_home)
+  fi
+}
+
+# Which java to use
+if [ -z "$JAVA_HOME" ]; then
+  JAVA_HOME=$(find_java_home)
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "Could not find java home. Please set JAVA_HOME to path to jdk installation directory"
+  exit 1
+fi
+
+KSQL_CLASSPATH="$JAVA_HOME/lib/*"
+JAVA="$JAVA_HOME/bin/java"
+
+base_dir=$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+
+for dir in "$base_dir/ksqldb-tools/target/ksqldb-tools"-*-development; do
+  KSQL_DIR="$dir/share/java/ksqldb-tools"
+  if [ -d $KSQL_DIR ]; then
+    KSQL_CLASSPATH="$KSQL_CLASSPATH:$KSQL_DIR/*"
+  fi
+done
+
+DIR="$base_dir/share/java/ksqldb"
+if [ -d "$DIR" ]; then
+  KSQL_CLASSPATH="$DIR/*:$KSQL_CLASSPATH"
+fi
+
+: "${KSQL_CONFIG_DIR:="$base_dir/config"}"
+
+exec "$JAVA" -cp "$KSQL_CLASSPATH" io.confluent.ksql.tools.migrations.Migrations "$@"

--- a/bin/ksql-migrations
+++ b/bin/ksql-migrations
@@ -41,6 +41,13 @@ fi
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
 : "${KSQL_LOG4J_OPTS:=""}"
 if [ -z "$KSQL_LOG4J_OPTS" ]; then
+  if [ -e "$base_dir/config/log4j-console.properties" ]; then # Dev environment
+    KSQL_CONFIG_DIR="$base_dir/config"
+  elif [ -e "$base_dir/etc/ksqldb/log4j-console.properties" ]; then # Simple zip file layout
+    KSQL_CONFIG_DIR="$base_dir/etc/ksqldb"
+  elif [ -e "/etc/ksqldb/log4j-console.properties" ]; then # Normal install layout
+    KSQL_CONFIG_DIR="/etc/ksqldb"
+  fi
   export KSQL_LOG4J_OPTS="$KSQL_CONFIG_DIR/log4j-console.properties"
 fi
 

--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -25,7 +25,7 @@ fi
 : "${JAVA_HOME:=""}"
 
 # Development jars. `mvn package` should collect all the required dependency jars here
-for project in ksqldb-engine ksqldb-examples ksqldb-rest-app ksqldb-cli ksqldb-functional-tests; do
+for project in ksqldb-engine ksqldb-examples ksqldb-rest-app ksqldb-cli ksqldb-functional-tests ksqldb-tools; do
     for dir in "$base_dir/$project/target/$project"-*-development; do
       KSQL_DIR="$dir/share/java/$project"
       if [ -d "$KSQL_DIR" ]; then
@@ -35,7 +35,7 @@ for project in ksqldb-engine ksqldb-examples ksqldb-rest-app ksqldb-cli ksqldb-f
 done
 
 # Production jars - each one is prepended so they will appear in reverse order.  KSQL jars take precedence over other stuff passed in via CLASSPATH env var
-for library in "confluent-common" "confluent-telemetry" "ksqldb-examples" "rest-utils" "ksqldb-engine" "ksqldb-rest-app" "ksqldb-cli" "ksqldb-functional-tests" "ksqldb" "monitoring-interceptors" "confluent-security/ksql"; do
+for library in "confluent-common" "confluent-telemetry" "ksqldb-examples" "rest-utils" "ksqldb-engine" "ksqldb-rest-app" "ksqldb-cli" "ksqldb-functional-tests" "ksqldb" "monitoring-interceptors" "confluent-security/ksql" "ksqldb-tools"; do
   DIR="$base_dir/share/java/$library"
   if [ -d "$DIR" ]; then
     KSQL_CLASSPATH="$DIR/*:$KSQL_CLASSPATH"

--- a/config/log4j-console.properties
+++ b/config/log4j-console.properties
@@ -1,0 +1,7 @@
+# Root logger
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.consoleAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n

--- a/ksqldb-docker/pom.xml
+++ b/ksqldb-docker/pom.xml
@@ -52,6 +52,12 @@
       <version>${io.confluent.ksql.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.confluent.ksql</groupId>
+      <artifactId>ksqldb-tools</artifactId>
+      <version>${io.confluent.ksql.version}</version>
+    </dependency>
+
     <!-- Need to explicitly add dependencies with classifier as they are not automatically pulled
          in. -->
     <dependency>

--- a/ksqldb-tools/src/assembly/development.xml
+++ b/ksqldb-tools/src/assembly/development.xml
@@ -58,9 +58,6 @@
                  dependencies happen to be missing in the assembly you may want to
                  disable transitive filtering. -->
             <useTransitiveFiltering>true</useTransitiveFiltering>
-            <excludes>
-                <exclude>org.slf4j:slf4j-log4j12</exclude> <!-- Already included by rest-app-->
-            </excludes>
         </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
### Description 
Script to run migration tool from command line as `ksql-migrations ...`

To test on docker, follow the instructions here:
https://github.com/confluentinc/ksql/tree/master/ksqldb-docker

And run the command `docker exec <container> ksql-migrations ...`

To build the tar, run this command:
`make VERSION=0.14.0 PACKAGE_TYPE=archive -f debian/Makefile archive`

If you're building on a Macbook, you might have to change `iPatch` to `IPatch` in debian/Makefile


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

