### PR TITLE
feat: add lambda feature flag

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -342,7 +342,8 @@ public class KsqlConfig extends AbstractConfig {
   public static final Boolean KSQL_LAMBDAS_ENABLED_DEFAULT = true;
   public static final String KSQL_LAMBDAS_ENABLED_DOC =
       "Feature flag for lambdas. Default is true. If true, lambdas are processed normally, "
-          + "if false, new lambda queries won't be processed but any existing lambda queries are unaffected.";
+          + "if false, new lambda queries won't be processed but any existing lambda "
+          + "queries are unaffected.";
 
   public static final String KSQL_SUPPRESS_BUFFER_SIZE_BYTES = "ksql.suppress.buffer.size.bytes";
   public static final Long KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DEFAULT = -1L;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -341,7 +341,8 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_LAMBDAS_ENABLED = "ksql.lambdas.enabled";
   public static final Boolean KSQL_LAMBDAS_ENABLED_DEFAULT = true;
   public static final String KSQL_LAMBDAS_ENABLED_DOC =
-      "Feature flag for lambdas";
+      "Feature flag for lambdas. Default is true. If true, lambdas are processed normally, "
+          + "if false, new lambda queries won't be processed but any existing lambda queries are unaffected.";
 
   public static final String KSQL_SUPPRESS_BUFFER_SIZE_BYTES = "ksql.suppress.buffer.size.bytes";
   public static final Long KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DEFAULT = -1L;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -338,6 +338,11 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_SUPPRESS_ENABLED_DOC =
       "Feature flag for suppression, specifically EMIT FINAL";
 
+  public static final String KSQL_LAMBDAS_ENABLED = "ksql.lambdas.enabled";
+  public static final Boolean KSQL_LAMBDAS_ENABLED_DEFAULT = true;
+  public static final String KSQL_LAMBDAS_ENABLED_DOC =
+      "Feature flag for lambdas";
+
   public static final String KSQL_SUPPRESS_BUFFER_SIZE_BYTES = "ksql.suppress.buffer.size.bytes";
   public static final Long KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DEFAULT = -1L;
   public static final String KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DOC =
@@ -892,6 +897,12 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT_DEFAULT,
             Importance.LOW,
             KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING_TRANSIENT_DOC
+        ).define(
+            KSQL_LAMBDAS_ENABLED,
+            Type.BOOLEAN,
+            KSQL_LAMBDAS_ENABLED_DEFAULT,
+            Importance.LOW,
+            KSQL_LAMBDAS_ENABLED_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
@@ -87,7 +87,8 @@ public class KsqlContext implements AutoCloseable {
         processingLogContext,
         functionRegistry,
         serviceInfo,
-        new SequentialQueryIdGenerator());
+        new SequentialQueryIdGenerator(),
+        ksqlConfig);
 
     return new KsqlContext(
         serviceContext,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.query.QueryValidator;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlReferentialIntegrityException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -91,13 +92,15 @@ final class EngineContext {
   private final QueryCleanupService cleanupService;
   private final Map<SourceName, QueryId> createAsQueries = new ConcurrentHashMap<>();
   private final Map<SourceName, Set<QueryId>> insertQueries = new ConcurrentHashMap<>();
+  private final KsqlConfig ksqlConfig;
 
   static EngineContext create(
       final ServiceContext serviceContext,
       final ProcessingLogContext processingLogContext,
       final MutableMetaStore metaStore,
       final QueryIdGenerator queryIdGenerator,
-      final QueryCleanupService cleanupService
+      final QueryCleanupService cleanupService,
+      final KsqlConfig ksqlConfig
   ) {
     return new EngineContext(
         serviceContext,
@@ -105,7 +108,8 @@ final class EngineContext {
         metaStore,
         queryIdGenerator,
         new DefaultKsqlParser(),
-        cleanupService
+        cleanupService,
+        ksqlConfig
     );
   }
 
@@ -115,7 +119,8 @@ final class EngineContext {
       final MutableMetaStore metaStore,
       final QueryIdGenerator queryIdGenerator,
       final KsqlParser parser,
-      final QueryCleanupService cleanupService
+      final QueryCleanupService cleanupService,
+      final KsqlConfig ksqlConfig
   ) {
     this.serviceContext = requireNonNull(serviceContext, "serviceContext");
     this.metaStore = requireNonNull(metaStore, "metaStore");
@@ -126,6 +131,7 @@ final class EngineContext {
     this.processingLogContext = requireNonNull(processingLogContext, "processingLogContext");
     this.parser = requireNonNull(parser, "parser");
     this.cleanupService = requireNonNull(cleanupService, "cleanupService");
+    this.ksqlConfig = requireNonNull(ksqlConfig);
   }
 
   EngineContext createSandbox(final ServiceContext serviceContext) {
@@ -134,7 +140,8 @@ final class EngineContext {
         processingLogContext,
         metaStore.copy(),
         queryIdGenerator.createSandbox(),
-        cleanupService
+        cleanupService,
+        ksqlConfig
     );
 
     persistentQueries.forEach((queryId, query) ->
@@ -206,7 +213,7 @@ final class EngineContext {
           parser.prepare(substituteVariables(stmt, variablesMap), metaStore);
       return PreparedStatement.of(
           preparedStatement.getStatementText(),
-          AstSanitizer.sanitize(preparedStatement.getStatement(), metaStore)
+          AstSanitizer.sanitize(preparedStatement.getStatement(), metaStore, ksqlConfig.getBoolean(KsqlConfig.KSQL_LAMBDAS_ENABLED))
       );
     } catch (final KsqlStatementException e) {
       throw e;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -213,8 +213,11 @@ final class EngineContext {
           parser.prepare(substituteVariables(stmt, variablesMap), metaStore);
       return PreparedStatement.of(
           preparedStatement.getStatementText(),
-          AstSanitizer.sanitize(preparedStatement.getStatement(), metaStore, ksqlConfig.getBoolean(KsqlConfig.KSQL_LAMBDAS_ENABLED))
-      );
+          AstSanitizer.sanitize(
+              preparedStatement.getStatement(),
+              metaStore,
+              ksqlConfig.getBoolean(KsqlConfig.KSQL_LAMBDAS_ENABLED)
+          ));
     } catch (final KsqlStatementException e) {
       throw e;
     } catch (final Exception e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -77,7 +78,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       final ProcessingLogContext processingLogContext,
       final FunctionRegistry functionRegistry,
       final ServiceInfo serviceInfo,
-      final QueryIdGenerator queryIdGenerator
+      final QueryIdGenerator queryIdGenerator,
+      final KsqlConfig ksqlConfig
   ) {
     this(
         serviceContext,
@@ -90,7 +92,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
             serviceInfo.customMetricsTags(),
             serviceInfo.metricsExtension()
         ),
-        queryIdGenerator);
+        queryIdGenerator,
+        ksqlConfig);
   }
 
   public KsqlEngine(
@@ -99,7 +102,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       final String serviceId,
       final MutableMetaStore metaStore,
       final Function<KsqlEngine, KsqlEngineMetrics> engineMetricsFactory,
-      final QueryIdGenerator queryIdGenerator
+      final QueryIdGenerator queryIdGenerator,
+      final KsqlConfig ksqlConfig
   ) {
     this.cleanupService = new QueryCleanupService();
     this.orphanedTransientQueryCleaner = new OrphanedTransientQueryCleaner(this.cleanupService);
@@ -108,7 +112,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
         processingLogContext,
         metaStore,
         queryIdGenerator,
-        cleanupService
+        cleanupService,
+        ksqlConfig
     );
     this.serviceId = Objects.requireNonNull(serviceId, "serviceId");
     this.engineMetrics = engineMetricsFactory.apply(this);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -40,8 +40,11 @@ import io.confluent.ksql.schema.ksql.ColumnAliasGenerator;
 import io.confluent.ksql.schema.ksql.ColumnNames;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.AmbiguousColumnException;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.UnknownSourceException;
+
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -66,7 +69,18 @@ public final class AstSanitizer {
   private AstSanitizer() {
   }
 
-  public static Statement sanitize(final Statement node, final MetaStore metaStore) {
+
+  public static Statement sanitize(
+      final Statement node,
+      final MetaStore metaStore) {
+    return sanitize(node, metaStore, true);
+  }
+
+  public static Statement sanitize(
+      final Statement node,
+      final MetaStore metaStore,
+      final Boolean lambdaEnabled
+  ) {
     final DataSourceExtractor dataSourceExtractor = new DataSourceExtractor(metaStore);
     dataSourceExtractor.extractDataSources(node);
 
@@ -74,7 +88,7 @@ public final class AstSanitizer {
         new RewriterPlugin(metaStore, dataSourceExtractor);
 
     final ExpressionRewriterPlugin expressionRewriterPlugin =
-        new ExpressionRewriterPlugin(dataSourceExtractor);
+        new ExpressionRewriterPlugin(dataSourceExtractor, lambdaEnabled);
 
     final BiFunction<Expression, SanitizerContext, Expression> expressionRewriter =
         (e,v) -> ExpressionTreeRewriter.rewriteWith(expressionRewriterPlugin::process, e, v);
@@ -90,10 +104,7 @@ public final class AstSanitizer {
     private final DataSourceExtractor dataSourceExtractor;
     private final ColumnAliasGenerator aliasGenerator;
 
-    RewriterPlugin(
-        final MetaStore metaStore,
-        final DataSourceExtractor dataSourceExtractor
-    ) {
+    RewriterPlugin(final MetaStore metaStore, final DataSourceExtractor dataSourceExtractor) {
       super(Optional.empty());
       this.metaStore = requireNonNull(metaStore, "metaStore");
       this.dataSourceExtractor = requireNonNull(dataSourceExtractor, "dataSourceExtractor");
@@ -166,10 +177,12 @@ public final class AstSanitizer {
       ExpressionTreeRewriter.Context<SanitizerContext>> {
 
     private final DataSourceExtractor dataSourceExtractor;
+    private final Boolean lambdaEnabled;
 
-    ExpressionRewriterPlugin(final DataSourceExtractor dataSourceExtractor) {
+    ExpressionRewriterPlugin(final DataSourceExtractor dataSourceExtractor, final Boolean lambdaEnabled) {
       super(Optional.empty());
       this.dataSourceExtractor = requireNonNull(dataSourceExtractor, "dataSourceExtractor");
+      this.lambdaEnabled = lambdaEnabled;
     }
 
     @Override
@@ -204,6 +217,9 @@ public final class AstSanitizer {
         final LambdaFunctionCall expression,
         final ExpressionTreeRewriter.Context<SanitizerContext> ctx
     ) {
+      if (!lambdaEnabled) {
+        throw new UnsupportedOperationException("Lambdas are not enabled at this time.");
+      }
       dataSourceExtractor.getAllSources().forEach(aliasedDataSource -> {
         for (String argument : expression.getArguments()) {
           if (aliasedDataSource.getDataSource().getSchema().columns().stream()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/AstSanitizer.java
@@ -40,11 +40,9 @@ import io.confluent.ksql.schema.ksql.ColumnAliasGenerator;
 import io.confluent.ksql.schema.ksql.ColumnNames;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.AmbiguousColumnException;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.UnknownSourceException;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -179,7 +177,10 @@ public final class AstSanitizer {
     private final DataSourceExtractor dataSourceExtractor;
     private final Boolean lambdaEnabled;
 
-    ExpressionRewriterPlugin(final DataSourceExtractor dataSourceExtractor, final Boolean lambdaEnabled) {
+    ExpressionRewriterPlugin(
+        final DataSourceExtractor dataSourceExtractor,
+        final Boolean lambdaEnabled
+    ) {
       super(Optional.empty());
       this.dataSourceExtractor = requireNonNull(dataSourceExtractor, "dataSourceExtractor");
       this.lambdaEnabled = lambdaEnabled;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
@@ -70,7 +70,8 @@ public final class KsqlContextTestUtil {
         ProcessingLogContext.create(),
         functionRegistry,
         ServiceInfo.create(ksqlConfig, metricsPrefix),
-        new SequentialQueryIdGenerator()
+        new SequentialQueryIdGenerator(),
+        ksqlConfig
     );
 
     return new KsqlContext(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -128,8 +128,7 @@ public class KsqlEngineTest {
 
     ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
         serviceContext,
-        metaStore,
-        KSQL_CONFIG
+        metaStore
     );
 
     sandbox = ksqlEngine.createSandbox(serviceContext);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -128,7 +128,8 @@ public class KsqlEngineTest {
 
     ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
         serviceContext,
-        metaStore
+        metaStore,
+        KSQL_CONFIG
     );
 
     sandbox = ksqlEngine.createSandbox(serviceContext);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -50,7 +50,8 @@ public final class KsqlEngineTestUtil {
 
   public static KsqlEngine createKsqlEngine(
       final ServiceContext serviceContext,
-      final MutableMetaStore metaStore
+      final MutableMetaStore metaStore,
+      KsqlConfig ksqlConfig
   ) {
     return new KsqlEngine(
         serviceContext,
@@ -58,7 +59,8 @@ public final class KsqlEngineTestUtil {
         "test_instance_",
         metaStore,
         (engine) -> new KsqlEngineMetrics("", engine, Collections.emptyMap(), Optional.empty()),
-        new SequentialQueryIdGenerator()
+        new SequentialQueryIdGenerator(),
+        ksqlConfig
     );
   }
 
@@ -66,7 +68,8 @@ public final class KsqlEngineTestUtil {
       final ServiceContext serviceContext,
       final MutableMetaStore metaStore,
       final Function<KsqlEngine, KsqlEngineMetrics> engineMetricsFactory,
-      final QueryIdGenerator queryIdGenerator
+      final QueryIdGenerator queryIdGenerator,
+      final KsqlConfig ksqlConfig
   ) {
     return new KsqlEngine(
         serviceContext,
@@ -74,7 +77,8 @@ public final class KsqlEngineTestUtil {
         "test_instance_",
         metaStore,
         engineMetricsFactory,
-        queryIdGenerator
+        queryIdGenerator,
+        ksqlConfig
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -50,8 +50,7 @@ public final class KsqlEngineTestUtil {
 
   public static KsqlEngine createKsqlEngine(
       final ServiceContext serviceContext,
-      final MutableMetaStore metaStore,
-      KsqlConfig ksqlConfig
+      final MutableMetaStore metaStore
   ) {
     return new KsqlEngine(
         serviceContext,
@@ -60,7 +59,7 @@ public final class KsqlEngineTestUtil {
         metaStore,
         (engine) -> new KsqlEngineMetrics("", engine, Collections.emptyMap(), Optional.empty()),
         new SequentialQueryIdGenerator(),
-        ksqlConfig
+        new KsqlConfig(Collections.emptyMap())
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/AstSanitizerTest.java
@@ -157,6 +157,23 @@ public class AstSanitizerTest {
   }
 
   @Test
+  public void shouldThrowIfLambdasAreDisabled() {
+    // Given:
+    final Statement stmt =
+        givenQuery("SELECT transform(arr, x => x+1) FROM TEST1;");
+
+    // When:
+    final Exception e = assertThrows(
+        UnsupportedOperationException.class,
+        () -> AstSanitizer.sanitize(stmt, META_STORE, false)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Lambdas are not enabled at this time."));
+  }
+
+  @Test
   public void shouldAddQualifierForColumnReference() {
     // Given:
     final Statement stmt = givenQuery("SELECT COL0 FROM TEST1;");

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -106,7 +106,8 @@ public class JsonFormatTest {
         ProcessingLogContext.create(),
         functionRegistry,
         ServiceInfo.create(ksqlConfig),
-        new SequentialQueryIdGenerator());
+        new SequentialQueryIdGenerator(),
+        ksqlConfig);
 
     topicClient = serviceContext.getTopicClient();
     metaStore = ksqlEngine.getMetaStore();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -419,7 +419,8 @@ public class SecureIntegrationTest {
         ProcessingLogContext.create(),
         new InternalFunctionRegistry(),
         ServiceInfo.create(ksqlConfig),
-        new SequentialQueryIdGenerator());
+        new SequentialQueryIdGenerator(),
+        ksqlConfig);
 
     execInitCreateStreamQueries();
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doThrow;
 
+import io.confluent.ksql.embedded.KsqlContext;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -592,7 +592,8 @@ public class TestExecutor implements Closeable {
             engine,
             Collections.emptyMap(),
             Optional.empty()),
-        new SequentialQueryIdGenerator()
+        new SequentialQueryIdGenerator(),
+        KsqlConfig.empty()
     );
   }
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -160,7 +160,8 @@ public class KsqlTesterTest {
         NoopProcessingLogContext.INSTANCE,
         metaStore,
         ServiceInfo.create(config),
-        new SequentialQueryIdGenerator()
+        new SequentialQueryIdGenerator(),
+        this.config
     );
 
     this.expectedException = null;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -673,7 +673,8 @@ public final class KsqlRestApplication implements Executable {
         processingLogContext,
         functionRegistry,
         ServiceInfo.create(ksqlConfig, metricsPrefix),
-        specificQueryIdGenerator
+        specificQueryIdGenerator,
+        new KsqlConfig(restConfig.getKsqlConfigProperties())
     );
 
     UserFunctionLoader.newInstance(ksqlConfig, functionRegistry, ksqlInstallDir).load();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -128,7 +128,8 @@ public final class StandaloneExecutorFactory {
         processingLogContext,
         functionRegistry,
         ServiceInfo.create(ksqlConfig),
-        new SequentialQueryIdGenerator());
+        new SequentialQueryIdGenerator(),
+        ksqlConfig);
 
     final UserFunctionLoader udfLoader =
         UserFunctionLoader.newInstance(ksqlConfig, functionRegistry, installDir);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -148,7 +148,8 @@ public class InteractiveStatementExecutorTest {
         serviceContext,
         new MetaStoreImpl(new InternalFunctionRegistry()),
         (engine) -> new KsqlEngineMetrics("", engine, Collections.emptyMap(), Optional.empty()),
-        hybridQueryIdGenerator
+        hybridQueryIdGenerator,
+        ksqlConfig
     );
 
     statementParser = new StatementParser(ksqlEngine);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -123,7 +123,8 @@ public class RecoveryTest {
         serviceContext,
         new MetaStoreImpl(new InternalFunctionRegistry()),
         ignored -> engineMetrics,
-        queryIdGenerator);
+        queryIdGenerator,
+        ksqlConfig);
   }
 
   private static class FakeCommandQueue implements CommandQueue {


### PR DESCRIPTION
### Description 
Adds a lambda feature flag so we can disable lambdas if anything awful happens after we ship them.

A bit of refactoring to pass in ksql config information all the way to AST sanitizer, could be used in the future if we want access to feature flag info in these classes
### Testing done 
unit test to make sure we throw the proper error

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

