### PR TITLE
feat: Adds Lambda functionality to the interpreter

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -395,13 +395,6 @@ public class PullFilterNode extends SingleSourcePlanNode {
             : (comp.getLeft() instanceof UnqualifiedColumnReferenceExp ? comp.getLeft() : null));
   }
 
-  private boolean isSingleColumnReference(final ComparisonExpression comp) {
-    return (comp.getRight() instanceof UnqualifiedColumnReferenceExp
-        && !(comp.getLeft() instanceof UnqualifiedColumnReferenceExp))
-            || (comp.getLeft() instanceof UnqualifiedColumnReferenceExp
-        && !(comp.getRight() instanceof UnqualifiedColumnReferenceExp));
-  }
-
   private Expression getNonColumnRefSide(final ComparisonExpression comparison) {
     return comparison.getRight() instanceof UnqualifiedColumnReferenceExp
         ? comparison.getLeft()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -395,6 +395,13 @@ public class PullFilterNode extends SingleSourcePlanNode {
             : (comp.getLeft() instanceof UnqualifiedColumnReferenceExp ? comp.getLeft() : null));
   }
 
+  private boolean isSingleColumnReference(final ComparisonExpression comp) {
+    return (comp.getRight() instanceof UnqualifiedColumnReferenceExp
+        && !(comp.getLeft() instanceof UnqualifiedColumnReferenceExp))
+            || (comp.getLeft() instanceof UnqualifiedColumnReferenceExp
+        && !(comp.getRight() instanceof UnqualifiedColumnReferenceExp));
+  }
+
   private Expression getNonColumnRefSide(final ComparisonExpression comparison) {
     return comparison.getRight() instanceof UnqualifiedColumnReferenceExp
         ? comparison.getLeft()

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -254,6 +254,28 @@ public class ExpressionEvaluatorParityTest {
     assertOrders("not (ORDERID > 9 AND ORDERUNITS < 100)", false);
   }
 
+  @Test
+  public void shouldDoLambda() throws Exception {
+    assertOrders("filter(Array[1,2,3], x => x > 5)", ImmutableList.of());
+    assertOrders("filter(Array[1,2,3], x => x > 1)", ImmutableList.of(2, 3));
+    assertOrders("filter(Array[Array[1,2,3],Array[4,5,6],Array[7,8,9]], "
+        + "x => array_length(filter(x, y => y % 2 = 0)) > 1)",
+        ImmutableList.of(ImmutableList.of(4, 5, 6)));
+    assertOrders("transform(Array[Array[1,2,3],Array[4,5,6],Array[7,8,9]], "
+            + "x => transform(x, y => y % 2 = 0))",
+        ImmutableList.of(
+            ImmutableList.of(false, true, false),
+            ImmutableList.of(true, false, true),
+            ImmutableList.of(false, true, false)));
+    assertOrders("filter(MAP(1 := 'cat', 2 := 'dog', 3 := 'rat'), (x,y)  => x > 1 "
+        + "AND instr(y, 'at') > 0)", ImmutableMap.of(3, "rat"));
+    assertOrders("transform(MAP(1 := MAP('a' := 'cat', 'b' := 'rat'),"
+        + " 2 := MAP('c' := 'dog', 'd' := 'frog')), (x,y) => x, (x,y) => "
+        + "transform(y, (a,b) => a + 'z', (a,b) => 'pet ' + b))",
+        ImmutableMap.of(1, ImmutableMap.of("bz", "pet rat", "az", "pet cat"),
+            2, ImmutableMap.of("dz", "pet frog", "cz", "pet dog")));
+  }
+
   private void assertOrders(
       final String expressionStr,
       final Object result

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermEvaluationContext.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermEvaluationContext.java
@@ -59,7 +59,7 @@ public final class TermEvaluationContext {
   /**
    * Looks up a variable from the mappings made with {@code pushVariableMappings} that have not yet
    * been popped with {@code popVariableMappings}.
-   * @param name
+   * @param name The name of the variable to lookup
    * @return
    */
   public Object lookupVariable(final String name) {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermEvaluationContext.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermEvaluationContext.java
@@ -16,10 +16,14 @@
 package io.confluent.ksql.execution.interpreter;
 
 import io.confluent.ksql.GenericRow;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Map;
 
 public final class TermEvaluationContext {
 
   private final GenericRow row;
+  private final Deque<Map<String, Object>> deque = new LinkedList<>();
 
   public TermEvaluationContext(final GenericRow row) {
     this.row = row;
@@ -27,5 +31,22 @@ public final class TermEvaluationContext {
 
   public GenericRow getRow() {
     return row;
+  }
+
+  public void pushVariableMappings(final Map<String, Object> mappings) {
+    deque.push(mappings);
+  }
+
+  public void popVariableMappings() {
+    deque.pop();
+  }
+
+  public Object lookupVariable(final String name) {
+    for (Map<String, Object> mappings : deque) {
+      if (mappings.containsKey(name)) {
+        return mappings.get(name);
+      }
+    }
+    throw new IllegalStateException("Can't find lambda variable " + name);
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermEvaluationContext.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermEvaluationContext.java
@@ -20,10 +20,15 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.Map;
 
+/**
+ * Holds all state associated with row-based evaluation of a {@code Term} tree. This for example
+ * consists of the current row itself and any lambda-created variables that are in the current
+ * call frame.
+ */
 public final class TermEvaluationContext {
 
   private final GenericRow row;
-  private final Deque<Map<String, Object>> deque = new LinkedList<>();
+  private final Deque<Map<String, Object>> variableMappingsStack = new LinkedList<>();
 
   public TermEvaluationContext(final GenericRow row) {
     this.row = row;
@@ -33,16 +38,32 @@ public final class TermEvaluationContext {
     return row;
   }
 
+  /**
+   * Used to push a set of variables and their object mappings into the evaluation context.  This is
+   * used for lambdas where such variables are created.
+   * @param mappings The new mappings
+   */
   public void pushVariableMappings(final Map<String, Object> mappings) {
-    deque.push(mappings);
+    variableMappingsStack.push(mappings);
   }
 
+  /**
+   * Used to pop the set of variables that were mapped by a previous call to
+   * {@code pushVariableMappings}. The calls to each of these methods is meant to be invoked
+   * alongside the start and completion of the calling stack of the lambda.
+   */
   public void popVariableMappings() {
-    deque.pop();
+    variableMappingsStack.pop();
   }
 
+  /**
+   * Looks up a variable from the mappings made with {@code pushVariableMappings} that have not yet
+   * been popped with {@code popVariableMappings}.
+   * @param name
+   * @return
+   */
   public Object lookupVariable(final String name) {
-    for (Map<String, Object> mappings : deque) {
+    for (Map<String, Object> mappings : variableMappingsStack) {
       if (mappings.containsKey(name)) {
         return mappings.get(name);
       }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LambdaFunctionTerms.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LambdaFunctionTerms.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.interpreter.terms;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.codegen.helpers.TriFunction;
+import io.confluent.ksql.execution.interpreter.TermEvaluationContext;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.Pair;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class LambdaFunctionTerms {
+
+  public static class LambdaFunction1Term implements Term {
+
+    private final List<Pair<String, SqlType>> argNamesToTypes;
+    private final Term body;
+
+    public LambdaFunction1Term(final List<Pair<String, SqlType>> argNamesToTypes, final Term body) {
+      this.argNamesToTypes = argNamesToTypes;
+      this.body = body;
+
+      Preconditions.checkState(argNamesToTypes.size() == 1);
+    }
+
+    @Override
+    public Object getValue(final TermEvaluationContext context) {
+      return (Function<Object, Object>) arg0 -> {
+        final String name0 = argNamesToTypes.get(0).getLeft();
+        context.pushVariableMappings(ImmutableMap.of(name0, arg0));
+        try {
+          return body.getValue(context);
+        } finally {
+          context.popVariableMappings();
+        }
+      };
+    }
+
+    @Override
+    public SqlType getSqlType() {
+      return null;
+    }
+  }
+
+  public static class LambdaFunction2Term implements Term {
+
+    private final List<Pair<String, SqlType>> argNamesToTypes;
+    private final Term body;
+
+    public LambdaFunction2Term(final List<Pair<String, SqlType>> argNamesToTypes, final Term body) {
+      this.argNamesToTypes = argNamesToTypes;
+      this.body = body;
+
+      Preconditions.checkState(argNamesToTypes.size() == 2);
+    }
+
+    @Override
+    public Object getValue(final TermEvaluationContext context) {
+      return (BiFunction<Object, Object, Object>) (arg0, arg1) -> {
+        final String name0 = argNamesToTypes.get(0).getLeft();
+        final String name1 = argNamesToTypes.get(1).getLeft();
+        context.pushVariableMappings(ImmutableMap.of(name0, arg0, name1, arg1));
+        try {
+          return body.getValue(context);
+        } finally {
+          context.popVariableMappings();
+        }
+      };
+    }
+
+    @Override
+    public SqlType getSqlType() {
+      return null;
+    }
+  }
+
+  public static class LambdaFunction3Term implements Term {
+
+    private final List<Pair<String, SqlType>> argNamesToTypes;
+    private final Term body;
+
+    public LambdaFunction3Term(final List<Pair<String, SqlType>> argNamesToTypes, final Term body) {
+      this.argNamesToTypes = argNamesToTypes;
+      this.body = body;
+
+      Preconditions.checkState(argNamesToTypes.size() == 3);
+    }
+
+    @Override
+    public Object getValue(final TermEvaluationContext context) {
+      return (TriFunction<Object, Object, Object, Object>) (arg0, arg1, arg2) -> {
+        final String name0 = argNamesToTypes.get(0).getLeft();
+        final String name1 = argNamesToTypes.get(1).getLeft();
+        final String name2 = argNamesToTypes.get(2).getLeft();
+        context.pushVariableMappings(ImmutableMap.of(name0, arg0, name1, arg1, name2, arg2));
+        try {
+          return body.getValue(context);
+        } finally {
+          context.popVariableMappings();
+        }
+      };
+    }
+
+    @Override
+    public SqlType getSqlType() {
+      return null;
+    }
+  }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LambdaFunctionTerms.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LambdaFunctionTerms.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.execution.interpreter.terms;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.codegen.helpers.TriFunction;
 import io.confluent.ksql.execution.interpreter.TermEvaluationContext;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -30,7 +29,7 @@ import java.util.function.Function;
 
 public class LambdaFunctionTerms {
 
-  public static abstract class LambdaFunctionBaseTerm implements Term {
+  public abstract static class LambdaFunctionBaseTerm implements Term {
     protected final List<Pair<String, SqlType>> argNamesToTypes;
     protected final Term body;
 
@@ -48,7 +47,7 @@ public class LambdaFunctionTerms {
       return null;
     }
 
-    protected Object getValueCommon(final TermEvaluationContext context, Object... args) {
+    protected Object getValueCommon(final TermEvaluationContext context, final Object... args) {
       context.pushVariableMappings(createVariableMap(argNamesToTypes, args));
       try {
         return body.getValue(context);
@@ -105,7 +104,7 @@ public class LambdaFunctionTerms {
   ) {
     Preconditions.checkArgument(argNamesToTypes.size() == args.length,
         "Argument length should be the same");
-    Map<String, Object> variableMap = new HashMap<>();
+    final Map<String, Object> variableMap = new HashMap<>();
     int i = 0;
     for (final Pair<String, SqlType> pair : argNamesToTypes) {
       final String name = pair.getLeft();

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LambdaVariableTerm.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LambdaVariableTerm.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.interpreter.terms;
+
+import io.confluent.ksql.execution.interpreter.TermEvaluationContext;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+
+public class LambdaVariableTerm implements Term {
+
+  private final String name;
+  private final SqlType sqlType;
+
+  public LambdaVariableTerm(final String name, final SqlType sqlType) {
+    this.name = name;
+    this.sqlType = sqlType;
+  }
+
+  @Override
+  public Object getValue(final TermEvaluationContext context) {
+    return context.lookupVariable(name);
+  }
+
+  @Override
+  public SqlType getSqlType() {
+    return sqlType;
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2911,6 +2911,33 @@
         "message": "Add EMIT CHANGES if you intended to issue a push query.",
         "status": 400
       }
+    },
+    {
+      "name": "lambdas - lambda use in select",
+      "statements": [
+        "CREATE STREAM INPUT (ID ARRAY<INTEGER> KEY, IGNORED INT) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT ID, COUNT, REDUCE(ID, 0, (x,y) => x + y) as sum FROM AGGREGATE;",
+        "SELECT ID, COUNT, TRANSFORM(ID, x => 2 * x) as doubled FROM AGGREGATE;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": [1, 2], "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": [3, 4], "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` ARRAY<INTEGER> KEY, `COUNT` BIGINT, `SUM` INTEGER"}},
+          {"row":{"columns":[[3, 4], 1, 7]}},
+          {"row":{"columns":[[1, 2], 1, 3]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` ARRAY<INTEGER> KEY, `COUNT` BIGINT, `DOUBLED` ARRAY<INTEGER>"}},
+          {"row":{"columns":[[3, 4], 1, [6, 8]]}},
+          {"row":{"columns":[[1, 2], 1, [2, 4]]}}
+        ]}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2913,7 +2913,7 @@
       }
     },
     {
-      "name": "lambdas - lambda use in select",
+      "name": "lambdas - lambda use in SELECT",
       "statements": [
         "CREATE STREAM INPUT (ID ARRAY<INTEGER> KEY, IGNORED INT) WITH (kafka_topic='test_topic', format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
@@ -2936,6 +2936,31 @@
           {"header":{"schema":"`ID` ARRAY<INTEGER> KEY, `COUNT` BIGINT, `DOUBLED` ARRAY<INTEGER>"}},
           {"row":{"columns":[[3, 4], 1, [6, 8]]}},
           {"row":{"columns":[[1, 2], 1, [2, 4]]}}
+        ]}
+      ]
+    },
+    {
+      "name": "lambdas - lambda use in WHERE",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, VAL INTEGER) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, count(1) as COUNT, COLLECT_LIST(VAL) as VAL_LIST FROM INPUT GROUP BY ID;",
+        "SELECT ID, count, VAL_LIST FROM AGGREGATE WHERE REDUCE(VAL_LIST, 0, (x,y) => x + y) > 4;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 1, "value": {"val": 1}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 1, "value": {"val": 2}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 1, "value": {"val": 3}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 2, "value": {"val": 1}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 2, "value": {"val": 2}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 3, "value": {"val": 5}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT, `VAL_LIST` ARRAY<INTEGER>"}},
+          {"row":{"columns":[1, 3, [1, 2, 3]]}},
+          {"row":{"columns":[3, 1, [5]]}}
         ]}
       ]
     }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-complex-lambda.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-complex-lambda.json
@@ -1,0 +1,80 @@
+{
+  "comments": [
+    "Pull Query tests covering the use of advanced lambda functions."
+  ],
+  "tests": [
+    {
+      "name": "transform a map with array values",
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, VALUE MAP<STRING, ARRAY<INT>>) WITH (kafka_topic='test_topic', value_format='AVRO');",
+        "CREATE TABLE MAT_TABLE AS SELECT ID, VALUE FROM TEST;",
+        "SELECT ID, TRANSFORM(TRANSFORM(VALUE, (x,y) => x, (x,y) => FIlTER(y, z => z < 5)), (x,y) => UCASE(x) , (k,v) => ARRAY_MAX(v)) as FILTERED_TRANSFORMED from MAT_TABLE;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"value":  {"a": [2,null,5,4], "b": [-1,-2]}}},
+        {"topic": "test_topic", "key": 1, "value": {"value":  {"c": [null,null,-1], "t": [3, 1]}}},
+        {"topic": "test_topic", "key": 2, "value": {"value":  {"d": [4], "q": [0, 0]}}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` BIGINT KEY, `FILTERED_TRANSFORMED` MAP<STRING, INTEGER>"}},
+          {"row":{"columns":[1, {"C": -1, "T":  3}]}},
+          {"row":{"columns":[2, {"D": 4, "Q": 0}]}},
+          {"row":{"columns":[0, {"A": 4, "B": -1}]}}
+        ]}
+      ]
+    },
+    {
+      "name": "complex lambda",
+      "statements": [
+        "CREATE TABLE TEST (ID STRING PRIMARY KEY, MAPPING MAP<STRING, ARRAY<INTEGER>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MAT_TABLE AS SELECT ID, MAPPING FROM TEST;",
+        "SELECT ID, TRANSFORM(FILTER(MAPPING, (a, b) => LEN(a) > 2 AND REDUCE(b, 0, (c, d) => c+d) < 20), (X,Y) => LPAD(x, REDUCE(Y, 2, (s, k) => ABS(ABS(k)-s)), 'a'), (X,Y) => REDUCE(ARRAY_UNION(Y, TRANSFORM(Y, z => z*3)), 0, (e, f) => e+f)) AS OUTPUT FROM MAT_TABLE;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "one", "value": {"MAPPING": {"a": [2,4,5], "bcd": [-5,7]}}},
+        {"topic": "test_topic", "key": "two", "value": {"MAPPING": {"hello": [200,4,5], "hey": [14, -3, -15, 3], "wow": [2, 3, 4]}}},
+        {"topic": "test_topic", "key": "three", "value": {"MAPPING": {"a": null, "bcdefg": [-15,72]}}},
+        {"topic": "test_topic", "key": "four", "value": {"MAPPING": null}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `OUTPUT` MAP<STRING, INTEGER>"}},
+          {"row":{"columns":["three", {}]}},
+          {"row":{"columns":["two", {"hey": -4, "w": 36}]}},
+          {"row":{"columns":["four", null]}},
+          {"row":{"columns":["one", {"abcd": 8}]}}
+        ]}
+      ]
+    },
+    {
+      "name": "reduce an array of maps",
+      "statements": [
+        "CREATE TABLE TEST (ID STRING PRIMARY KEY, arraying ARRAY<MAP<STRING, INTEGER>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MAT_TABLE AS SELECT ID, arraying FROM TEST;",
+        "SELECT ID, reduce(arraying, 5, (s, a) => s + REDUCE(TRANSFORM(FILTER(a, (x, y) => len(x) > 5 AND y % 2 != 0), (e, f) => concat(e, 'leah'), (g, h) => h + len(g)), 0, (s2,r, b) => s2+2*b)) AS OUTPUT FROM MAT_TABLE;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "one", "value": {"arraying": [{"to be or not to be": 15}, {"hello": 25}]}},
+        {"topic": "test_topic", "key": "two", "value": {"arraying": [{"goodmorning": 23, "gn": 12}, {"woooooow": 9}]}},
+        {"topic": "test_topic", "key": "three", "value": {"arraying": [{"a": null, "bcdefg": 4}]}},
+        {"topic": "test_topic", "key": "four", "value": {"arraying": null}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `OUTPUT` INTEGER"}},
+          {"row":{"columns":["three", 5]}},
+          {"row":{"columns":["two", 107]}},
+          {"row":{"columns":["four", 5]}},
+          {"row":{"columns":["one", 71]}}
+        ]}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
Adds lambda functionality to the interpreter used with pull queries.  Now you should be able to use expressions like `SELECT ID, REDUCE(ID, 0, (x,y) => x + y) as sum FROM TABLE;` or `SELECT ID, count, VAL_LIST FROM AGGREGATE WHERE REDUCE(VAL_LIST, 0, (x,y) => x + y) > 4` where lambdas exist in either the `SELECT` or `WHERE `clauses. 

### Testing done 
Wrote a bunch of unit tests and RQTT tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

