### PR TITLE
feat(migrations): implement `clean` command

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
@@ -29,9 +29,9 @@ public final class MigrationConfig extends AbstractConfig {
   public static final String KSQL_SERVER_URL = "ksql.server.url";
 
   public static final String KSQL_MIGRATIONS_STREAM_NAME = "ksql.migrations.stream.name";
-  public static final String KSQL_MIGRATIONS_STREAM_NAME_DEFAULT = "migration_events";
+  public static final String KSQL_MIGRATIONS_STREAM_NAME_DEFAULT = "MIGRATION_EVENTS";
   public static final String KSQL_MIGRATIONS_TABLE_NAME = "ksql.migrations.table.name";
-  public static final String KSQL_MIGRATIONS_TABLE_NAME_DEFAULT = "migration_schema_versions";
+  public static final String KSQL_MIGRATIONS_TABLE_NAME_DEFAULT = "MIGRATION_SCHEMA_VERSIONS";
   public static final String KSQL_MIGRATIONS_STREAM_TOPIC_NAME =
       "ksql.migrations.stream.topic.name";
   public static final String KSQL_MIGRATIONS_TABLE_TOPIC_NAME = "ksql.migrations.table.topic.name";
@@ -73,16 +73,16 @@ public final class MigrationConfig extends AbstractConfig {
             id + "ksql_" + configs
                 .getOrDefault(KSQL_MIGRATIONS_STREAM_NAME, KSQL_MIGRATIONS_STREAM_NAME_DEFAULT),
             Importance.MEDIUM,
-            "The name of the migration stream topic. It defaults to " + id + "ksql_" + configs
-                .getOrDefault(KSQL_MIGRATIONS_STREAM_NAME, KSQL_MIGRATIONS_STREAM_NAME_DEFAULT)
+            "The name of the migration stream topic. It defaults to "
+                + "'<ksql_service_id>ksql_<migrations_stream_name>'"
         ).define(
             KSQL_MIGRATIONS_TABLE_TOPIC_NAME,
             Type.STRING,
             id + "ksql_" + configs
                 .getOrDefault(KSQL_MIGRATIONS_TABLE_NAME, KSQL_MIGRATIONS_TABLE_NAME_DEFAULT),
             Importance.MEDIUM,
-            "The name of the migration table topic. It defaults to" + id + "ksql_" + configs
-                .getOrDefault(KSQL_MIGRATIONS_TABLE_NAME, KSQL_MIGRATIONS_TABLE_NAME_DEFAULT)
+            "The name of the migration table topic. It defaults to "
+                + "'<ksql_service_id>ksql_<migrations_table_name>'"
         ).define(
             KSQL_MIGRATIONS_TOPIC_REPLICAS,
             Type.INT,

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.tools.migrations.commands;
 import com.github.rvesse.airline.annotations.Command;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.api.client.Client;
-import io.confluent.ksql.api.client.ServerInfo;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.MigrationException;
 import io.confluent.ksql.tools.migrations.util.MigrationsUtil;
@@ -57,8 +56,12 @@ public class InitializeMigrationCommand extends BaseCommand {
         + ");\n";
   }
 
-  private String createVersionTable(final String name, final String topic) {
-    return "CREATE TABLE " + name + "\n"
+  private String createVersionTable(
+      final String tableName,
+      final String streamName,
+      final String topic
+  ) {
+    return "CREATE TABLE " + tableName + "\n"
         + "  WITH (\n"
         + "    KAFKA_TOPIC='" + topic + "'\n"
         + "  )\n"
@@ -71,7 +74,7 @@ public class InitializeMigrationCommand extends BaseCommand {
         + "    latest_by_offset(started_on) AS started_on, \n"
         + "    latest_by_offset(completed_on) AS completed_on, \n"
         + "    latest_by_offset(previous) AS previous\n"
-        + "  FROM migration_events \n"
+        + "  FROM " + streamName + " \n"
         + "  GROUP BY version_key;\n";
   }
 
@@ -106,6 +109,7 @@ public class InitializeMigrationCommand extends BaseCommand {
     );
     final String versionTableCommand = createVersionTable(
         tableName,
+        streamName,
         config.getString(MigrationConfig.KSQL_MIGRATIONS_TABLE_TOPIC_NAME)
     );
 
@@ -117,10 +121,10 @@ public class InitializeMigrationCommand extends BaseCommand {
       return 1;
     }
 
-    if (serverVersionCompatible(ksqlClient, config)
+    if (ServerVersionUtil.serverVersionCompatible(ksqlClient, config)
         && tryCreate(ksqlClient, eventStreamCommand, streamName, true)
         && tryCreate(ksqlClient, versionTableCommand, tableName, false)) {
-      LOGGER.info("Schema metadata initialized successfully");
+      LOGGER.info("Migrations metadata initialized successfully");
       ksqlClient.close();
     } else {
       ksqlClient.close();
@@ -128,28 +132,6 @@ public class InitializeMigrationCommand extends BaseCommand {
     }
 
     return 0;
-  }
-
-  private static boolean serverVersionCompatible(
-      final Client ksqlClient,
-      final MigrationConfig config
-  ) {
-    final String ksqlServerUrl = config.getString(MigrationConfig.KSQL_SERVER_URL);
-    final ServerInfo serverInfo;
-    try {
-      serverInfo = ServerVersionUtil.getServerInfo(ksqlClient, ksqlServerUrl);
-    } catch (MigrationException e) {
-      LOGGER.error("Failed to get server info to verify version compatibility: {}", e.getMessage());
-      return false;
-    }
-
-    final String serverVersion = serverInfo.getServerVersion();
-    try {
-      return ServerVersionUtil.isSupportedVersion(serverVersion);
-    } catch (MigrationException e) {
-      LOGGER.warn(e.getMessage() + ". Proceeding anyway.");
-      return true;
-    }
   }
 
   private static boolean tryCreate(

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommandTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.commands;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.rvesse.airline.SingleCommand;
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.api.client.Client;
+import io.confluent.ksql.api.client.ExecuteStatementResult;
+import io.confluent.ksql.api.client.QueryInfo;
+import io.confluent.ksql.api.client.ServerInfo;
+import io.confluent.ksql.api.client.SourceDescription;
+import io.confluent.ksql.api.client.StreamInfo;
+import io.confluent.ksql.api.client.TableInfo;
+import io.confluent.ksql.tools.migrations.MigrationConfig;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CleanMigrationsCommandTest {
+
+  private static final SingleCommand<CleanMigrationsCommand> PARSER =
+      SingleCommand.singleCommand(CleanMigrationsCommand.class);
+
+  private static final String MIGRATIONS_STREAM = "migrations_stream";
+  private static final String MIGRATIONS_TABLE = "migrations_table";
+  private static final String CTAS_QUERY_ID = "ctas_migration_table_0";
+
+  @Mock
+  private MigrationConfig config;
+  @Mock
+  private Client client;
+  @Mock
+  private CompletableFuture<ServerInfo> serverInfoCf;
+  @Mock
+  private CompletableFuture<ExecuteStatementResult> executeStatementCf;
+  @Mock
+  private CompletableFuture<List<StreamInfo>> listStreamsCf;
+  @Mock
+  private CompletableFuture<List<TableInfo>> listTablesCf;
+  @Mock
+  private CompletableFuture<SourceDescription> describeSourceCf;
+  @Mock
+  private ServerInfo serverInfo;
+  @Mock
+  private ExecuteStatementResult executeStatementResult;
+  @Mock
+  private StreamInfo streamInfo;
+  @Mock
+  private TableInfo tableInfo;
+  @Mock
+  private SourceDescription sourceDescription;
+  @Mock
+  private QueryInfo ctasQueryInfo;
+  @Mock
+  private QueryInfo otherQueryInfo;
+
+  private CleanMigrationsCommand command;
+
+  @Before
+  public void setUp() throws Exception {
+    when(config.getString(MigrationConfig.KSQL_MIGRATIONS_STREAM_NAME)).thenReturn(MIGRATIONS_STREAM);
+    when(config.getString(MigrationConfig.KSQL_MIGRATIONS_TABLE_NAME)).thenReturn(MIGRATIONS_TABLE);
+    when(client.serverInfo()).thenReturn(serverInfoCf);
+    when(client.executeStatement(anyString())).thenReturn(executeStatementCf);
+    when(client.listStreams()).thenReturn(listStreamsCf);
+    when(client.listTables()).thenReturn(listTablesCf);
+    when(client.describeSource(MIGRATIONS_TABLE)).thenReturn(describeSourceCf);
+
+    when(serverInfoCf.get()).thenReturn(serverInfo);
+    when(serverInfo.getServerVersion()).thenReturn("v0.14.0");
+    when(executeStatementCf.get()).thenReturn(executeStatementResult);
+    when(listStreamsCf.get()).thenReturn(ImmutableList.of(streamInfo));
+    when(listTablesCf.get()).thenReturn(ImmutableList.of(tableInfo));
+    when(describeSourceCf.get()).thenReturn(sourceDescription);
+
+    when(streamInfo.getName()).thenReturn(MIGRATIONS_STREAM);
+    when(tableInfo.getName()).thenReturn(MIGRATIONS_TABLE);
+    when(sourceDescription.writeQueries()).thenReturn(ImmutableList.of(ctasQueryInfo));
+    when(ctasQueryInfo.getId()).thenReturn(CTAS_QUERY_ID);
+    when(otherQueryInfo.getId()).thenReturn("other_query_id");
+
+    command = PARSER.parse();
+  }
+
+  @Test
+  public void shouldCleanMigrationsStreamAndTable() {
+    // When:
+    final int status = command.command(config, cfg -> client);
+
+    // Then:
+    assertThat(status, is(0));
+
+    verify(client).executeStatement("TERMINATE " + CTAS_QUERY_ID + ";");
+    verify(client).executeStatement("DROP TABLE " + MIGRATIONS_TABLE + " DELETE TOPIC;");
+    verify(client).executeStatement("DROP STREAM " + MIGRATIONS_STREAM + " DELETE TOPIC;");
+  }
+
+  @Test
+  public void shouldCleanMigrationsStreamEvenIfTableDoesntExist() throws Exception {
+    // Given:
+    givenMigrationsTableDoesNotExist();
+
+    // When:
+    final int status = command.command(config, cfg -> client);
+
+    // Then:
+    assertThat(status, is(0));
+
+    verify(client).executeStatement("DROP STREAM " + MIGRATIONS_STREAM + " DELETE TOPIC;");
+    verify(client, never()).executeStatement("DROP TABLE " + MIGRATIONS_TABLE + " DELETE TOPIC;");
+    verify(client, never()).executeStatement("TERMINATE " + CTAS_QUERY_ID + ";");
+  }
+
+  @Test
+  public void shouldCleanMigrationsTableEvenIfStreamDoesntExist() throws Exception {
+    // Given:
+    givenMigrationsStreamDoesNotExist();
+
+    // When:
+    final int status = command.command(config, cfg -> client);
+
+    // Then:
+    assertThat(status, is(0));
+
+    verify(client).executeStatement("DROP TABLE " + MIGRATIONS_TABLE + " DELETE TOPIC;");
+    verify(client, never()).executeStatement("DROP STREAM " + MIGRATIONS_STREAM + " DELETE TOPIC;");
+
+    // a single query writing to the table will still be dropped, even if the stream
+    // doesn't exist. we could change this in the future but it's an unlikely (and
+    // unexpected) edge case that doesn't seem too important.
+    verify(client).executeStatement("TERMINATE " + CTAS_QUERY_ID + ";");
+  }
+
+  @Test
+  public void shouldCleanMigrationsTableEvenIfQueryDoesntExist() {
+    // Given:
+    when(sourceDescription.writeQueries()).thenReturn(ImmutableList.of());
+
+    // When:
+    final int status = command.command(config, cfg -> client);
+
+    // Then:
+    assertThat(status, is(0));
+
+    verify(client).executeStatement("DROP TABLE " + MIGRATIONS_TABLE + " DELETE TOPIC;");
+    verify(client).executeStatement("DROP STREAM " + MIGRATIONS_STREAM + " DELETE TOPIC;");
+  }
+
+  @Test
+  public void shouldFailIfMultipleQueriesWritingToTable() {
+    // Given:
+    when(sourceDescription.writeQueries()).thenReturn(ImmutableList.of(ctasQueryInfo, otherQueryInfo));
+
+    // When:
+    final int status = command.command(config, cfg -> client);
+
+    // Then:
+    assertThat(status, is(1));
+
+    verify(client, never()).executeStatement("TERMINATE " + CTAS_QUERY_ID + ";");
+    verify(client, never()).executeStatement("DROP TABLE " + MIGRATIONS_TABLE + " DELETE TOPIC;");
+    verify(client, never()).executeStatement("DROP STREAM " + MIGRATIONS_STREAM + " DELETE TOPIC;");
+  }
+
+  @Test
+  public void shouldSucceedIfNeverInitialized() throws Exception {
+    // Given:
+    givenMigrationsStreamDoesNotExist();
+    givenMigrationsTableDoesNotExist();
+
+    // When:
+    final int status = command.command(config, cfg -> client);
+
+    // Then:
+    assertThat(status, is(0));
+  }
+
+  @Test
+  public void shouldNotCleanIfServerVersionIncompatible() {
+    // Given:
+    when(serverInfo.getServerVersion()).thenReturn("v0.9.0");
+
+    // When:
+    final int status = command.command(config, cfg -> client);
+
+    // Then:
+    assertThat(status, is(1));
+
+    verify(client, never()).executeStatement(anyString());
+  }
+
+  @Test
+  public void shouldCleanEvenIfCantParseServerVersion() {
+    // Given:
+    when(serverInfo.getServerVersion()).thenReturn("not_a_valid_version");
+
+    // When:
+    final int status = command.command(config, cfg -> client);
+
+    // Then:
+    assertThat(status, is(0));
+
+    verify(client).executeStatement("TERMINATE " + CTAS_QUERY_ID + ";");
+    verify(client).executeStatement("DROP TABLE " + MIGRATIONS_TABLE + " DELETE TOPIC;");
+    verify(client).executeStatement("DROP STREAM " + MIGRATIONS_STREAM + " DELETE TOPIC;");
+  }
+
+  private void givenMigrationsStreamDoesNotExist() throws Exception {
+    when(listStreamsCf.get()).thenReturn(ImmutableList.of());
+  }
+
+  private void givenMigrationsTableDoesNotExist() throws Exception {
+    when(listTablesCf.get()).thenReturn(ImmutableList.of());
+  }
+}

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommandTest.java
@@ -77,7 +77,7 @@ public class InitializeMigrationCommandTest {
           + "    latest_by_offset(started_on) AS started_on, \n"
           + "    latest_by_offset(completed_on) AS completed_on, \n"
           + "    latest_by_offset(previous) AS previous\n"
-          + "  FROM migration_events \n"
+          + "  FROM " + MIGRATIONS_STREAM + " \n"
           + "  GROUP BY version_key;\n";
 
   @Mock


### PR DESCRIPTION
### Description 

This PR implements the `migrations clean` command, which cleans up the migrations metadata stream and table (and underlying Kafka topics), if present.

Also fixes a bug around custom migrations stream names.

### Testing done 

Unit + integration.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

