### PR TITLE
feat: Allows lots of table scans cases where keys cannot easily be extracted

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericExpressionResolver.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericExpressionResolver.java
@@ -20,7 +20,6 @@ import static io.confluent.ksql.schema.ksql.types.SqlTypes.TIMESTAMP;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
-import io.confluent.ksql.execution.codegen.CompiledExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericExpressionResolver.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericExpressionResolver.java
@@ -27,6 +27,8 @@ import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.TraversalExpressionVisitor;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
+import io.confluent.ksql.execution.interpreter.InterpretedExpressionFactory;
+import io.confluent.ksql.execution.transform.ExpressionEvaluator;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.RecordProcessingError;
@@ -63,19 +65,22 @@ public class GenericExpressionResolver {
   private final FunctionRegistry functionRegistry;
   private final KsqlConfig config;
   private final String operation;
+  private final boolean shouldUseInterpreter;
 
   public GenericExpressionResolver(
       final SqlType fieldType,
       final ColumnName fieldName,
       final FunctionRegistry functionRegistry,
       final KsqlConfig config,
-      final String operation
+      final String operation,
+      final boolean shouldUseInterpreter
   ) {
     this.fieldType = Objects.requireNonNull(fieldType, "fieldType");
     this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
     this.config = Objects.requireNonNull(config, "config");
     this.operation = Objects.requireNonNull(operation, "operation");
+    this.shouldUseInterpreter = shouldUseInterpreter;
   }
 
   public Object resolve(final Expression expression) {
@@ -87,17 +92,17 @@ public class GenericExpressionResolver {
     @Override
     protected Object visitExpression(final Expression expression, final Void context) {
       new EnsureNoColReferences(expression).process(expression, context);
-      final CompiledExpression metadata =
-          CodeGenRunner.compileExpression(
+      final ExpressionEvaluator evaluator = shouldUseInterpreter
+          ? InterpretedExpressionFactory.create(expression, NO_COLUMNS, functionRegistry, config)
+          : CodeGenRunner.compileExpression(
               expression,
               operation,
               NO_COLUMNS,
               config,
-              functionRegistry
-          );
+              functionRegistry);
 
       // we expect no column references, so we can pass in an empty generic row
-      final Object value = metadata.evaluate(new GenericRow(), null, THROWING_LOGGER, IGNORED_MSG);
+      final Object value = evaluator.evaluate(new GenericRow(), null, THROWING_LOGGER, IGNORED_MSG);
 
       return sqlValueCoercer.coerce(value, fieldType)
           .orElseThrow(() -> {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/generic/GenericRecordFactory.java
@@ -146,7 +146,8 @@ public class GenericRecordFactory {
           column,
           functionRegistry,
           config,
-          "insert value").resolve(valueExp);
+          "insert value",
+          false).resolve(valueExp);
 
       values.put(column, value);
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -611,23 +611,23 @@ public class PullFilterNode extends SingleSourcePlanNode {
         }
       }
 
-      final Object obj = new GenericExpressionResolver(
-          SqlTypes.BIGINT,
-          name,
-          metaStore,
-          ksqlConfig,
-          "pull query window bounds extractor",
-          ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED)
-      ).resolve(other);
+      try {
+        final Long value = (Long) new GenericExpressionResolver(
+            SqlTypes.BIGINT,
+            name,
+            metaStore,
+            ksqlConfig,
+            "pull query window bounds extractor",
+            ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED)
+        ).resolve(other);
 
-      if (obj instanceof Long) {
-        return Instant.ofEpochMilli((long) obj);
+        return Instant.ofEpochMilli(value);
+      } catch (final KsqlException e) {
+        throw invalidWhereClauseException(
+            "Window bounds must resolve to an INT, BIGINT, or STRING containing a datetime.",
+            true
+        );
       }
-
-      throw invalidWhereClauseException(
-          "Window bounds must resolve to an INT, BIGINT, or STRING containing a datetime.",
-          true
-      );
     }
 
     private BoundType getRangeBoundType(final ComparisonExpression lowerComparison) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -366,7 +366,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
     }
   }
 
-  private final class HasColumnRef extends TraversalExpressionVisitor<Object> {
+  private static final class HasColumnRef extends TraversalExpressionVisitor<Object> {
 
     private boolean hasColumnRef;
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -298,6 +298,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
         final ComparisonExpression node,
         final Object context
     ) {
+      // First see if we can find a direct column reference
       final UnqualifiedColumnReferenceExp column = getColumnRefSideOrNull(node);
       if (column != null) {
         final Expression other = getNonColumnRefSide(node);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/generic/GenericExpressionResolverTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/generic/GenericExpressionResolverTest.java
@@ -56,7 +56,8 @@ public class GenericExpressionResolverTest {
     ));
 
     // When:
-    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value").resolve(exp);
+    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config,
+        "insert value", false).resolve(exp);
 
     // Then:
     assertThat(o, is(new Struct(
@@ -71,7 +72,8 @@ public class GenericExpressionResolverTest {
     final Expression exp = new NullLiteral();
 
     // When:
-    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value").resolve(exp);
+    final Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config,
+        "insert value", false).resolve(exp);
 
     // Then:
     assertThat(o, Matchers.nullValue());
@@ -86,7 +88,8 @@ public class GenericExpressionResolverTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value").resolve(exp));
+        () -> new GenericExpressionResolver(type, FIELD_NAME, registry, config,
+            "insert value", false).resolve(exp));
 
     // Then:
     assertThat(e.getMessage(), containsString("Expected type ARRAY<INTEGER> for field `FOO` but got INTEGER(1)"));
@@ -101,7 +104,8 @@ public class GenericExpressionResolverTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value").resolve(exp));
+        () -> new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value",
+            false).resolve(exp));
 
     // Then:
     assertThat(e.getMessage(), containsString("Timestamp format must be yyyy-mm-ddThh:mm:ss[.S]"));
@@ -114,7 +118,8 @@ public class GenericExpressionResolverTest {
     final Expression exp = new StringLiteral("2021-01-09T04:40:02");
 
     // When:
-    Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value").resolve(exp);
+    Object o = new GenericExpressionResolver(type, FIELD_NAME, registry, config, "insert value",
+        false).resolve(exp);
 
     // Then:
     assertTrue(o instanceof Timestamp);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullFilterNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullFilterNodeTest.java
@@ -1316,7 +1316,8 @@ public class PullFilterNodeTest {
         ));
 
     // Then:
-    assertThat(e.getMessage(), containsString("Window bounds must be an INT, BIGINT or STRING containing a datetime."));
+    assertThat(e.getMessage(), containsString("Window bounds must resolve to an INT, BIGINT, or "
+        + "STRING containing a datetime."));
   }
 
 

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -1914,9 +1914,12 @@
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
         "SELECT * FROM AGGREGATE WHERE ID IN (2, COUNT + 1, 3);"
       ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Unsupported column reference in pull query: (COUNT + 1)",
+        "message": "A comparison must be between a key column and a resolvable expression.",
         "status": 400
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2139,13 +2139,17 @@
       ]
     },
     {
-      "name": "non-windowed - Table Scan - non column ref is not literal",
+      "name": "non-windowed - Table Scan - non column ref is unresolvable or there is no column ref",
       "statements": [
         "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
         "SELECT * FROM AGGREGATE WHERE ID = 20 - 10;",
         "SELECT * FROM AGGREGATE WHERE ID < COUNT;",
-        "SELECT * FROM AGGREGATE WHERE ID = COUNT;"
+        "SELECT * FROM AGGREGATE WHERE ID = COUNT;",
+        "SELECT * FROM AGGREGATE WHERE ID + 1 = COUNT;",
+        "SELECT * FROM AGGREGATE WHERE ID + 1 = COUNT + 1;",
+        "SELECT * FROM AGGREGATE WHERE 2 < 5;",
+        "SELECT * FROM AGGREGATE WHERE 2 > 5;"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 12365, "key": 2, "value": {}},
@@ -2174,6 +2178,24 @@
         {"query": [
           {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
           {"row":{"columns":[3, 3]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[2, 3]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[3, 3]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 2]}},
+          {"row":{"columns":[2, 3]}},
+          {"row":{"columns":[3, 3]}},
+          {"row":{"columns":[11, 3]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}}
         ]}
       ]
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2139,6 +2139,93 @@
       ]
     },
     {
+      "name": "non-windowed - Table Scan - non column ref is not literal",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID = 20 - 10;",
+        "SELECT * FROM AGGREGATE WHERE ID < COUNT;",
+        "SELECT * FROM AGGREGATE WHERE ID = COUNT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12365, "key": 2, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 2, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 2, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 3, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 3, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 3, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12375, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12355, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 11, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[2, 3]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[3, 3]}}
+        ]}
+      ]
+    },
+    {
+      "name": "fail on unsupported query feature: No column key",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID + 10 = 20;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "A comparison must reference a key column and literal.",
+        "status": 400
+      }
+    },
+    {
+      "name": "fail on unsupported query feature: Two columns in comparison",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID = COUNT;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "A comparison must reference a key column and literal.",
+        "status": 400
+      }
+    },
+    {
+      "name": "fail on unsupported query feature: Non column key is unresolvable",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID = COUNT - 1;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Non column reference must be resolvable.",
+        "status": 400
+      }
+    },
+    {
       "name": "multi-column aggregation",
       "statements": [
         "CREATE STREAM INPUT (ID1 STRING KEY, ID2 INT) WITH (kafka_topic='test_topic', format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2216,7 +2216,7 @@
           {"row":{"columns":[10, 12000, 13000, 1]}}
         ]}
       ]
-    }x,
+    },
     {
       "name": "non-windowed - Table Scan - non column ref is unresolvable or there is no column ref",
       "statements": [
@@ -2290,7 +2290,7 @@
       },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "A comparison must reference a key column and literal.",
+        "message": "A comparison must directly reference a key column.",
         "status": 400
       }
     },
@@ -2306,7 +2306,7 @@
       },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "A comparison must reference a key column and literal.",
+        "message": "A comparison must be between a key column and a resolvable expression.",
         "status": 400
       }
     },
@@ -2322,7 +2322,7 @@
       },
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Non column reference must be resolvable.",
+        "message": "A comparison must be between a key column and a resolvable expression.",
         "status": 400
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2061,6 +2061,84 @@
       ]
     },
     {
+      "name": "non-windowed - Table Scan - indirect column reference",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID + 10 = 20;",
+        "SELECT * FROM AGGREGATE WHERE 2 * COUNT > 5;",
+        "SELECT id, floor(exp(ID)) as val  FROM AGGREGATE WHERE floor(exp(ID)) > 30000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12365, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12375, "key": 10, "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12355, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 11, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 2]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[11, 3]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `VAL` DOUBLE"}},
+          {"row":{"columns":[11, 59874.0]}}
+        ]}
+      ]
+    },
+    {
+      "name": "windowed - Table Scan - indirect column reference",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID + 10 = 20;",
+        "SELECT * FROM AGGREGATE WHERE ID + 10 = 20 and WINDOWSTART > 12500;",
+        "SELECT id, WINDOWSTART, WINDOWEND, COUNT, FLOOR(SQRT(WINDOWSTART)) as val FROM AGGREGATE WHERE SQRT(WINDOWSTART) > 110.0;",
+        "SELECT id, WINDOWSTART, WINDOWEND, COUNT, floor(exp(ID)) as val  FROM AGGREGATE WHERE floor(exp(ID)) > 30000;",
+        "SELECT id, WINDOWSTART, WINDOWEND, COUNT, floor(exp(ID)) as val  FROM AGGREGATE WHERE floor(exp(ID)) > 30000 AND WINDOWEND < 13500;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 10, "value": {"val": 1}},
+        {"topic": "test_topic", "timestamp": 12346, "key": 11, "value": {"val": 2}},
+        {"topic": "test_topic", "timestamp": 13346, "key": 11, "value": {"val": 3}},
+        {"topic": "test_topic", "timestamp": 13345, "key": 10, "value": {"val": 4}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 12000, 13000, 1]}},
+          {"row":{"columns":[10, 13000, 14000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 13000, 14000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT, `VAL` DOUBLE"}},
+          {"row":{"columns":[10, 13000, 14000, 1, 114.0]}},
+          {"row":{"columns":[11, 13000, 14000, 1, 114.0]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT, `VAL` DOUBLE"}},
+          {"row":{"columns":[11, 12000, 13000, 1, 59874.0]}},
+          {"row":{"columns":[11, 13000, 14000, 1, 59874.0]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT, `VAL` DOUBLE"}},
+          {"row":{"columns":[11, 12000, 13000, 1, 59874.0]}}
+        ]}
+      ]
+    },
+    {
       "name": "multi-column aggregation",
       "statements": [
         "CREATE STREAM INPUT (ID1 STRING KEY, ID2 INT) WITH (kafka_topic='test_topic', format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -2061,6 +2061,45 @@
       ]
     },
     {
+      "name": "windowed - Table Scan - missing key, windowed system columns only",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE WINDOWSTART > 12500;",
+        "SELECT * FROM AGGREGATE WHERE WINDOWEND < 13500;",
+        "SELECT * FROM AGGREGATE WHERE WINDOWSTART > 12500 AND WINDOWEND < 13500;",
+        "SELECT * FROM AGGREGATE WHERE WINDOWSTART > 11500 AND WINDOWEND < 13500;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 10, "value": {"val": 1}},
+        {"topic": "test_topic", "timestamp": 12346, "key": 11, "value": {"val": 2}},
+        {"topic": "test_topic", "timestamp": 13346, "key": 11, "value": {"val": 3}},
+        {"topic": "test_topic", "timestamp": 13345, "key": 10, "value": {"val": 4}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 13000, 14000, 1]}},
+          {"row":{"columns":[11, 13000, 14000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 12000, 13000, 1]}},
+          {"row":{"columns":[11, 12000, 13000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 12000, 13000, 1]}},
+          {"row":{"columns":[11, 12000, 13000, 1]}}
+        ]}
+      ]
+    },
+    {
       "name": "non-windowed - Table Scan - indirect column reference",
       "statements": [
         "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -2138,6 +2177,46 @@
         ]}
       ]
     },
+    {
+      "name": "windowed - Resolving keys for key lookups",
+      "statements": [
+        "CREATE STREAM INPUT (ID INTEGER KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ID;",
+        "SELECT * FROM AGGREGATE WHERE ID = 10 AND WINDOWSTART > 12500 + 10;",
+        "SELECT * FROM AGGREGATE WHERE ID = 10 + 1 AND WINDOWSTART > 12500 + 10;",
+        "SELECT * FROM AGGREGATE WHERE ID = 10 + 1 AND WINDOWEND < 13500 + 10;",
+        "SELECT * FROM AGGREGATE WHERE ID = 11 - 1 AND WINDOWSTART > 11000 + 50 AND WINDOWEND < 13500 + 10;"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 10, "value": {"val": 1}},
+        {"topic": "test_topic", "timestamp": 12346, "key": 11, "value": {"val": 2}},
+        {"topic": "test_topic", "timestamp": 13346, "key": 11, "value": {"val": 3}},
+        {"topic": "test_topic", "timestamp": 13345, "key": 10, "value": {"val": 4}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 13000, 14000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[11, 13000, 14000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[11, 12000, 13000, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` INTEGER KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 12000, 13000, 1]}}
+        ]}
+      ]
+    }x,
     {
       "name": "non-windowed - Table Scan - non column ref is unresolvable or there is no column ref",
       "statements": [


### PR DESCRIPTION
fixes #4484 

### Description 
This allows many cases when table scans are enabled.  Prior to this, a comparison must have been of the form `KEY=12345` or possibly `KEY=1 + 2` where there was a column on one side and a resolvable expression on the other.  When table scans are enabled, now these can be done:
- Both sides are column references (e.g. `KEY = COL`)
- Neither side is a column reference (e.g. `5 > 3`, `KEY + 1 = COL + 1` )
- One side is a column reference and the other is an unresolveable expression (e.g. `KEY = COL + 10`)

Resolves #4484 

### Testing done 
RQTT tests and unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

