### PR TITLE
chore(migrations): miscellaneous migrations tool cleanup

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
@@ -163,7 +163,7 @@ public final class MigrationConfig extends AbstractConfig {
             Importance.MEDIUM,
             "The number of replicas for the migration stream topic. It defaults to "
                 + KSQL_MIGRATIONS_TOPIC_REPLICAS_DEFAULT
-        ), configs);
+        ), configs, false);
   }
 
   private static String getServiceId(final Map<String, String> configs) throws MigrationException {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
@@ -54,10 +54,16 @@ public final class Migrations {
   private Migrations() {}
 
   public static void main(final String[] args) {
-    // all Migrations commands must implement BaseCommand, so we
-    // are safe to assume that the type returned is Cli<BaseCommand>
-    final Cli<BaseCommand> cli = new Cli<>(Migrations.class);
-    System.exit(cli.parse(args).run());
+    // even though all migrations commands implement BaseCommand, the Help
+    // command does not so we infer the type as Runnable instead
+    final Cli<Runnable> cli = new Cli<>(Migrations.class);
+    final Runnable command = cli.parse(args);
+    if (command instanceof Help) {
+      command.run();
+      System.exit(0);
+    }
+
+    System.exit(((BaseCommand) command).runCommand());
   }
 
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -121,6 +121,7 @@ public class ApplyMigrationCommand extends BaseCommand {
     );
   }
 
+  // CHECKSTYLE_RULES.OFF: NPathComplexity
   @VisibleForTesting
   int command(
       final MigrationConfig config,
@@ -128,6 +129,7 @@ public class ApplyMigrationCommand extends BaseCommand {
       final String migrationsDir,
       final Clock clock
   ) {
+    // CHECKSTYLE_RULES.ON: NPathComplexity
     if (untilVersion < 0) {
       LOGGER.error("'until' migration version must be positive. Got: {}", untilVersion);
       return 1;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -150,6 +150,11 @@ public class ApplyMigrationCommand extends BaseCommand {
       return 1;
     }
 
+    if (dryRun) {
+      LOGGER.info("This is a dry run. No ksqlDB statements will be submitted "
+          + "to the ksqlDB server.");
+    }
+
     boolean success;
     try {
       success = validateCurrentState(config, ksqlClient, migrationsDir)

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 
 @Command(
     name = "apply",
-    description = "Migrates a schema to new available schema versions"
+    description = "Migrates the metadata schema to a new schema version."
 )
 public class ApplyMigrationCommand extends BaseCommand {
 
@@ -57,7 +57,7 @@ public class ApplyMigrationCommand extends BaseCommand {
   @Option(
       title = "all",
       name = {"-a", "--all"},
-      description = "run all available migrations"
+      description = "Run all available migrations"
   )
   @RequireOnlyOne(tag = "target")
   private boolean all;
@@ -65,7 +65,7 @@ public class ApplyMigrationCommand extends BaseCommand {
   @Option(
       title = "next",
       name = {"-n", "--next"},
-      description = "migrate the next available version"
+      description = "Run the next available migration version"
   )
   @RequireOnlyOne(tag = "target")
   private boolean next;
@@ -74,19 +74,30 @@ public class ApplyMigrationCommand extends BaseCommand {
       title = "untilVersion",
       name = {"-u", "--until"},
       arity = 1,
-      description = "migrate until the specified version"
+      description = "Run all available migrations up through the specified version"
   )
   @RequireOnlyOne(tag = "target")
   private int untilVersion;
 
   @Option(
-      title = "untilVersion",
+      title = "version",
       name = {"-v", "--version"},
       arity = 1,
-      description = "apply the migration with the specified version"
+      description = "Run the migration with the specified version"
   )
   @RequireOnlyOne(tag = "target")
   private int version;
+
+  @Option(
+      name = {"--dry-run"},
+      title = "dry-run",
+      description = "Dry run the current command. No ksqlDB statements will be "
+          + "sent to the ksqlDB server. Note that this dry run is for purposes of "
+          + "displaying which migration files (and what ksqlDB statements) the command "
+          + "would run in non-dry-run mode, and does NOT attempt to validate whether "
+          + "the ksqlDB statements will be accepted by the ksqlDB server."
+  )
+  private boolean dryRun = false;
 
   @Override
   protected int command() {
@@ -122,7 +133,7 @@ public class ApplyMigrationCommand extends BaseCommand {
       return 1;
     }
     if (version < 0) {
-      LOGGER.error("migration version to apply must be positive. Got: {}", version);
+      LOGGER.error("Migration version to apply must be positive. Got: {}", version);
       return 1;
     }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -19,7 +19,6 @@ import static io.confluent.ksql.tools.migrations.commands.InitializeMigrationCom
 
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.OptionType;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.util.MigrationsUtil;
@@ -30,11 +29,7 @@ import org.slf4j.Logger;
  * Defines common options across all of the migration
  * tool commands.
  */
-@SuppressFBWarnings(
-    value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
-    justification = "code is skeleton only at the moment, used to generate HELP message"
-)
-public abstract class BaseCommand {
+public abstract class BaseCommand implements Runnable {
 
   private static final String CONFIG_FILE_OPTION = "--config-file";
   private static final String CONFIG_FILE_OPTION_SHORT = "-c";
@@ -42,23 +37,21 @@ public abstract class BaseCommand {
   @Option(
       name = {CONFIG_FILE_OPTION_SHORT, CONFIG_FILE_OPTION},
       title = "config-file",
-      description = "Specifies a configuration file",
+      description = "Path to migrations configuration file. Required for all commands "
+          + "with the exception of `" + NewMigrationCommand.NEW_COMMAND_NAME + "`.",
       type = OptionType.GLOBAL
   )
   protected String configFile;
 
-  @Option(
-      name = {"--dry-run"},
-      title = "dry-run",
-      description = "dry run the current command, no ksqlDB statements will be executed",
-      type = OptionType.GLOBAL
-  )
-  protected boolean dryRun = false;
+  @Override
+  public void run() {
+    runCommand();
+  }
 
   /**
    * @return exit status of the command
    */
-  public int run() {
+  public int runCommand() {
     final long startTime = System.nanoTime();
     final int status = command();
     getLogger().info("Execution time: " + (System.nanoTime() - startTime) / 1000000000);

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -52,9 +52,10 @@ public abstract class BaseCommand implements Runnable {
    * @return exit status of the command
    */
   public int runCommand() {
-    final long startTime = System.nanoTime();
+    final long startTime = System.currentTimeMillis();
     final int status = command();
-    getLogger().info("Execution time: " + (System.nanoTime() - startTime) / 1000000000);
+    getLogger().info(String.format("Execution time: %.4f seconds",
+        (System.currentTimeMillis() - startTime) / 1000.));
     return status;
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
@@ -77,6 +77,7 @@ public class CleanMigrationsCommand extends BaseCommand {
       return 1;
     }
 
+    LOGGER.info("Cleaning migrations metadata stream and table from ksqlDB server");
     if (ServerVersionUtil.serverVersionCompatible(ksqlClient, config)
         && deleteMigrationsTable(ksqlClient, tableName)
         && deleteMigrationsStream(ksqlClient, streamName)) {
@@ -97,7 +98,7 @@ public class CleanMigrationsCommand extends BaseCommand {
   private boolean deleteMigrationsTable(final Client ksqlClient, final String tableName) {
     try {
       if (!sourceExists(ksqlClient, tableName, true)) {
-        // nothing to delete
+        LOGGER.info("Metadata table does not exist. Skipping cleanup.");
         return true;
       }
 
@@ -115,7 +116,7 @@ public class CleanMigrationsCommand extends BaseCommand {
   private boolean deleteMigrationsStream(final Client ksqlClient, final String streamName) {
     try {
       if (!sourceExists(ksqlClient, streamName, false)) {
-        // nothing to delete
+        LOGGER.info("Metadata stream does not exist. Skipping cleanup.");
         return true;
       }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
@@ -36,7 +36,9 @@ import org.slf4j.LoggerFactory;
 
 @Command(
     name = "clean",
-    description = "Cleans all resources related to migrations. WARNING: this is not reversible!"
+    description = "Cleans all ksqlDB server resources related to migrations, including "
+        + "the migrations metadata stream and table and their underlying Kafka topics. "
+        + "WARNING: this is not reversible!"
 )
 public class CleanMigrationsCommand extends BaseCommand {
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -145,11 +145,12 @@ public class CreateMigrationCommand extends BaseCommand {
     final String filename = getNewFileName(newVersion, description);
     final String filePath = Paths.get(migrationsDir, filename).toString();
     try {
-      LOGGER.info("Creating file: " + filePath);
+      LOGGER.info("Creating migration file: " + filePath);
       final boolean result = new File(filePath).createNewFile();
       if (!result) {
         throw new IllegalStateException("File should not exist");
       }
+      LOGGER.info("Migration file successfully created");
     } catch (IOException | IllegalStateException e) {
       throw new MigrationException(String.format(
           "Failed to create file %s: %s", filePath, e.getMessage()));

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -38,12 +38,12 @@ import org.slf4j.LoggerFactory;
 
 @Command(
     name = "create",
-    description = "Create a blank migration file with <description> as description, which "
-        + "can then be edited and applied as the next schema version."
+    description = "Creates a blank migration file with the specified description, which "
+        + "can then be populated with ksqlDB statements and applied as the next schema version."
 )
 @Examples(
-    examples = "$ ksql-migrations create Add_users",
-    descriptions = "Creates a new migrations file for adding a users table to ksqlDB "
+    examples = "$ ksql-migrations --config-file <config-file> create Add_users",
+    descriptions = "Creates a new migrations file with the next available version number "
         + "(e.g. V000002__Add_users.sql)"
 )
 public class CreateMigrationCommand extends BaseCommand {
@@ -54,7 +54,7 @@ public class CreateMigrationCommand extends BaseCommand {
 
   @Option(
       name = {"-v", "--version"},
-      description = "the schema version to initialize, defaults to the next"
+      description = "(Optional) The schema version to initialize. Defaults to the next"
           + " schema version based on existing migration files."
   )
   private int version;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
@@ -124,6 +124,7 @@ public class InitializeMigrationCommand extends BaseCommand {
       return 1;
     }
 
+    LOGGER.info("Initializing migrations metadata");
     if (ServerVersionUtil.serverVersionCompatible(ksqlClient, config)
         && tryCreate(ksqlClient, eventStreamCommand, streamName, true)
         && tryCreate(ksqlClient, versionTableCommand, tableName, false)) {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
@@ -30,7 +30,8 @@ import org.slf4j.LoggerFactory;
 
 @Command(
     name = InitializeMigrationCommand.INITIALIZE_COMMAND_NAME,
-    description = "Initializes the schema metadata (stream and table)."
+    description = "Initializes the migrations schema metadata (ksqlDB stream and table) "
+        + "on the ksqlDB server."
 )
 public class InitializeMigrationCommand extends BaseCommand {
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommand.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 @Command(
     name = "info",
-    description = "Displays information about the current and available migrations"
+    description = "Displays information about the current and available migrations."
 )
 public class MigrationInfoCommand extends BaseCommand {
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 @Command(
     name = NewMigrationCommand.NEW_COMMAND_NAME,
-    description = "Creates a new migrations project, directory structure and config file."
+    description = "Creates a new migrations project directory structure and config file."
 )
 public class NewMigrationCommand extends BaseCommand {
 
@@ -48,16 +48,22 @@ public class NewMigrationCommand extends BaseCommand {
 
   @Required
   @Arguments(
-      description = "project-path: the project path to create the directory\n"
-          + "ksql-server-url: the address of the ksqlDB server to connect to",
+      description = "project-path: the path that will be used as the root directory for "
+          + "this migrations project.\n"
+          + "ksql-server-url: the address of the ksqlDB server to connect to.",
       title = {"project-path", "ksql-server-url"})
   private List<String> args;
 
   @Override
   protected int command() {
+    if (configFile != null && !configFile.equals("")) {
+      LOGGER.error("This command does not expect a config file to be passed. "
+          + "Rather, this command will create one as part of preparing the migrations directory.");
+      return 1;
+    }
     if (args.size() != 2) {
       LOGGER.error(
-          "Unexpected number of arguments to `{} {}}`. Expected: 2. Got: {}. "
+          "Unexpected number of arguments to `{} {}`. Expected: 2. Got: {}. "
               + "See `{} help {}` for usage.",
           MigrationsUtil.MIGRATIONS_COMMAND, NEW_COMMAND_NAME, args.size(),
           MigrationsUtil.MIGRATIONS_COMMAND, NEW_COMMAND_NAME);

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -72,6 +72,7 @@ public class NewMigrationCommand extends BaseCommand {
 
     final String projectPath = args.get(0);
     final String ksqlServerUrl = args.get(1);
+    LOGGER.info("Creating new migrations project at {}", projectPath);
     if (tryCreateDirectory(projectPath)
         && tryCreateDirectory(Paths.get(projectPath, MIGRATIONS_DIR).toString())
         && tryCreatePropertiesFile(
@@ -116,9 +117,13 @@ public class NewMigrationCommand extends BaseCommand {
 
   private boolean tryCreatePropertiesFile(final String path, final String ksqlServerUrl) {
     try {
-      LOGGER.info("Creating file: " + path);
-      if (!new File(path).createNewFile()) {
-        LOGGER.warn(path + " already exists. Skipping file creation.");
+      final File file = new File(path);
+      if (!file.exists()) {
+        LOGGER.info("Creating file: " + path);
+      }
+      if (!file.createNewFile()) {
+        LOGGER.error("Failed to create file. File already exists: {}", path);
+        return false;
       }
     } catch (IOException e) {
       LOGGER.error(String.format("Failed to create file %s: %s", path, e.getMessage()));

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
@@ -40,13 +40,14 @@ import org.slf4j.LoggerFactory;
 
 @Command(
     name = "validate",
-    description = "Validate applied migrations against local files."
+    description = "Validates applied migrations against local files."
 )
 @Discussion(
     paragraphs = {
-      "Compares local files checksum against the current metadata checksums to check "
-          + "for migrations files that have changed."
-          + "This tells the user that their schema might be not valid against their local files."
+      "This command checks whether the migration files that have been applied are "
+          + "the same as the local migration files with the same version, by computing "
+          + "hashes for the local files and comparing them to the checksums saved with "
+          + "the applied migrations."
     }
 )
 public class ValidateMigrationsCommand extends BaseCommand {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationVersionInfoFormatter.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationVersionInfoFormatter.java
@@ -61,18 +61,22 @@ public class MigrationVersionInfoFormatter {
 
     final StringBuilder builder = new StringBuilder();
 
-    // format header
+    // format initial divider
+    final int totalColLength = columnLengths.stream()
+        .reduce(Integer::sum)
+        .orElseThrow(IllegalStateException::new);
+    final int dividerLength = totalColLength + 3 * VERSION_INFO_FIELDS.size() - 1;
+    final String divider = StringUtils.repeat("-", dividerLength);
+    builder.append(divider);
+    builder.append("\n");
+
+    // format header row
     builder.append(String.format(rowFormatString,
         VERSION_INFO_FIELDS.stream()
             .map(f -> f.header)
             .toArray()));
 
     // format divider
-    final int totalColLength = columnLengths.stream()
-        .reduce(Integer::sum)
-        .orElseThrow(IllegalStateException::new);
-    final int dividerLength = totalColLength + 3 * VERSION_INFO_FIELDS.size() - 1;
-    final String divider = StringUtils.repeat("-", dividerLength);
     builder.append(divider);
     builder.append("\n");
 
@@ -84,7 +88,7 @@ public class MigrationVersionInfoFormatter {
               .toArray()));
     }
 
-    // format footer
+    // format trailing divider
     builder.append(divider);
     builder.append("\n");
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -186,12 +186,12 @@ public class MigrationsTest {
           .map(LoggingEvent::getRenderedMessage)
           .collect(Collectors.toList());
       assertThat(logMessages, hasItem(containsString("Current migration version: 2")));
-      assertThat(logMessages, hasItem(matchesRegex(
+      assertThat(logMessages, hasItem(matchesRegex("-+\n" +
           " Version \\| Name        \\| State    \\| Previous Version \\| Started On\\s+\\| Completed On\\s+\\| Error Reason \n" +
-              "-+\n" +
-              " 1       \\| foo FOO fO0 \\| MIGRATED \\| <none>           \\| \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\S+ \\| \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\S+ \\| N/A          \n" +
-              " 2       \\| bar bar BAR \\| MIGRATED \\| 1                \\| \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\S+ \\| \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\S+ \\| N/A          \n" +
-              "-+\n"
+          "-+\n" +
+          " 1       \\| foo FOO fO0 \\| MIGRATED \\| <none>           \\| \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\S+ \\| \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\S+ \\| N/A          \n" +
+          " 2       \\| bar bar BAR \\| MIGRATED \\| 1                \\| \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\S+ \\| \\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\S+ \\| N/A          \n" +
+          "-+\n"
       )));
     } finally {
       Logger.getRootLogger().removeAppender(logAppender);

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -162,7 +162,7 @@ public class MigrationsTest {
     );
 
     // When:
-    final int applyStatus = MIGRATIONS_CLI.parse("--config-file", configFilePath, "apply", "-a").run();
+    final int applyStatus = MIGRATIONS_CLI.parse("--config-file", configFilePath, "apply", "-a").runCommand();
 
     // Then:
     assertThat(applyStatus, is(0));
@@ -176,7 +176,7 @@ public class MigrationsTest {
 
     try {
       // When:
-      final int infoStatus = MIGRATIONS_CLI.parse("--config-file", configFilePath, "info").run();
+      final int infoStatus = MIGRATIONS_CLI.parse("--config-file", configFilePath, "info").runCommand();
 
       // Then:
       assertThat(infoStatus, is(0));
@@ -233,7 +233,7 @@ public class MigrationsTest {
 
   private static void createAndVerifyDirectoryStructure(final String testDir) throws Exception {
     // use `new` to create directory structure
-    final int status = MIGRATIONS_CLI.parse("new", testDir, REST_APP.getHttpListener().toString()).run();
+    final int status = MIGRATIONS_CLI.parse("new", testDir, REST_APP.getHttpListener().toString()).runCommand();
     assertThat(status, is(0));
 
     // verify root directory
@@ -268,7 +268,7 @@ public class MigrationsTest {
 
   private static void initializeAndVerifyMetadataStreamAndTable(final String configFile) {
     // use `initialize` to create metadata stream and table
-    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "initialize").run();
+    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "initialize").runCommand();
     assertThat(status, is(0));
 
     // verify metadata stream
@@ -318,7 +318,7 @@ public class MigrationsTest {
     assertThat(sourceExists(MIGRATIONS_TABLE, true), is(true));
 
     // When: use `clean` to clean up metadata stream and table
-    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "clean").run();
+    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "clean").runCommand();
     assertThat(status, is(0));
 
     // Then:
@@ -421,7 +421,7 @@ public class MigrationsTest {
   ) throws IOException {
     // use `create` to create empty file
     final int status = MIGRATIONS_CLI.parse("--config-file", configFilePath,
-        "create", name, "-v", String.valueOf(version)).run();
+        "create", name, "-v", String.valueOf(version)).runCommand();
     assertThat(status, is(0));
 
     // validate file created

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
@@ -55,7 +55,7 @@ public class NewMigrationCommandTest {
   @Test
   public void shouldCreateRootDirectory() {
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(0));
@@ -68,7 +68,7 @@ public class NewMigrationCommandTest {
   @Test
   public void shouldCreateMigrationsDirectory() {
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(0));
@@ -81,7 +81,7 @@ public class NewMigrationCommandTest {
   @Test
   public void shouldCreateAndWriteToConfigFile() throws Exception {
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(0));
@@ -102,7 +102,7 @@ public class NewMigrationCommandTest {
     command = PARSER.parse(testDir + "/", KSQL_SERVER_URL);
 
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(0));
@@ -119,7 +119,7 @@ public class NewMigrationCommandTest {
     command = PARSER.parse(testDir, KSQL_SERVER_URL);
 
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(0));
@@ -136,7 +136,7 @@ public class NewMigrationCommandTest {
     Files.createDirectories(Paths.get(testDir, MIGRATIONS_DIR));
 
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(0));
@@ -152,7 +152,7 @@ public class NewMigrationCommandTest {
     new File(Paths.get(testDir, MIGRATIONS_CONFIG_FILE).toString()).createNewFile();
 
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(0));
@@ -167,7 +167,7 @@ public class NewMigrationCommandTest {
     new File(testDir).createNewFile();
 
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(1));
@@ -179,7 +179,7 @@ public class NewMigrationCommandTest {
     command = PARSER.parse(testDir, KSQL_SERVER_URL, "other_arg");
 
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(1));
@@ -191,7 +191,7 @@ public class NewMigrationCommandTest {
     command = PARSER.parse(testDir);
 
     // When:
-    final int status = command.run();
+    final int status = command.runCommand();
 
     // Then:
     assertThat(status, is(1));

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
@@ -146,7 +146,7 @@ public class NewMigrationCommandTest {
 
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
   @Test
-  public void shouldNotFailIfConfigFileAlreadyExist() throws Exception {
+  public void shouldFailIfConfigFileAlreadyExists() throws Exception {
     // Given:
     Files.createDirectories(Paths.get(testDir));
     new File(Paths.get(testDir, MIGRATIONS_CONFIG_FILE).toString()).createNewFile();
@@ -155,9 +155,7 @@ public class NewMigrationCommandTest {
     final int status = command.runCommand();
 
     // Then:
-    assertThat(status, is(0));
-
-    assertThat(new File(Paths.get(testDir, MIGRATIONS_DIR).toString()).exists(), is(true));
+    assertThat(status, is(1));
   }
 
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/MigrationVersionInfoFormatterTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/MigrationVersionInfoFormatterTest.java
@@ -45,6 +45,7 @@ public class MigrationVersionInfoFormatterTest {
 
     // Then:
     assertThat(formatted, is(
+        "-----------------------------------------------------------------------------------------------\n" +
         " Version | Name       | State    | Previous Version | Started On | Completed On | Error Reason \n" +
         "-----------------------------------------------------------------------------------------------\n" +
         " 1       | name       | MIGRATED | <none>           | N/A        | N/A          | N/A          \n" +


### PR DESCRIPTION
### Description 

Various fixes and improvements to the migrations tool:
- BaseCommand now implements Runnable, so `migrations help` works again
- various command description cleanup and improved log messages
- dry-run option moved from BaseCommand to ApplyMigrationCommand since that's the only command for which it makes sense
- don't print MigrationsConfig contents on each command since that's too spammy
- fix execution time to not always print zero due to integer division
- `migrations new` now fails if a config file already exists
- add extra divider on `migrations info` table output for improved readability

### Testing done 

Played around with the tool manually.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

