### PR TITLE
feat(migrations): enable insert values and create connector for migrations tool

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.util;
+
+import io.confluent.ksql.api.client.ColumnType.Type;
+import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
+import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
+import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
+import io.confluent.ksql.execution.expression.tree.LongLiteral;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.metastore.TypeRegistry;
+import io.confluent.ksql.parser.AstBuilder;
+import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.InsertValues;
+import io.confluent.ksql.tools.migrations.MigrationException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.ws.rs.NotSupportedException;
+
+public class CommandParser {
+  private static final Pattern STRING_WS_SEMICOLON = Pattern.compile("('([^']*|(''))*')|;|[\\s]+");
+  private static final String INSERT_VALUES_PATTERN =
+      "\\s*INSERT\\s+INTO\\s+[\\S]+(\\s+\\(.*\\))?\\s+VALUES\\s+\\(.*\\)\\s*;\\s*";
+  private static final KsqlParser KSQL_PARSER = new DefaultKsqlParser();
+
+  public static List<SqlCommand> parse(final String sql) {
+    final List<String> commands = collectCommands(tokenize(sql));
+
+    return commands.stream()
+        .map(CommandParser::transformToSqlCommand)
+        .collect(Collectors.toList());
+  }
+
+  private static List<String> tokenize(final String sql) {
+    final List<String> result = new ArrayList<>();
+    Matcher matcher = STRING_WS_SEMICOLON.matcher(sql);
+    int prev = 0;
+    while (matcher.find()) {
+      result.add(sql.substring(prev, matcher.start()));
+      result.add(matcher.group());
+      prev = matcher.end();
+    }
+    result.add(sql.substring(prev));
+
+    return result;
+  }
+
+  private static List<String> collectCommands(final List<String> parts) {
+    final List<String> commands = new ArrayList<>();
+    String current = "";
+    for (String part : parts) {
+      if (part.equals(";")) {
+        current += part;
+        commands.add(current);
+        current = "";
+      } else if (isSqlString(part)) {
+        current += part;
+      } else {
+        current += part.toUpperCase();
+      }
+    }
+    return commands;
+  }
+
+  private static boolean isSqlString(final String string) {
+    return string.startsWith("'") && string.endsWith("'");
+  }
+
+  public static Object toFieldType(final Expression expressionValue, final Type type) {
+    switch (type) {
+      case STRING:
+      case INTEGER:
+      case BIGINT:
+      case DOUBLE:
+      case BOOLEAN:
+      case DECIMAL:
+        return getPrimitiveValue(expressionValue);
+      case ARRAY:
+        return ((CreateArrayExpression) expressionValue)
+            .getValues()
+            .stream()
+            .map(val -> getPrimitiveValue(val)).collect(Collectors.toList());
+      case MAP:
+        final Map<Object, Object> resolvedMap = new HashMap<>();
+        ((CreateMapExpression) expressionValue).getMap()
+            .forEach((k, v) -> resolvedMap.put(getPrimitiveValue(k), getPrimitiveValue(v)));
+        return resolvedMap;
+      case STRUCT:
+        final Map<Object, Object> resolvedStruct = new HashMap<>();
+        ((CreateStructExpression) expressionValue)
+            .getFields().stream().forEach(
+                field -> resolvedStruct.put(field.getName(), getPrimitiveValue(field.getValue())));
+        return resolvedStruct;
+      default:
+        throw new NotSupportedException();
+    }
+  }
+
+  private static Object getPrimitiveValue(final Expression expressionValue) {
+    if (expressionValue instanceof StringLiteral) {
+      return ((StringLiteral) expressionValue).getValue();
+    } else if (expressionValue instanceof IntegerLiteral) {
+      return ((IntegerLiteral) expressionValue).getValue();
+    } else if (expressionValue instanceof LongLiteral) {
+      return ((LongLiteral) expressionValue).getValue();
+    } else if (expressionValue instanceof DoubleLiteral) {
+      return ((DoubleLiteral) expressionValue).getValue();
+    } else if (expressionValue instanceof BooleanLiteral) {
+      return ((BooleanLiteral) expressionValue).getValue();
+    } else if (expressionValue instanceof DecimalLiteral) {
+      return ((DecimalLiteral) expressionValue).getValue();
+    }
+    throw new MigrationException("");
+  }
+
+  private static SqlCommand transformToSqlCommand(final String sql) {
+    if (sql.matches(INSERT_VALUES_PATTERN)) {
+      final InsertValues parsedStatement = (InsertValues) new AstBuilder(TypeRegistry.EMPTY)
+          .buildStatement(KSQL_PARSER.parse(sql).get(0).getStatement());
+      return new SqlInsertValues(
+          sql,
+          parsedStatement.getTarget().text(),
+          parsedStatement.getValues(),
+          parsedStatement.getColumns().stream()
+              .map(name -> name.text()).collect(Collectors.toList()));
+    } else {
+      return new SqlStatement(sql);
+    }
+  }
+
+  public abstract static class SqlCommand {
+    private final String command;
+
+    SqlCommand(final String command) {
+      this.command = command;
+    }
+
+    public String getCommand() {
+      return command;
+    }
+  }
+
+  public static class SqlInsertValues extends SqlCommand {
+    private final String sourceName;
+    private final List<String> columns;
+    private final List<Expression> values;
+
+    SqlInsertValues(
+        final String command,
+        final String sourceName,
+        final List<Expression> values,
+        final List<String> columns
+    ) {
+      super(command);
+      this.sourceName = sourceName;
+      this.values = values;
+      this.columns = columns;
+    }
+
+    public String getSourceName() {
+      return sourceName;
+    }
+
+    public List<Expression> getValues() {
+      return values;
+    }
+
+    public List<String> getColumns() {
+      return columns;
+    }
+  }
+
+  public static class SqlStatement extends SqlCommand {
+    SqlStatement(final String command) {
+      super(command);
+    }
+  }
+}

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
@@ -18,10 +18,13 @@ package io.confluent.ksql.tools.migrations.util;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.ClientOptions;
+import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.MigrationException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
+import java.util.Optional;
 
 public final class MigrationsUtil {
 
@@ -112,5 +115,14 @@ public final class MigrationsUtil {
       options.setVerifyHost(verifyHost);
     }
     return options;
+  }
+
+  public static KsqlRestClient createRestClient(final MigrationConfig config) {
+    return KsqlRestClient.create(
+        config.getString(MigrationConfig.KSQL_SERVER_URL),
+        Collections.EMPTY_MAP,
+        Collections.EMPTY_MAP,
+        Optional.empty()
+    );
   }
 }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -27,11 +27,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.api.client.BatchedQueryResult;
 import io.confluent.ksql.api.client.Client;
+import io.confluent.ksql.api.client.ColumnType;
+import io.confluent.ksql.api.client.ColumnType.Type;
 import io.confluent.ksql.api.client.ExecuteStatementResult;
+import io.confluent.ksql.api.client.FieldInfo;
 import io.confluent.ksql.api.client.KsqlArray;
 import io.confluent.ksql.api.client.KsqlObject;
 import io.confluent.ksql.api.client.Row;
 import io.confluent.ksql.api.client.SourceDescription;
+import io.confluent.ksql.api.client.impl.ColumnTypeImpl;
+import io.confluent.ksql.api.client.impl.FieldInfoImpl;
 import io.confluent.ksql.api.client.impl.RowImpl;
 import io.confluent.ksql.api.client.util.RowUtil;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
@@ -46,6 +51,7 @@ import java.nio.charset.Charset;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -71,6 +77,7 @@ public class ApplyMigrationCommandTest {
   private static final String MIGRATIONS_STREAM = "migrations_stream";
   private static final String NAME = "FOO";
   private static final String COMMAND = "CREATE STREAM FOO (A STRING) WITH (KAFKA_TOPIC='FOO', PARTITIONS=1, VALUE_FORMAT='DELIMITED');";
+  private static final String INSERT = "INSERT INTO FOO VALUES ('abcd');";
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
@@ -87,6 +94,12 @@ public class ApplyMigrationCommandTest {
   private ExecuteStatementResult statementResult;
   @Mock
   private SourceDescription sourceDescription;
+  @Mock
+  private SourceDescription fooDescription;
+  @Mock
+  private CompletableFuture<SourceDescription> fooDescriptionCf;
+  @Mock
+  private FieldInfo field;
   @Mock
   private CompletableFuture<Void> insertResult;
   @Mock
@@ -112,8 +125,13 @@ public class ApplyMigrationCommandTest {
         .thenReturn(infoQueryResult);
     when(ksqlClient.describeSource(MIGRATIONS_STREAM)).thenReturn(sourceDescriptionCf);
     when(ksqlClient.describeSource(MIGRATIONS_TABLE)).thenReturn(sourceDescriptionCf);
+    when(ksqlClient.describeSource("FOO")).thenReturn(fooDescriptionCf);
     when(sourceDescriptionCf.get()).thenReturn(sourceDescription);
     when(statementResultCf.get()).thenReturn(statementResult);
+    when(fooDescriptionCf.get()).thenReturn(fooDescription);
+    when(fooDescription.fields()).thenReturn(Collections.singletonList(field));
+    when(field.name()).thenReturn("A");
+    when(field.type()).thenReturn(new ColumnTypeImpl("STRING"));
 
     migrationsDir = folder.getRoot().getPath();
   }
@@ -134,7 +152,7 @@ public class ApplyMigrationCommandTest {
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -155,7 +173,7 @@ public class ApplyMigrationCommandTest {
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED, true);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -176,8 +194,8 @@ public class ApplyMigrationCommandTest {
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
-    verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED, true);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -200,8 +218,8 @@ public class ApplyMigrationCommandTest {
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
-    verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED, true);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -222,7 +240,7 @@ public class ApplyMigrationCommandTest {
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED, true);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -243,7 +261,7 @@ public class ApplyMigrationCommandTest {
     // Then:
     assertThat(result, is(1));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
     inOrder.verify(ksqlClient).close();
     Mockito.verify(ksqlClient, Mockito.times(1)).executeStatement(COMMAND);
   }
@@ -265,7 +283,7 @@ public class ApplyMigrationCommandTest {
     final InOrder inOrder = inOrder(ksqlClient);
     verifyMigratedVersion(
         inOrder, 1, "<none>", MigrationState.ERROR,
-        Optional.of("Failed to execute sql: " + COMMAND + ". Error: sql rejected"));
+        Optional.of("Failed to execute sql: " + COMMAND + ". Error: sql rejected"), true);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -307,7 +325,7 @@ public class ApplyMigrationCommandTest {
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -329,6 +347,27 @@ public class ApplyMigrationCommandTest {
     assertThat(result, is(1));
     Mockito.verify(ksqlClient, Mockito.times(0)).executeStatement(any());
     Mockito.verify(ksqlClient, Mockito.times(0)).insertInto(any(), any());
+  }
+
+  @Test
+  public void shouldApplyInsertStatement() throws Exception {
+    // Given:
+    command = PARSER.parse("-v", "3");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    createMigrationFile(3, NAME, migrationsDir, INSERT);
+    givenCurrentMigrationVersion("1");
+    givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(0));
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED,false);
+    inOrder.verify(ksqlClient).close();
+    inOrder.verifyNoMoreInteractions();
   }
 
   private void createMigrationFile(
@@ -414,9 +453,10 @@ public class ApplyMigrationCommandTest {
       final InOrder inOrder,
       final int version,
       final String previous,
-      final MigrationState finalState
+      final MigrationState finalState,
+      final boolean isCommand
   ) {
-    verifyMigratedVersion(inOrder, version, previous, finalState, Optional.empty());
+    verifyMigratedVersion(inOrder, version, previous, finalState, Optional.empty(), isCommand);
   }
 
   private void verifyMigratedVersion(
@@ -424,7 +464,8 @@ public class ApplyMigrationCommandTest {
       final int version,
       final String previous,
       final MigrationState finalState,
-      final Optional<String> errorReason
+      final Optional<String> errorReason,
+      final boolean isCommand
   ) {
     inOrder.verify(ksqlClient).insertInto(
         MIGRATIONS_STREAM,
@@ -436,7 +477,12 @@ public class ApplyMigrationCommandTest {
         createKsqlObject(Integer.toString(version), version, NAME, MigrationState.RUNNING,
             "1000", "", previous, Optional.empty())
     );
-    inOrder.verify(ksqlClient).executeStatement(COMMAND);
+    if (isCommand) {
+      inOrder.verify(ksqlClient).executeStatement(COMMAND);
+    } else {
+      inOrder.verify(ksqlClient).insertInto("FOO", new KsqlObject(ImmutableMap.of("A", "abcd")));
+    }
+
     inOrder.verify(ksqlClient).insertInto(
         MIGRATIONS_STREAM,
         createKsqlObject(MetadataUtil.CURRENT_VERSION_KEY, version, NAME, finalState,

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -39,10 +39,13 @@ import io.confluent.ksql.api.client.impl.ColumnTypeImpl;
 import io.confluent.ksql.api.client.impl.FieldInfoImpl;
 import io.confluent.ksql.api.client.impl.RowImpl;
 import io.confluent.ksql.api.client.util.RowUtil;
+import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil.MigrationState;
 import io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil;
+import io.confluent.ksql.tools.migrations.util.MigrationsUtil;
+import io.confluent.ksql.util.ExecutorUtil.Function;
 import io.vertx.core.json.JsonArray;
 import java.io.File;
 import java.io.IOException;
@@ -78,6 +81,7 @@ public class ApplyMigrationCommandTest {
   private static final String NAME = "FOO";
   private static final String COMMAND = "CREATE STREAM FOO (A STRING) WITH (KAFKA_TOPIC='FOO', PARTITIONS=1, VALUE_FORMAT='DELIMITED');";
   private static final String INSERT = "INSERT INTO FOO VALUES ('abcd');";
+  private static final String CREATE_CONNECTOR = "CREATE SINK CONNECTOR WOOF WITH (WOOF);";
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
@@ -106,6 +110,8 @@ public class ApplyMigrationCommandTest {
   private CompletableFuture<ExecuteStatementResult> statementResultCf;
   @Mock
   private CompletableFuture<SourceDescription> sourceDescriptionCf;
+  @Mock
+  private KsqlRestClient restClient;
 
   private String migrationsDir;
   private ApplyMigrationCommand command;
@@ -146,13 +152,13 @@ public class ApplyMigrationCommandTest {
     when(versionQueryResult.get()).thenReturn(ImmutableList.of());
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -167,13 +173,13 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -188,14 +194,14 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
-    verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -212,14 +218,14 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
-    verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
+    verifyMigratedVersion(inOrder, 2, "1", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -234,13 +240,13 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -255,13 +261,13 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.RUNNING);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
     assertThat(result, is(1));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
     Mockito.verify(ksqlClient, Mockito.times(1)).executeStatement(COMMAND);
   }
@@ -275,7 +281,7 @@ public class ApplyMigrationCommandTest {
     when(statementResultCf.get()).thenThrow(new ExecutionException("sql rejected", new RuntimeException()));
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -283,7 +289,7 @@ public class ApplyMigrationCommandTest {
     final InOrder inOrder = inOrder(ksqlClient);
     verifyMigratedVersion(
         inOrder, 1, "<none>", MigrationState.ERROR,
-        Optional.of("Failed to execute sql: " + COMMAND + ". Error: sql rejected"), true);
+        Optional.of("Failed to execute sql: " + COMMAND + ". Error: sql rejected"));
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -298,7 +304,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -319,13 +325,13 @@ public class ApplyMigrationCommandTest {
     assertThat(new File(migrationsDir + "/foo.sql").createNewFile(), is(true));
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, true);
+    verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -340,7 +346,7 @@ public class ApplyMigrationCommandTest {
         .thenThrow(new ExecutionException("Source not found", new RuntimeException()));
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -359,13 +365,36 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
-    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED,false);
+    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED,
+        () -> inOrder.verify(ksqlClient).insertInto("FOO", new KsqlObject(ImmutableMap.of("A", "abcd"))));
+    inOrder.verify(ksqlClient).close();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldApplyCreateConnectorStatement() throws Exception {
+    // Given:
+    command = PARSER.parse("-v", "3");
+    createMigrationFile(1, NAME, migrationsDir, COMMAND);
+    createMigrationFile(3, NAME, migrationsDir,CREATE_CONNECTOR );
+    givenCurrentMigrationVersion("1");
+    givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, cfg -> restClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(0));
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED,
+        () -> Mockito.verify(restClient, Mockito.times(1)).makeKsqlRequest(CREATE_CONNECTOR));
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -454,9 +483,28 @@ public class ApplyMigrationCommandTest {
       final int version,
       final String previous,
       final MigrationState finalState,
-      final boolean isCommand
-  ) {
-    verifyMigratedVersion(inOrder, version, previous, finalState, Optional.empty(), isCommand);
+      final Function testMigrationCommands
+  ) throws Exception {
+    verifyMigratedVersion(inOrder, version, previous, finalState, Optional.empty(), testMigrationCommands);
+  }
+
+  private void verifyMigratedVersion(
+      final InOrder inOrder,
+      final int version,
+      final String previous,
+      final MigrationState finalState
+  ) throws Exception {
+    verifyMigratedVersion(inOrder, version, previous, finalState, Optional.empty(), () -> {inOrder.verify(ksqlClient).executeStatement(COMMAND);});
+  }
+
+  private void verifyMigratedVersion(
+      final InOrder inOrder,
+      final int version,
+      final String previous,
+      final MigrationState finalState,
+      final Optional<String> errorReason
+  ) throws Exception {
+    verifyMigratedVersion(inOrder, version, previous, finalState, errorReason, () -> {inOrder.verify(ksqlClient).executeStatement(COMMAND);});
   }
 
   private void verifyMigratedVersion(
@@ -465,8 +513,8 @@ public class ApplyMigrationCommandTest {
       final String previous,
       final MigrationState finalState,
       final Optional<String> errorReason,
-      final boolean isCommand
-  ) {
+      final Function testMigrationCommands
+  ) throws Exception {
     inOrder.verify(ksqlClient).insertInto(
         MIGRATIONS_STREAM,
         createKsqlObject(MetadataUtil.CURRENT_VERSION_KEY, version, NAME, MigrationState.RUNNING,
@@ -477,11 +525,8 @@ public class ApplyMigrationCommandTest {
         createKsqlObject(Integer.toString(version), version, NAME, MigrationState.RUNNING,
             "1000", "", previous, Optional.empty())
     );
-    if (isCommand) {
-      inOrder.verify(ksqlClient).executeStatement(COMMAND);
-    } else {
-      inOrder.verify(ksqlClient).insertInto("FOO", new KsqlObject(ImmutableMap.of("A", "abcd")));
-    }
+
+    testMigrationCommands.call();
 
     inOrder.verify(ksqlClient).insertInto(
         MIGRATIONS_STREAM,

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations.util;
+
+import static io.confluent.ksql.tools.migrations.util.CommandParser.toFieldType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.api.client.ColumnType.Type;
+import io.confluent.ksql.tools.migrations.util.CommandParser.SqlInsertValues;
+import io.confluent.ksql.tools.migrations.util.CommandParser.SqlCommand;
+import io.confluent.ksql.tools.migrations.util.CommandParser.SqlStatement;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import org.junit.Test;
+
+public class CommandParserTest {
+
+  @Test
+  public void shouldParseInsertStatement() {
+    List<SqlCommand> commands = CommandParser.parse("INSERT INTO FOO VALUES (55);");
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0), instanceOf(SqlInsertValues.class));
+    assertThat(((SqlInsertValues) commands.get(0)).getSourceName(), is("FOO"));
+    assertThat(((SqlInsertValues) commands.get(0)).getValues().size(), is(1));
+    assertThat(toFieldType(((SqlInsertValues) commands.get(0)).getValues().get(0), Type.INTEGER), is(55));
+  }
+
+  @Test
+  public void shouldParseMultipleStatements() {
+    List<SqlCommand> commands = CommandParser.parse("INSERT INTO foo VALUES (32);INSERT INTO FOO_2 VALUES ('wow',3,'hello ''world''!');");
+    assertThat(commands.size(), is(2));
+    assertThat(commands.get(0), instanceOf(SqlInsertValues.class));
+    assertThat(((SqlInsertValues) commands.get(0)).getSourceName(), is("FOO"));
+    assertThat(((SqlInsertValues) commands.get(0)).getValues().size(), is(1));
+    assertThat(toFieldType(((SqlInsertValues) commands.get(0)).getValues().get(0), Type.INTEGER), is(32));
+    assertThat(commands.get(1), instanceOf(SqlInsertValues.class));
+    assertThat(((SqlInsertValues) commands.get(1)).getSourceName(), is("FOO_2"));
+    assertThat(toFieldType(((SqlInsertValues) commands.get(1)).getValues().get(0), Type.STRING), is("wow"));
+    assertThat(toFieldType(((SqlInsertValues) commands.get(1)).getValues().get(1), Type.INTEGER), is(3));
+    assertThat(toFieldType(((SqlInsertValues) commands.get(1)).getValues().get(2), Type.STRING), is("hello 'world'!"));
+  }
+
+  @Test
+  public void shouldParseCreateStatement() {
+    List<SqlCommand> commands = CommandParser.parse("CREATE STREAM FOO (A STRING) WITH (KAFKA_TOPIC='FOO', PARTITIONS=1, VALUE_FORMAT='DELIMITED');");
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0), instanceOf(SqlStatement.class));
+    assertThat(commands.get(0).getCommand(), is("CREATE STREAM FOO (A STRING) WITH (KAFKA_TOPIC='FOO', PARTITIONS=1, VALUE_FORMAT='DELIMITED');"));
+  }
+
+  @Test
+  public void shouldParseSeveralCommands() {
+    List<SqlCommand> commands = CommandParser.parse("CREATE STREAM riderLocations (profileId VARCHAR, latitude DOUBLE, longitude DOUBLE) WITH (kafka_topic='locations', value_format='json', partitions=1);\n"
+        + "INSERT INTO riderLocations (profileId, latitude, longitude) VALUES ('c2309eec', 37.7877, -122.4205);\n"
+        + "INSERT INTO riderLocations (profileId, latitude, longitude) VALUES ('18f4ea86', 37.3903, -122.0643);\n"
+        + "INSERT INTO riderLocations (profileId, latitude, longitude) VALUES ('4ab5cbad', 37.3952, -122.0813);\n"
+        + "INSERT INTO riderLocations (profileId, latitude, longitude) VALUES ('8b6eae59', 37.3944, -122.0813);\n"
+        + "INSERT INTO riderLocations (profileId, latitude, longitude) VALUES ('4a7c7b41', 37.4049, -122.0822);\n"
+        + "INSERT INTO riderLocations (profileId, latitude, longitude) VALUES ('4ddad000', 37.7857, -122.4011);");
+    assertThat(commands.size(), is(7));
+    assertThat(commands.get(0), instanceOf(SqlStatement.class));
+    assertThat(commands.get(0).getCommand(), is("CREATE STREAM RIDERLOCATIONS (PROFILEID VARCHAR, LATITUDE DOUBLE, LONGITUDE DOUBLE) WITH (KAFKA_TOPIC='locations', VALUE_FORMAT='json', PARTITIONS=1);"));
+    assertThat(commands.get(1), instanceOf(SqlInsertValues.class));
+    assertThat(((SqlInsertValues) commands.get(1)).getSourceName(), is("RIDERLOCATIONS"));
+    assertThat(((SqlInsertValues) commands.get(1)).getColumns().size(), is(3));
+    assertThat(((SqlInsertValues) commands.get(1)).getColumns().get(0), is("PROFILEID"));
+    assertThat(((SqlInsertValues) commands.get(1)).getColumns().get(1), is("LATITUDE"));
+    assertThat(((SqlInsertValues) commands.get(1)).getColumns().get(2), is("LONGITUDE"));
+    assertThat(((SqlInsertValues) commands.get(1)).getValues().size(), is(3));
+    assertThat(toFieldType(((SqlInsertValues) commands.get(1)).getValues().get(0), Type.STRING), is("c2309eec"));
+    assertThat(toFieldType(((SqlInsertValues) commands.get(1)).getValues().get(1), Type.DECIMAL), is(new BigDecimal(37.7877).setScale(4, RoundingMode.DOWN)));
+    assertThat(toFieldType(((SqlInsertValues) commands.get(1)).getValues().get(2), Type.DECIMAL), is(new BigDecimal(-122.4205).setScale(4, RoundingMode.DOWN)));
+  }
+}


### PR DESCRIPTION
### Description
Adds logic to decide where to send a command, instead of sending them all to `Client.executeStatement`

After the migration file gets split up into separate commands, the command matches against different regex patterns.

If the command matches `INSERT INTO ... VALUES ...` then parse it with the KsqlParser to evaluate the column names and values.

If the command matches `CREATE SINK|SOURCE CONNECTOR ...` then it's send to the old rest client. In the future, this will also support `DROP CONNECTOR;`.

Otherwise, it's sent to `Client.executeStatement`.

### Testing done 
Added some unit and integration tests. Nothing too complicated though.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

