### PR TITLE
fix: prevent IOB when printing topics with a key/value with an empty string

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
@@ -109,15 +109,15 @@ public final class RecordFormatter {
 
     final List<String> formatted = formatRecords(records);
 
-    final boolean sameKeyFormatChanged = keyDeserializers.getPossibleFormats().stream()
-        .map(activeKeyFormat::equals)
-        .findFirst()
-        .orElse(false);
+    final boolean sameKeyFormatChanged = keyDeserializers
+        .getPossibleFormats()
+        .stream()
+        .anyMatch(activeKeyFormat::equals);
 
-    final boolean sameValueFormatChanged = valueDeserializers.getPossibleFormats().stream()
-        .map(activeValueFormat::equals)
-        .findFirst()
-        .orElse(false);
+    final boolean sameValueFormatChanged = valueDeserializers
+        .getPossibleFormats()
+        .stream()
+        .anyMatch(activeValueFormat::equals);
 
     if (sameKeyFormatChanged && sameValueFormatChanged) {
       return formatted;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatter.java
@@ -109,11 +109,15 @@ public final class RecordFormatter {
 
     final List<String> formatted = formatRecords(records);
 
-    final boolean sameKeyFormatChanged = activeKeyFormat
-        .equals(keyDeserializers.getPossibleFormats().get(0));
+    final boolean sameKeyFormatChanged = keyDeserializers.getPossibleFormats().stream()
+        .map(activeKeyFormat::equals)
+        .findFirst()
+        .orElse(false);
 
-    final boolean sameValueFormatChanged = activeValueFormat
-        .equals(valueDeserializers.getPossibleFormats().get(0));
+    final boolean sameValueFormatChanged = valueDeserializers.getPossibleFormats().stream()
+        .map(activeValueFormat::equals)
+        .findFirst()
+        .orElse(false);
 
     if (sameKeyFormatChanged && sameValueFormatChanged) {
       return formatted;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/RecordFormatterTest.java
@@ -1274,7 +1274,8 @@ public class RecordFormatterTest {
       final Iterable<ConsumerRecord<Bytes, Bytes>> records = consumerRecords(
           // Key that is same size as  BIGINT / DOUBLE:
           consumerRecord(Bytes.wrap("Die Hard".getBytes(UTF_8)), null),
-          consumerRecord(Bytes.wrap("Key that's clearly a string".getBytes(UTF_8)), null)
+          consumerRecord(Bytes.wrap("Key that's clearly a string".getBytes(UTF_8)), null),
+          consumerRecord(Bytes.wrap("".getBytes(UTF_8)), null)
       );
 
       // When:
@@ -1282,6 +1283,7 @@ public class RecordFormatterTest {
 
       // Then:
       assertThat(formatted.get(0), containsString("Die Hard"));
+      assertThat(formatted.get(1), containsString("Key that's clearly a string"));
     }
 
     @Test
@@ -1290,7 +1292,8 @@ public class RecordFormatterTest {
       final Iterable<ConsumerRecord<Bytes, Bytes>> records = consumerRecords(
           // Value that is same size as  BIGINT / DOUBLE:
           consumerRecord(null, Bytes.wrap("Die Hard".getBytes(UTF_8))),
-          consumerRecord(null, Bytes.wrap("Key that's clearly a string".getBytes(UTF_8)))
+          consumerRecord(null, Bytes.wrap("Value that's clearly a string".getBytes(UTF_8))),
+          consumerRecord(null, Bytes.wrap("".getBytes(UTF_8)))
       );
 
       // When:
@@ -1298,6 +1301,7 @@ public class RecordFormatterTest {
 
       // Then:
       assertThat(formatted.get(0), containsString("Die Hard"));
+      assertThat(formatted.get(1), containsString("Value that's clearly a string"));
     }
 
 


### PR DESCRIPTION
### Description 
When printing topics, the record formatter throws and Index Out of Bounds exception in case the key or value is an empty string because the deserializers might not have a format to use. This PR fix this checking if the possible formats are not empty.

### Testing done 
Included empty values in the tests which already exist to validate this behavior.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

