### PR TITLE
docs: add redirect from ksqldb-rest-api.md to api.md (DOCS-7369)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,6 +205,7 @@ plugins:
             developer-guide/implement-a-udf.md: how-to-guides/create-a-user-defined-function.md
             developer-guide/serialization.md: reference/serialization.md
             developer-guide/syntax-reference.md: reference/index.md
+            developer-guide/ksqldb-rest-api.md: developer-guide/api.md
             developer-guide/index.md: reference/index.md
 
             operate-and-deploy/installation/server-config/config-reference.md: reference/server-configuration.md


### PR DESCRIPTION
Accidentally deleted this line while resolving a manual merge conflict in https://github.com/confluentinc/ksql/pull/7163.