### PR TITLE
docs: adds java 8 and java 11 compatibility note for ksqlDB

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ ksqlDB requires only:
 We recommend using [Confluent
 Platform](https://www.confluent.io/product/confluent-platform/) or
 [Confluent Cloud](https://www.confluent.io/confluent-cloud/) to run
-{{ site.ak }}. ksqlDB only supports Java 8 and 11.
+{{ site.ak }}. ksqlDB supports Java 8 and 11.
 
 Is ksqlDB owned by the Apache Software Foundation?
 --------------------------------------------------

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ What are the technical requirements of ksqlDB?
 
 ksqlDB requires only:
 
-1.  A Java runtime environment
+1.  A Java runtime environment.
 2.  Access to a {{ site.ak }} cluster for reading and writing data in
     real-time. The cluster can be on-premises or in the cloud. ksqlDB
     works with clusters running vanilla {{ site.ak }} as well as with
@@ -28,7 +28,7 @@ ksqlDB requires only:
 We recommend using [Confluent
 Platform](https://www.confluent.io/product/confluent-platform/) or
 [Confluent Cloud](https://www.confluent.io/confluent-cloud/) to run
-{{ site.ak }}.
+{{ site.ak }}. ksqlDB only supports Java 8 and 11.
 
 Is ksqlDB owned by the Apache Software Foundation?
 --------------------------------------------------

--- a/docs/operate-and-deploy/installation/installing.md
+++ b/docs/operate-and-deploy/installation/installing.md
@@ -378,6 +378,8 @@ versions.
 | {{ site.aktm }} version | 0.11.0 and later         |
 | {{ site.cp }} version   | 5.5.0 and later          |
 
+ksqlDB only supports Java 8 and Java 11.
+
 Scale your ksqlDB Server deployment
 -----------------------------------
 

--- a/docs/operate-and-deploy/installation/installing.md
+++ b/docs/operate-and-deploy/installation/installing.md
@@ -378,7 +378,7 @@ versions.
 | {{ site.aktm }} version | 0.11.0 and later         |
 | {{ site.cp }} version   | 5.5.0 and later          |
 
-ksqlDB only supports Java 8 and Java 11.
+ksqlDB supports Java 8 and Java 11.
 
 Scale your ksqlDB Server deployment
 -----------------------------------


### PR DESCRIPTION
### Description 
Adds java 8 and java 11 compatibility note for ksqlDB to the docs.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

