### PR TITLE
fix: fix the cache max bytes buffering check

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -95,7 +95,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
 
   @Override
   public List<QueryMetadata> getAllLiveQueries() {
-    return ImmutableList.of();
+    return engineContext.getAllLiveQueries();
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedTransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedTransientQueryMetadata.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.query.BlockingRowQueue;
+import io.confluent.ksql.query.LimitHandler;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+public class SandboxedTransientQueryMetadata extends TransientQueryMetadata {
+  private SandboxedTransientQueryMetadata(
+      final TransientQueryMetadata actual,
+      final Consumer<QueryMetadata> closeCallback
+  ) {
+    super(
+        actual.getStatementString(),
+        actual.getLogicalSchema(),
+        actual.getSourceNames(),
+        actual.getExecutionPlan(),
+        new SandboxQueue(),
+        actual.getQueryApplicationId(),
+        actual.getTopology(),
+        (t, c) -> {
+          throw new IllegalStateException(
+              "SandboxedTransientQueryMetadata should never create a streams instance");
+        },
+        actual.getStreamsProperties(),
+        actual.getOverriddenProperties(),
+        closeCallback,
+        -1,
+        0,
+        actual.getResultType(),
+        -1,
+        -1
+    );
+  }
+
+  public static SandboxedTransientQueryMetadata of(
+      final TransientQueryMetadata queryMetadata,
+      final Consumer<QueryMetadata> closeCallback
+  ) {
+    return new SandboxedTransientQueryMetadata(
+        Objects.requireNonNull(queryMetadata, "queryMetadata"),
+        Objects.requireNonNull(closeCallback, "closeCallback")
+    );
+  }
+
+  @Override
+  public void initialize() {
+    // no-op
+  }
+
+  @Override
+  public void stop() {
+    throw new IllegalStateException("SandboxedTransientQueryMetadta should never be stopped");
+  }
+
+  @Override
+  public void start() {
+    throw new IllegalStateException("SandboxedTransientQueryMetadta should never be started");
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+    closeCallback.accept(this);
+  }
+
+  private static class SandboxQueue implements BlockingRowQueue {
+    private static void throwUseException() {
+      throw new IllegalStateException("SandboxedTransientQueryMetadata should never use queue");
+    }
+
+    public void setLimitHandler(LimitHandler limitHandler) {
+      throwUseException();
+    }
+
+    public void setQueuedCallback(Runnable callback) {
+      throwUseException();
+    }
+
+    public KeyValue<List<?>, GenericRow> poll(long timeout, TimeUnit unit) {
+      throwUseException();
+      return null;
+    }
+
+    public KeyValue<List<?>, GenericRow> poll() {
+      throwUseException();
+      return null;
+    }
+
+    public void drainTo(Collection<? super KeyValue<List<?>, GenericRow>> collection) {
+      throwUseException();
+    }
+
+    public int size() {
+      throwUseException();
+      return -1;
+    }
+
+    public boolean isEmpty() {
+      throwUseException();
+      return false;
+    }
+
+    public void close() {
+      throwUseException();
+    }
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedTransientQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedTransientQueryMetadataTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.TransientQueryMetadata.ResultType;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.apache.kafka.streams.Topology;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SandboxedTransientQueryMetadataTest {
+  private static final String STATEMENT = "stmt";
+  private static final Map<String, Object> PROPERTIES = ImmutableMap.of("foo", "bar");
+  private static final Map<String, Object> OVERRIDES = ImmutableMap.of("biz", "baz");
+  private static final Set<SourceName> SOURCE_NAMES = ImmutableSet.of(SourceName.of("one"));
+  private static final String PLAN = "plan";
+  private static final String APP_ID = "appid";
+  private static final ResultType RESULT_TYPE = ResultType.TABLE;
+
+  @Mock
+  private TransientQueryMetadata original;
+  @Mock
+  private Consumer<QueryMetadata> closeCallback;
+  @Mock
+  private LogicalSchema schema;
+  @Mock
+  private Topology topology;
+
+  SandboxedTransientQueryMetadata sandboxed;
+
+  @Before
+  public void setup() {
+    sandboxed = SandboxedTransientQueryMetadata.of(original, closeCallback);
+    when(original.getStatementString()).thenReturn(STATEMENT);
+    when(original.getStreamsProperties()).thenReturn(PROPERTIES);
+    when(original.getOverriddenProperties()).thenReturn(OVERRIDES);
+    when(original.getSourceNames()).thenReturn(SOURCE_NAMES);
+    when(original.getExecutionPlan()).thenReturn(PLAN);
+    when(original.getQueryApplicationId()).thenReturn(APP_ID);
+    when(original.getResultType()).thenReturn(RESULT_TYPE);
+    when(original.getLogicalSchema()).thenReturn(schema);
+    when(original.getTopology()).thenReturn(topology);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldThrowIfRowQueueUsed() {
+    sandboxed.getRowQueue().poll();
+  }
+
+  @Test
+  public void shouldThrowIfStarted() {
+    sandboxed.start();
+  }
+
+  @Test
+  public void shouldThrowIfStopped() {
+    sandboxed.stop();
+  }
+
+  @Test
+  public void shouldCallbackOnClose() {
+    // when:
+    sandboxed.close();
+
+    // then:
+    verify(closeCallback).accept(sandboxed);
+  }
+}


### PR DESCRIPTION
this patch fixes our validation of cache.max.bytes.buffering. We validate based
on the set of live queries in the engine context. However, we weren't popullating
this set for sandboxes. This is fixed in this change by introducing a sandbox type
for transient query metadata, and filling in the live queries set with sandboxed
query metadatas