### PR TITLE
chore: improve error logs

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -289,16 +289,16 @@ public class KsqlResource implements KsqlConfigurable {
           commandRunnerWarning);
       return EndpointResponse.ok(entities);
     } catch (final KsqlRestException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: " + e.getMessage());
+      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
       throw e;
     } catch (final KsqlStatementException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: " + e.getMessage());
+      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
       return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
     } catch (final KsqlException e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: " + e.getMessage());
+      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
       return errorHandler.generateResponse(e, Errors.badRequest(e));
     } catch (final Exception e) {
-      LOG.info("Processed unsuccessfully: " + request + ", reason: " + e.getMessage());
+      LOG.info("Processed unsuccessfully: " + request + ", reason: ", e);
       return errorHandler.generateResponse(
           e, Errors.serverErrorForStatement(e, request.getKsql()));
     }


### PR DESCRIPTION
If a request fails, the logs should contain the full stack trace.

Closes #6725

