### PR TITLE
chore: Put interpreter use of lambdas behind the flag ksql.lambdas.enabled

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
@@ -266,6 +266,11 @@ public class TermCompiler implements ExpressionVisitor<Term, Context> {
   @Override
   public Term visitLambdaExpression(
       final LambdaFunctionCall lambdaFunctionCall, final Context context) {
+    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_LAMBDAS_ENABLED)) {
+      throw new KsqlException("Lambdas are currently disabled. "
+          + "Set ksql.lambdas.enabled=true to enable lambda functionality.");
+    }
+
     final Term lambdaBody = process(lambdaFunctionCall.getBody(), context);
 
     final ImmutableList.Builder<Pair<String, SqlType>> nameToType = ImmutableList.builder();

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -91,6 +91,7 @@ public class RestQueryTranslationTest {
       .withProperty(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "set")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_LAMBDAS_ENABLED, true)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .build();
 

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-complex-lambda.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-complex-lambda.json
@@ -75,6 +75,22 @@
           {"row":{"columns":["one", 71]}}
         ]}
       ]
+    },
+    {
+      "name": "Lambdas disabled",
+      "statements": [
+        "CREATE TABLE TEST (ID STRING PRIMARY KEY, arraying ARRAY<INTEGER>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MAT_TABLE AS SELECT ID, arraying FROM TEST;",
+        "SELECT ID, reduce(arraying, 5, (s, a) => a) AS OUTPUT FROM MAT_TABLE;"
+      ],
+      "properties": {
+        "ksql.lambdas.enabled":  false
+      },
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Lambdas are currently disabled. ",
+        "status": 400
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 
Now throws an error if the use of lambdas in the interpreter is attempted without setting `ksql.lambdas.enabled=true`

### Testing done 
Added RQTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

