### PR TITLE
feat: Adds max concurrent pull queries to limit effects of table scans

### DIFF
--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -529,6 +529,18 @@ for persistent and push queries, which are naturally longer-lived than pull quer
 interpreter gives significant performance gains. This can be disabled per query if the code compiler
 is preferred.
 
+## `ksql.query.pull.max.qps`
+
+Sets a query per second limit for pull queries. This limit is enforced per host (not per cluster).
+After hitting the limit, the host will fail pull query requests until it determines it's no longer
+at the limit.
+
+## `ksql.query.pull.max.concurrent.requests`
+
+Sets a concurrent query limit for pull queries. This limit is enforced per host (not per cluster).
+After hitting the limit, the host will fail pull query requests until it determines it's no longer
+at the limit.
+
 ## `ksql.variable.substitution.enable`
 
 Enables variable substitution through [`DEFINE`](../../../../developer-guide/ksqldb-reference/define) statements.

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -531,14 +531,14 @@ is preferred.
 
 ## `ksql.query.pull.max.qps`
 
-Sets a query per second limit for pull queries. This limit is enforced per host (not per cluster).
-After hitting the limit, the host will fail pull query requests until it determines it's no longer
+Sets a rate limit for pull queries, in queries per second. This limit is enforced per host, not per cluster.
+After hitting the limit, the host will fail pull query requests until it determines that it's no longer
 at the limit.
 
 ## `ksql.query.pull.max.concurrent.requests`
 
-Sets a concurrent query limit for pull queries. This limit is enforced per host (not per cluster).
-After hitting the limit, the host will fail pull query requests until it determines it's no longer
+Sets the maximum number of concurrent pull queries. This limit is enforced per host, not per cluster.
+After hitting the limit, the host will fail pull query requests until it determines that it's no longer
 at the limit.
 
 ## `ksql.variable.substitution.enable`

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -232,6 +232,13 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_QUERY_PULL_MAX_QPS_DOC = "The maximum qps allowed for pull "
       + "queries. Once the limit is hit, queries will fail immediately";
 
+  public static final String KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_CONFIG
+      = "ksql.query.pull.max.concurrent.requests";
+  public static final Integer KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DEFAULT = Integer.MAX_VALUE;
+  public static final String KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DOC =
+      "The maximum number of concurrent requests allowed for pull "
+      + "queries. Once the limit is hit, queries will fail immediately";
+
   public static final String KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG
       = "ksql.query.pull.thread.pool.size";
   public static final Integer KSQL_QUERY_PULL_THREAD_POOL_SIZE_DEFAULT = 100;
@@ -787,6 +794,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PULL_MAX_QPS_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PULL_MAX_QPS_DOC
+        )
+        .define(
+            KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_CONFIG,
+            Type.INT,
+            KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DOC
         )
         .define(
             KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -230,14 +230,14 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_QUERY_PULL_MAX_QPS_CONFIG = "ksql.query.pull.max.qps";
   public static final Integer KSQL_QUERY_PULL_MAX_QPS_DEFAULT = Integer.MAX_VALUE;
   public static final String KSQL_QUERY_PULL_MAX_QPS_DOC = "The maximum qps allowed for pull "
-      + "queries. Once the limit is hit, queries will fail immediately";
+      + "queries on this host. Once the limit is hit, queries will fail immediately";
 
   public static final String KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_CONFIG
       = "ksql.query.pull.max.concurrent.requests";
   public static final Integer KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DEFAULT = Integer.MAX_VALUE;
   public static final String KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DOC =
       "The maximum number of concurrent requests allowed for pull "
-      + "queries. Once the limit is hit, queries will fail immediately";
+      + "queries on this host. Once the limit is hit, queries will fail immediately";
 
   public static final String KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG
       = "ksql.query.pull.thread.pool.size";

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullQueryResult.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullQueryResult.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class PullQueryResult {
@@ -89,5 +90,12 @@ public class PullQueryResult {
 
   public void onCompletion(final Consumer<Void> consumer) {
     future.thenAccept(consumer::accept);
+  }
+
+  public void onCompletionOrException(final BiConsumer<Void, Throwable> biConsumer) {
+    future.handle((v, t) -> {
+      biConsumer.accept(v, t);
+      return null;
+    });
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -175,9 +175,11 @@ public class QueryEndpoint {
           false
       );
 
-      result.onCompletionOrException((v, t) -> decrementer.decrementAtMostOnce());
-      result.onCompletion(v -> {
-        pullQueryMetrics.ifPresent(p -> p.recordLatency(startTimeNanos));
+      result.onCompletionOrException((v, throwable) -> {
+        decrementer.decrementAtMostOnce();
+        if (throwable == null) {
+          pullQueryMetrics.ifPresent(p -> p.recordLatency(startTimeNanos));
+        }
       });
 
       final BlockingQueryPublisher publisher = new BlockingQueryPublisher(context, workerExecutor);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -37,6 +37,8 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.LocalCommands;
 import io.confluent.ksql.rest.server.resources.streaming.PullQueryConfigPlannerOptions;
 import io.confluent.ksql.rest.server.resources.streaming.PullQueryConfigRoutingOptions;
+import io.confluent.ksql.rest.util.ConcurrencyLimiter;
+import io.confluent.ksql.rest.util.ConcurrencyLimiter.Decrementer;
 import io.confluent.ksql.rest.util.QueryCapacityUtil;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.utils.FormatOptions;
@@ -66,6 +68,7 @@ public class QueryEndpoint {
   private final RoutingFilterFactory routingFilterFactory;
   private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
   private final RateLimiter rateLimiter;
+  private final ConcurrencyLimiter pullConcurrencyLimiter;
   private final HARouting routing;
   private final Optional<LocalCommands> localCommands;
 
@@ -76,6 +79,7 @@ public class QueryEndpoint {
       final RoutingFilterFactory routingFilterFactory,
       final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
       final RateLimiter rateLimiter,
+      final ConcurrencyLimiter pullConcurrencyLimiter,
       final HARouting routing,
       final Optional<LocalCommands> localCommands
   ) {
@@ -85,6 +89,7 @@ public class QueryEndpoint {
     this.routingFilterFactory = routingFilterFactory;
     this.pullQueryMetrics = pullQueryMetrics;
     this.rateLimiter = rateLimiter;
+    this.pullConcurrencyLimiter = pullConcurrencyLimiter;
     this.routing = routing;
     this.localCommands = localCommands;
   }
@@ -157,26 +162,33 @@ public class QueryEndpoint {
     );
 
     PullQueryExecutionUtil.checkRateLimit(rateLimiter);
+    final Decrementer decrementer = pullConcurrencyLimiter.increment();
 
-    final PullQueryResult result = ksqlEngine.executePullQuery(
-        serviceContext,
-        statement,
-        routing,
-        routingOptions,
-        plannerOptions,
-        pullQueryMetrics,
-        false
-    );
+    try {
+      final PullQueryResult result = ksqlEngine.executePullQuery(
+          serviceContext,
+          statement,
+          routing,
+          routingOptions,
+          plannerOptions,
+          pullQueryMetrics,
+          false
+      );
 
-    result.onCompletion(v -> {
-      pullQueryMetrics.ifPresent(p -> p.recordLatency(startTimeNanos));
-    });
+      result.onCompletionOrException((v, t) -> decrementer.decrementAtMostOnce());
+      result.onCompletion(v -> {
+        pullQueryMetrics.ifPresent(p -> p.recordLatency(startTimeNanos));
+      });
 
-    final BlockingQueryPublisher publisher = new BlockingQueryPublisher(context, workerExecutor);
+      final BlockingQueryPublisher publisher = new BlockingQueryPublisher(context, workerExecutor);
 
-    publisher.setQueryHandle(new KsqlPullQueryHandle(result, pullQueryMetrics), true);
+      publisher.setQueryHandle(new KsqlPullQueryHandle(result, pullQueryMetrics), true);
 
-    return publisher;
+      return publisher;
+    } catch (Throwable t) {
+      decrementer.decrementAtMostOnce();
+      throw t;
+    }
   }
 
   private ConfiguredStatement<Query> createStatement(final String queryString,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.rest.server.resources.streaming;
 
 import io.confluent.ksql.planner.PullPlannerOptions;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
 
 public class PullQueryConfigPlannerOptions implements PullPlannerOptions {
@@ -33,16 +32,9 @@ public class PullQueryConfigPlannerOptions implements PullPlannerOptions {
 
   @Override
   public boolean getTableScansEnabled() {
-    final boolean configured = ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
     if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED)) {
-      final boolean override
-          = (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
-      if (override && !configured) {
-        throw new KsqlException("You can only disable table scans with an override, "
-            + "not enable them.");
-      }
-      return override;
+      return (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
     }
-    return configured;
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -33,6 +33,8 @@ import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
+import io.confluent.ksql.rest.util.ConcurrencyLimiter;
+import io.confluent.ksql.rest.util.ConcurrencyLimiter.Decrementer;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KeyValue;
@@ -51,6 +53,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
   private final long startTimeNanos;
   private final RoutingFilterFactory routingFilterFactory;
   private final RateLimiter rateLimiter;
+  private final ConcurrencyLimiter concurrencyLimiter;
   private final HARouting routing;
 
   @VisibleForTesting
@@ -63,6 +66,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
       final long startTimeNanos,
       final RoutingFilterFactory routingFilterFactory,
       final RateLimiter rateLimiter,
+      final ConcurrencyLimiter concurrencyLimiter,
       final HARouting routing
   ) {
     this.ksqlEngine = requireNonNull(ksqlEngine, "ksqlEngine");
@@ -73,6 +77,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
     this.startTimeNanos = startTimeNanos;
     this.routingFilterFactory = requireNonNull(routingFilterFactory, "routingFilterFactory");
     this.rateLimiter = requireNonNull(rateLimiter, "rateLimiter");
+    this.concurrencyLimiter = concurrencyLimiter;
     this.routing = requireNonNull(routing, "routing");
   }
 
@@ -90,25 +95,32 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
     );
 
     PullQueryExecutionUtil.checkRateLimit(rateLimiter);
+    final Decrementer decrementer = concurrencyLimiter.increment();
 
-    final PullQueryResult result = ksqlEngine.executePullQuery(
-        serviceContext,
-        query,
-        routing,
-        routingOptions,
-        plannerOptions,
-        pullQueryMetrics,
-        true
-    );
+    try {
+      final PullQueryResult result = ksqlEngine.executePullQuery(
+          serviceContext,
+          query,
+          routing,
+          routingOptions,
+          plannerOptions,
+          pullQueryMetrics,
+          true
+      );
 
-    result.onCompletion(v -> {
-      pullQueryMetrics.ifPresent(p -> p.recordLatency(startTimeNanos));
-    });
+      result.onCompletionOrException((v, t) -> decrementer.decrementAtMostOnce());
+      result.onCompletion(v -> {
+        pullQueryMetrics.ifPresent(p -> p.recordLatency(startTimeNanos));
+      });
 
-    final PullQuerySubscription subscription = new PullQuerySubscription(
-        exec, subscriber, result);
+      final PullQuerySubscription subscription = new PullQuerySubscription(
+          exec, subscriber, result);
 
-    subscriber.onSubscribe(subscription);
+      subscriber.onSubscribe(subscription);
+    } catch (Throwable t) {
+      decrementer.decrementAtMostOnce();
+      throw t;
+    }
   }
 
   private static final class PullQuerySubscription

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -112,6 +112,12 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
       result.onCompletion(v -> {
         pullQueryMetrics.ifPresent(p -> p.recordLatency(startTimeNanos));
       });
+      result.onCompletionOrException((v, throwable) -> {
+        decrementer.decrementAtMostOnce();
+        if (throwable == null) {
+          pullQueryMetrics.ifPresent(p -> p.recordLatency(startTimeNanos));
+        }
+      });
 
       final PullQuerySubscription subscription = new PullQuerySubscription(
           exec, subscriber, result);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.util.KsqlException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Limits the concurrency of the caller by checking against a limit and if it's exceeded, throwing
@@ -45,7 +44,7 @@ public class ConcurrencyLimiter {
       throw new KsqlException(
           String.format("Host is at concurrency limit for %s. Currently set to %d maximum "
               + "concurrent operations.", operationType, limit));
-    };
+    }
     return new Decrementer();
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.util.KsqlException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ConcurrencyLimiter {
+
+  private final int limit;
+  private final String operationType;
+
+  private AtomicInteger count = new AtomicInteger(0);
+
+  public ConcurrencyLimiter(final int limit, final String operationType) {
+    this.limit = limit;
+    this.operationType = operationType;
+  }
+
+  public Decrementer increment() {
+    count.updateAndGet(value -> {
+      if (value + 1 > limit) {
+        throw new KsqlException(
+            String.format("Host is at concurrency limit for %s. Currently set to %d maximum "
+                + "concurrent operations.", operationType, limit));
+      }
+      return value + 1;
+    });
+    return new Decrementer();
+  }
+
+  private void decrement() {
+    count.decrementAndGet();
+  }
+
+  @VisibleForTesting
+  int getCount() {
+    return count.get();
+  }
+
+  public class Decrementer {
+
+    private final AtomicBoolean called = new AtomicBoolean(false);
+
+    public void decrementAtMostOnce() {
+      if (!called.getAndSet(true)) {
+        ConcurrencyLimiter.this.decrement();
+      }
+    }
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -54,6 +54,7 @@ import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.resources.StatusResource;
+import io.confluent.ksql.rest.util.ConcurrencyLimiter;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.security.KsqlSecurityContext;
@@ -141,6 +142,8 @@ public class KsqlRestApplicationTest {
   private RoutingFilterFactory routingFilterFactory;
   @Mock
   private RateLimiter rateLimiter;
+  @Mock
+  private ConcurrencyLimiter concurrencyLimiter;
   @Mock
   private HARouting haRouting;
 
@@ -485,6 +488,7 @@ public class KsqlRestApplicationTest {
         Optional.empty(),
         routingFilterFactory,
         rateLimiter,
+        concurrencyLimiter,
         haRouting,
         Optional.empty()
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/WSQueryEndpointTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
+import io.confluent.ksql.rest.util.ConcurrencyLimiter;
 import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
 import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.util.KsqlConfig;
@@ -80,6 +81,7 @@ public class WSQueryEndpointTest {
         Optional.empty(),
         mock(RoutingFilterFactory.class),
         mock(RateLimiter.class),
+        mock(ConcurrencyLimiter.class),
         mock(HARouting.class),
         Optional.empty()
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -42,6 +42,8 @@ import io.confluent.ksql.physical.pull.HARouting;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.query.PullQueryQueue;
 import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.util.ConcurrencyLimiter;
+import io.confluent.ksql.rest.util.ConcurrencyLimiter.Decrementer;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -102,6 +104,10 @@ public class PullQueryPublisherTest {
   private KsqlConfig ksqlConfig;
   @Mock
   private HARouting haRouting;
+  @Mock
+  private ConcurrencyLimiter concurrencyLimiter;
+  @Mock
+  private Decrementer decrementer;
 
   @Captor
   private ArgumentCaptor<Subscription> subscriptionCaptor;
@@ -124,6 +130,7 @@ public class PullQueryPublisherTest {
         TIME_NANOS,
         routingFilterFactory,
         create(1),
+        concurrencyLimiter,
         haRouting);
 
     when(statement.getSessionConfig()).thenReturn(sessionConfig);
@@ -152,6 +159,7 @@ public class PullQueryPublisherTest {
       runnable.run();
       return null;
     });
+    when(concurrencyLimiter.increment()).thenReturn(decrementer);
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
@@ -32,7 +32,7 @@ public class ConcurrencyLimiterTest {
   @Test
   public void shouldSucceedUnderLimit() {
     // Given:
-    ConcurrencyLimiter limiter = new ConcurrencyLimiter(1, "pull query");
+    ConcurrencyLimiter limiter = new ConcurrencyLimiter(1, "pull queries");
 
     // When:
     Decrementer decrementer = limiter.increment();
@@ -59,7 +59,6 @@ public class ConcurrencyLimiterTest {
     // Then:
     assertThat(e.getMessage(), containsString("Host is at concurrency limit for pull queries."));
     assertThat(limiter.getCount(), is(1));
-    decrementer.decrementAtMostOnce();
     decrementer.decrementAtMostOnce();
     assertThat(limiter.getCount(), is(0));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ConcurrencyLimiterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import io.confluent.ksql.rest.util.ConcurrencyLimiter.Decrementer;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConcurrencyLimiterTest {
+
+  @Test
+  public void shouldSucceedUnderLimit() {
+    // Given:
+    ConcurrencyLimiter limiter = new ConcurrencyLimiter(1, "pull query");
+
+    // When:
+    Decrementer decrementer = limiter.increment();
+
+    // Then:
+    assertThat(limiter.getCount(), is(1));
+    decrementer.decrementAtMostOnce();
+    decrementer.decrementAtMostOnce();
+    assertThat(limiter.getCount(), is(0));
+  }
+
+  @Test
+  public void shouldError_atLimit() {
+    // Given:
+    ConcurrencyLimiter limiter = new ConcurrencyLimiter(1, "pull queries");
+
+    // When:
+    Decrementer decrementer = limiter.increment();
+    final Exception e = assertThrows(
+        KsqlException.class,
+        limiter::increment
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Host is at concurrency limit for pull queries."));
+    assertThat(limiter.getCount(), is(1));
+    decrementer.decrementAtMostOnce();
+    decrementer.decrementAtMostOnce();
+    assertThat(limiter.getCount(), is(0));
+  }
+}


### PR DESCRIPTION
### Description 
While we already have `ksql.query.pull.max.qps` to limit the volume of requests in a given time period, this introduces `ksql.query.pull.max.concurrent.requests` to limit the number of concurrent requests to minimize the effects of long running requests such as table scans.  Most queries such as key lookups are quick and could register high qps while having a relatively low number of concurrent requests.  Table scans on the other hand can handle relatively low qps while still taxing the system, so this aims to mitigate that by limiting concurrent requests, which are a truer measure of system load.

Also removes the limitation of only allowing the client to disallow table scans.  Now the client can do either, including enabling them, even if the server config has them disabled.

### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

