### PR TITLE
chore(migrations): command option ordering + misc UX improvements

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
@@ -29,8 +29,8 @@ import com.github.rvesse.airline.parser.errors.handlers.CollectAll;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand;
 import io.confluent.ksql.tools.migrations.commands.BaseCommand;
-import io.confluent.ksql.tools.migrations.commands.CleanMigrationsCommand;
 import io.confluent.ksql.tools.migrations.commands.CreateMigrationCommand;
+import io.confluent.ksql.tools.migrations.commands.DestroyMigrationsCommand;
 import io.confluent.ksql.tools.migrations.commands.InitializeMigrationCommand;
 import io.confluent.ksql.tools.migrations.commands.MigrationInfoCommand;
 import io.confluent.ksql.tools.migrations.commands.NewMigrationCommand;
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
         CreateMigrationCommand.class,
         ApplyMigrationCommand.class,
         MigrationInfoCommand.class,
-        CleanMigrationsCommand.class,
+        DestroyMigrationsCommand.class,
         ValidateMigrationsCommand.class,
         InitializeMigrationCommand.class,
         Help.class

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
@@ -85,7 +85,7 @@ public final class Migrations {
       System.exit(1);
       return;
     }
-    
+
     if (!command.isPresent()) {
       System.exit(0);
       return;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/Migrations.java
@@ -26,6 +26,7 @@ import com.github.rvesse.airline.parser.errors.ParseCommandMissingException;
 import com.github.rvesse.airline.parser.errors.ParseCommandUnrecognizedException;
 import com.github.rvesse.airline.parser.errors.ParseException;
 import com.github.rvesse.airline.parser.errors.handlers.CollectAll;
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand;
 import io.confluent.ksql.tools.migrations.commands.BaseCommand;
 import io.confluent.ksql.tools.migrations.commands.CleanMigrationsCommand;
@@ -100,7 +101,8 @@ public final class Migrations {
     System.exit(((BaseCommand) command.get()).runCommand());
   }
 
-  private static Optional<Runnable> parseCommandFromArgs(
+  @VisibleForTesting
+  static Optional<Runnable> parseCommandFromArgs(
       final Cli<Runnable> cli,
       final String[] args
   ) {
@@ -136,7 +138,6 @@ public final class Migrations {
     }
   }
 
-  // TODO: add unit tests
   private static boolean isGlobalHelpMessageRequested(
       final Collection<ParseException> errors
   ) {
@@ -149,7 +150,6 @@ public final class Migrations {
         .anyMatch(inp -> inp.equals("--help") || inp.equals("-h"));
   }
 
-  // TODO: add unit test
   private static boolean isCommandSpecificHelpMessageRequested(
       final ParseState<Runnable> parseState
   ) {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -22,6 +22,7 @@ import static io.confluent.ksql.tools.migrations.util.MigrationsDirectoryUtil.ge
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.RequireOnlyOne;
+import com.github.rvesse.airline.annotations.restrictions.ranges.IntegerRange;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
@@ -77,6 +78,7 @@ public class ApplyMigrationCommand extends BaseCommand {
       description = "Run all available migrations up through the specified version"
   )
   @RequireOnlyOne(tag = "target")
+  @IntegerRange(min = 1, max = 999999)
   private int untilVersion;
 
   @Option(
@@ -86,6 +88,7 @@ public class ApplyMigrationCommand extends BaseCommand {
       description = "Run the migration with the specified version"
   )
   @RequireOnlyOne(tag = "target")
+  @IntegerRange(min = 1, max = 999999)
   private int version;
 
   @Option(
@@ -130,15 +133,6 @@ public class ApplyMigrationCommand extends BaseCommand {
       final Clock clock
   ) {
     // CHECKSTYLE_RULES.ON: NPathComplexity
-    if (untilVersion < 0) {
-      LOGGER.error("'until' migration version must be positive. Got: {}", untilVersion);
-      return 1;
-    }
-    if (version < 0) {
-      LOGGER.error("Migration version to apply must be positive. Got: {}", version);
-      return 1;
-    }
-
     final Client ksqlClient;
     try {
       ksqlClient = clientSupplier.apply(config);

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -110,7 +110,7 @@ public class ApplyMigrationCommand extends BaseCommand {
 
     final MigrationConfig config;
     try {
-      config = MigrationConfig.load(configFile);
+      config = MigrationConfig.load(getConfigFile());
     } catch (KsqlException | MigrationException e) {
       LOGGER.error(e.getMessage());
       return 1;
@@ -119,7 +119,7 @@ public class ApplyMigrationCommand extends BaseCommand {
     return command(
         config,
         MigrationsUtil::getKsqlClient,
-        getMigrationsDirFromConfigFile(configFile),
+        getMigrationsDirFromConfigFile(getConfigFile()),
         Clock.systemDefaultZone()
     );
   }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -49,7 +49,6 @@ public abstract class BaseCommand implements Runnable {
   )
   protected String configFileGlobal;
 
-  // TODO: add tests
   @Option(
       name = {CONFIG_FILE_OPTION_SHORT, CONFIG_FILE_OPTION},
       title = "config-file",

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -44,9 +44,24 @@ public abstract class BaseCommand implements Runnable {
       title = "config-file",
       description = "Path to migrations configuration file. Required for all commands "
           + "with the exception of `" + NewMigrationCommand.NEW_COMMAND_NAME + "`.",
+      // allows users to specify config file before the name of the command
       type = OptionType.GLOBAL
   )
-  protected String configFile;
+  protected String configFileGlobal;
+
+  // TODO: add tests
+  @Option(
+      name = {CONFIG_FILE_OPTION_SHORT, CONFIG_FILE_OPTION},
+      title = "config-file",
+      description = "Path to migrations configuration file. Required for all commands "
+          + "with the exception of `" + NewMigrationCommand.NEW_COMMAND_NAME + "`.",
+      // allows users to specify config file after the name of the command
+      type = OptionType.COMMAND,
+      // hide this version of the config file option so only the version above appears
+      // in help text, to avoid duplication
+      hidden = true
+  )
+  protected String configFileNonGlobal;
 
   @Override
   public void run() {
@@ -75,8 +90,18 @@ public abstract class BaseCommand implements Runnable {
 
   protected abstract Logger getLogger();
 
+  protected String getConfigFile() {
+    if (configFileGlobal != null) {
+      return configFileGlobal;
+    }
+    if (configFileNonGlobal != null) {
+      return configFileNonGlobal;
+    }
+    return null;
+  }
+
   protected boolean validateConfigFilePresent() {
-    if (configFile == null || configFile.equals("")) {
+    if (getConfigFile() == null || getConfigFile().trim().equals("")) {
       getLogger().error("Migrations config file required but not specified. "
           + "Specify with {} (or, equivalently, {}).",
           CONFIG_FILE_OPTION, CONFIG_FILE_OPTION_SHORT);

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/BaseCommand.java
@@ -17,12 +17,14 @@ package io.confluent.ksql.tools.migrations.commands;
 
 import static io.confluent.ksql.tools.migrations.commands.InitializeMigrationCommand.INITIALIZE_COMMAND_NAME;
 
+import com.github.rvesse.airline.HelpOption;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.OptionType;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.util.MigrationsUtil;
 import java.util.concurrent.ExecutionException;
+import javax.inject.Inject;
 import org.slf4j.Logger;
 
 /**
@@ -33,6 +35,9 @@ public abstract class BaseCommand implements Runnable {
 
   private static final String CONFIG_FILE_OPTION = "--config-file";
   private static final String CONFIG_FILE_OPTION_SHORT = "-c";
+
+  @Inject
+  protected HelpOption<BaseCommand> help;
 
   @Option(
       name = {CONFIG_FILE_OPTION_SHORT, CONFIG_FILE_OPTION},
@@ -52,6 +57,10 @@ public abstract class BaseCommand implements Runnable {
    * @return exit status of the command
    */
   public int runCommand() {
+    if (help.showHelpIfRequested()) {
+      return 0;
+    }
+
     final long startTime = System.currentTimeMillis();
     final int status = command();
     getLogger().info(String.format("Execution time: %.4f seconds",

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CleanMigrationsCommand.java
@@ -52,7 +52,7 @@ public class CleanMigrationsCommand extends BaseCommand {
 
     final MigrationConfig config;
     try {
-      config = MigrationConfig.load(configFile);
+      config = MigrationConfig.load(getConfigFile());
     } catch (KsqlException | MigrationException e) {
       LOGGER.error(e.getMessage());
       return 1;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -70,7 +70,7 @@ public class CreateMigrationCommand extends BaseCommand {
 
   @Override
   protected int command() {
-    return command(getMigrationsDirFromConfigFile(configFile));
+    return command(getMigrationsDirFromConfigFile(getConfigFile()));
   }
 
   @VisibleForTesting

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -25,6 +25,7 @@ import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.help.Examples;
 import com.github.rvesse.airline.annotations.restrictions.Required;
+import com.github.rvesse.airline.annotations.restrictions.ranges.IntegerRange;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.tools.migrations.MigrationException;
 import io.confluent.ksql.tools.migrations.util.MigrationFile;
@@ -57,6 +58,7 @@ public class CreateMigrationCommand extends BaseCommand {
       description = "(Optional) The schema version to initialize. Defaults to the next"
           + " schema version based on existing migration files."
   )
+  @IntegerRange(min = 1, max = 999999)
   private int version;
 
   @Required
@@ -98,8 +100,6 @@ public class CreateMigrationCommand extends BaseCommand {
    */
   private boolean validateVersionDoesNotAlreadyExist(final String migrationsDir) {
     // no explicit version was specified, nothing to verify
-    // (airline actually can't distinguish between explicit 0 and nothing specified,
-    // but we won't worry about this edge case for now)
     if (version == 0) {
       return true;
     }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/DestroyMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/DestroyMigrationsCommand.java
@@ -35,14 +35,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Command(
-    name = "clean",
-    description = "Cleans all ksqlDB server resources related to migrations, including "
+    name = "destroy-metadata",
+    description = "Destroys all ksqlDB server resources related to migrations, including "
         + "the migrations metadata stream and table and their underlying Kafka topics. "
         + "WARNING: this is not reversible!"
 )
-public class CleanMigrationsCommand extends BaseCommand {
+public class DestroyMigrationsCommand extends BaseCommand {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(CleanMigrationsCommand.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DestroyMigrationsCommand.class);
 
   @Override
   protected int command() {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 )
 public class InitializeMigrationCommand extends BaseCommand {
 
-  static final String INITIALIZE_COMMAND_NAME = "initialize";
+  static final String INITIALIZE_COMMAND_NAME = "initialize-metadata";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InitializeMigrationCommand.class);
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/InitializeMigrationCommand.java
@@ -89,7 +89,7 @@ public class InitializeMigrationCommand extends BaseCommand {
 
     final MigrationConfig config;
     try {
-      config = MigrationConfig.load(configFile);
+      config = MigrationConfig.load(getConfigFile());
     } catch (KsqlException | MigrationException e) {
       LOGGER.error(e.getMessage());
       return 1;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommand.java
@@ -54,7 +54,7 @@ public class MigrationInfoCommand extends BaseCommand {
 
     final MigrationConfig config;
     try {
-      config = MigrationConfig.load(configFile);
+      config = MigrationConfig.load(getConfigFile());
     } catch (KsqlException | MigrationException e) {
       LOGGER.error(e.getMessage());
       return 1;
@@ -63,7 +63,7 @@ public class MigrationInfoCommand extends BaseCommand {
     return command(
         config,
         MigrationsUtil::getKsqlClient,
-        getMigrationsDirFromConfigFile(configFile)
+        getMigrationsDirFromConfigFile(getConfigFile())
     );
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 )
 public class NewMigrationCommand extends BaseCommand {
 
-  static final String NEW_COMMAND_NAME = "new";
+  static final String NEW_COMMAND_NAME = "new-project";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NewMigrationCommand.class);
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommand.java
@@ -56,7 +56,7 @@ public class NewMigrationCommand extends BaseCommand {
 
   @Override
   protected int command() {
-    if (configFile != null && !configFile.equals("")) {
+    if (getConfigFile() != null && !getConfigFile().equals("")) {
       LOGGER.error("This command does not expect a config file to be passed. "
           + "Rather, this command will create one as part of preparing the migrations directory.");
       return 1;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommand.java
@@ -62,7 +62,7 @@ public class ValidateMigrationsCommand extends BaseCommand {
 
     final MigrationConfig config;
     try {
-      config = MigrationConfig.load(configFile);
+      config = MigrationConfig.load(getConfigFile());
     } catch (KsqlException | MigrationException e) {
       LOGGER.error(e.getMessage());
       return 1;
@@ -71,7 +71,7 @@ public class ValidateMigrationsCommand extends BaseCommand {
     return command(
         config,
         MigrationsUtil::getKsqlClient,
-        getMigrationsDirFromConfigFile(configFile)
+        getMigrationsDirFromConfigFile(getConfigFile())
     );
   }
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsParsingTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsParsingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.tools.migrations;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import com.github.rvesse.airline.Cli;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MigrationsParsingTest {
+
+  private static final Cli<Runnable> MIGRATIONS_CLI = new Cli<>(Migrations.class);
+
+  private static final String CONFIG_FILE_PATH = "/path/to/ksql-migrations.properties";
+
+  private final ByteArrayOutputStream systemOut = new ByteArrayOutputStream();
+
+  @Before
+  public void setUp() {
+    System.setOut(new PrintStream(systemOut));
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(System.out);
+  }
+
+  @Test
+  public void shouldPrintHelpIfNoArgs() {
+    // When:
+    Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{});
+
+    // Then:
+    validateGlobalHelpPrinted();
+  }
+
+  @Test
+  public void shouldPrintHelpOnGlobalHelpOptionLong() {
+    // When:
+    Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"--help"});
+
+    // Then:
+    validateGlobalHelpPrinted();
+  }
+
+  @Test
+  public void shouldPrintHelpOnGlobalHelpOptionShort() {
+    // When:
+    Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"-h"});
+
+    // Then:
+    validateGlobalHelpPrinted();
+  }
+
+  @Test
+  public void shouldPrintHelpForSpecificCommandLong() {
+    // When:
+    Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"apply", "--help"});
+
+    // Then:
+    validateCommandHelpPrinted();
+  }
+
+  @Test
+  public void shouldPrintHelpForSpecificCommandShort() {
+    // When:
+    Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"apply", "-h"});
+
+    // Then:
+    validateCommandHelpPrinted();
+  }
+
+  @Test
+  public void shouldAcceptConfigFileBeforeCommand() {
+    // When:
+    Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"--config-file", CONFIG_FILE_PATH, "info"});
+
+    // Then: no exception
+  }
+
+  @Test
+  public void shouldAcceptConfigFileAfterCommand() {
+    // When:
+    Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"info", "--config-file", CONFIG_FILE_PATH});
+
+    // Then: no exception
+  }
+
+  private void validateGlobalHelpPrinted() {
+    assertThat(systemOut.toString(), containsString(
+        "ksql-migrations [ {-c | --config-file} <config-file> ] <command> [ <args> ]"));
+  }
+
+  private void validateCommandHelpPrinted() {
+    assertThat(systemOut.toString(), containsString(
+        "ksql-migrations apply - Migrates the metadata schema to a new schema"));
+  }
+}

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsParsingTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsParsingTest.java
@@ -30,12 +30,13 @@ public class MigrationsParsingTest {
   private static final Cli<Runnable> MIGRATIONS_CLI = new Cli<>(Migrations.class);
 
   private static final String CONFIG_FILE_PATH = "/path/to/ksql-migrations.properties";
+  private static final String UTF_8 = "UTF-8";
 
   private final ByteArrayOutputStream systemOut = new ByteArrayOutputStream();
 
   @Before
-  public void setUp() {
-    System.setOut(new PrintStream(systemOut));
+  public void setUp() throws Exception {
+    System.setOut(new PrintStream(systemOut, true, UTF_8));
   }
 
   @After
@@ -44,7 +45,7 @@ public class MigrationsParsingTest {
   }
 
   @Test
-  public void shouldPrintHelpIfNoArgs() {
+  public void shouldPrintHelpIfNoArgs() throws Exception {
     // When:
     Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{});
 
@@ -53,7 +54,7 @@ public class MigrationsParsingTest {
   }
 
   @Test
-  public void shouldPrintHelpOnGlobalHelpOptionLong() {
+  public void shouldPrintHelpOnGlobalHelpOptionLong() throws Exception {
     // When:
     Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"--help"});
 
@@ -62,7 +63,7 @@ public class MigrationsParsingTest {
   }
 
   @Test
-  public void shouldPrintHelpOnGlobalHelpOptionShort() {
+  public void shouldPrintHelpOnGlobalHelpOptionShort() throws Exception {
     // When:
     Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"-h"});
 
@@ -71,7 +72,7 @@ public class MigrationsParsingTest {
   }
 
   @Test
-  public void shouldPrintHelpForSpecificCommandLong() {
+  public void shouldPrintHelpForSpecificCommandLong() throws Exception {
     // When:
     Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"apply", "--help"});
 
@@ -80,7 +81,7 @@ public class MigrationsParsingTest {
   }
 
   @Test
-  public void shouldPrintHelpForSpecificCommandShort() {
+  public void shouldPrintHelpForSpecificCommandShort() throws Exception {
     // When:
     Migrations.parseCommandFromArgs(MIGRATIONS_CLI, new String[]{"apply", "-h"});
 
@@ -104,13 +105,13 @@ public class MigrationsParsingTest {
     // Then: no exception
   }
 
-  private void validateGlobalHelpPrinted() {
-    assertThat(systemOut.toString(), containsString(
+  private void validateGlobalHelpPrinted() throws Exception {
+    assertThat(systemOut.toString(UTF_8), containsString(
         "ksql-migrations [ {-c | --config-file} <config-file> ] <command> [ <args> ]"));
   }
 
-  private void validateCommandHelpPrinted() {
-    assertThat(systemOut.toString(), containsString(
+  private void validateCommandHelpPrinted() throws Exception {
+    assertThat(systemOut.toString(UTF_8), containsString(
         "ksql-migrations apply - Migrates the metadata schema to a new schema"));
   }
 }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -306,8 +306,8 @@ public class MigrationsTest {
   }
 
   private static void initializeAndVerifyMetadataStreamAndTable(final String configFile) {
-    // use `initialize` to create metadata stream and table
-    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "initialize").runCommand();
+    // use `initialize-metadata` to create metadata stream and table
+    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "initialize-metadata").runCommand();
     assertThat(status, is(0));
 
     // verify metadata stream
@@ -356,8 +356,8 @@ public class MigrationsTest {
     assertThat(sourceExists(MIGRATIONS_STREAM, false), is(true));
     assertThat(sourceExists(MIGRATIONS_TABLE, true), is(true));
 
-    // When: use `clean` to clean up metadata stream and table
-    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "clean").runCommand();
+    // When: use `destroy-metadata` to clean up metadata stream and table
+    final int status = MIGRATIONS_CLI.parse("--config-file", configFile, "destroy-metadata").runCommand();
     assertThat(status, is(0));
 
     // Then:

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -232,8 +232,8 @@ public class MigrationsTest {
   }
 
   private static void createAndVerifyDirectoryStructure(final String testDir) throws Exception {
-    // use `new` to create directory structure
-    final int status = MIGRATIONS_CLI.parse("new", testDir, REST_APP.getHttpListener().toString()).runCommand();
+    // use `new-project` to create directory structure
+    final int status = MIGRATIONS_CLI.parse("new-project", testDir, REST_APP.getHttpListener().toString()).runCommand();
     assertThat(status, is(0));
 
     // verify root directory

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommandTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.github.rvesse.airline.SingleCommand;
 import com.github.rvesse.airline.parser.errors.ParseArgumentsMissingException;
+import com.github.rvesse.airline.parser.errors.ParseOptionOutOfRangeException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.nio.file.Paths;
@@ -115,26 +116,35 @@ public class CreateMigrationCommandTest {
 
   @Test
   public void shouldFailOnNegativeVersion() {
-    // Given:
-    command = PARSER.parse(DESCRIPTION, "-v", "-1");
-
     // When:
-    final int result = command.command(migrationsDir);
+    final Exception e = assertThrows(ParseOptionOutOfRangeException.class,
+        () -> PARSER.parse(DESCRIPTION, "-v", "-1"));
 
     // Then:
-    assertThat(result, is(1));
+    assertThat(e.getMessage(), is("Value for option 'version' was given as '-1' "
+        + "which is not in the acceptable range: 1 <= value <= 999999"));
+  }
+
+  @Test
+  public void shouldFailOnZeroVersion() {
+    // When:
+    final Exception e = assertThrows(ParseOptionOutOfRangeException.class,
+        () -> PARSER.parse(DESCRIPTION, "-v", "0"));
+
+    // Then:
+    assertThat(e.getMessage(), is("Value for option 'version' was given as '0' "
+        + "which is not in the acceptable range: 1 <= value <= 999999"));
   }
 
   @Test
   public void shouldFailIfVersionTooLarge() {
-    // Given:
-    command = PARSER.parse(DESCRIPTION, "-v", "10000000");
-
     // When:
-    final int result = command.command(migrationsDir);
+    final Exception e = assertThrows(ParseOptionOutOfRangeException.class,
+        () -> PARSER.parse(DESCRIPTION, "-v", "10000000"));
 
     // Then:
-    assertThat(result, is(1));
+    assertThat(e.getMessage(), is("Value for option 'version' was given as '10000000' "
+        + "which is not in the acceptable range: 1 <= value <= 999999"));
   }
 
   @Test

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/DestroyMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/DestroyMigrationsCommandTest.java
@@ -41,10 +41,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CleanMigrationsCommandTest {
+public class DestroyMigrationsCommandTest {
 
-  private static final SingleCommand<CleanMigrationsCommand> PARSER =
-      SingleCommand.singleCommand(CleanMigrationsCommand.class);
+  private static final SingleCommand<DestroyMigrationsCommand> PARSER =
+      SingleCommand.singleCommand(DestroyMigrationsCommand.class);
 
   private static final String MIGRATIONS_STREAM = "migrations_stream";
   private static final String MIGRATIONS_TABLE = "migrations_table";
@@ -79,7 +79,7 @@ public class CleanMigrationsCommandTest {
   @Mock
   private QueryInfo otherQueryInfo;
 
-  private CleanMigrationsCommand command;
+  private DestroyMigrationsCommand command;
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
### Description 

This PR includes various UX improvements to the `ksql-migrations` tool:
- `ksql-migrations --help` and `ksql-migrations -h` are now supported (in addition to `ksql-migrations help`). Similarly, `ksql-migrations <command name> --help` and `ksql-migrations <command name> -h` are now supported, in addition to `ksql-migrations help <command name>`. 
- The `--config-file` flag is now accepted after the command name, in addition to before.
- Exceptions thrown when commands fail to parse arguments no longer print stacktraces (in order to clean up the error messages that users see).
- Three commands have been renamed in order to disambiguate and clarify their behaviors: `ksql-migrations new` is now `ksql-migrations initialize`, `ksql-migrations initialize` is now `ksql-migrations initialize-metadata`, and `ksql-migrations clean` is now `ksql-migrations destroy-metadata`.
- Other misc. cleanup, including having the CLI framework enforce bounds on integer arguments, rather than having custom code for this.

### Testing done 

Added unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

