### PR TITLE
fix: ksql.service.id should not be usable as a query parameter

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -521,7 +521,6 @@ public class Cli implements KsqlRequestExecutor, Closeable {
 
   private void setProperty(final String property, final String value) {
     final Object priorValue = restClient.setProperty(property, value);
-
     terminal.writer().printf(
         "Successfully changed local property '%s'%s to '%s'.%s%n",
         property,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.properties;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 
 import java.util.Collection;
@@ -32,8 +33,8 @@ public class DenyListPropertyValidator {
   private final Set<String> immutableProps;
 
   public DenyListPropertyValidator(final Collection<String> immutableProps) {
-    this.immutableProps = ImmutableSet.copyOf(
-        Objects.requireNonNull(immutableProps, "immutableProps"));
+    this.immutableProps = ImmutableSet.<String>builder().addAll(
+        Objects.requireNonNull(immutableProps, "immutableProps")).add(KsqlConfig.KSQL_SERVICE_ID_CONFIG).build();
   }
 
   /**

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/DenyListPropertyValidatorTest.java
@@ -64,4 +64,21 @@ public class DenyListPropertyValidatorTest {
         "anything", "v2"
     ));
   }
+
+  @Test
+  public void shouldThrowOnKsqlServiceIdProperty() {
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> validator.validateAll(ImmutableMap.of(
+            "ksql.service.id", "v1"
+        ))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "One or more properties overrides set locally are prohibited by the KSQL server "
+            + "(use UNSET to reset their default value): [ksql.service.id]"
+    ));
+  }
 }


### PR DESCRIPTION
Issue: [#6869](https://github.com/confluentinc/ksql/issues/6869)
ksql.service.id was settable as a query-level parameter but it should only be settable as a server-level parameter.

### Description 
The query-parameters that aren't allowed to be set are defined in the denylist that is imported from the ksql-server.properties. I hardcoded the 'ksql.servier.id' in the denylist as I wasn't sure if I should edit the config files. Hence, alternative to my approach we could edit the config files from where the denylist is imported.

### Testing done 
Just made sure that all tests run as there were already tests checking whether the properties set in the denylist actually are actually denied from query-level parameter setting.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

