### PR TITLE
fix: Pull Queries: Avoids inefficient KsqlConfig copy with overrides

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -163,7 +163,10 @@ final class EngineExecutor {
           queryAnalyzer.analyze(statement.getStatement(), Optional.empty()),
           new PullQueryExecutionUtil.ColumnReferenceRewriter()::process
       );
-      final KsqlConfig ksqlConfig = sessionConfig.getConfig(true);
+      // Do not set sessionConfig.getConfig to true! The copying is inefficient and slows down pull
+      // query performance significantly.  Instead use PullPlannerOptions which check overrides
+      // deliberately.
+      final KsqlConfig ksqlConfig = sessionConfig.getConfig(false);
       final LogicalPlanNode logicalPlan = buildAndValidateLogicalPlan(
           statement, analysis, ksqlConfig, pullPlannerOptions);
       final PullPhysicalPlan physicalPlan = buildPullPhysicalPlan(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -217,7 +217,8 @@ public class LogicalPlanner {
         metaStore,
         ksqlConfig,
         analysis,
-        isWindowed);
+        isWindowed,
+        pullPlannerOptions);
 
     return buildOutputNode(currentNode);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/PullPlannerOptions.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/PullPlannerOptions.java
@@ -18,4 +18,6 @@ package io.confluent.ksql.planner;
 public interface PullPlannerOptions {
 
   boolean getTableScansEnabled();
+
+  boolean getInterpreterEnabled();
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullFilterNode.java
@@ -130,7 +130,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
         source.getSchema().withoutPseudoAndKeyColsInValue(),
         addAdditionalColumnsToIntermediateSchema, isWindowed);
     compiledWhereClause = getExpressionEvaluator(
-        rewrittenPredicate, intermediateSchema, metaStore, ksqlConfig);
+        rewrittenPredicate, intermediateSchema, metaStore, ksqlConfig, pullPlannerOptions);
   }
 
   public Expression getRewrittenPredicate() {
@@ -470,7 +470,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
             metaStore,
             config,
             "pull query",
-            ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED)
+            pullPlannerOptions.getInterpreterEnabled()
         ).resolve(exp);
       }
 
@@ -618,7 +618,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
             metaStore,
             ksqlConfig,
             "pull query window bounds extractor",
-            ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED)
+            pullPlannerOptions.getInterpreterEnabled()
         ).resolve(other);
 
         return Instant.ofEpochMilli(value);
@@ -882,9 +882,10 @@ public class PullFilterNode extends SingleSourcePlanNode {
       final Expression expression,
       final LogicalSchema schema,
       final MetaStore metaStore,
-      final KsqlConfig ksqlConfig) {
+      final KsqlConfig ksqlConfig,
+      final PullPlannerOptions pullPlannerOptions) {
 
-    if (ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED)) {
+    if (pullPlannerOptions.getInterpreterEnabled()) {
       return InterpretedExpressionFactory.create(
           expression,
           schema,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullProjectNodeTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.SingleColumn;
+import io.confluent.ksql.planner.PullPlannerOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -87,6 +88,8 @@ public class PullProjectNodeTest {
   private KsqlTopic ksqlTopic;
   @Mock
   private KeyFormat keyFormat;
+  @Mock
+  private PullPlannerOptions plannerOptions;
 
 
   private List<SelectItem> selects;
@@ -117,7 +120,8 @@ public class PullProjectNodeTest {
         metaStore,
         ksqlConfig,
         analysis,
-        false
+        false,
+        plannerOptions
     );
 
     // Then:
@@ -140,7 +144,8 @@ public class PullProjectNodeTest {
         metaStore,
         ksqlConfig,
         analysis,
-        true
+        true,
+        plannerOptions
     );
 
     // Then:
@@ -162,7 +167,8 @@ public class PullProjectNodeTest {
         metaStore,
         ksqlConfig,
         analysis,
-        false
+        false,
+        plannerOptions
     );
 
     // Then:
@@ -183,7 +189,8 @@ public class PullProjectNodeTest {
         metaStore,
         ksqlConfig,
         analysis,
-        false
+        false,
+        plannerOptions
     );
 
     // Then:
@@ -217,7 +224,8 @@ public class PullProjectNodeTest {
         metaStore,
         ksqlConfig,
         analysis,
-        true
+        true,
+        plannerOptions
     );
 
     // Then:
@@ -253,7 +261,8 @@ public class PullProjectNodeTest {
         metaStore,
         ksqlConfig,
         analysis,
-        true
+        true,
+        plannerOptions
     );
 
     // Then:
@@ -281,7 +290,8 @@ public class PullProjectNodeTest {
         metaStore,
         ksqlConfig,
         analysis,
-        false
+        false,
+        plannerOptions
     );
 
     // Then:

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryConfigPlannerOptions.java
@@ -45,4 +45,12 @@ public class PullQueryConfigPlannerOptions implements PullPlannerOptions {
     }
     return configured;
   }
+
+  @Override
+  public boolean getInterpreterEnabled() {
+    if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED)) {
+      return (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED);
+    }
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED);
+  }
 }


### PR DESCRIPTION
### Description 
The call to `sessionConfig.getConfig(true);` copies fields of ksqlconfig in order to apply overrides.  This is very inefficient, slowing pull query performance locally on my Mac from 10k qps for key lookups to 6k, a 40% reduction.

I had made this change recently with #7006 so that the interpreter override would be available for pull queries.  It had this unfortunate effect.  The solution is to avoid the large copy and check overrides deliberately.  We already have a pattern for this in `PullQueryConfigPlannerOptions`.

### Testing done 
Ran unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

