### PR TITLE
chore: improve error message for custom type parsing

### DIFF
--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultKsqlParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultKsqlParser.java
@@ -37,7 +37,7 @@ import org.antlr.v4.runtime.misc.ParseCancellationException;
 public class DefaultKsqlParser implements KsqlParser {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
-  private static final BaseErrorListener ERROR_VALIDATOR = new SyntaxErrorValidator();
+  public static final BaseErrorListener ERROR_VALIDATOR = new SyntaxErrorValidator();
 
   @Override
   public List<ParsedStatement> parse(final String sql) {

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/schema/ksql/SqlTypeParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/schema/ksql/SqlTypeParserTest.java
@@ -174,4 +174,25 @@ public class SqlTypeParserTest {
         "Value must be integer for command: DECIMAL(SCALE)"
     ));
   }
+
+  @Test
+  public void shouldThrowMeaningfulErrorOnBadStructDeclaration() {
+    // Given:
+    final String schemaString = "STRUCT<foo VARCHAR,>";
+
+    // When:
+    final KsqlException e = assertThrows(
+        KsqlException.class,
+        () -> parser.parse(schemaString)
+    );
+
+    // Then:
+    System.out.println(e.getMessage());
+    assertThat(e.getMessage(), containsString(
+        "Failed to parse: STRUCT<foo VARCHAR,>"
+    ));
+    assertThat(e.getCause().getMessage(), containsString(
+        "line 1:20: mismatched input '>'"
+    ));
+  }
 }


### PR DESCRIPTION
### Description 

fixes #7077

Improves the error message when encountering a bad type in parsing UDFs. This was particularly salient when the parser was parsing a sub-type with an empty token (e.g. `STRUCT<foo VARCHAR,>`) because the error message would be empty.

### Testing done 

Unit testing, e2e testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

