### PR TITLE
chore(migrations): fail early on unsupported sql statements

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -340,6 +340,7 @@ public class ApplyMigrationCommand extends BaseCommand {
     } else if (command instanceof SqlInsertValues) {
       final List<FieldInfo> fields =
           ksqlClient.describeSource(((SqlInsertValues) command).getSourceName()).get().fields();
+      // TODO: fix case-sensitivity
       ksqlClient.insertInto(
           ((SqlInsertValues) command).getSourceName(),
           getRow(
@@ -347,10 +348,10 @@ public class ApplyMigrationCommand extends BaseCommand {
               ((SqlInsertValues) command).getColumns(),
               ((SqlInsertValues) command).getValues())).get();
     } else if (command instanceof SqlConnectorStatement) {
-      final RestResponse<KsqlEntityList> respose
-          = restClient.makeKsqlRequest(command.getCommand());
-      if (!respose.isSuccessful()) {
-        throw new MigrationException(respose.getErrorMessage().getMessage());
+      final RestResponse<KsqlEntityList> response =
+          restClient.makeKsqlRequest(command.getCommand());
+      if (!response.isSuccessful()) {
+        throw new MigrationException(response.getErrorMessage().getMessage());
       }
     } else if (command instanceof SqlPropertyCommand) {
       if (((SqlPropertyCommand) command).isSetCommand()

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -392,7 +392,10 @@ public class ApplyMigrationCommand extends BaseCommand {
     return new KsqlObject(row);
   }
 
-  private static void verifyColumnValuesMatch(final List<String> columns, final List<Expression> values) {
+  private static void verifyColumnValuesMatch(
+      final List<String> columns,
+      final List<Expression> values
+  ) {
     if (columns.size() != values.size()) {
       throw new MigrationException(String.format("Invalid `INSERT VALUES` statement. Number of "
           + "columns and values must match. Got: Columns: %d. Values: %d.",

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommand.java
@@ -70,6 +70,10 @@ public class CreateMigrationCommand extends BaseCommand {
 
   @Override
   protected int command() {
+    if (!validateConfigFilePresent()) {
+      return 1;
+    }
+
     return command(getMigrationsDirFromConfigFile(getConfigFile()));
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.metastore.TypeRegistry;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.AstBuilder;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser;
@@ -171,7 +172,7 @@ public final class CommandParser {
       return ((CreateArrayExpression) expressionValue)
           .getValues()
           .stream()
-          .map(val -> toFieldType(val)).collect(Collectors.toList());
+          .map(CommandParser::toFieldType).collect(Collectors.toList());
     } else if (expressionValue instanceof CreateMapExpression) {
       final Map<Object, Object> resolvedMap = new HashMap<>();
       ((CreateMapExpression) expressionValue).getMap()
@@ -180,7 +181,7 @@ public final class CommandParser {
     } else if (expressionValue instanceof CreateStructExpression) {
       final Map<Object, Object> resolvedStruct = new HashMap<>();
       ((CreateStructExpression) expressionValue)
-          .getFields().stream().forEach(
+          .getFields().forEach(
               field -> resolvedStruct.put(field.getName(), toFieldType(field.getValue())));
       return resolvedStruct;
     }
@@ -212,7 +213,7 @@ public final class CommandParser {
             parsedStatement.getTarget().text(),
             parsedStatement.getValues(),
             parsedStatement.getColumns().stream()
-                .map(name -> name.text()).collect(Collectors.toList()));
+                .map(ColumnName::text).collect(Collectors.toList()));
       case CONNECTOR:
         return new SqlConnectorStatement(sql);
       case STATEMENT:

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
@@ -16,15 +16,21 @@
 package io.confluent.ksql.tools.migrations.util;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.ClientOptions;
+import io.confluent.ksql.rest.client.BasicCredentials;
+import io.confluent.ksql.rest.client.KsqlClient;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.MigrationException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import org.apache.kafka.common.config.SslConfigs;
 
 public final class MigrationsUtil {
 
@@ -118,11 +124,37 @@ public final class MigrationsUtil {
   }
 
   public static KsqlRestClient createRestClient(final MigrationConfig config) {
+    final String ksqlServerUrl = config.getString(MigrationConfig.KSQL_SERVER_URL);
+
+    final boolean useTls = ksqlServerUrl.trim().toLowerCase().startsWith("https://");
+    final Map<String, String> clientProps = new HashMap<>();
+    if (useTls) {
+      clientProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, config.getString(MigrationConfig.SSL_TRUSTSTORE_LOCATION));
+      clientProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, config.getString(MigrationConfig.SSL_TRUSTSTORE_PASSWORD));
+      clientProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, config.getString(MigrationConfig.SSL_KEYSTORE_LOCATION));
+      clientProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, config.getString(MigrationConfig.SSL_KEYSTORE_PASSWORD));
+      clientProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, config.getString(MigrationConfig.SSL_KEY_PASSWORD));
+      clientProps.put(KsqlClient.SSL_KEYSTORE_ALIAS_CONFIG, config.getString(MigrationConfig.SSL_KEY_ALIAS));
+      if (config.getBoolean(MigrationConfig.SSL_VERIFY_HOST)) {
+        clientProps.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "https");
+      }
+      // rest client doesn't set alpn anywhere, so MigrationConfig.SSL_ALPN is ignored
+    }
+
+    final String username = config.getString(MigrationConfig.KSQL_BASIC_AUTH_USERNAME);
+    final String password = config.getString(MigrationConfig.KSQL_BASIC_AUTH_PASSWORD);
+    final Optional<BasicCredentials> basicAuthCreds;
+    if (!Strings.isNullOrEmpty(username) || !Strings.isNullOrEmpty(password)) {
+      basicAuthCreds = Optional.of(BasicCredentials.of(username, password));
+    } else {
+      basicAuthCreds = Optional.empty();
+    }
+
     return KsqlRestClient.create(
-        config.getString(MigrationConfig.KSQL_SERVER_URL),
+        ksqlServerUrl,
         Collections.EMPTY_MAP,
-        Collections.EMPTY_MAP,
-        Optional.empty()
+        clientProps,
+        basicAuthCreds
     );
   }
 }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
@@ -129,16 +129,28 @@ public final class MigrationsUtil {
     final boolean useTls = ksqlServerUrl.trim().toLowerCase().startsWith("https://");
     final Map<String, String> clientProps = new HashMap<>();
     if (useTls) {
-      clientProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, config.getString(MigrationConfig.SSL_TRUSTSTORE_LOCATION));
-      clientProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, config.getString(MigrationConfig.SSL_TRUSTSTORE_PASSWORD));
-      clientProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, config.getString(MigrationConfig.SSL_KEYSTORE_LOCATION));
-      clientProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, config.getString(MigrationConfig.SSL_KEYSTORE_PASSWORD));
-      clientProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, config.getString(MigrationConfig.SSL_KEY_PASSWORD));
-      clientProps.put(KsqlClient.SSL_KEYSTORE_ALIAS_CONFIG, config.getString(MigrationConfig.SSL_KEY_ALIAS));
+      clientProps.put(
+          SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+          config.getString(MigrationConfig.SSL_TRUSTSTORE_LOCATION));
+      clientProps.put(
+          SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+          config.getString(MigrationConfig.SSL_TRUSTSTORE_PASSWORD));
+      clientProps.put(
+          SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+          config.getString(MigrationConfig.SSL_KEYSTORE_LOCATION));
+      clientProps.put(
+          SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
+          config.getString(MigrationConfig.SSL_KEYSTORE_PASSWORD));
+      clientProps.put(
+          SslConfigs.SSL_KEY_PASSWORD_CONFIG,
+          config.getString(MigrationConfig.SSL_KEY_PASSWORD));
+      clientProps.put(
+          KsqlClient.SSL_KEYSTORE_ALIAS_CONFIG,
+          config.getString(MigrationConfig.SSL_KEY_ALIAS));
       if (config.getBoolean(MigrationConfig.SSL_VERIFY_HOST)) {
         clientProps.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "https");
       }
-      // rest client doesn't set alpn anywhere, so MigrationConfig.SSL_ALPN is ignored
+      // rest client doesn't set ALPN anywhere, so MigrationConfig.SSL_ALPN is ignored
     }
 
     final String username = config.getString(MigrationConfig.KSQL_BASIC_AUTH_USERNAME);

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -302,7 +302,7 @@ public class MigrationsTest {
 
     // verify config file contents
     final List<String> lines = Files.readAllLines(configFile.toPath());
-    assertThat(lines, hasSize(31));
+    assertThat(lines, hasSize(22));
     assertThat(lines.get(0), is(MigrationConfig.KSQL_SERVER_URL + "=" + REST_APP.getHttpListener().toString()));
   }
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
@@ -41,37 +41,28 @@ public class NewMigrationCommandTest {
 
   private static final String KSQL_SERVER_URL = "http://localhost:8088";
 
-  private static final String DEFAULT_CONFIGS = "ksql.server.url=http://localhost:8088\n"
-      + "# The key store path\n"
-      + "# ssl.keystore.location=null\n"
-      + "# The name of the migration table. It defaults to MIGRATION_SCHEMA_VERSIONS\n"
-      + "# ksql.migrations.table.name=MIGRATION_SCHEMA_VERSIONS\n"
-      + "# The username for the KSQL server\n"
-      + "# ksql.auth.basic.username=null\n"
-      + "# The password for the KSQL server\n"
-      + "# ksql.auth.basic.password=null\n"
-      + "# The name of the migration stream topic. It defaults to '<ksql_service_id>ksql_<migrations_stream_name>'\n"
-      + "# ksql.migrations.stream.topic.name=ksql-service-idksql_MIGRATION_EVENTS\n"
-      + "# The name of the migration table topic. It defaults to '<ksql_service_id>ksql_<migrations_table_name>'\n"
-      + "# ksql.migrations.table.topic.name=ksql-service-idksql_MIGRATION_SCHEMA_VERSIONS\n"
-      + "# The trust store path\n"
-      + "# ssl.truststore.location=null\n"
-      + "# The key store password\n"
-      + "# ssl.keystore.password=null\n"
-      + "# The number of replicas for the migration stream topic. It defaults to 1\n"
-      + "# ksql.migrations.topic.replicas=1\n"
-      + "# The key password\n"
-      + "# ssl.key.password=null\n"
-      + "# Whether hostname verification is enabled. It defaults to true.\n"
-      + "# ssl.verify.host=true\n"
-      + "# The trust store password\n"
-      + "# ssl.truststore.password=null\n"
-      + "# The key alias\n"
-      + "# ssl.key.alias=null\n"
-      + "# The name of the migration stream. It defaults to MIGRATION_EVENTS\n"
-      + "# ksql.migrations.stream.name=MIGRATION_EVENTS\n"
-      + "# Whether ALPN should be used. It defaults to false.\n"
-      + "# ssl.alpn=false\n";
+  private static final String DEFAULT_CONFIGS = "ksql.server.url=" + KSQL_SERVER_URL + "\n" +
+      "\n" +
+      "# Migrations metadata configs:\n" +
+      "# ksql.migrations.stream.name=MIGRATION_EVENTS\n" +
+      "# ksql.migrations.table.name=MIGRATION_SCHEMA_VERSIONS\n" +
+      "# ksql.migrations.stream.topic.name=ksql-service-idksql_MIGRATION_EVENTS\n" +
+      "# ksql.migrations.table.topic.name=ksql-service-idksql_MIGRATION_SCHEMA_VERSIONS\n" +
+      "# ksql.migrations.topic.replicas=1\n" +
+      "\n" +
+      "# TLS configs:\n" +
+      "# ssl.truststore.location=\n" +
+      "# ssl.truststore.password=\n" +
+      "# ssl.keystore.location=\n" +
+      "# ssl.keystore.password=\n" +
+      "# ssl.key.password=\n" +
+      "# ssl.key.alias=\n" +
+      "# ssl.alpn=false\n" +
+      "# ssl.verify.host=true\n" +
+      "\n" +
+      "# ksqlDB server authentication configs:\n" +
+      "# ksql.auth.basic.username=\n" +
+      "# ksql.auth.basic.password=\n";
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -230,8 +230,6 @@ public class CommandParserTest {
     assertThat(commands.get(0).getCommand(), is("drop type address;"));
   }
 
-  // TODO: check we have unit tests for set and unset
-
   @Test
   public void shouldParseSeveralCommands() {
     // When:

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.tools.migrations.util;
 
 import static io.confluent.ksql.tools.migrations.util.CommandParser.toFieldType;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
@@ -83,6 +84,16 @@ public class CommandParserTest {
     assertThat(insertValues.getColumns(), is(ImmutableList.of("col1")));
     assertThat(insertValues.getValues().size(), is(1));
     assertThat(toFieldType(insertValues.getValues().get(0)), is(55));
+  }
+
+  @Test
+  public void shouldThrowOnInvalidInsertValues() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("insert into foo values (this_should_not_here) ('val');"));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Failed to parse INSERT VALUES statement"));
   }
 
   @Test
@@ -322,6 +333,16 @@ public class CommandParserTest {
 
     // Then:
     assertThat(e.getMessage(), is("Invalid sql - failed to find closing token '''"));
+  }
+
+  @Test
+  public void shouldThrowOnMissingSemicolon() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("create stream foo as select * from no_semicolon_after_this"));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Unmatched command at end of file; missing semicolon"));
   }
 
   @Test

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -164,11 +164,112 @@ public class CommandParserTest {
   }
 
   @Test
-  public void shouldThowOnMalformedComment() throws Exception {
+  public void shouldThrowOnMalformedComment() {
     // When:
     final MigrationException e = assertThrows(MigrationException.class,
         () -> CommandParser.splitSql("/* Comment "));
+
     // Then:
     assertThat(e.getMessage(), is("Invalid sql - failed to find closing token '*/'"));
+  }
+
+  @Test
+  public void shouldThrowOnMalformedQuote() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.splitSql("select 'unclosed quote;"));
+
+    // Then:
+    assertThat(e.getMessage(), is("Invalid sql - failed to find closing token '''"));
+  }
+
+  @Test
+  public void shouldThrowOnDefineStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("define var = 'value';"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'DEFINE' statements are not supported."));
+  }
+
+  @Test
+  public void shouldThrowOnUndefineStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("undefine var;"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'UNDEFINE' statements are not supported."));
+  }
+
+  @Test
+  public void shouldThrowOnDescribeStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("describe my_stream;"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'DESCRIBE' statements are not supported."));
+  }
+
+  @Test
+  public void shouldThrowOnExplainStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("explain my_query_id;"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'EXPLAIN' statements are not supported."));
+  }
+
+  @Test
+  public void shouldThrowOnSelectStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("select * from my_stream emit changes;"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'SELECT' statements are not supported."));
+  }
+
+  @Test
+  public void shouldThrowOnPrintStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("print 'my_topic';"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'PRINT' statements are not supported."));
+  }
+
+  @Test
+  public void shouldThrowOnShowStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("show connectors;"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'SHOW' statements are not supported."));
+  }
+
+  @Test
+  public void shouldThrowOnListStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("list queries;"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'LIST' statements are not supported."));
+  }
+
+  @Test
+  public void shouldThrowOnRunScriptStatement() {
+    // When:
+    final MigrationException e = assertThrows(MigrationException.class,
+        () -> CommandParser.parse("RUN SCRIPT 'my_script.sql';"));
+
+    // Then:
+    assertThat(e.getMessage(), is("'RUN SCRIPT' statements are not supported."));
   }
 }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -70,6 +70,22 @@ public class CommandParserTest {
   }
 
   @Test
+  public void shouldParseInsertValuesStatementWithExplicitQuoting() {
+    // When:
+    List<SqlCommand> commands = CommandParser.parse("INSERT INTO `foo` (`col1`) VALUES (55);");
+
+    // Then:
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0), instanceOf(SqlInsertValues.class));
+    final SqlInsertValues insertValues = (SqlInsertValues) commands.get(0);
+
+    assertThat(insertValues.getSourceName(), is("foo"));
+    assertThat(insertValues.getColumns(), is(ImmutableList.of("col1")));
+    assertThat(insertValues.getValues().size(), is(1));
+    assertThat(toFieldType(insertValues.getValues().get(0)), is(55));
+  }
+
+  @Test
   public void shouldParseInsertIntoStatement() {
     // When:
     List<SqlCommand> commands = CommandParser.parse("INSERT INTO FOO SELECT VALUES FROM BAR;");


### PR DESCRIPTION
### Description 

This PR contains various minor improvements/fixes to the migrations tool:
- the tool now throws if an unsupported statement type (`DEFINE`, `UNDEFINE`, `DESCRIBE`, `EXPLAIN`, `SELECT`, `PRINT`, `SHOW`, `LIST`, `RUN SCRIPT`) is encountered when applying a migration
- the tool now throws if a migration file contains un-parsed statements at the end (i.e., missing semicolon), rather than silently ignoring such statements
- fixes case-sensitivity of `INSERT VALUES` commands, so we can now insert into case-sensitive streams and streams with case-sensitive field names
- adds a bunch of unit tests, both for negative cases (unsupported statement types) and positive cases (everything we explicitly want to support)
- fixes the case where an invalid `INSERT VALUES` command is thrown, by wrapping the parse exception in a MigrationException
- cleans up the default config file created with `migrations new-project`
- adds support for `CREATE/DROP CONNECTOR` against auth-enabled servers (automated testing will be added in a follow-up PR)
- validates the `--config-file` flag is passed in the `create` command
- other minor, miscellaneous refactors

### Testing done 

Unit tests added. Automated testing for supporting `CREATE/DROP CONNECTOR` against auth-enabled servers will be added in a follow-up PR.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

