### PR TITLE
test(migrations): add auth and more commands to integration test

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
@@ -184,8 +184,8 @@ public final class MigrationConfig extends AbstractConfig {
         configs.get(SSL_TRUSTSTORE_PASSWORD),
         configs.get(SSL_KEYSTORE_LOCATION),
         configs.get(SSL_KEYSTORE_PASSWORD),
-        configs.get(SSL_KEY_ALIAS),
         configs.get(SSL_KEY_PASSWORD),
+        configs.get(SSL_KEY_ALIAS),
         configs.getOrDefault(SSL_ALPN, "false").toLowerCase().equals("true"),
         configs.getOrDefault(SSL_VERIFY_HOST, "true").toLowerCase().equals("true")
     );


### PR DESCRIPTION
### Description 
* Adds all supported commands to the integration test except for `TERMINATE`
* Adds auth to the integration test
* Also fixes a bug in `MigrationsConfig` that mixes up the ssl alias and password

### Testing done 
.
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

