### PR TITLE
chore: fix checkstyle violation on DenyListPropertyValidator

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java
@@ -33,8 +33,9 @@ public class DenyListPropertyValidator {
   private final Set<String> immutableProps;
 
   public DenyListPropertyValidator(final Collection<String> immutableProps) {
-    this.immutableProps = ImmutableSet.<String>builder().addAll(
-        Objects.requireNonNull(immutableProps, "immutableProps")).add(KsqlConfig.KSQL_SERVICE_ID_CONFIG).build();
+    this.immutableProps = ImmutableSet.<String>builder()
+        .addAll(Objects.requireNonNull(immutableProps, "immutableProps"))
+        .add(KsqlConfig.KSQL_SERVICE_ID_CONFIG).build();
   }
 
   /**


### PR DESCRIPTION
### Description 
`confluent-snapshot/master` is failing with a checkstyle violation
```
[2021-03-11T12:05:42.510Z] [ERROR] /home/jenkins/workspace/ntinc_confluent-snapshots_master/prod/ksql/ksqldb-common/src/main/java/io/confluent/ksql/properties/DenyListPropertyValidator.java:37: Line is longer than 100 characters (found 113). [LineLength]
```

This PR fixes it.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

