### PR TITLE
fix: Ensures BaseSubscriber.makeRequest is called on context in PollableSubscriber

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/PollableSubscriber.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/PollableSubscriber.java
@@ -27,10 +27,9 @@ import java.util.function.Consumer;
 import org.reactivestreams.Subscription;
 
 public class PollableSubscriber extends BaseSubscriber<Row> {
-
-  private static final int REQUEST_BATCH_SIZE = 100;
   // 100ms in ns
   private static final long MAX_POLL_NANOS = TimeUnit.MILLISECONDS.toNanos(100);
+  static final int REQUEST_BATCH_SIZE = 100;
 
   private final BlockingQueue<Row> queue = new LinkedBlockingQueue<>();
   private final Consumer<Throwable> errorHandler;
@@ -112,7 +111,7 @@ public class PollableSubscriber extends BaseSubscriber<Row> {
   private void checkRequestTokens() {
     if (tokens == 0) {
       tokens += REQUEST_BATCH_SIZE;
-      runOnRightContext(() -> makeRequest(REQUEST_BATCH_SIZE));
+      context.runOnContext(v -> makeRequest(REQUEST_BATCH_SIZE));
     }
   }
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/PollableSubscriber.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/PollableSubscriber.java
@@ -112,7 +112,7 @@ public class PollableSubscriber extends BaseSubscriber<Row> {
   private void checkRequestTokens() {
     if (tokens == 0) {
       tokens += REQUEST_BATCH_SIZE;
-      makeRequest(REQUEST_BATCH_SIZE);
+      runOnRightContext(() -> makeRequest(REQUEST_BATCH_SIZE));
     }
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/PollableSubscriberTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/PollableSubscriberTest.java
@@ -90,11 +90,13 @@ public class PollableSubscriberTest {
     publisher.subscribe(pollableSubscriber);
 
     Row row = pollableSubscriber.poll(POLL_DURATION);
-    for (int i = 0; row != null; i++) {
+    int i = 0;
+    for (; row != null; i++) {
       Long col1 = row.getLong(COLUMN_NAME);
       assertThat(col1, is((long) i));
       row = pollableSubscriber.poll(POLL_DURATION);
     }
+    assertThat(i, is(numRows));
     assertThat(throwable, is(nullValue()));
   }
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/PollableSubscriberTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/PollableSubscriberTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.client.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.api.client.Row;
+import io.confluent.ksql.reactive.BufferedPublisher;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+
+public class PollableSubscriberTest {
+  private static Duration POLL_DURATION = Duration.ofMillis(100);
+  private static String COLUMN_NAME = "id";
+
+  private Publisher<Row> publisher;
+
+  private Vertx vertx;
+  private Throwable throwable;
+  private Context context;
+  private PollableSubscriber pollableSubscriber;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+    context = vertx.getOrCreateContext();
+    pollableSubscriber = new PollableSubscriber(context, t -> throwable = t);
+  }
+
+  @Test
+  public void shouldPollSingleBatch() {
+    shouldPollRows(PollableSubscriber.REQUEST_BATCH_SIZE - 10);
+  }
+
+  @Test
+  public void shouldPollMultiBatch() {
+    shouldPollRows(PollableSubscriber.REQUEST_BATCH_SIZE + 10);
+  }
+
+  @Test
+  public void shouldSetError() {
+    publisher = new BufferedPublisher<Row>(context, ImmutableList.of()) {
+      @Override
+      protected void maybeSend() {
+        sendError(new RuntimeException("Error!"));
+      }
+    };
+
+    publisher.subscribe(pollableSubscriber);
+
+    Row row = pollableSubscriber.poll(POLL_DURATION);
+    assertThat(row, is(nullValue()));
+    assertThat(throwable, is(notNullValue()));
+    assertThat(throwable.getMessage(), is("Error!"));
+  }
+
+  private void shouldPollRows(int numRows) {
+    final List<Row> rows = new ArrayList<>();
+    for (int i = 0; i < numRows; i++) {
+      rows.add(createRow(i));
+    }
+
+    publisher = new BufferedPublisher<>(context, rows);
+
+    publisher.subscribe(pollableSubscriber);
+
+    Row row = pollableSubscriber.poll(POLL_DURATION);
+    for (int i = 0; row != null; i++) {
+      Long col1 = row.getLong(COLUMN_NAME);
+      assertThat(col1, is((long) i));
+      row = pollableSubscriber.poll(POLL_DURATION);
+    }
+    assertThat(throwable, is(nullValue()));
+  }
+
+  private Row createRow(long id) {
+    return new RowImpl(
+        ImmutableList.of(COLUMN_NAME),
+        ImmutableList.of(new ColumnTypeImpl("BIGINT")),
+        new JsonArray().add(id),
+        ImmutableMap.of(COLUMN_NAME, 1));
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BaseSubscriber.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BaseSubscriber.java
@@ -147,7 +147,7 @@ public class BaseSubscriber<T> implements Subscriber<T> {
     VertxUtils.checkContext(context);
   }
 
-  protected void runOnRightContext(final Runnable runnable) {
+  private void runOnRightContext(final Runnable runnable) {
     if (VertxUtils.isEventLoopAndSameContext(context)) {
       // Execute directly
       runnable.run();

--- a/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BaseSubscriber.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BaseSubscriber.java
@@ -147,7 +147,7 @@ public class BaseSubscriber<T> implements Subscriber<T> {
     VertxUtils.checkContext(context);
   }
 
-  private void runOnRightContext(final Runnable runnable) {
+  protected void runOnRightContext(final Runnable runnable) {
     if (VertxUtils.isEventLoopAndSameContext(context)) {
       // Execute directly
       runnable.run();


### PR DESCRIPTION
### Description 

Fixes a small bug where `BaseSubscriber.makeRequest` can be called from outside the Vertx context, which should be disallowed.

`makeRequest` is called from `checkRequestTokens` and there are currently a few paths into `checkRequestTokens`:
- One is `afterSubscribe` which is called from the context
- The other is `poll` which is inherently blocking and shouldn't be called from the context.

For this reason, this PR exposes `runOnRightContext` and invokes `makeRequest` using that.

Fixes #7115 

### Testing done 
Ran tests and manually exercised this path by fetching more than the batch size.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

