### PR TITLE
chore: bump clients and connect logging level to INFO

### DIFF
--- a/config/log4j-rolling.properties
+++ b/config/log4j-rolling.properties
@@ -66,7 +66,11 @@ log4j.additivity.processing=false
 log4j.logger.org.apache.kafka.streams=INFO, streams
 log4j.additivity.org.apache.kafka.streams=false
 
-## Kafka client logs:
+## Kafka Clients logs:
+log4j.logger.org.apache.kafka.clients=INFO, clients
+log4j.additivity.org.apache.kafka.clients=false
+
+## Other Kafka logs:
 log4j.logger.kafka=WARN, kafka
 log4j.additivity.kafka=false
 

--- a/config/log4j-rolling.properties
+++ b/config/log4j-rolling.properties
@@ -70,6 +70,10 @@ log4j.additivity.org.apache.kafka.streams=false
 log4j.logger.org.apache.kafka.clients=INFO, clients
 log4j.additivity.org.apache.kafka.clients=false
 
+## Kafka Connect logs:
+log4j.logger.org.apache.kafka.connect=INFO, connect
+log4j.additivity.org.apache.kafka.connect=false
+
 ## Other Kafka logs:
 log4j.logger.kafka=WARN, kafka
 log4j.additivity.kafka=false

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -39,9 +39,12 @@ log4j.logger.org.reflections=ERROR, stdout
 log4j.logger.org.apache.kafka.streams=INFO, streams
 log4j.additivity.org.apache.kafka.streams=false
 
+## Kafka Clients logs:
+log4j.logger.org.apache.kafka.clients=INFO, clients
+log4j.additivity.org.apache.kafka.clients=false
+
 ## Kafka logs:
 log4j.logger.kafka=WARN, stdout
 log4j.logger.org.apache.zookeeper=WARN, stdout
 log4j.logger.org.apache.kafka=WARN, stdout
-log4j.logger.org.apache.kafka.clients=INFO, stdout
 log4j.logger.org.I0Itec.zkclient=WARN, stdout

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -39,8 +39,9 @@ log4j.logger.org.reflections=ERROR, stdout
 log4j.logger.org.apache.kafka.streams=INFO, streams
 log4j.additivity.org.apache.kafka.streams=false
 
-## Kafka Client logs:
+## Kafka logs:
 log4j.logger.kafka=WARN, stdout
 log4j.logger.org.apache.zookeeper=WARN, stdout
 log4j.logger.org.apache.kafka=WARN, stdout
+log4j.logger.org.apache.kafka.clients=INFO, stdout
 log4j.logger.org.I0Itec.zkclient=WARN, stdout

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -43,7 +43,11 @@ log4j.additivity.org.apache.kafka.streams=false
 log4j.logger.org.apache.kafka.clients=INFO, clients
 log4j.additivity.org.apache.kafka.clients=false
 
-## Kafka logs:
+## Kafka Connect logs:
+log4j.logger.org.apache.kafka.connect=INFO, connect
+log4j.additivity.org.apache.kafka.connect=false
+
+## Other Kafka logs:
 log4j.logger.kafka=WARN, stdout
 log4j.logger.org.apache.zookeeper=WARN, stdout
 log4j.logger.org.apache.kafka=WARN, stdout


### PR DESCRIPTION
The consumer and producer logs in particular are often critical for telling the whole story. They should be logged at the same level as Streams itself by default.