### PR TITLE
feat: update sourcedescription and errorstats to have statistics as structured objects

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.api.client.util.ClientTestUtil.TestSubscriber;
 import io.confluent.ksql.api.client.util.RowUtil;
 import io.confluent.ksql.api.server.KsqlApiException;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
+import io.confluent.ksql.metrics.TopicSensors.Stat;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.query.QueryId;
@@ -129,6 +130,10 @@ public class ClientTest extends BaseApiTest {
   protected static final String EXECUTE_STATEMENT_USAGE_DOC = "The executeStatement() method is only "
       + "for 'CREATE', 'CREATE ... AS SELECT', 'DROP', 'TERMINATE', and 'INSERT INTO ... AS "
       + "SELECT' statements. ";
+
+  protected static final Stat STAT =  new Stat("TEST", 0, 0);
+
+  protected static final ImmutableMap<String, Stat> IMMUTABLE_MAP = new ImmutableMap.Builder<String, Stat>().put("TEST", STAT).build();
 
   protected Client javaClient;
 
@@ -918,6 +923,8 @@ public class ClientTest extends BaseApiTest {
             "timestamp",
             "statistics",
             "errorStats",
+            IMMUTABLE_MAP,
+            IMMUTABLE_MAP,
             false,
             "keyFormat",
             "valueFormat",
@@ -1348,6 +1355,8 @@ public class ClientTest extends BaseApiTest {
             "",
             "",
             "",
+            IMMUTABLE_MAP,
+            IMMUTABLE_MAP,
             false,
             "KAFKA",
             "JSON",

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.cli.console.table.builder.TablesListTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.TopicDescriptionTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.TypeListTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.WarningEntityTableBuilder;
+import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.rest.ApiJsonMapper;
@@ -665,8 +666,8 @@ public class Console implements Closeable {
         "Local runtime statistics",
         "------------------------"
     ));
-    writer().println(source.getStatistics());
-    writer().println(source.getErrorStats());
+    writer().println(MetricCollectors.format(source.getStatisticsMap().values(), "last-message"));
+    writer().println(MetricCollectors.format(source.getErrorStatsMap().values(), "last-message"));
     writer().println(String.format(
         "(%s)",
         "Statistics of the local KSQL server interaction with the Kafka topic "

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.TestTerminal;
 import io.confluent.ksql.cli.console.Console.NoOpRowCaptor;
 import io.confluent.ksql.cli.console.cmd.CliSpecificCommand;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.metrics.TopicSensors.Stat;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryError.Type;
@@ -120,6 +121,8 @@ public class ConsoleTest {
   private static final String NEWLINE = System.lineSeparator();
   private static final String STATUS_COUNT_STRING = "RUNNING:1,ERROR:2";
   private static final String AGGREGATE_STATUS = "ERROR";
+  protected static final Stat STAT =  new Stat("TEST", 0, 0);
+  protected static final ImmutableMap<String, Stat> IMMUTABLE_MAP = new ImmutableMap.Builder<String, Stat>().put("TEST", STAT).build();
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("foo"), SqlTypes.INTEGER)
@@ -140,6 +143,8 @@ public class ConsoleTest {
       "2000-01-01",
       "stats",
       "errors",
+      IMMUTABLE_MAP,
+      IMMUTABLE_MAP,
       true,
       "kafka",
       "avro",
@@ -541,6 +546,8 @@ public class ConsoleTest {
                 "2000-01-01",
                 "stats",
                 "errors",
+                IMMUTABLE_MAP,
+                IMMUTABLE_MAP,
                 false,
                 "kafka",
                 "avro",
@@ -672,8 +679,10 @@ public class ConsoleTest {
           + "    } ]," + NEWLINE
           + "    \"type\" : \"TABLE\"," + NEWLINE
           + "    \"timestamp\" : \"2000-01-01\"," + NEWLINE
-          + "    \"statistics\" : \"stats\"," + NEWLINE
-          + "    \"errorStats\" : \"errors\"," + NEWLINE
+          + "    \"statistics\" : \"The statistics field is deprecated and will be removed in a future version of ksql. Please update your client to the latest version and use statisticsMap instead.\\nstats\"," + NEWLINE
+          + "    \"errorStats\" : \"The errorStats field is deprecated and will be removed in a future version of ksql. Please update your client to the latest version and use errorStatsMap instead.\\nerrors\\n\"," + NEWLINE
+          + "    \"statisticsMap\" : {" + NEWLINE + "      \"TEST\" : {" + NEWLINE + "        \"name\" : \"TEST\"," + NEWLINE + "        \"value\" : 0.0," + NEWLINE + "        \"timestamp\" : 0" + NEWLINE + "      }" + NEWLINE + "    }," + NEWLINE
+          + "    \"errorStatsMap\" : {" + NEWLINE + "      \"TEST\" : {" + NEWLINE + "        \"name\" : \"TEST\"," + NEWLINE + "        \"value\" : 0.0," + NEWLINE + "        \"timestamp\" : 0" + NEWLINE + "      }" + NEWLINE + "    }," + NEWLINE
           + "    \"extended\" : false," + NEWLINE
           + "    \"keyFormat\" : \"kafka\"," + NEWLINE
           + "    \"valueFormat\" : \"avro\"," + NEWLINE
@@ -812,8 +821,10 @@ public class ConsoleTest {
           + "    } ]," + NEWLINE
           + "    \"type\" : \"TABLE\"," + NEWLINE
           + "    \"timestamp\" : \"2000-01-01\"," + NEWLINE
-          + "    \"statistics\" : \"stats\"," + NEWLINE
-          + "    \"errorStats\" : \"errors\"," + NEWLINE
+          + "    \"statistics\" : \"The statistics field is deprecated and will be removed in a future version of ksql. Please update your client to the latest version and use statisticsMap instead.\\nstats\"," + NEWLINE
+          + "    \"errorStats\" : \"The errorStats field is deprecated and will be removed in a future version of ksql. Please update your client to the latest version and use errorStatsMap instead.\\nerrors\\n\"," + NEWLINE
+          + "    \"statisticsMap\" : {" + NEWLINE + "      \"TEST\" : {" + NEWLINE + "        \"name\" : \"TEST\"," + NEWLINE + "        \"value\" : 0.0," + NEWLINE + "        \"timestamp\" : 0" + NEWLINE + "      }" + NEWLINE + "    }," + NEWLINE
+          + "    \"errorStatsMap\" : {" + NEWLINE + "      \"TEST\" : {" + NEWLINE + "        \"name\" : \"TEST\"," + NEWLINE + "        \"value\" : 0.0," + NEWLINE + "        \"timestamp\" : 0" + NEWLINE + "      }" + NEWLINE + "    }," + NEWLINE
           + "    \"extended\" : true," + NEWLINE
           + "    \"keyFormat\" : \"kafka\"," + NEWLINE
           + "    \"valueFormat\" : \"avro\"," + NEWLINE
@@ -1116,6 +1127,8 @@ public class ConsoleTest {
                 "2000-01-01",
                 "stats",
                 "errors",
+                IMMUTABLE_MAP,
+                IMMUTABLE_MAP,
                 true,
                 "json",
                 "avro",
@@ -1202,8 +1215,10 @@ public class ConsoleTest {
           + "    } ]," + NEWLINE
           + "    \"type\" : \"TABLE\"," + NEWLINE
           + "    \"timestamp\" : \"2000-01-01\"," + NEWLINE
-          + "    \"statistics\" : \"stats\"," + NEWLINE
-          + "    \"errorStats\" : \"errors\"," + NEWLINE
+          + "    \"statistics\" : \"The statistics field is deprecated and will be removed in a future version of ksql. Please update your client to the latest version and use statisticsMap instead.\\nstats\"," + NEWLINE
+          + "    \"errorStats\" : \"The errorStats field is deprecated and will be removed in a future version of ksql. Please update your client to the latest version and use errorStatsMap instead.\\nerrors\\n\"," + NEWLINE
+          + "    \"statisticsMap\" : {" + NEWLINE + "      \"TEST\" : {" + NEWLINE + "        \"name\" : \"TEST\"," + NEWLINE + "        \"value\" : 0.0," + NEWLINE + "        \"timestamp\" : 0" + NEWLINE + "      }" + NEWLINE + "    }," + NEWLINE
+          + "    \"errorStatsMap\" : {" + NEWLINE + "      \"TEST\" : {" + NEWLINE + "        \"name\" : \"TEST\"," + NEWLINE + "        \"value\" : 0.0," + NEWLINE + "        \"timestamp\" : 0" + NEWLINE + "      }" + NEWLINE + "    }," + NEWLINE
           + "    \"extended\" : true," + NEWLINE
           + "    \"keyFormat\" : \"json\"," + NEWLINE
           + "    \"valueFormat\" : \"avro\"," + NEWLINE
@@ -1283,8 +1298,8 @@ public class ConsoleTest {
           + "" + NEWLINE
           + "Local runtime statistics" + NEWLINE
           + "------------------------" + NEWLINE
-          + "stats" + NEWLINE
-          + "errors" + NEWLINE
+          + "            TEST:         0     last-message:       n/a" + NEWLINE
+          + "            TEST:         0     last-message:       n/a" + NEWLINE
           + "(Statistics of the local KSQL server interaction with the Kafka topic kadka-topic)"
           + NEWLINE
           + NEWLINE

--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
@@ -156,7 +156,7 @@ public final class MetricCollectors {
     collectorMap.remove(id);
   }
 
-  static Map<String, TopicSensors.Stat> getStatsFor(
+  public static Map<String, TopicSensors.Stat> getStatsFor(
       final String topic, final boolean isError) {
     return getAggregateMetrics(
         collectorMap.values().stream()
@@ -185,7 +185,7 @@ public final class MetricCollectors {
     return results;
   }
 
-  private static String format(
+  public static String format(
       final Collection<TopicSensors.Stat> stats,
       final String lastEventTimestampMsg) {
     final StringBuilder results = new StringBuilder();

--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/TopicSensors.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/TopicSensors.java
@@ -15,9 +15,19 @@
 
 package io.confluent.ksql.metrics;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.MoreObjects;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.common.utils.Time;
+import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -30,7 +40,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Rate;
 
-class TopicSensors<R> {
+public class TopicSensors<R> {
 
   private final String topic;
   private final List<SensorMetric<R>> sensors;
@@ -70,14 +80,16 @@ class TopicSensors<R> {
         .map(SensorMetric::asStat)
         .collect(Collectors.toList());
   }
-
-  static class Stat {
+  
+  @JsonDeserialize(using = StatDeserializer.class)
+  @JsonSerialize(using = StatSerializer.class)
+  public static class Stat {
 
     private final String name;
     private double value;
     private final long timestamp;
 
-    Stat(final String name, final double value, final long timestamp) {
+    public Stat(final String name, final double value, final long timestamp) {
       this.name = name;
       this.value = value;
       this.timestamp = timestamp;
@@ -160,6 +172,40 @@ class TopicSensors<R> {
     public Stat aggregate(final double value) {
       this.value += value;
       return this;
+    }
+  }
+
+
+  public static class StatDeserializer extends JsonDeserializer<Stat> {
+
+    @Override
+    public Stat deserialize(
+        final JsonParser jp,
+        final DeserializationContext ctxt
+    ) throws IOException {
+      final JsonNode node = jp.getCodec().readTree(jp);
+
+      final String name = node.get("name").textValue();
+      final double value = node.get("value").numberValue().doubleValue();
+      final long timestamp = node.get("timestamp").numberValue().longValue();
+
+      return new Stat(name, value, timestamp);
+    }
+  }
+
+  public static class StatSerializer extends JsonSerializer<Stat> {
+
+    @Override
+    public void serialize(
+        final Stat stat,
+        final JsonGenerator jsonGenerator,
+        final SerializerProvider serializerProvider
+    ) throws IOException {
+      jsonGenerator.writeStartObject();
+      jsonGenerator.writeStringField("name", stat.name());
+      jsonGenerator.writeObjectField("value", stat.getValue());
+      jsonGenerator.writeNumberField("timestamp", stat.getTimestamp());
+      jsonGenerator.writeEndObject();
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.entity;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
@@ -54,6 +55,10 @@ public final class SourceDescriptionFactory {
         (extended
             ? MetricCollectors.getAndFormatStatsFor(
             dataSource.getKafkaTopicName(), true) : ""),
+        ImmutableMap.copyOf(MetricCollectors.getStatsFor(
+            dataSource.getKafkaTopicName(), false)),
+        ImmutableMap.copyOf(MetricCollectors.getStatsFor(
+            dataSource.getKafkaTopicName(), true)),
         extended,
         dataSource.getKsqlTopic().getKeyFormat().getFormatInfo().getFormat(),
         dataSource.getKsqlTopic().getValueFormat().getFormatInfo().getFormat(),

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.metrics.TopicSensors.Stat;
 import io.confluent.ksql.model.WindowType;
 import java.util.List;
 import java.util.Objects;
@@ -40,6 +42,8 @@ public class SourceDescription {
   private final String timestamp;
   private final String statistics;
   private final String errorStats;
+  private final ImmutableMap<String, Stat> statisticsMap;
+  private final ImmutableMap<String, Stat> errorStatsMap;
   private final boolean extended;
   private final String keyFormat;
   private final String valueFormat;
@@ -62,6 +66,8 @@ public class SourceDescription {
       @JsonProperty("timestamp") final String timestamp,
       @JsonProperty("statistics") final String statistics,
       @JsonProperty("errorStats") final String errorStats,
+      @JsonProperty("statisticsMap") final ImmutableMap<String, Stat> statisticsMap,
+      @JsonProperty("errorStatsMap") final ImmutableMap<String, Stat> errorStatsMap,
       @JsonProperty("extended") final boolean extended,
       @JsonProperty("keyFormat") final String keyFormat,
       @JsonProperty("valueFormat") final String valueFormat,
@@ -85,6 +91,8 @@ public class SourceDescription {
     this.timestamp = Objects.requireNonNull(timestamp, "timestamp");
     this.statistics = Objects.requireNonNull(statistics, "statistics");
     this.errorStats = Objects.requireNonNull(errorStats, "errorStats");
+    this.statisticsMap = Objects.requireNonNull(statisticsMap, "statisticsMap");
+    this.errorStatsMap = Objects.requireNonNull(errorStatsMap, "errorStatsMap");
     this.extended = extended;
     this.keyFormat = Objects.requireNonNull(keyFormat, "keyFormat");
     this.valueFormat = Objects.requireNonNull(valueFormat, "valueFormat");
@@ -155,11 +163,29 @@ public class SourceDescription {
   }
 
   public String getStatistics() {
-    return statistics;
+    if (statistics.length() > 0) {
+      return "The statistics field is deprecated and will be removed in a future version of ksql. "
+              + "Please update your client to the latest version and use statisticsMap instead.\n"
+              + statistics;
+    }
+    return "";
   }
 
   public String getErrorStats() {
-    return errorStats;
+    if (errorStats.length() > 0) {
+      return "The errorStats field is deprecated and will be removed in a future version of ksql. "
+              + "Please update your client to the latest version and use errorStatsMap instead.\n"
+              + errorStats + '\n';
+    }
+    return "";
+  }
+
+  public ImmutableMap<String, Stat> getStatisticsMap() {
+    return statisticsMap;
+  }
+
+  public ImmutableMap<String, Stat> getErrorStatsMap() {
+    return errorStatsMap;
   }
 
   public List<QueryOffsetSummary> getQueryOffsetSummaries() {

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -16,7 +16,9 @@
 package io.confluent.ksql.rest.entity;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.metrics.TopicSensors.Stat;
 import io.confluent.ksql.model.WindowType;
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +34,8 @@ public class SourceDescriptionTest {
     private static final String SOME_STRING = "some string";
     private static final int SOME_INT = 3;
     private static final boolean SOME_BOOL = true;
+    private static final Stat STAT =  new Stat("TEST", 0, 0);
+    private static final ImmutableMap<String, Stat> IMMUTABLE_MAP = new ImmutableMap.Builder<String, Stat>().put("TEST", STAT).build();
 
     @Mock
     private RunningQuery query1;
@@ -56,138 +60,138 @@ public class SourceDescriptionTest {
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints),
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     "diff", Optional.of(WindowType.SESSION), readQueries, writeQueries, fields,
-                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     "diff", Optional.of(WindowType.SESSION), readQueries, writeQueries, fields,
-                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, ImmutableList.of("s1"))
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), ImmutableList.of(), writeQueries, fields,
-                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, ImmutableList.of(), fields,
-                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, ImmutableList.of(),
-                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields,
-                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, ImmutableList.of(), sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, "diff",
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                     "diff", SOME_STRING, SOME_STRING,
+                     "diff", SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, "diff", SOME_STRING,
+                    SOME_STRING, "diff", SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, "diff",
+                    SOME_STRING, SOME_STRING, "diff",IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, "diff", SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     !SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, "diff", SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, "diff", SOME_INT, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT + 1, SOME_INT,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT + 1,
                     SOME_STRING, summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     "diff", summaries, sourceConstraints)
             )
             .addEqualityGroup(
                 new SourceDescription(
                     SOME_STRING, Optional.empty(), readQueries, writeQueries, fields, SOME_STRING,
-                    SOME_STRING, SOME_STRING, SOME_STRING,
+                    SOME_STRING, SOME_STRING, SOME_STRING,IMMUTABLE_MAP, IMMUTABLE_MAP,
                     SOME_BOOL, SOME_STRING, SOME_STRING, SOME_STRING, SOME_INT, SOME_INT,
                     SOME_STRING,
                     ImmutableList.of(new QueryOffsetSummary("g1",


### PR DESCRIPTION
Jira: [KCI-284](https://confluentinc.atlassian.net/browse/KCI-284)

### Description
We are currently working towards displaying error metrics in the UI. These were returned as formatted string forcing us to parse it back if we want to use the numbers. The reason for that was so that they could be easily printed in the CLI. 

To simplify rendering in the UI, the additional fields "statisticsMap" and "errorStatsMap"  that return the JSON objects were added as can be seen in the following HTTP request:
<img width="1702" alt="Screenshot 2021-03-16 at 15 58 52" src="https://user-images.githubusercontent.com/19579420/111342455-62634a00-8672-11eb-9b96-f9a0fed36b59.png">

The old fields "statistics" and "errorStats" still exist to make sure that the update doesn't break older clients:
<img width="1604" alt="Screenshot 2021-03-16 at 15 59 26" src="https://user-images.githubusercontent.com/19579420/111342968-dd2c6500-8672-11eb-912e-958a2125a5e4.png">


### Testing done 
Adjusted the unit tests and made sure that all run.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

