### PR TITLE
docs: fix since version for STDDEV_SAMP function (DOCS-7522)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -227,7 +227,7 @@ Rows that have `col1` set to null are ignored.
 
 ## `STDDEV_SAMP`
 
-Since: - 0.15.0
+Since: - 0.16.0
 
 ```sql
 STDDEV_SAMP(col1)


### PR DESCRIPTION
### Description 
The correct the "since" version for the STDDEV_SAMP function is `0.16.0`.

Related: https://github.com/confluentinc/ksql/pull/6845.