### PR TITLE
build: copy cp-base-new to artifactory as part of build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ def baseConfig = {
     packaging_build_number = "1"
     default_git_revision = 'refs/heads/master' 
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
+    altDockerRegistry = 'confluent-docker.jfrog.io/'
     dockerArtifacts = ['confluentinc/ksqldb-docker', 'confluentinc/ksqldb-docker']
     dockerRepos = ['confluentinc/ksqldb-cli', 'confluentinc/ksqldb-server']
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
@@ -240,6 +241,11 @@ def job = {
 
                             config.dockerPullDeps.each { dockerRepo ->
                                 sh "docker pull ${config.dockerRegistry}${dockerRepo}:${config.cp_version}-latest"
+                                
+                                // we want to make sure that any dependency we use to build an image is backed up 
+                                // the artifactory repo (which is not ephemeral, like ECR)
+                                sh "docker tag ${config.dockerRegistry}${dockerRepo}:${config.cp_version}-latest ${config.altDockerRegistry}${dockerRepo}:${config.cp_version}-latest"
+                                sh "docker push ${config.altDockerRegistry}${dockerRepo}:${config.cp_version}-latest"
                             }
 
                             // Install utilities required for building. XXX: Add to base image


### PR DESCRIPTION
### Description 
Fixes a long-standing issue where we need to manually copy the ECR cp-base-new into artifactory. This patch does that automatically as part of the release.

### Testing done 

Hacked it together in a replay here: https://jenkins.confluent.io/job/confluentinc/job/ksql/job/ksql-db-release/921/console

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

