### PR TITLE
fix: Bubble up errors from HARouting unless using StandbyFallbackException

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/StandbyFallbackException.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/StandbyFallbackException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.physical.pull;
+
+import io.confluent.ksql.util.KsqlException;
+
+public class StandbyFallbackException extends KsqlException {
+
+  public StandbyFallbackException(final Throwable cause) {
+    super(cause);
+  }
+
+  public StandbyFallbackException(final String message) {
+    super(message);
+  }
+
+  public StandbyFallbackException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/StandbyFallbackException.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/StandbyFallbackException.java
@@ -17,6 +17,10 @@ package io.confluent.ksql.physical.pull;
 
 import io.confluent.ksql.util.KsqlException;
 
+/**
+ * This exception is thrown to indicate that pull queries should fallback on the next standby in
+ * line.
+ */
 public class StandbyFallbackException extends KsqlException {
 
   public StandbyFallbackException(final Throwable cause) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
@@ -27,6 +27,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.execution.streams.RoutingFilter.RoutingFilterFactory;
 import io.confluent.ksql.execution.streams.RoutingOptions;
 import io.confluent.ksql.execution.streams.materialization.Locator;
@@ -38,16 +41,22 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.physical.pull.HARouting.RouteQuery;
 import io.confluent.ksql.query.PullQueryQueue;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.ArrayList;
+import io.confluent.ksql.util.KsqlRequestConfig;
+import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -90,6 +99,8 @@ public class HARoutingTest {
   @Mock
   private LogicalSchema logicalSchema;
   @Mock
+  private LogicalSchema logicalSchema2;
+  @Mock
   private RoutingFilterFactory routingFilterFactory;
   @Mock
   private PullPhysicalPlan pullPhysicalPlan;
@@ -101,6 +112,8 @@ public class HARoutingTest {
   private RouteQuery routeQuery;
   @Mock
   private KsqlConfig ksqlConfig;
+  @Mock
+  private SimpleKsqlClient ksqlClient;
 
   private PullQueryQueue pullQueryQueue = new PullQueryQueue();
 
@@ -108,15 +121,29 @@ public class HARoutingTest {
 
   @Before
   public void setUp() {
+    when(pullPhysicalPlan.getMaterialization()).thenReturn(materialization);
+    when(pullPhysicalPlan.getMaterialization().locator()).thenReturn(locator);
     when(statement.getStatementText()).thenReturn("foo");
+    when(statement.getSessionConfig()).thenReturn(SessionConfig.of(ksqlConfig,
+        ImmutableMap.of()));
+    when(node1.isLocal()).thenReturn(true);
+    when(node2.isLocal()).thenReturn(false);
+    when(node1.location()).thenReturn(URI.create("http://node1:8088"));
+    when(node2.location()).thenReturn(URI.create("http://node2:8089"));
     when(location1.getNodes()).thenReturn(ImmutableList.of(node1, node2));
     when(location2.getNodes()).thenReturn(ImmutableList.of(node2, node1));
     when(location3.getNodes()).thenReturn(ImmutableList.of(node1, node2));
     when(location4.getNodes()).thenReturn(ImmutableList.of(node2, node1));
+    when(location1.getPartition()).thenReturn(1);
+    when(location2.getPartition()).thenReturn(2);
+    when(location3.getPartition()).thenReturn(3);
+    when(location4.getPartition()).thenReturn(4);
     // We require at least two threads, one for the orchestrator, and the other for the partitions.
     when(ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG)).thenReturn(2);
+
+    when(serviceContext.getKsqlClient()).thenReturn(ksqlClient);
     haRouting = new HARouting(
-        routingFilterFactory, Optional.empty(), ksqlConfig, routeQuery);
+        routingFilterFactory, Optional.empty(), ksqlConfig);
   }
 
   @After
@@ -129,29 +156,25 @@ public class HARoutingTest {
   @Test
   public void shouldCallRouteQuery_success() throws InterruptedException, ExecutionException {
     // Given:
-    List<KsqlPartitionLocation> locations = ImmutableList.of(location1, location2, location3, location4);
-    when(pullPhysicalPlan.getMaterialization()).thenReturn(materialization);
-    when(pullPhysicalPlan.getMaterialization().locator()).thenReturn(locator);
-    when(pullPhysicalPlan.getMaterialization().locator().locate(
-        pullPhysicalPlan.getKeys(),
-        routingOptions,
-        routingFilterFactory
-    )).thenReturn(locations);
-    List<List<KsqlPartitionLocation>> locationsQueried = new ArrayList<>();
-    doAnswer(inv -> {
-      locationsQueried.add(inv.getArgument(1));
-      PullQueryQueue queue = inv.getArgument(9);
+    locate(location1, location2, location3, location4);
+    doAnswer(i -> {
+      final PullQueryQueue queue = i.getArgument(1);
       queue.acceptRow(PQ_ROW1);
       return null;
-    }).when(routeQuery).routeQuery(eq(node1), any(), any(), any(), any(), any(), any(), any(),
-        any(), any());
-    doAnswer(inv -> {
-      locationsQueried.add(inv.getArgument(1));
-      PullQueryQueue queue = inv.getArgument(9);
-      queue.acceptRow(PQ_ROW2);
-      return null;
-    }).when(routeQuery).routeQuery(eq(node2), any(), any(), any(), any(), any(), any(), any(),
-        any(), any());
+    }).when(pullPhysicalPlan).execute(eq(ImmutableList.of(location1, location3)), any(), any());
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any())).thenAnswer(
+        i -> {
+          Map<String, ?> requestProperties = i.getArgument(3);
+          Consumer<List<StreamedRow>> rowConsumer = i.getArgument(4);
+          assertThat(requestProperties.get(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS),
+              is ("2,4"));
+          rowConsumer.accept(
+              ImmutableList.of(
+                  StreamedRow.header(queryId, logicalSchema),
+                  StreamedRow.pullRow(GenericRow.fromList(ROW2), Optional.empty())));
+          return RestResponse.successful(200, 2);
+        }
+    );
 
     // When:
     CompletableFuture<Void> future = haRouting.handlePullQuery(
@@ -160,14 +183,7 @@ public class HARoutingTest {
     future.get();
 
     // Then:
-    verify(routeQuery).routeQuery(eq(node1), any(), any(), any(), any(), any(), any(), any(), any(),
-        any());
-    assertThat(locationsQueried.get(0).get(0), is(location1));
-    assertThat(locationsQueried.get(0).get(1), is(location3));
-    verify(routeQuery).routeQuery(eq(node2), any(), any(), any(), any(), any(), any(), any(), any(),
-        any());
-    assertThat(locationsQueried.get(1).get(0), is(location2));
-    assertThat(locationsQueried.get(1).get(1), is(location4));
+    verify(pullPhysicalPlan).execute(eq(ImmutableList.of(location1, location3)), any(), any());
 
     assertThat(pullQueryQueue.size(), is(2));
     assertThat(pullQueryQueue.pollRow(1, TimeUnit.SECONDS).getRow(), is(ROW1));
@@ -177,35 +193,37 @@ public class HARoutingTest {
   @Test
   public void shouldCallRouteQuery_twoRound() throws InterruptedException, ExecutionException {
     // Given:
-    List<KsqlPartitionLocation> locations = ImmutableList.of(location1, location2, location3, location4);
-    when(pullPhysicalPlan.getMaterialization()).thenReturn(materialization);
-    when(pullPhysicalPlan.getMaterialization().locator()).thenReturn(locator);
-    when(pullPhysicalPlan.getMaterialization().locator().locate(
-        pullPhysicalPlan.getKeys(),
-        routingOptions,
-        routingFilterFactory
-    )).thenReturn(locations);
-    List<List<KsqlPartitionLocation>> locationsQueried = new ArrayList<>();
-    doAnswer(inv -> {
-      locationsQueried.add(inv.getArgument(1));
-      throw new RuntimeException("Error!");
-    }).when(routeQuery).routeQuery(eq(node1), any(), any(), any(), any(), any(), any(), any(),
-        any(), any());
-    doAnswer(new Answer() {
-      private int count = 0;
+    locate(location1, location2, location3, location4);
+    doAnswer(i -> {
+      throw new StandbyFallbackException("Error!");
+    }).when(pullPhysicalPlan).execute(eq(ImmutableList.of(location1, location3)), any(), any());
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any())).thenAnswer(
+        new Answer() {
+          private int count = 0;
 
-      public Object answer(InvocationOnMock invocation) {
-        locationsQueried.add(invocation.getArgument(1));
-        PullQueryQueue queue = invocation.getArgument(9);
-        if (++count == 1) {
-          queue.acceptRow(PQ_ROW2);
-        } else {
-          queue.acceptRow(PQ_ROW1);
+          public Object answer(InvocationOnMock i) {
+            Map<String, ?> requestProperties = i.getArgument(3);
+            Consumer<List<StreamedRow>> rowConsumer = i.getArgument(4);
+            if (++count == 1) {
+              assertThat(requestProperties.get(
+                  KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS), is ("2,4"));
+              rowConsumer.accept(
+                  ImmutableList.of(
+                      StreamedRow.header(queryId, logicalSchema),
+                      StreamedRow.pullRow(GenericRow.fromList(ROW2), Optional.empty())));
+            } else {
+              assertThat(requestProperties.get(
+                  KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS), is ("1,3"));
+              rowConsumer.accept(
+                  ImmutableList.of(
+                      StreamedRow.header(queryId, logicalSchema),
+                      StreamedRow.pullRow(GenericRow.fromList(ROW1), Optional.empty())));
+            }
+
+            return RestResponse.successful(200, 2);
+          }
         }
-        return null;
-      }
-    }).when(routeQuery).routeQuery(eq(node2), any(), any(), any(), any(), any(), any(), any(),
-        any(), any());
+    );
 
     // When:
     CompletableFuture<Void> future = haRouting.handlePullQuery(serviceContext, pullPhysicalPlan,
@@ -213,16 +231,8 @@ public class HARoutingTest {
     future.get();
 
     // Then:
-    verify(routeQuery).routeQuery(eq(node1), any(), any(), any(), any(), any(), any(), any(), any(),
-        any());
-    assertThat(locationsQueried.get(0).get(0), is(location1));
-    assertThat(locationsQueried.get(0).get(1), is(location3));
-    verify(routeQuery, times(2)).routeQuery(eq(node2), any(), any(), any(), any(), any(), any(),
-        any(), any(), any());
-    assertThat(locationsQueried.get(1).get(0), is(location2));
-    assertThat(locationsQueried.get(1).get(1), is(location4));
-    assertThat(locationsQueried.get(2).get(0), is(location1));
-    assertThat(locationsQueried.get(2).get(1), is(location3));
+    verify(pullPhysicalPlan).execute(eq(ImmutableList.of(location1, location3)), any(), any());
+    verify(ksqlClient, times(2)).makeQueryRequest(eq(node2.location()), any(), any(), any(), any());
 
     assertThat(pullQueryQueue.size(), is(2));
     assertThat(pullQueryQueue.pollRow(1, TimeUnit.SECONDS).getRow(), is(ROW2));
@@ -230,37 +240,65 @@ public class HARoutingTest {
   }
 
   @Test
-  public void shouldCallRouteQuery_allFail() {
+  public void shouldCallRouteQuery_twoRound_networkError()
+      throws InterruptedException, ExecutionException {
     // Given:
-    List<KsqlPartitionLocation> locations = ImmutableList.of(location1, location2, location3, location4);
-    when(pullPhysicalPlan.getMaterialization()).thenReturn(materialization);
-    when(pullPhysicalPlan.getMaterialization().locator()).thenReturn(locator);
-    when(pullPhysicalPlan.getMaterialization().locator().locate(
-        pullPhysicalPlan.getKeys(),
-        routingOptions,
-        routingFilterFactory
-    )).thenReturn(locations);
-    List<List<KsqlPartitionLocation>> locationsQueried = new ArrayList<>();
-    doAnswer(inv -> {
-      locationsQueried.add(inv.getArgument(1));
-      throw new RuntimeException("Error!");
-    }).when(routeQuery).routeQuery(eq(node1), any(), any(), any(), any(), any(), any(), any(),
-        any(), any());
-    doAnswer(new Answer() {
-      private int count = 0;
-
-      public Object answer(InvocationOnMock invocation) {
-        locationsQueried.add(invocation.getArgument(1));
-        PullQueryQueue queue = invocation.getArgument(9);
-        if (++count == 1) {
-          queue.acceptRow(PQ_ROW2);
-        } else {
-          throw new RuntimeException("Error!");
+    locate(location2);
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any())).thenAnswer(
+        i -> {
+          throw new RuntimeException("Network error!");
         }
-        return null;
-      }
-    }).when(routeQuery).routeQuery(eq(node2), any(), any(), any(), any(), any(), any(), any(),
-        any(), any());
+    );
+    doAnswer(i -> {
+      final PullQueryQueue queue = i.getArgument(1);
+      queue.acceptRow(PQ_ROW1);
+      return null;
+    }).when(pullPhysicalPlan).execute(eq(ImmutableList.of(location2)), any(), any());
+
+    // When:
+    CompletableFuture<Void> future = haRouting.handlePullQuery(serviceContext, pullPhysicalPlan,
+        statement, routingOptions, logicalSchema, queryId, pullQueryQueue);
+    future.get();
+
+    // Then:
+    verify(ksqlClient, times(1)).makeQueryRequest(eq(node2.location()), any(), any(), any(), any());
+    verify(pullPhysicalPlan).execute(eq(ImmutableList.of(location2)), any(), any());
+
+    assertThat(pullQueryQueue.size(), is(1));
+    assertThat(pullQueryQueue.pollRow(1, TimeUnit.SECONDS).getRow(), is(ROW1));
+  }
+
+  @Test
+  public void shouldCallRouteQuery_allStandbysFail() {
+    // Given:
+    locate(location1, location2, location3, location4);
+    doAnswer(i -> {
+      throw new StandbyFallbackException("Error1!");
+    }).when(pullPhysicalPlan).execute(eq(ImmutableList.of(location1, location3)), any(), any());
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any())).thenAnswer(
+        new Answer() {
+          private int count = 0;
+
+          public Object answer(InvocationOnMock i) {
+            Map<String, ?> requestProperties = i.getArgument(3);
+            Consumer<List<StreamedRow>> rowConsumer = i.getArgument(4);
+            if (++count == 1) {
+              assertThat(requestProperties.get(
+                  KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS), is ("2,4"));
+              rowConsumer.accept(
+                  ImmutableList.of(
+                      StreamedRow.header(queryId, logicalSchema),
+                      StreamedRow.pullRow(GenericRow.fromList(ROW2), Optional.empty())));
+            } else {
+              assertThat(requestProperties.get(
+                  KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS), is ("1,3"));
+              throw new RuntimeException("Error2!");
+            }
+
+            return RestResponse.successful(200, 2);
+          }
+        }
+    );
 
     // When:
     final Exception e = assertThrows(
@@ -273,18 +311,10 @@ public class HARoutingTest {
     );
 
     // Then:
-    verify(routeQuery).routeQuery(eq(node1), any(), any(), any(), any(), any(), any(), any(), any(),
-        any());
-    assertThat(locationsQueried.get(0).get(0), is(location1));
-    assertThat(locationsQueried.get(0).get(1), is(location3));
-    verify(routeQuery, times(2)).routeQuery(eq(node2), any(), any(), any(), any(), any(), any(),
-        any(), any(), any());
-    assertThat(locationsQueried.get(1).get(0), is(location2));
-    assertThat(locationsQueried.get(1).get(1), is(location4));
-    assertThat(locationsQueried.get(2).get(0), is(location1));
-    assertThat(locationsQueried.get(2).get(1), is(location3));
+    verify(pullPhysicalPlan).execute(eq(ImmutableList.of(location1, location3)), any(), any());
+    verify(ksqlClient, times(2)).makeQueryRequest(eq(node2.location()), any(), any(), any(), any());
 
-    assertThat(e.getCause().getMessage(), containsString("Unable to execute pull query: foo. "
+    assertThat(e.getCause().getMessage(), containsString("Unable to execute pull query: \"foo\". "
                                                   + "Exhausted standby hosts to try."));
   }
 
@@ -292,14 +322,7 @@ public class HARoutingTest {
   public void shouldCallRouteQuery_allFiltered() {
     // Given:
     when(location1.getNodes()).thenReturn(ImmutableList.of());
-    List<KsqlPartitionLocation> locations = ImmutableList.of(location1, location2, location3, location4);
-    when(pullPhysicalPlan.getMaterialization()).thenReturn(materialization);
-    when(pullPhysicalPlan.getMaterialization().locator()).thenReturn(locator);
-    when(pullPhysicalPlan.getMaterialization().locator().locate(
-        pullPhysicalPlan.getKeys(),
-        routingOptions,
-        routingFilterFactory
-    )).thenReturn(locations);
+    locate(location1, location2, location3, location4);
 
     // When:
     final Exception e = assertThrows(
@@ -310,6 +333,139 @@ public class HARoutingTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Unable to execute pull query foo. All nodes are dead or exceed max allowed lag."));
+        "Unable to execute pull query \"foo\". All nodes are dead or exceed max allowed lag."));
+  }
+
+  @Test
+  public void forwardingError_errorRow() {
+    // Given:
+    locate(location2);
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any())).thenAnswer(
+        i -> {
+          Map<String, ?> requestProperties = i.getArgument(3);
+          Consumer<List<StreamedRow>> rowConsumer = i.getArgument(4);
+          assertThat(requestProperties.get(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS),
+              is ("2"));
+          rowConsumer.accept(
+              ImmutableList.of(
+                  StreamedRow.header(queryId, logicalSchema),
+                  StreamedRow.error(new RuntimeException("Row Error!"), 500)));
+          return RestResponse.successful(200, 2);
+        }
+    );
+
+    // When:
+    CompletableFuture<Void> future = haRouting.handlePullQuery(
+        serviceContext, pullPhysicalPlan, statement, routingOptions, logicalSchema, queryId,
+        pullQueryQueue);
+    final Exception e = assertThrows(
+        ExecutionException.class,
+        future::get
+    );
+
+    // Then:
+    assertThat(pullQueryQueue.size(), is(0));
+    assertThat(e.getMessage(), containsString("Row Error!"));
+  }
+
+  @Test
+  public void forwardingError_authError() {
+    // Given:
+    locate(location2);
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any())).thenAnswer(
+        i -> {
+          Map<String, ?> requestProperties = i.getArgument(3);
+          Consumer<List<StreamedRow>> rowConsumer = i.getArgument(4);
+          assertThat(requestProperties.get(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS),
+              is ("2"));
+          rowConsumer.accept(ImmutableList.of());
+          return RestResponse.erroneous(401, "Authentication Error");
+        }
+    );
+
+    // When:
+    CompletableFuture<Void> future = haRouting.handlePullQuery(
+        serviceContext, pullPhysicalPlan, statement, routingOptions, logicalSchema, queryId,
+        pullQueryQueue);
+    final Exception e = assertThrows(
+        ExecutionException.class,
+        future::get
+    );
+
+    // Then:
+    assertThat(pullQueryQueue.size(), is(0));
+    assertThat(e.getMessage(), containsString("Authentication Error"));
+  }
+
+  @Test
+  public void forwardingError_noRows() {
+    // Given:
+    locate(location2);
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any())).thenAnswer(
+        i -> {
+          Map<String, ?> requestProperties = i.getArgument(3);
+          Consumer<List<StreamedRow>> rowConsumer = i.getArgument(4);
+          assertThat(requestProperties.get(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS),
+              is ("2"));
+          rowConsumer.accept(ImmutableList.of());
+          return RestResponse.successful(200, 0);
+        }
+    );
+
+    // When:
+    CompletableFuture<Void> future = haRouting.handlePullQuery(
+        serviceContext, pullPhysicalPlan, statement, routingOptions, logicalSchema, queryId,
+        pullQueryQueue);
+    final Exception e = assertThrows(
+        ExecutionException.class,
+        future::get
+    );
+
+    // Then:
+    assertThat(pullQueryQueue.size(), is(0));
+    assertThat(e.getMessage(),
+        containsString("empty response from forwarding call, expected a header row"));
+  }
+
+  @Test
+  public void forwardingError_invalidSchema() {
+    // Given:
+    locate(location2);
+    when(ksqlClient.makeQueryRequest(eq(node2.location()), any(), any(), any(), any())).thenAnswer(
+        i -> {
+          Map<String, ?> requestProperties = i.getArgument(3);
+          Consumer<List<StreamedRow>> rowConsumer = i.getArgument(4);
+          assertThat(requestProperties.get(KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_PARTITIONS),
+              is ("2"));
+          rowConsumer.accept(
+              ImmutableList.of(
+                  StreamedRow.header(queryId, logicalSchema2),
+                  StreamedRow.error(new RuntimeException("Row Error!"), 500)));
+          return RestResponse.successful(200, 2);
+        }
+    );
+
+    // When:
+    CompletableFuture<Void> future = haRouting.handlePullQuery(
+        serviceContext, pullPhysicalPlan, statement, routingOptions, logicalSchema, queryId,
+        pullQueryQueue);
+    final Exception e = assertThrows(
+        ExecutionException.class,
+        future::get
+    );
+
+    // Then:
+    assertThat(pullQueryQueue.size(), is(0));
+    assertThat(e.getMessage(),
+        containsString("Schemas logicalSchema2 from host node2 differs from schema logicalSchema"));
+  }
+
+  private void locate(final KsqlPartitionLocation... locations) {
+    List<KsqlPartitionLocation> locationsList = ImmutableList.copyOf(locations);
+    when(pullPhysicalPlan.getMaterialization().locator().locate(
+        pullPhysicalPlan.getKeys(),
+        routingOptions,
+        routingFilterFactory
+    )).thenReturn(locationsList);
   }
 }


### PR DESCRIPTION
### Description 
`HARouting` has previously treated all Exceptions the same and used them as reason to retry with standbys.  The issue is that certain errors are deterministic and often caused by some form of user error or code bug.  Not only is there no use in retrying something that will have the same effect on a standby, but if we treat it similar to a transient error and print the error message `Unable to execute pull query: "%s". Exhausted standby hosts to try.`, it's rather confusing since trying again won't fix the issue.

The goal of this PR is to surface any bug by requiring any standby retries to explicitly use `StandbyFallbackException` and by bubbling up other exceptions by default.  In particular, any network error gets wrapped in a `StandbyFallbackException` and everything else, including local lookup errors, is surfaced.

Fixes #6799 

### Testing done 
I rewrote much of `HARoutingTest` since it wasn't well tested before and stopped at the routing step.  It's now tested all the way down to either the network call or execution at the physical plan layer.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

