### PR TITLE
fix(java client): allow java client to accept statements with more than one semicolon

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
@@ -46,6 +46,16 @@ final class DdlDmlRequestValidators {
     return true;
   }
 
+  /**
+   * Counts the number of sql statements in a string by
+   *  1. Removing all of the sql strings
+   *  2. Splitting the remaining substrings by ';'. The -1 argument in the split
+   *     function call ensures that each ';' will always have two partitions surrounding it, so that
+   *     the number of partitions is the same whether or not the final ';' has whitespace after it.
+   *  3. Counting the partitions
+   * @param sql a string containing sql statements
+   * @return the number of sql statements in the string
+   */
   private static int countStatements(final String sql) {
     return Arrays.stream(sql.split(QUOTED_STRING))
         .mapToInt(part -> part.split(";", -1).length - 1)

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture;
 
 final class DdlDmlRequestValidators {
 
-  private static final String QUOTED_STRING_OR_SEMICOLON = "(`([^`]*|(``))*`)|('([^']*|(''))*')";
+  private static final String QUOTED_STRING = "(`([^`]*|(``))*`)|('([^']*|(''))*')";
 
   private DdlDmlRequestValidators() {
   }
@@ -37,15 +37,18 @@ final class DdlDmlRequestValidators {
       return false;
     }
 
-    if (Arrays.stream(sql.split(QUOTED_STRING_OR_SEMICOLON))
-        .mapToInt(part -> part.split(";", -1).length - 1)
-        .sum() > 1
-    ) {
+    if (countStatements(sql) > 1) {
       cf.completeExceptionally(new KsqlClientException(
           "executeStatement() may only be used to execute one statement at a time."));
       return false;
     }
 
     return true;
+  }
+
+  private static int countStatements(final String sql) {
+    return Arrays.stream(sql.split(QUOTED_STRING))
+        .mapToInt(part -> part.split(";", -1).length - 1)
+        .sum();
   }
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture;
 
 final class DdlDmlRequestValidators {
 
-  private static final String QUOTED_STRING = "(`([^`]*|(``))*`)|('([^']*|(''))*')";
+  private static final String QUOTED_STRING_OR_IDENTIFIER = "(`([^`]*|(``))*`)|('([^']*|(''))*')";
 
   private DdlDmlRequestValidators() {
   }
@@ -57,7 +57,7 @@ final class DdlDmlRequestValidators {
    * @return the number of sql statements in the string
    */
   private static int countStatements(final String sql) {
-    return Arrays.stream(sql.split(QUOTED_STRING))
+    return Arrays.stream(sql.split(QUOTED_STRING_OR_IDENTIFIER))
         .mapToInt(part -> part.split(";", -1).length - 1)
         .sum();
   }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlRequestValidators.java
@@ -48,7 +48,7 @@ final class DdlDmlRequestValidators {
 
   /**
    * Counts the number of sql statements in a string by
-   *  1. Removing all of the sql strings
+   *  1. Removing all of the sql strings and identifiers
    *  2. Splitting the remaining substrings by ';'. The -1 argument in the split
    *     function call ensures that each ';' will always have two partitions surrounding it, so that
    *     the number of partitions is the same whether or not the final ';' has whitespace after it.

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -783,10 +783,10 @@ public class ClientTest extends BaseApiTest {
   }
 
   @Test
-  public void shouldHandleSingleWithStatementMultipleSemicolonsFromExecuteStatement() throws Exception {
+  public void shouldExecuteSingleStatementWithMultipleSemicolons() throws Exception {
     // Given
     final CommandStatusEntity entity = new CommandStatusEntity(
-        "C';'SAS;",
+        "CREATE STREAM FOO AS CONCAT(A, `wow;`) FROM `BAR`;  ",
         new CommandId("STREAM", "FOO", "CREATE"),
         new CommandStatus(
             CommandStatus.Status.SUCCESS,
@@ -799,10 +799,10 @@ public class ClientTest extends BaseApiTest {
     final Map<String, Object> properties = ImmutableMap.of("auto.offset.reset", "earliest");
 
     // When
-    final ExecuteStatementResult result = javaClient.executeStatement("C';'SAS;", properties).get();
+    final ExecuteStatementResult result = javaClient.executeStatement("CREATE STREAM FOO AS CONCAT(A, `wow;`) FROM `BAR`;  ", properties).get();
 
     // Then
-    assertThat(testEndpoints.getLastSql(), is("C';'SAS;"));
+    assertThat(testEndpoints.getLastSql(), is("CREATE STREAM FOO AS CONCAT(A, `wow;`) FROM `BAR`;  "));
     assertThat(testEndpoints.getLastProperties(), is(new JsonObject().put("auto.offset.reset", "earliest")));
     assertThat(result.queryId(), is(Optional.empty()));
   }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -786,7 +786,7 @@ public class ClientTest extends BaseApiTest {
   public void shouldExecuteSingleStatementWithMultipleSemicolons() throws Exception {
     // Given
     final CommandStatusEntity entity = new CommandStatusEntity(
-        "CREATE STREAM FOO AS CONCAT(A, `wow;`) FROM `BAR`;  ",
+        "CREATE STREAM FOO AS CONCAT(A, 'wow;') FROM `BAR`;  ",
         new CommandId("STREAM", "FOO", "CREATE"),
         new CommandStatus(
             CommandStatus.Status.SUCCESS,

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -783,6 +783,31 @@ public class ClientTest extends BaseApiTest {
   }
 
   @Test
+  public void shouldHandleSingleWithStatementMultipleSemicolonsFromExecuteStatement() throws Exception {
+    // Given
+    final CommandStatusEntity entity = new CommandStatusEntity(
+        "C';'SAS;",
+        new CommandId("STREAM", "FOO", "CREATE"),
+        new CommandStatus(
+            CommandStatus.Status.SUCCESS,
+            "Success"
+        ),
+        0L
+    );
+    testEndpoints.setKsqlEndpointResponse(Collections.singletonList(entity));
+
+    final Map<String, Object> properties = ImmutableMap.of("auto.offset.reset", "earliest");
+
+    // When
+    final ExecuteStatementResult result = javaClient.executeStatement("C';'SAS;", properties).get();
+
+    // Then
+    assertThat(testEndpoints.getLastSql(), is("C';'SAS;"));
+    assertThat(testEndpoints.getLastProperties(), is(new JsonObject().put("auto.offset.reset", "earliest")));
+    assertThat(result.queryId(), is(Optional.empty()));
+  }
+
+  @Test
   public void shouldRejectMultipleRequestsFromExecuteStatement() {
     // When
     final Exception e = assertThrows(


### PR DESCRIPTION
### Description 
The `executeStatement` Java client method fails if the given statement contains a string with semicolons. This PR updates the validator logic to ignore semicolons in strings when counting semicolons.

### Testing done 
Added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

