### PR TITLE
refactor(executor): factor out a class allowing you to merge local results with results for running the same statement on other nodes

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -148,7 +148,7 @@ public class ConsoleTest {
       true,
       "kafka",
       "avro",
-      "kadka-topic",
+      "kafka-topic",
       2,
       1,
       "statement",
@@ -551,7 +551,7 @@ public class ConsoleTest {
                 false,
                 "kafka",
                 "avro",
-                "kadka-topic",
+                "kafka-topic",
                 1,
                 1,
                 "sql statement",
@@ -686,7 +686,7 @@ public class ConsoleTest {
           + "    \"extended\" : false," + NEWLINE
           + "    \"keyFormat\" : \"kafka\"," + NEWLINE
           + "    \"valueFormat\" : \"avro\"," + NEWLINE
-          + "    \"topic\" : \"kadka-topic\"," + NEWLINE
+          + "    \"topic\" : \"kafka-topic\"," + NEWLINE
           + "    \"partitions\" : 1," + NEWLINE
           + "    \"replication\" : 1," + NEWLINE
           + "    \"statement\" : \"sql statement\"," + NEWLINE
@@ -828,7 +828,7 @@ public class ConsoleTest {
           + "    \"extended\" : true," + NEWLINE
           + "    \"keyFormat\" : \"kafka\"," + NEWLINE
           + "    \"valueFormat\" : \"avro\"," + NEWLINE
-          + "    \"topic\" : \"kadka-topic\"," + NEWLINE
+          + "    \"topic\" : \"kafka-topic\"," + NEWLINE
           + "    \"partitions\" : 2," + NEWLINE
           + "    \"replication\" : 1," + NEWLINE
           + "    \"statement\" : \"statement\"," + NEWLINE
@@ -854,7 +854,7 @@ public class ConsoleTest {
           + "" + NEWLINE
           + " KSQL Source Name | Kafka Topic | Type  " + NEWLINE
           + "----------------------------------------" + NEWLINE
-          + " TestSource       | kadka-topic | TABLE " + NEWLINE
+          + " TestSource       | kafka-topic | TABLE " + NEWLINE
           + "----------------------------------------" + NEWLINE
           + "" + NEWLINE
           + " Related Topics " + NEWLINE
@@ -1132,7 +1132,7 @@ public class ConsoleTest {
                 true,
                 "json",
                 "avro",
-                "kadka-topic",
+                "kafka-topic",
                 2, 1,
                 "sql statement text",
                 ImmutableList.of(
@@ -1140,13 +1140,13 @@ public class ConsoleTest {
                         "consumer1",
                         ImmutableList.of(
                             new QueryTopicOffsetSummary(
-                                "kadka-topic",
+                                "kafka-topic",
                                 ImmutableList.of(
                                     new ConsumerPartitionOffsets(0, 100, 900, 800),
                                     new ConsumerPartitionOffsets(1, 50, 900, 900)
                                 )),
                             new QueryTopicOffsetSummary(
-                                "kadka-topic-2",
+                                "kafka-topic-2",
                                 ImmutableList.of(
                                     new ConsumerPartitionOffsets(0, 0, 90, 80),
                                     new ConsumerPartitionOffsets(1, 10, 90, 90)
@@ -1222,14 +1222,14 @@ public class ConsoleTest {
           + "    \"extended\" : true," + NEWLINE
           + "    \"keyFormat\" : \"json\"," + NEWLINE
           + "    \"valueFormat\" : \"avro\"," + NEWLINE
-          + "    \"topic\" : \"kadka-topic\"," + NEWLINE
+          + "    \"topic\" : \"kafka-topic\"," + NEWLINE
           + "    \"partitions\" : 2," + NEWLINE
           + "    \"replication\" : 1," + NEWLINE
           + "    \"statement\" : \"sql statement text\"," + NEWLINE
           + "    \"queryOffsetSummaries\" : [ {" + NEWLINE
           + "      \"groupId\" : \"consumer1\"," + NEWLINE
           + "      \"topicSummaries\" : [ {" + NEWLINE
-          + "        \"kafkaTopic\" : \"kadka-topic\"," + NEWLINE
+          + "        \"kafkaTopic\" : \"kafka-topic\"," + NEWLINE
           + "        \"offsets\" : [ {" + NEWLINE
           + "          \"partition\" : 0," + NEWLINE
           + "          \"logStartOffset\" : 100," + NEWLINE
@@ -1242,7 +1242,7 @@ public class ConsoleTest {
           + "          \"consumerOffset\" : 900" + NEWLINE
           + "        } ]" + NEWLINE
           + "      }, {" + NEWLINE
-          + "        \"kafkaTopic\" : \"kadka-topic-2\"," + NEWLINE
+          + "        \"kafkaTopic\" : \"kafka-topic-2\"," + NEWLINE
           + "        \"offsets\" : [ {" + NEWLINE
           + "          \"partition\" : 0," + NEWLINE
           + "          \"logStartOffset\" : 0," + NEWLINE
@@ -1270,7 +1270,7 @@ public class ConsoleTest {
           + "Timestamp field      : 2000-01-01" + NEWLINE
           + "Key format           : json" + NEWLINE
           + "Value format         : avro" + NEWLINE
-          + "Kafka topic          : kadka-topic (partitions: 2, replication: 1)" + NEWLINE
+          + "Kafka topic          : kafka-topic (partitions: 2, replication: 1)" + NEWLINE
           + "Statement            : sql statement text" + NEWLINE
           + "" + NEWLINE
           + " Field  | Type                           " + NEWLINE
@@ -1300,14 +1300,14 @@ public class ConsoleTest {
           + "------------------------" + NEWLINE
           + "            TEST:         0     last-message:       n/a" + NEWLINE
           + "            TEST:         0     last-message:       n/a" + NEWLINE
-          + "(Statistics of the local KSQL server interaction with the Kafka topic kadka-topic)"
+          + "(Statistics of the local KSQL server interaction with the Kafka topic kafka-topic)"
           + NEWLINE
           + NEWLINE
           + "Consumer Groups summary:" + NEWLINE
           + NEWLINE
           + "Consumer Group       : consumer1" + NEWLINE
           + NEWLINE
-          + "Kafka topic          : kadka-topic" + NEWLINE
+          + "Kafka topic          : kafka-topic" + NEWLINE
           + "Max lag              : 100" + NEWLINE
           + NEWLINE
           + " Partition | Start Offset | End Offset | Offset | Lag " + NEWLINE
@@ -1316,7 +1316,7 @@ public class ConsoleTest {
           + " 1         | 50           | 900        | 900    | 0   " + NEWLINE
           + "------------------------------------------------------" + NEWLINE
           + NEWLINE
-          + "Kafka topic          : kadka-topic-2" + NEWLINE
+          + "Kafka topic          : kafka-topic-2" + NEWLINE
           + "Max lag              : 10" + NEWLINE
           + NEWLINE
           + " Partition | Start Offset | End Offset | Offset | Lag " + NEWLINE

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/DescribeStreams.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/DescribeStreams.java
@@ -15,56 +15,20 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.Objects;
+
 import java.util.Optional;
 
 @Immutable
-public class DescribeStreams extends Statement {
+public class DescribeStreams extends StatementWithExtendedClause {
 
-  private final boolean showExtended;
-
-  public DescribeStreams(
-      final Optional<NodeLocation> location,
-      final boolean showExtended
-  ) {
-    super(location);
-    this.showExtended = showExtended;
-  }
-
-  public boolean getShowExtended() {
-    return showExtended;
+  public DescribeStreams(final Optional<NodeLocation> location, final boolean showExtended) {
+    super(location, showExtended);
   }
 
   @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitDescribeStreams(this, context);
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final DescribeStreams that = (DescribeStreams) o;
-    return showExtended == that.showExtended;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(showExtended);
-  }
-
-  @Override
-  public String toString() {
-    return toStringHelper(this)
-        .add("showExtended", showExtended)
-        .toString();
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/DescribeTables.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/DescribeTables.java
@@ -15,29 +15,18 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import com.google.errorprone.annotations.Immutable;
+
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.Objects;
+
 import java.util.Optional;
 
 @Immutable
+public class DescribeTables extends StatementWithExtendedClause {
 
-public class DescribeTables extends Statement {
 
-  private final boolean showExtended;
-
-  public DescribeTables(
-      final Optional<NodeLocation> location,
-      final boolean showExtended
-  ) {
-    super(location);
-    this.showExtended = showExtended;
-  }
-
-  public boolean getShowExtended() {
-    return showExtended;
+  public DescribeTables(final Optional<NodeLocation> location, final boolean showExtended) {
+    super(location, showExtended);
   }
 
   @Override
@@ -45,27 +34,4 @@ public class DescribeTables extends Statement {
     return visitor.visitDescribeTables(this, context);
   }
 
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final DescribeTables that = (DescribeTables) o;
-    return showExtended == that.showExtended;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(showExtended);
-  }
-
-  @Override
-  public String toString() {
-    return toStringHelper(this)
-        .add("showExtended", showExtended)
-        .toString();
-  }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
@@ -15,51 +15,14 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class ListQueries extends Statement {
+public class ListQueries extends StatementWithExtendedClause {
 
-  private final boolean showExtended;
-
-  public ListQueries(
-      final Optional<NodeLocation> location,
-      final boolean showExtended
-  ) {
-    super(location);
-    this.showExtended = showExtended;
-  }
-
-  public boolean getShowExtended() {
-    return showExtended;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ListQueries that = (ListQueries) o;
-    return showExtended == that.showExtended;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(showExtended);
-  }
-
-  @Override
-  public String toString() {
-    return toStringHelper(this)
-        .add("showExtended", showExtended)
-        .toString();
+  public ListQueries(final Optional<NodeLocation> location, final boolean showExtended) {
+    super(location, showExtended);
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
@@ -15,53 +15,19 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.Objects;
+
 import java.util.Optional;
 
 @Immutable
-public class ListStreams extends Statement {
-
-  private final boolean showExtended;
-
+public class ListStreams extends StatementWithExtendedClause {
   public ListStreams(final Optional<NodeLocation> location, final boolean showExtended) {
-    super(location);
-    this.showExtended = showExtended;
-  }
-
-  public boolean getShowExtended() {
-    return showExtended;
+    super(location, showExtended);
   }
 
   @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitListStreams(this, context);
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ListStreams that = (ListStreams) o;
-    return showExtended == that.showExtended;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(showExtended);
-  }
-
-  @Override
-  public String toString() {
-    return toStringHelper(this)
-        .add("showExtended", showExtended)
-        .toString();
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
@@ -15,53 +15,22 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 import com.google.errorprone.annotations.Immutable;
+
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.Objects;
+
 import java.util.Optional;
 
 @Immutable
-public class ListTables extends Statement {
+public class ListTables extends StatementWithExtendedClause {
 
-  private final boolean showExtended;
 
   public ListTables(final Optional<NodeLocation> location, final boolean showExtended) {
-    super(location);
-    this.showExtended = showExtended;
-  }
-
-  public boolean getShowExtended() {
-    return showExtended;
+    super(location, showExtended);
   }
 
   @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitListTables(this, context);
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ListTables that = (ListTables) o;
-    return showExtended == that.showExtended;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(showExtended);
-  }
-
-  @Override
-  public String toString() {
-    return toStringHelper(this)
-        .add("showExtended", showExtended)
-        .toString();
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/StatementWithExtendedClause.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/StatementWithExtendedClause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -22,21 +22,24 @@ import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
 import java.util.Optional;
 
-public class ListTopics extends StatementWithExtendedClause {
+public abstract class StatementWithExtendedClause extends Statement {
+  final boolean showExtended;
 
-  private final boolean showAll;
-
-  public ListTopics(
+  protected StatementWithExtendedClause(
       final Optional<NodeLocation> location,
-      final boolean showAll,
       final boolean showExtended
   ) {
-    super(location, showExtended);
-    this.showAll = showAll;
+    super(location);
+    this.showExtended = showExtended;
   }
 
-  public boolean getShowAll() {
-    return showAll;
+  public boolean getShowExtended() {
+    return showExtended;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(showExtended);
   }
 
   @Override
@@ -47,19 +50,13 @@ public class ListTopics extends StatementWithExtendedClause {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final ListTopics that = (ListTopics) o;
-    return showAll == that.showAll && showExtended == that.showExtended;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(showAll, showExtended);
+    final StatementWithExtendedClause that = (StatementWithExtendedClause) o;
+    return showExtended == that.showExtended;
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
-        .add("showAll", showAll)
         .add("showExtended", showExtended)
         .toString();
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -15,16 +15,13 @@
 
 package io.confluent.ksql.rest.server.execution;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.ListQueries;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.SessionProperties;
-import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlEntity;
-import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryDescription;
@@ -32,39 +29,23 @@ import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.QueryStatusCount;
 import io.confluent.ksql.rest.entity.RunningQuery;
-import io.confluent.ksql.rest.server.ServerUtil;
-import io.confluent.ksql.rest.util.DiscoverRemoteHostsUtil;
 import io.confluent.ksql.services.ServiceContext;
-import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
-import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.state.HostInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressFBWarnings("SE_BAD_FIELD")
 public final class ListQueriesExecutor {
-
-  private static final int TIMEOUT_SECONDS = 10;
-  private static final Logger LOG = LoggerFactory.getLogger(ListQueriesExecutor.class);
 
   private ListQueriesExecutor() {
   }
@@ -75,22 +56,26 @@ public final class ListQueriesExecutor {
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    final Pair<List<KsqlEntity>, Set<HostInfo>> remoteResults =
-        scatterGather(statement, sessionProperties, executionContext, serviceContext);
-
+    final RemoteDataAugmenter remoteDataAugmenter = RemoteDataAugmenter.create(
+        statement.getStatementText(),
+        sessionProperties,
+        executionContext,
+        serviceContext.getKsqlClient()
+    );
     return statement.getStatement().getShowExtended()
-        ? executeExtended(remoteResults, sessionProperties, statement, executionContext)
-        : executeSimple(remoteResults, statement, executionContext);
+        ? executeExtended(statement, sessionProperties, executionContext, remoteDataAugmenter)
+        : executeSimple(statement, executionContext, remoteDataAugmenter);
   }
 
   private static Optional<KsqlEntity> executeSimple(
-      final Pair<List<KsqlEntity>, Set<HostInfo>> remoteResults,
       final ConfiguredStatement<ListQueries> statement,
-      final KsqlExecutionContext executionContext
+      final KsqlExecutionContext executionContext,
+      final RemoteDataAugmenter remoteDataAugmenter
   ) {
-    final Map<QueryId, RunningQuery> runningQueries = getLocalSimple(executionContext);
-    mergeSimple(remoteResults, runningQueries);
-
+    final Map<QueryId, RunningQuery> runningQueries = remoteDataAugmenter.augmentWithRemote(
+        getLocalSimple(executionContext),
+        ListQueriesExecutor::mergeSimple
+    );
     return Optional.of(new Queries(
         statement.getStatementText(),
         runningQueries.values()));
@@ -130,9 +115,9 @@ public final class ListQueriesExecutor {
         ));
   }
 
-  private static void mergeSimple(
-      final Pair<List<KsqlEntity>, Set<HostInfo>> remoteResults,
-      final Map<QueryId, RunningQuery> allResults
+  private static Map<QueryId, RunningQuery> mergeSimple(
+      final Map<QueryId, RunningQuery> allResults,
+      final Pair<List<KsqlEntity>, Set<HostInfo>> remoteResults
   ) {
     final List<KsqlEntity> remoteQueries = remoteResults.getLeft();
     final List<RunningQuery> remoteRunningQueries = remoteQueries.stream()
@@ -140,7 +125,7 @@ public final class ListQueriesExecutor {
         .map(Queries::getQueries)
         .flatMap(List::stream)
         .collect(Collectors.toList());
-    
+
     for (RunningQuery q : remoteRunningQueries) {
       final QueryId queryId = q.getId();
 
@@ -165,18 +150,19 @@ public final class ListQueriesExecutor {
             .updateStatusCount(KsqlQueryStatus.UNRESPONSIVE, unresponsiveRemoteHosts.size());
       }
     }
+    return allResults;
   }
-  
-  private static Optional<KsqlEntity> executeExtended(
-      final Pair<List<KsqlEntity>, Set<HostInfo>> remoteResults,
-      final SessionProperties sessionProperties,
-      final ConfiguredStatement<ListQueries> statement,
-      final KsqlExecutionContext executionContext
-  ) {
-    final Map<QueryId, QueryDescription> queryDescriptions =
-        getLocalExtended(sessionProperties, executionContext);
 
-    mergeExtended(remoteResults, queryDescriptions);
+  private static Optional<KsqlEntity> executeExtended(
+      final ConfiguredStatement<ListQueries> statement,
+      final SessionProperties sessionProperties,
+      final KsqlExecutionContext executionContext,
+      final RemoteDataAugmenter remoteDataAugmenter
+  ) {
+    final Map<QueryId, QueryDescription> queryDescriptions = remoteDataAugmenter.augmentWithRemote(
+        getLocalExtended(sessionProperties, executionContext),
+        ListQueriesExecutor::mergeExtended
+    );
 
     return Optional.of(new QueryDescriptionList(
         statement.getStatementText(),
@@ -201,9 +187,9 @@ public final class ListQueriesExecutor {
                 ))));
   }
 
-  private static void mergeExtended(
-      final Pair<List<KsqlEntity>, Set<HostInfo>> remoteResults,
-      final Map<QueryId, QueryDescription> allResults
+  private static Map<QueryId, QueryDescription> mergeExtended(
+      final Map<QueryId, QueryDescription> allResults,
+      final Pair<List<KsqlEntity>, Set<HostInfo>> remoteResults
   ) {
     final List<KsqlEntity> remoteQueries = remoteResults.getLeft();
     final List<QueryDescription> remoteQueryDescriptions = remoteQueries.stream()
@@ -226,85 +212,15 @@ public final class ListQueriesExecutor {
         allResults.put(queryId, q);
       }
     }
-    
+
     final Set<HostInfo> unresponsiveRemoteHosts = remoteResults.getRight();
-    for (HostInfo hostInfo: unresponsiveRemoteHosts) {
-      for (QueryDescription queryDescription: allResults.values()) {
+    for (HostInfo hostInfo : unresponsiveRemoteHosts) {
+      for (QueryDescription queryDescription : allResults.values()) {
         queryDescription.updateKsqlHostQueryStatus(
             new KsqlHostInfoEntity(hostInfo.host(), hostInfo.port()),
             KsqlQueryStatus.UNRESPONSIVE);
       }
     }
-  }
-
-  private static Pair<List<KsqlEntity>, Set<HostInfo>> scatterGather(
-      final ConfiguredStatement<ListQueries> statement,
-      final SessionProperties sessionProperties,
-      final KsqlExecutionContext executionContext,
-      final ServiceContext serviceContext
-  ) {
-    if (sessionProperties.getInternalRequest()) {
-      return new Pair<>(ImmutableList.of(), ImmutableSet.of());
-    }
-
-    final Set<HostInfo> remoteHosts = DiscoverRemoteHostsUtil.getRemoteHosts(
-        executionContext.getPersistentQueries(),
-        sessionProperties.getKsqlHostInfo()
-    );
-
-    if (remoteHosts.isEmpty()) {
-      return new Pair<>(ImmutableList.of(), ImmutableSet.of());
-    }
-
-    final Set<HostInfo> unresponsiveHosts = new HashSet<>();
-    final ExecutorService executorService = Executors.newFixedThreadPool(remoteHosts.size());
-
-    try {
-      final SimpleKsqlClient ksqlClient = serviceContext.getKsqlClient();
-
-      final Map<HostInfo, CompletableFuture<RestResponse<KsqlEntityList>>> futureResponses =
-          new HashMap<>();
-      for (HostInfo host : remoteHosts) {
-        final CompletableFuture<RestResponse<KsqlEntityList>> future = new CompletableFuture<>();
-        executorService.execute(() -> {
-          final RestResponse<KsqlEntityList> response = ksqlClient
-              .makeKsqlRequest(
-                  ServerUtil.buildRemoteUri(
-                      sessionProperties.getLocalUrl(),
-                      host.host(),
-                      host.port()
-                  ),
-                  statement.getStatementText(),
-                  Collections.singletonMap(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST, true));
-          future.complete(response);
-        });
-
-        futureResponses.put(host, future);
-      }
-      
-      final List<KsqlEntity> results = new ArrayList<>();
-      for (final Map.Entry<HostInfo, CompletableFuture<RestResponse<KsqlEntityList>>> e
-          : futureResponses.entrySet()) {
-        try {
-          final RestResponse<KsqlEntityList> response =
-              e.getValue().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-          if (response.isErroneous()) {
-            LOG.warn("Error response from host. host: {}, cause: {}",
-                e.getKey(), response.getErrorMessage().getMessage());
-            unresponsiveHosts.add(e.getKey());
-          } else {
-            results.add(response.getResponse().get(0));
-          }
-        } catch (final Exception cause) {
-          LOG.warn("Failed to retrieve query info from host. host: {}, cause: {}",
-              e.getKey(), cause.getMessage());
-          unresponsiveHosts.add(e.getKey());
-        }
-      }
-
-      return new Pair<>(results, unresponsiveHosts);
-    } finally {
-      executorService.shutdown();
-    }
+    return allResults;
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteDataAugmenter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteDataAugmenter.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.rest.SessionProperties;
+import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.server.ServerUtil;
+import io.confluent.ksql.rest.util.DiscoverRemoteHostsUtil;
+import io.confluent.ksql.services.SimpleKsqlClient;
+import io.confluent.ksql.util.KsqlRequestConfig;
+import io.confluent.ksql.util.Pair;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import org.apache.kafka.streams.state.HostInfo;
+
+
+public final class RemoteDataAugmenter {
+  private static final int TIMEOUT_SECONDS = 10;
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteDataAugmenter.class);
+
+  private final String statementText;
+  private final SessionProperties sessionProperties;
+  private final KsqlExecutionContext executionContext;
+  private final SimpleKsqlClient ksqlClient;
+
+
+  private RemoteDataAugmenter(
+      final String statementText,
+      final SessionProperties sessionProperties,
+      final KsqlExecutionContext executionContext,
+      final SimpleKsqlClient ksqlClient
+  ) {
+    this.statementText = Objects.requireNonNull(statementText);
+    this.sessionProperties = Objects.requireNonNull(sessionProperties);
+    this.executionContext = Objects.requireNonNull(executionContext);
+    this.ksqlClient = Objects.requireNonNull(ksqlClient);
+  }
+
+  public static RemoteDataAugmenter create(
+      final String statementText,
+      final SessionProperties sessionProperties,
+      final KsqlExecutionContext executionContext,
+      final SimpleKsqlClient ksqlClient
+  ) {
+    return new RemoteDataAugmenter(
+        statementText, sessionProperties, executionContext, ksqlClient);
+  }
+
+
+  public <R> R augmentWithRemote(
+      final R localResult,
+      final BiFunction<R, Pair<List<KsqlEntity>, Set<HostInfo>>, R> mergeFunc
+  ) {
+    Objects.requireNonNull(mergeFunc);
+    if (sessionProperties.getInternalRequest()) {
+      return mergeFunc.apply(localResult, new Pair<>(ImmutableList.of(), ImmutableSet.of()));
+    }
+    final Pair<List<KsqlEntity>, Set<HostInfo>> remoteResults = fetchAllRemoteResults();
+
+    return mergeFunc.apply(localResult, remoteResults);
+  }
+
+  private RestResponse<KsqlEntityList> makeKsqlRequest(
+      final HostInfo host,
+      final String statementText
+  ) {
+    return ksqlClient.makeKsqlRequest(
+        ServerUtil.buildRemoteUri(
+            sessionProperties.getLocalUrl(),
+            host.host(),
+            host.port()
+        ),
+        statementText,
+        Collections.singletonMap(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST, true)
+    );
+  }
+
+  private CompletableFuture<RestResponse<KsqlEntityList>> fetchRemoteData(
+      final String statementText,
+      final HostInfo host,
+      final Executor executor
+  ) {
+    return CompletableFuture.supplyAsync(() -> makeKsqlRequest(host, statementText), executor);
+  }
+
+  private Pair<List<KsqlEntity>, Set<HostInfo>> fetchAllRemoteResults() {
+    final Set<HostInfo> remoteHosts = DiscoverRemoteHostsUtil.getRemoteHosts(
+        executionContext.getPersistentQueries(),
+        sessionProperties.getKsqlHostInfo()
+    );
+
+    if (remoteHosts.isEmpty()) {
+      return new Pair<>(ImmutableList.of(), ImmutableSet.of());
+    }
+
+    final Set<HostInfo> unresponsiveHosts = new HashSet<>();
+    final ExecutorService executorService = Executors.newFixedThreadPool(remoteHosts.size());
+
+    try {
+      final Map<HostInfo, CompletableFuture<RestResponse<KsqlEntityList>>> futureResponses =
+          new HashMap<>();
+      for (HostInfo host : remoteHosts) {
+        futureResponses.put(host, fetchRemoteData(statementText, host, executorService));
+      }
+
+      final List<KsqlEntity> results = new ArrayList<>();
+      for (final Map.Entry<HostInfo, CompletableFuture<RestResponse<KsqlEntityList>>> e
+          : futureResponses.entrySet()) {
+        try {
+          final RestResponse<KsqlEntityList> response =
+              e.getValue().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+          if (response.isErroneous()) {
+            LOG.warn("Error response from host. host: {}, cause: {}",
+                e.getKey(), response.getErrorMessage().getMessage());
+            unresponsiveHosts.add(e.getKey());
+          } else {
+            results.add(response.getResponse().get(0));
+          }
+        } catch (final Exception cause) {
+          LOG.warn("Failed to retrieve info from host: {}, statement: {}, cause: {}",
+              e.getKey(), statementText, cause.getMessage());
+          unresponsiveHosts.add(e.getKey());
+        }
+      }
+
+      return new Pair<>(results, unresponsiveHosts);
+    } finally {
+      executorService.shutdown();
+    }
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteDataAugmenterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteDataAugmenterTest.java
@@ -1,0 +1,118 @@
+package io.confluent.ksql.rest.server.execution;
+
+
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.rest.SessionProperties;
+import io.confluent.ksql.rest.client.KsqlRestClientException;
+import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.server.TemporaryEngine;
+import io.confluent.ksql.rest.util.DiscoverRemoteHostsUtil;
+import io.confluent.ksql.services.SimpleKsqlClient;
+import org.apache.kafka.streams.state.HostInfo;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoteDataAugmenterTest {
+  @Mock
+  public final KsqlEngine executionContext = mock(KsqlEngine.class);
+  private final Set<HostInfo> hosts = Stream.of("otherhost:1234", "anotherhost:444")
+      .map(HostInfo::buildFromEndpoint)
+      .collect(Collectors.toSet());
+  private final Map<String, String> localData = Collections.singletonMap("cat", "cutest");
+  @Mock
+  private SimpleKsqlClient ksqlClient;
+  @Mock
+  private SessionProperties sessionProperties;
+  @Mock
+  private RestResponse<KsqlEntityList> response;
+  @Mock
+  private KsqlEntityList ksqlEntityList;
+  private RemoteDataAugmenter augmenter;
+
+  @Before
+  public void setup() throws MalformedURLException {
+
+    when(sessionProperties.getInternalRequest()).thenReturn(false);
+    when(sessionProperties.getLocalUrl()).thenReturn(new URL("https://address"));
+
+    augmenter = RemoteDataAugmenter.create(
+        "describe streams;",
+        sessionProperties,
+        executionContext,
+        ksqlClient);
+
+  }
+
+  @Test
+  public void testReturnsHostsThatHaveThrownAnException() {
+    when(ksqlClient.makeKsqlRequest(any(), any(), any())).thenThrow(new KsqlRestClientException("error"));
+    try (MockedStatic<DiscoverRemoteHostsUtil> hdu = mockStatic(DiscoverRemoteHostsUtil.class)) {
+      hdu.when(() -> DiscoverRemoteHostsUtil.getRemoteHosts(any(), any())).thenReturn(hosts);
+
+      augmenter.augmentWithRemote(localData, (localResult, remoteResults) -> {
+        assertEquals( hosts, remoteResults.getRight());
+        assertThat(remoteResults.getLeft(), is(empty()));
+        return localResult;
+      });
+    }
+  }
+
+  @Test
+  public void testReturnsHostsThatHaveReturnedAnErroneousResponse() {
+    when(ksqlClient.makeKsqlRequest(any(), any(), any())).thenReturn(response);
+    when(response.isErroneous()).thenReturn(true);
+    try (MockedStatic<DiscoverRemoteHostsUtil> hdu = mockStatic(DiscoverRemoteHostsUtil.class)) {
+      hdu.when(() -> DiscoverRemoteHostsUtil.getRemoteHosts(any(), any())).thenReturn(hosts);
+
+      augmenter.augmentWithRemote(localData, (localResult, remoteResults) -> {
+        assertEquals( hosts, remoteResults.getRight());
+        assertThat(remoteResults.getLeft(), is(empty()));
+        return localResult;
+      });
+    }
+  }
+
+  @Test
+  public void testReturnsRemoteResultsWhenEverythingIsFine() {
+    when(ksqlClient.makeKsqlRequest(any(), any(), any())).thenReturn(response);
+    when(response.isErroneous()).thenReturn(false);
+    when(response.getResponse()).thenReturn(ksqlEntityList);
+    try (MockedStatic<DiscoverRemoteHostsUtil> hdu = mockStatic(DiscoverRemoteHostsUtil.class)) {
+      hdu.when(() -> DiscoverRemoteHostsUtil.getRemoteHosts(any(), any())).thenReturn(hosts);
+
+      augmenter.augmentWithRemote(localData, (localResult, remoteResults) -> {
+        assertThat(remoteResults.getRight(), is(empty()));
+        assertThat(remoteResults.getLeft(), hasSize(2));
+        return localResult;
+      });
+    }
+  }
+}

--- a/ksqldb-rocksdb-config-setter/pom.xml
+++ b/ksqldb-rocksdb-config-setter/pom.xml
@@ -28,7 +28,6 @@
     <artifactId>ksqldb-rocksdb-config-setter</artifactId>
     <name>ksqlDB RocksDB Config Setter</name>
     <packaging>jar</packaging>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -53,7 +52,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ksqldb-test-util/pom.xml
+++ b/ksqldb-test-util/pom.xml
@@ -25,7 +25,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>ksqldb-test-util</artifactId>
-
   <dependencies>
 
     <dependency>
@@ -90,7 +89,15 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>${mockito.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -599,7 +599,7 @@
                 <version>${spotbugs.maven.plugin.version}</version>
                 <configuration>
                     <xmlOutput>true</xmlOutput>
-                    <excludeFilterFile>findbugs/findbugs-exclude.xml</excludeFilterFile>
+                    <excludeFilterFile>${project.basedir}/../findbugs/findbugs-exclude.xml</excludeFilterFile>
                     <effort>Max</effort>
                     <threshold>Max</threshold>
                     <failOnError>true</failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
         <apache.io.version>2.6</apache.io.version>
         <io.confluent.ksql.version>7.0.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
+        <mockito.version>3.8.0</mockito.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
This PR factors out the generic mechanism used to merge query results across multiple nodes without using the MetaStore (e.g. `list queries` or `describe streams`). This will let us collate stream/topic statistics across multiple nodes regardless of the node service the request in the consequent PR. This PR serves to prove that this mechanism works for `ListQueriesExecutor`

### Testing done 
Unit tests pass

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

