### PR TITLE
feat(executor): Allow SourceDescription returning executors to return cluster wide stream stats

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.metrics;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.Time;
 import io.confluent.ksql.util.AppInfo;
 import io.confluent.ksql.util.KsqlConfig;
@@ -24,7 +28,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -43,11 +46,9 @@ import org.apache.kafka.common.utils.SystemTime;
  */
 @SuppressWarnings("ClassDataAbstractionCoupling")
 public final class MetricCollectors {
-  private static final String KSQL_JMX_PREFIX = "io.confluent.ksql.metrics";
+
   public static final String RESOURCE_LABEL_PREFIX =
       CommonClientConfigs.METRICS_CONTEXT_PREFIX + "resource.";
-  private static final String KSQL_RESOURCE_TYPE = "ksql";
-
   public static final String RESOURCE_LABEL_TYPE =
       RESOURCE_LABEL_PREFIX + "type";
   public static final String RESOURCE_LABEL_VERSION =
@@ -58,15 +59,15 @@ public final class MetricCollectors {
       RESOURCE_LABEL_PREFIX + "cluster.id";
   public static final String RESOURCE_LABEL_KAFKA_CLUSTER_ID =
       RESOURCE_LABEL_PREFIX + "kafka.cluster.id";
-
+  private static final String KSQL_JMX_PREFIX = "io.confluent.ksql.metrics";
+  private static final String KSQL_RESOURCE_TYPE = "ksql";
+  private static final Time time = new io.confluent.common.utils.SystemTime();
   private static Map<String, MetricCollector> collectorMap;
   private static Metrics metrics;
 
   static {
     initialize();
   }
-
-  private static final Time time = new io.confluent.common.utils.SystemTime();
 
   private MetricCollectors() {
   }
@@ -156,7 +157,7 @@ public final class MetricCollectors {
     collectorMap.remove(id);
   }
 
-  public static Map<String, TopicSensors.Stat> getStatsFor(
+  public static ImmutableMap<String, TopicSensors.Stat> getStatsFor(
       final String topic, final boolean isError) {
     return getAggregateMetrics(
         collectorMap.values().stream()
@@ -171,18 +172,14 @@ public final class MetricCollectors {
         isError ? "last-failed" : "last-message");
   }
 
-  static Map<String, TopicSensors.Stat> getAggregateMetrics(
+  static ImmutableMap<String, TopicSensors.Stat> getAggregateMetrics(
       final List<TopicSensors.Stat> allStats
   ) {
-    final Map<String, TopicSensors.Stat> results = new TreeMap<>();
-    allStats.forEach(stat -> {
-      results.computeIfAbsent(
-          stat.name(),
-          k -> new TopicSensors.Stat(stat.name(), 0, stat.getTimestamp())
-      );
-      results.get(stat.name()).aggregate(stat.getValue());
-    });
-    return results;
+    return allStats.stream().collect(toImmutableMap(
+        TopicSensors.Stat::name,
+        Functions.identity(),
+        (first, other) -> first.aggregate(other.getValue())
+    ));
   }
 
   public static String format(

--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/TopicSensors.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/TopicSensors.java
@@ -40,7 +40,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Rate;
 
-public class TopicSensors<R> {
+public final class TopicSensors<R> {
 
   private final String topic;
   private final List<SensorMetric<R>> sensors;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlHostInfo.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlHostInfo.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
+import org.apache.kafka.streams.state.HostInfo;
 
 
 /**
@@ -63,5 +64,9 @@ public class KsqlHostInfo {
   @Override
   public String toString() {
     return "KsqlHostInfo{host='" + this.host + '\'' + ", port=" + this.port + '}';
+  }
+
+  public static KsqlHostInfo fromHostInfo(HostInfo hostInfo) {
+    return new KsqlHostInfo(hostInfo.host(), hostInfo.port());
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlHostInfo.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlHostInfo.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.util;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 import org.apache.kafka.streams.state.HostInfo;
@@ -26,13 +27,17 @@ import org.apache.kafka.streams.state.HostInfo;
  */
 @Immutable
 public class KsqlHostInfo {
-
   private final String host;
+
   private final int port;
 
   public KsqlHostInfo(final String host, final int port) {
     this.host = host;
     this.port = port;
+  }
+
+  public static KsqlHostInfo fromHostInfo(final HostInfo hostInfo) {
+    return new KsqlHostInfo(hostInfo.host(), hostInfo.port());
   }
 
   @Override
@@ -62,11 +67,8 @@ public class KsqlHostInfo {
   }
 
   @Override
+  @JsonValue
   public String toString() {
     return "KsqlHostInfo{host='" + this.host + '\'' + ", port=" + this.port + '}';
-  }
-
-  public static KsqlHostInfo fromHostInfo(HostInfo hostInfo) {
-    return new KsqlHostInfo(hostInfo.host(), hostInfo.port());
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/ShowColumns.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/ShowColumns.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class ShowColumns extends Statement {
+public class ShowColumns extends StatementWithExtendedClause {
 
   private final SourceName table;
   private final boolean isExtended;
@@ -38,7 +38,7 @@ public class ShowColumns extends Statement {
       final SourceName table,
       final boolean isExtended
   ) {
-    super(location);
+    super(location, isExtended);
     this.table = requireNonNull(table, "table");
     this.isExtended = isExtended;
   }

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -177,6 +177,14 @@
             <scope>test</scope>
         </dependency>
 
+
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-random-core</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ClusterQueryStats.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ClusterQueryStats.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.metrics.TopicSensors;
+import io.confluent.ksql.rest.entity.SourceDescription;
+import io.confluent.ksql.util.KsqlHostInfo;
+import java.util.Collection;
+import java.util.Map;
+
+public final class ClusterQueryStats {
+  private final ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> stats;
+  private final ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> errors;
+  private final String sourceName;
+
+  private ClusterQueryStats(
+      final ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> stats,
+      final ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> errors,
+      final String sourceName
+  ) {
+    this.stats = stats;
+    this.errors = errors;
+    this.sourceName = sourceName;
+  }
+
+  public static ClusterQueryStats create(
+      final KsqlHostInfo localHostInfo,
+      final SourceDescription localSourceDescription,
+      final Collection<RemoteSourceDescription> remoteSourceDescriptions
+  ) {
+    final Map<KsqlHostInfo, SourceDescription> rds = remoteSourceDescriptions.stream()
+        .collect(toImmutableMap(
+            RemoteSourceDescription::getKsqlHostInfo,
+            RemoteSourceDescription::getSourceDescription
+        ));
+
+
+    final ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> remoteStats = rds
+        .entrySet()
+        .stream()
+        .collect(
+            toImmutableMap(
+                Map.Entry::getKey,
+                e -> ImmutableMap.copyOf(e.getValue().getStatisticsMap())
+            )
+        );
+    final ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> remoteErrors = rds
+        .entrySet()
+        .stream()
+        .collect(
+            toImmutableMap(
+                Map.Entry::getKey,
+                e -> ImmutableMap.copyOf(e.getValue().getErrorStatsMap())
+            )
+        );
+
+
+    final ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> stats = ImmutableMap
+        .<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>>builder()
+        .put(localHostInfo, localSourceDescription.getStatisticsMap())
+        .putAll(remoteStats)
+        .build();
+
+    final ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> errors = ImmutableMap
+        .<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>>builder()
+        .put(localHostInfo, localSourceDescription.getErrorStatsMap())
+        .putAll(remoteErrors)
+        .build();
+
+    return new ClusterQueryStats(stats, errors, localSourceDescription.getName());
+  }
+
+  public ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> getStats() {
+    return stats;
+  }
+
+  public ImmutableMap<KsqlHostInfo, ImmutableMap<String, TopicSensors.Stat>> getErrors() {
+    return errors;
+  }
+
+  public String getSourceName() {
+    return sourceName;
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteSourceDescription.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteSourceDescription.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import io.confluent.ksql.rest.entity.SourceDescription;
+import io.confluent.ksql.util.KsqlHostInfo;
+
+
+public final class RemoteSourceDescription {
+  private final String sourceName;
+  private final SourceDescription sourceDescription;
+  private final KsqlHostInfo hostInfo;
+
+  public RemoteSourceDescription(
+      final String sourceName,
+      final SourceDescription sourceDescription,
+      final KsqlHostInfo hostInfo
+  ) {
+    this.sourceName = sourceName;
+    this.sourceDescription = sourceDescription;
+    this.hostInfo = hostInfo;
+  }
+
+  public String getSourceName() {
+    return sourceName;
+  }
+
+  public SourceDescription getSourceDescription() {
+    return sourceDescription;
+  }
+
+  public KsqlHostInfo getKsqlHostInfo() {
+    return hostInfo;
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteSourceDescriptionExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RemoteSourceDescriptionExecutor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.ksql.rest.server.execution;
+
+import static com.google.common.collect.ImmutableListMultimap.flatteningToImmutableListMultimap;
+import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import io.confluent.ksql.rest.entity.SourceDescriptionList;
+import io.confluent.ksql.util.KsqlHostInfo;
+import java.util.Map;
+
+public final class RemoteSourceDescriptionExecutor {
+  private RemoteSourceDescriptionExecutor() {
+  }
+
+  public static Multimap<String, RemoteSourceDescription> fetchSourceDescriptions(
+      final RemoteHostExecutor remoteHostExecutor
+  ) {
+    return Maps
+        .transformValues(
+            remoteHostExecutor.fetchAllRemoteResults().getLeft(),
+            SourceDescriptionList.class::cast)
+        .entrySet()
+        .stream()
+        .collect(
+            flatteningToImmutableListMultimap(
+                Map.Entry::getKey,
+                (e) -> e.getValue().getSourceDescriptions().stream())
+        )
+        .entries()
+        .stream()
+        .collect(toImmutableListMultimap(
+            e -> e.getValue().getName(),
+            e -> new RemoteSourceDescription(
+                e.getValue().getName(),
+                e.getValue(),
+                KsqlHostInfo.fromHostInfo(e.getKey())
+            )
+        ));
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -62,9 +62,12 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @SuppressWarnings("unchecked")
 @Category({IntegrationTest.class})
+@RunWith(MockitoJUnitRunner.class)
 public class KsqlResourceFunctionalTest {
 
   private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PageViewDataProvider;
 import io.vertx.core.net.SocketAddress;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.security.Principal;
 import java.util.Map;
 import java.util.Optional;
@@ -61,6 +62,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.experimental.runners.Enclosed;
@@ -75,45 +77,46 @@ import org.mockito.junit.MockitoJUnitRunner;
 @Category({IntegrationTest.class})
 @RunWith(Enclosed.class)
 public class SystemAuthenticationFunctionalTest {
-
   private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
-  private static final TemporaryFolder TMP = new TemporaryFolder();
-
-  static {
-    try {
-      TMP.create();
-    } catch (final IOException e) {
-      throw new AssertionError("Failed to init TMP", e);
-    }
-  }
-
-  private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
-  private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
-  private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.sourceName();
+  @ClassRule
+  public static final TemporaryFolder TMP = new TemporaryFolder();
+  private static PageViewDataProvider PAGE_VIEWS_PROVIDER;
+  private static String PAGE_VIEW_TOPIC;
   private static final BiFunction<Integer, String, SocketAddress> LOCALHOST_FACTORY =
       (port, host) -> SocketAddress.inetSocketAddress(port, "localhost");
+  private static String PAGE_VIEW_STREAM;
 
-  private static final Map<String, Object> JASS_AUTH_CONFIG = ImmutableMap.<String, Object>builder()
-      .put("authentication.method", "BASIC")
-      .put("authentication.roles", "**")
-      // Reuse the Kafka JAAS config for KSQL authentication which has the same valid users
-      .put("authentication.realm", JAAS_KAFKA_PROPS_NAME)
-      .put(
-          KsqlConfig.KSQL_SECURITY_EXTENSION_CLASS,
-          MockKsqlSecurityExtension.class.getName()
-      )
-      .build();
+  private static Map<String, Object> JASS_AUTH_CONFIG;
+  private static Map<String, Object> COMMON_CONFIG;
 
-  private static final Map<String, Object> COMMON_CONFIG = ImmutableMap.<String, Object>builder()
-      .put(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
-      .put(KsqlRestConfig.KSQL_HEARTBEAT_SEND_INTERVAL_MS_CONFIG, 1000)
-      .put(KsqlRestConfig.KSQL_HEARTBEAT_CHECK_INTERVAL_MS_CONFIG, 3000)
-      .put(KsqlRestConfig.KSQL_HEARTBEAT_DISCOVER_CLUSTER_MS_CONFIG, 3000)
-      .put(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir())
-      .put(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1)
-      .put(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
-      .putAll(SERVER_KEY_STORE.keyStoreProps())
-      .build();
+  @BeforeClass
+  public static void setupClass() {
+    PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
+    PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
+    PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.sourceName();
+
+    JASS_AUTH_CONFIG = ImmutableMap.<String, Object>builder()
+        .put("authentication.method", "BASIC")
+        .put("authentication.roles", "**")
+        // Reuse the Kafka JAAS config for KSQL authentication which has the same valid users
+        .put("authentication.realm", JAAS_KAFKA_PROPS_NAME)
+        .put(
+            KsqlConfig.KSQL_SECURITY_EXTENSION_CLASS,
+            MockKsqlSecurityExtension.class.getName()
+        )
+        .build();
+
+    COMMON_CONFIG = ImmutableMap.<String, Object>builder()
+        .put(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
+        .put(KsqlRestConfig.KSQL_HEARTBEAT_SEND_INTERVAL_MS_CONFIG, 1000)
+        .put(KsqlRestConfig.KSQL_HEARTBEAT_CHECK_INTERVAL_MS_CONFIG, 3000)
+        .put(KsqlRestConfig.KSQL_HEARTBEAT_DISCOVER_CLUSTER_MS_CONFIG, 3000)
+        .put(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir(TMP))
+        .put(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1)
+        .put(KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG, 1000)
+        .putAll(SERVER_KEY_STORE.keyStoreProps())
+        .build();
+  }
 
   private static Map<String, String> internalKeyStoreProps(boolean node1) {
     Map<String, String> keyStoreProps = MultiNodeKeyStore.keyStoreProps();
@@ -331,9 +334,9 @@ public class SystemAuthenticationFunctionalTest {
     }
   }
 
-  private static String getNewStateDir() {
+  public static String getNewStateDir(TemporaryFolder rootTempDir) {
     try {
-      return TMP.newFolder().getAbsolutePath();
+      return rootTempDir.newFolder().getAbsolutePath();
     } catch (final IOException e) {
       throw new AssertionError("Failed to create new state dir", e);
     }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.rest.server;
 
 import static java.util.Objects.requireNonNull;
-import static org.easymock.EasyMock.niceMock;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -311,7 +311,7 @@ public class TestKsqlRestApp extends ExternalResource {
       ksqlRestApplication = KsqlRestApplication.buildApplication(
           metricsPrefix,
           ksqlRestConfig,
-          (booleanSupplier) -> niceMock(VersionCheckerAgent.class),
+          (booleanSupplier) -> mock(VersionCheckerAgent.class),
           3,
           serviceContext.get(),
           () -> serviceContext.get().getSchemaRegistryClient(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestAppTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestAppTest.java
@@ -19,7 +19,7 @@ import io.confluent.ksql.integration.IntegrationTestHarness;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-public class TestKsqlRestAppTest {
+public final class TestKsqlRestAppTest {
 
   @ClassRule
   public static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ClusterQueryStatsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ClusterQueryStatsTest.java
@@ -1,0 +1,66 @@
+package io.confluent.ksql.rest.server.execution;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.entity.SourceDescription;
+import io.confluent.ksql.util.KsqlHostInfo;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.streams.state.HostInfo;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterQueryStatsTest {
+
+  final EasyRandomParameters parameters = new EasyRandomParameters()
+      .randomize(ImmutableMap.class, ImmutableMap::of)
+      .randomize(ImmutableList.class, ImmutableList::of);
+  final EasyRandom objectMother = new EasyRandom(parameters);
+  final KsqlHostInfo localHostInfo = objectMother.nextObject(KsqlHostInfo.class);
+  final SourceDescription sourceDescription = objectMother.nextObject(SourceDescription.class);
+
+  @Test
+  public void testMergesRemoteAndLocalResults() {
+    List<RemoteSourceDescription> remote = objectMother
+        .objects(RemoteSourceDescription.class, 5)
+        .collect(toList());
+
+    ClusterQueryStats res = ClusterQueryStats.create(
+        localHostInfo,
+        sourceDescription,
+        remote
+    );
+    assertEquals(sourceDescription.getStatisticsMap(), res.getStats().get(localHostInfo));
+    assertEquals(sourceDescription.getErrorStatsMap(), res.getErrors().get(localHostInfo));
+
+    remote.forEach(rsd -> {
+      assertEquals(
+          rsd.getSourceDescription().getStatisticsMap(),
+          res.getStats().get(rsd.getKsqlHostInfo()));
+      assertEquals(
+          rsd.getSourceDescription().getErrorStatsMap(),
+          res.getErrors().get(rsd.getKsqlHostInfo()));
+    });
+  }
+
+  @Test
+  public void testCanCreateWithEmptyRemoteResults() {
+    ClusterQueryStats res = ClusterQueryStats.create(
+        localHostInfo,
+        sourceDescription,
+        new ArrayList<>()
+    );
+    assertEquals(sourceDescription.getStatisticsMap(), res.getStats().get(localHostInfo));
+    assertEquals(sourceDescription.getErrorStatsMap(), res.getErrors().get(localHostInfo));
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteSourceDescriptionExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteSourceDescriptionExecutorTest.java
@@ -1,0 +1,84 @@
+package io.confluent.ksql.rest.server.execution;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Streams;
+import io.confluent.ksql.rest.entity.SourceDescription;
+import io.confluent.ksql.rest.entity.SourceDescriptionList;
+import io.confluent.ksql.util.Pair;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.state.HostInfo;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.jeasy.random.FieldPredicates.inClass;
+import static org.jeasy.random.FieldPredicates.named;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoteSourceDescriptionExecutorTest  {
+  final EasyRandomParameters parameters = new EasyRandomParameters()
+      .randomize(ImmutableMap.class, ImmutableMap::of)
+      .excludeField(
+          named("fields")
+              .and(inClass(SourceDescription.class))
+      );
+  final EasyRandom objectMother = new EasyRandom(parameters);
+
+
+  @Mock
+  RemoteHostExecutor augmenter = mock(RemoteHostExecutor.class);
+
+  List<HostInfo> hosts = objectMother
+      .objects(HostInfo.class, 3)
+      .collect(Collectors.toList());
+
+  List<SourceDescriptionList> descriptionLists = objectMother
+      .objects(SourceDescriptionList.class, 3)
+      .collect(Collectors.toList());
+
+  Map<HostInfo, SourceDescriptionList> response = Streams
+      .zip(hosts.stream(), descriptionLists.stream(), AbstractMap.SimpleImmutableEntry::new)
+      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+  @Test
+  public void itShouldReturnRemoteSourceDescriptionsGroupedByName() {
+    // Given
+    when(augmenter.fetchAllRemoteResults()).thenReturn(new Pair(response, ImmutableSet.of()));
+
+    Multimap<String, RemoteSourceDescription> res = RemoteSourceDescriptionExecutor.fetchSourceDescriptions(augmenter);
+
+    Map<String, List<SourceDescription>> queryHostCounts = descriptionLists.stream()
+        .flatMap((v) -> v.getSourceDescriptions().stream())
+        .collect(Collectors.groupingBy(SourceDescription::getName));
+
+    assertThat(res.values(), everyItem(instanceOf(RemoteSourceDescription.class)));
+    response.forEach((host, value) -> value.getSourceDescriptions().forEach((sd) -> {
+      assertThat(res.get(sd.getName()), hasSize(queryHostCounts.get(sd.getName()).size()));
+    }));
+  }
+
+  @Test
+  public void itShouldReturnEmptyIfNoRemoteResults() {
+    // Given
+    when(augmenter.fetchAllRemoteResults()).thenReturn(new Pair(ImmutableMap.of(), response.keySet()));
+
+    Multimap<String, RemoteSourceDescription> res = RemoteSourceDescriptionExecutor.fetchSourceDescriptions(augmenter);
+    response.forEach((key, value) -> value.getSourceDescriptions().forEach((sd) -> {
+      assertThat(res.get(sd.getName()), hasSize(0));
+    }));
+  }
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -53,6 +54,10 @@ public class SourceDescription {
   private final String statement;
   private final List<QueryOffsetSummary> queryOffsetSummaries;
   private final List<String> sourceConstraints;
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private final ImmutableMap<KsqlHostInfoEntity, ImmutableMap<String, Stat>> clusterStatistics;
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private final ImmutableMap<KsqlHostInfoEntity, ImmutableMap<String, Stat>> clusterErrorStats;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   @JsonCreator
@@ -76,7 +81,11 @@ public class SourceDescription {
       @JsonProperty("replication") final int replication,
       @JsonProperty("statement") final String statement,
       @JsonProperty("queryOffsetSummaries") final List<QueryOffsetSummary> queryOffsetSummaries,
-      @JsonProperty("sourceConstraints") final List<String> sourceConstraints
+      @JsonProperty("sourceConstraints") final List<String> sourceConstraints,
+      @JsonProperty("clusterStatistics")
+      final ImmutableMap<KsqlHostInfoEntity, ImmutableMap<String, Stat>> clusterStats,
+      @JsonProperty("clusterErrorStats")
+      final ImmutableMap<KsqlHostInfoEntity, ImmutableMap<String, Stat>> clusterErrors
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.name = Objects.requireNonNull(name, "name");
@@ -104,7 +113,59 @@ public class SourceDescription {
         Objects.requireNonNull(queryOffsetSummaries, "queryOffsetSummaries"));
     this.sourceConstraints =
         ImmutableList.copyOf(Objects.requireNonNull(sourceConstraints, "sourceConstraints"));
+    this.clusterErrorStats = clusterErrors;
+    this.clusterStatistics = clusterStats;
   }
+
+  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
+  public SourceDescription(
+      @JsonProperty("name") final String name,
+      @JsonProperty("windowType") final Optional<WindowType> windowType,
+      @JsonProperty("readQueries") final List<RunningQuery> readQueries,
+      @JsonProperty("writeQueries") final List<RunningQuery> writeQueries,
+      @JsonProperty("fields") final List<FieldInfo> fields,
+      @JsonProperty("type") final String type,
+      @JsonProperty("timestamp") final String timestamp,
+      @JsonProperty("statistics") final String statistics,
+      @JsonProperty("errorStats") final String errorStats,
+      @JsonProperty("statisticsMap") final ImmutableMap<String, Stat> statisticsMap,
+      @JsonProperty("errorStatsMap") final ImmutableMap<String, Stat> errorStatsMap,
+      @JsonProperty("extended") final boolean extended,
+      @JsonProperty("keyFormat") final String keyFormat,
+      @JsonProperty("valueFormat") final String valueFormat,
+      @JsonProperty("topic") final String topic,
+      @JsonProperty("partitions") final int partitions,
+      @JsonProperty("replication") final int replication,
+      @JsonProperty("statement") final String statement,
+      @JsonProperty("queryOffsetSummaries") final List<QueryOffsetSummary> queryOffsetSummaries,
+      @JsonProperty("sourceConstraints") final List<String> sourceConstraints
+  ) {
+    this(
+        name,
+        windowType,
+        readQueries,
+        writeQueries,
+        fields,
+        type,
+        timestamp,
+        statistics,
+        errorStats,
+        statisticsMap,
+        errorStatsMap,
+        extended,
+        keyFormat,
+        valueFormat,
+        topic,
+        partitions,
+        replication,
+        statement,
+        queryOffsetSummaries,
+        sourceConstraints,
+        ImmutableMap.of(),
+        ImmutableMap.of()
+    );
+  }
+  // CHECKSTYLE_RULES.ON: ParameterNumberCheck
 
   public String getStatement() {
     return statement;
@@ -165,8 +226,8 @@ public class SourceDescription {
   public String getStatistics() {
     if (statistics.length() > 0) {
       return "The statistics field is deprecated and will be removed in a future version of ksql. "
-              + "Please update your client to the latest version and use statisticsMap instead.\n"
-              + statistics;
+          + "Please update your client to the latest version and use statisticsMap instead.\n"
+          + statistics;
     }
     return "";
   }
@@ -174,8 +235,8 @@ public class SourceDescription {
   public String getErrorStats() {
     if (errorStats.length() > 0) {
       return "The errorStats field is deprecated and will be removed in a future version of ksql. "
-              + "Please update your client to the latest version and use errorStatsMap instead.\n"
-              + errorStats + '\n';
+          + "Please update your client to the latest version and use errorStatsMap instead.\n"
+          + errorStats + '\n';
     }
     return "";
   }
@@ -194,6 +255,14 @@ public class SourceDescription {
 
   public List<String> getSourceConstraints() {
     return sourceConstraints;
+  }
+
+  public ImmutableMap<KsqlHostInfoEntity, ImmutableMap<String, Stat>> getClusterStatistics() {
+    return clusterStatistics;
+  }
+
+  public ImmutableMap<KsqlHostInfoEntity, ImmutableMap<String, Stat>> getClusterErrorStats() {
+    return clusterErrorStats;
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity


### PR DESCRIPTION
### Description 
This PR exposes new fields on SourceDescription - `clusterStatistics` and `clusterErrorStats`
These are mappings from the host running a partition of a query to its aggregated jmx metrics obtained from `MetricsCollectors`.

This is the backend side of this ticket: [KCI-206](https://confluentinc.atlassian.net/browse/KCI-206)


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

