### PR TITLE
chore: add rocksdbjni as explicit dependency to config setter module

### DIFF
--- a/ksqldb-rocksdb-config-setter/pom.xml
+++ b/ksqldb-rocksdb-config-setter/pom.xml
@@ -36,6 +36,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>5.18.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### Description 

The master build is currently failing because the ksqldb-rocksdb-config-setter module can't find dependencies from `org.rocksdb`. This dependency was previously being pulled in transitively from the module's kafka-streams dependency but this no longer appears to be the case. (The transitive dependency is now pulled in with scope `runtime` which I believe explains the compilation error.) This PR fixes the build by adding the dependency explicitly. 

~~Weirdly, I can't find any recent changes to explain the change in behavior; if anyone else has more ideas for where to look that'd be great. The build started failing between 10:18am and 11:51am PST today.~~

Update: mystery has been solved (thanks, Sophie!). Here's the culprit (a change in Streams's transitive dependency handling): https://github.com/confluentinc/kafka/pull/536/commits/7a3ebbebbc6aed2049f22c650a52f6f685546207#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R1428

### Testing done 

Build passes.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

