### PR TITLE
chore: update pull query metrics naming

### DIFF
--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -9,116 +9,116 @@ doing. This reference describes each metric and grouping.
 Metrics that describe the full set of persistent queries on a given server.
 
 ```
-io.confluent.ksql.metrics:type=ksql-engine-query-stats
+io.confluent.ksql.metrics:type=_confluent-ksql-engine-query-stats,ksql_service_id=<ksql.service.id>
 ```
 
 ### Attributes
 
 **Number of persistent queries**
 
-`_confluent-ksql-default_num-persistent-queries`
+`num-persistent-queries`
 
 The current number of persistent queries running in this engine.
 
 **Number of active queries**
 
-`_confluent-ksql-default_num-active-queries`
+`num-active-queries`
 
 The current number of active queries running in this engine.
 
 **Number of running queries**
 
-`_confluent-ksql-default_ksql-engine-query-stats-RUNNING-queries`
+`RUNNING-queries`
 
 Count of queries in `RUNNING` state.
 
 **Number of idle queries**
 
-`_confluent-ksql-default_num-idle-queries`
+`num-idle-queries`
 
 Number of inactive queries.
 
 **Number of not running queries**
 
-`_confluent-ksql-default_ksql-engine-query-stats-NOT_RUNNING-queries`
+`NOT_RUNNING-queries`
 
 Count of queries in `NOT_RUNNING` state.
 
 **Number of rebalancing queries**
 
-`_confluent-ksql-default_ksql-engine-query-stats-REBALANCING-queries`
+`REBALANCING-queries`
 
 Count of queries in `REBALANCING` state.
 
 **Number of created queries**
 
-`_confluent-ksql-default_ksql-engine-query-stats-CREATED-queries`
+`CREATED-queries`
 
 Count of queries in `CREATED` state.
 
 **Number of pending shutdown queries**
 
-`_confluent-ksql-default_ksql-engine-query-stats-PENDING_SHUTDOWN-queries`
+`PENDING_SHUTDOWN-queries`
 
 Count of queries in `PENDING_SHUTDOWN` state.
 
 **Number of error queries**
 
-`_confluent-ksql-default_ksql-engine-query-stats-ERROR-queries`
+`ERROR-queries`
 
 Count of queries in `ERROR` state.
 
 **Total bytes consumed**
 
-`_confluent-ksql-default_bytes-consumed-total`
+`bytes-consumed-total`
 
 The total number of bytes consumed across all queries.
 
 **Minimum messages consumed**
 
-`_confluent-ksql-default_messages-consumed-min`
+`messages-consumed-min`
 
 Min msgs consumed by query.
 
 **Maximum messages consumed**
 
-`_confluent-ksql-default_messages-consumed-max`
+`messages-consumed-max`
 
 Max msgs consumed by query.
 
 **Average messages consumed**
 
-`_confluent-ksql-default_messages-consumed-avg`
+`messages-consumed-avg`
 
 Mean msgs consumed by query.
 
 **Messages consumed per second**
 
-`_confluent-ksql-default_messages-consumed-per-sec`
+`messages-consumed-per-sec`
 
 The number of messages consumed per second across all queries.
 
 **Messages consumed total**
 
-`_confluent-ksql-default_messages-consumed-total`
+`messages-consumed-total`
 
 The total number of messages consumed across all queries.
 
 **Messages produced per second**
 
-`_confluent-ksql-default_messages-produced-per-sec`
+`messages-produced-per-sec`
 
 The number of messages produced per second across all queries.
 
 **Error rate**
 
-`_confluent-ksql-default_error-rate`
+`error-rate`
 
 The number of messages that were consumed but not processed. Messages may not be processed if, for instance, the message contents could not be deserialized due to an incompatible schema. Alternately, a consumed message may not have been produced, hence being effectively dropped. Such messages would also be counted toward the error rate.
 
 **Liveness indicator**
 
-`_confluent-ksql-default_liveness-indicator`
+`liveness-indicator`
 
 A metric with constant value `1` indicating the server is up and emitting metrics.
 
@@ -366,7 +366,7 @@ Metrics that describe the health of the `CommandRunner` thread, which
 enables each node to participate in distributed computation.
 
 ```
-io.confluent.ksql.metrics:type=_confluent-ksql-default_ksql-rest-app-command-runner
+io.confluent.ksql.metrics:type=_confluent-ksql-rest-app-command-runner
 ```
 
 ### Attributes

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
@@ -71,7 +71,7 @@ public class PullQueryExecutorMetrics implements Closeable {
         + ksqlServiceId;
     this.legacyCustomMetricsTags = Objects.requireNonNull(customMetricsTags, "customMetricsTags");
 
-    this.ksqlServicePrefix = ReservedInternalTopics.CONFLUENT_PREFIX;
+    this.ksqlServicePrefix = ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX;
     final Map<String, String> metricsTags = new HashMap<>(customMetricsTags);
     metricsTags.put(KsqlConstants.KSQL_SERVICE_ID_METRICS_TAG, ksqlServiceId);
     this.customMetricsTags = ImmutableMap.copyOf(metricsTags);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryMetricsTest.java
@@ -183,7 +183,7 @@ public class PullQueryMetricsTest {
         metrics.metric(
             metrics.metricName(
                 "pull-query-requests" + metricName,
-                ReservedInternalTopics.CONFLUENT_PREFIX + "pull-query",
+                ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX + "pull-query",
                 CUSTOM_TAGS_WITH_SERVICE_ID)
         ).metricValue().toString()
     );


### PR DESCRIPTION
### Description 
Updating the metrics bean name for ksql engine and ksql rest app metrics in the docs (no code change)

Also the new metric convention for pull queries didn't have the ksql prefix

Before change:
io.confluent.ksql.metrics:type=_confluent-pull-query,ksql_service_id=default_

After change:
io.confluent.ksql.metrics:type=_confluent-ksql-pull-query,ksql_service_id=default_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

