### PR TITLE
feat: enable variable substitution for /query-stream and /ksql endpoints

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -105,7 +105,8 @@ public class QueryEndpoint {
     // Must be run on worker as all this stuff is slow
     VertxUtils.checkIsWorker();
 
-    final ConfiguredStatement<Query> statement = createStatement(sql, properties.getMap(), sessionVariables.getMap());
+    final ConfiguredStatement<Query> statement = createStatement(
+        sql, properties.getMap(), sessionVariables.getMap());
 
     if (statement.getStatement().isPullQuery()) {
       return createPullQueryPublisher(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -79,7 +79,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
 
     final MetricsCallbackHolder metricsCallbackHolder = new MetricsCallbackHolder();
     final long startTimeNanos = Time.SYSTEM.nanoseconds();
-    endpoints.createQueryPublisher(queryStreamArgs.get().sql, queryStreamArgs.get().properties,
+    endpoints.createQueryPublisher(queryStreamArgs.get().sql, queryStreamArgs.get().properties, queryStreamArgs.get().sessionVariables,
         context, server.getWorkerExecutor(), DefaultApiSecurityContext.create(routingContext),
         metricsCallbackHolder)
         .thenAccept(queryPublisher -> {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -79,9 +79,9 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
 
     final MetricsCallbackHolder metricsCallbackHolder = new MetricsCallbackHolder();
     final long startTimeNanos = Time.SYSTEM.nanoseconds();
-    endpoints.createQueryPublisher(queryStreamArgs.get().sql, queryStreamArgs.get().properties, queryStreamArgs.get().sessionVariables,
-        context, server.getWorkerExecutor(), DefaultApiSecurityContext.create(routingContext),
-        metricsCallbackHolder)
+    endpoints.createQueryPublisher(queryStreamArgs.get().sql, queryStreamArgs.get().properties,
+        queryStreamArgs.get().sessionVariables, context, server.getWorkerExecutor(),
+        DefaultApiSecurityContext.create(routingContext), metricsCallbackHolder)
         .thenAccept(queryPublisher -> {
 
           final QueryResponseMetadata metadata;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -51,7 +51,7 @@ public interface Endpoints {
    * @param workerExecutor The worker executor to use for blocking operations
    * @return A CompletableFuture representing the future result of the operation
    */
-  CompletableFuture<QueryPublisher> createQueryPublisher(String sql, JsonObject properties,
+  CompletableFuture<QueryPublisher> createQueryPublisher(String sql, JsonObject properties, JsonObject sessionVariables,
       Context context, WorkerExecutor workerExecutor, ApiSecurityContext apiSecurityContext,
       MetricsCallbackHolder metricsCallbackHolder);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -51,9 +51,9 @@ public interface Endpoints {
    * @param workerExecutor The worker executor to use for blocking operations
    * @return A CompletableFuture representing the future result of the operation
    */
-  CompletableFuture<QueryPublisher> createQueryPublisher(String sql, JsonObject properties, JsonObject sessionVariables,
-      Context context, WorkerExecutor workerExecutor, ApiSecurityContext apiSecurityContext,
-      MetricsCallbackHolder metricsCallbackHolder);
+  CompletableFuture<QueryPublisher> createQueryPublisher(String sql, JsonObject properties,
+      JsonObject sessionVariables, Context context, WorkerExecutor workerExecutor,
+      ApiSecurityContext apiSecurityContext, MetricsCallbackHolder metricsCallbackHolder);
 
   /**
    * Create a subscriber which will receive a stream of inserts from the API server and process

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -141,6 +141,7 @@ public class KsqlServerEndpoints implements Endpoints {
   @Override
   public CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
       final JsonObject properties,
+      final JsonObject sessionVariables,
       final Context context,
       final WorkerExecutor workerExecutor,
       final ApiSecurityContext apiSecurityContext,
@@ -155,6 +156,7 @@ public class KsqlServerEndpoints implements Endpoints {
             .createQueryPublisher(
                 sql,
                 properties,
+                sessionVariables,
                 context,
                 workerExecutor,
                 ksqlSecurityContext.getServiceContext(),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -279,7 +279,8 @@ public class KsqlResource implements KsqlConfigurable {
               configProperties,
               localHost,
               localUrl,
-              requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST)
+              requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST),
+              request.getSessionVariables()
           )
       );
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -116,6 +116,33 @@ public class ApiTest extends BaseApiTest {
   }
 
   @Test
+  public void shouldExecutePullQueryWithVariableSubstitution() throws Exception {
+
+    // Given
+    JsonObject requestBody = new JsonObject().put("sql", "select * from ${name} where rowkey='1234';");
+    JsonObject properties = new JsonObject().put("prop1", "val1").put("prop2", 23);
+    JsonObject sessionVariables = new JsonObject().put("name", "foo");
+    requestBody.put("properties", properties).put("sessionVariables", sessionVariables);
+
+    // When
+    HttpResponse<Buffer> response = sendPostRequest("/query-stream", requestBody.toBuffer());
+
+    // Then
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.statusMessage(), is("OK"));
+    assertThat(testEndpoints.getLastSql(), is("select * from ${name} where rowkey='1234';"));
+    assertThat(testEndpoints.getLastProperties(), is(properties));
+    assertThat(testEndpoints.getLastSessionVariables(), is(sessionVariables));
+    QueryResponse queryResponse = new QueryResponse(response.bodyAsString());
+    assertThat(queryResponse.responseObject.getJsonArray("columnNames"), is(DEFAULT_COLUMN_NAMES));
+    assertThat(queryResponse.responseObject.getJsonArray("columnTypes"), is(DEFAULT_COLUMN_TYPES));
+    assertThat(queryResponse.rows, is(DEFAULT_JSON_ROWS));
+    assertThat(server.getQueryIDs(), hasSize(0));
+    String queryId = queryResponse.responseObject.getString("queryId");
+    assertThat(queryId, is(nullValue()));
+  }
+
+  @Test
   @CoreApiTest
   public void shouldExecutePushQuery() throws Exception {
 
@@ -125,6 +152,29 @@ public class ApiTest extends BaseApiTest {
     // Then
     assertThat(testEndpoints.getLastSql(), is(DEFAULT_PUSH_QUERY));
     assertThat(testEndpoints.getLastProperties(), is(DEFAULT_PUSH_QUERY_REQUEST_PROPERTIES));
+    assertThat(queryResponse.responseObject.getJsonArray("columnNames"), is(DEFAULT_COLUMN_NAMES));
+    assertThat(queryResponse.responseObject.getJsonArray("columnTypes"), is(DEFAULT_COLUMN_TYPES));
+    assertThat(queryResponse.rows, is(DEFAULT_JSON_ROWS));
+    assertThat(server.getQueryIDs(), hasSize(1));
+    String queryId = queryResponse.responseObject.getString("queryId");
+    assertThat(queryId, is(notNullValue()));
+    assertThat(server.getQueryIDs().contains(new PushQueryId(queryId)), is(true));
+  }
+
+  @Test
+  public void shouldExecutePushQueryWithVariableSubstitution() throws Exception {
+
+    // When
+    JsonObject requestBody = new JsonObject().put("sql", "select * from ${name} emit changes;");
+    JsonObject properties = new JsonObject().put("prop1", "val1").put("prop2", 23);
+    JsonObject sessionVariables = new JsonObject().put("name", "foo");
+    requestBody.put("properties", properties).put("sessionVariables", sessionVariables);
+    QueryResponse queryResponse = executePushQueryAndWaitForRows(requestBody);
+
+    // Then
+    assertThat(testEndpoints.getLastSql(), is("select * from ${name} emit changes;"));
+    assertThat(testEndpoints.getLastProperties(), is(DEFAULT_PUSH_QUERY_REQUEST_PROPERTIES));
+    assertThat(testEndpoints.getLastSessionVariables(), is(sessionVariables));
     assertThat(queryResponse.responseObject.getJsonArray("columnNames"), is(DEFAULT_COLUMN_NAMES));
     assertThat(queryResponse.responseObject.getJsonArray("columnTypes"), is(DEFAULT_COLUMN_TYPES));
     assertThat(queryResponse.rows, is(DEFAULT_JSON_ROWS));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -54,6 +54,7 @@ public class TestEndpoints implements Endpoints {
   private List<KsqlEntity> ksqlEndpointResponse;
   private String lastSql;
   private JsonObject lastProperties;
+  private JsonObject lastSessionVariables;
   private String lastTarget;
   private Set<TestQueryPublisher> queryPublishers = new HashSet<>();
   private int acksBeforePublisherError = -1;
@@ -65,7 +66,7 @@ public class TestEndpoints implements Endpoints {
 
   @Override
   public synchronized CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
-      final JsonObject properties, final Context context, final WorkerExecutor workerExecutor,
+      final JsonObject properties, JsonObject sessionVariables, final Context context, final WorkerExecutor workerExecutor,
       final ApiSecurityContext apiSecurityContext,
       final MetricsCallbackHolder metricsCallbackHolder) {
     CompletableFuture<QueryPublisher> completableFuture = new CompletableFuture<>();
@@ -75,6 +76,7 @@ public class TestEndpoints implements Endpoints {
     } else {
       this.lastSql = sql;
       this.lastProperties = properties;
+      this.lastSessionVariables = sessionVariables;
       this.lastApiSecurityContext = apiSecurityContext;
       final boolean push = sql.toLowerCase().contains("emit changes");
       final int limit = extractLimit(sql);
@@ -232,6 +234,10 @@ public class TestEndpoints implements Endpoints {
 
   public synchronized JsonObject getLastProperties() {
     return lastProperties;
+  }
+
+  public synchronized JsonObject getLastSessionVariables() {
+    return lastSessionVariables;
   }
 
   public synchronized Set<TestQueryPublisher> getQueryPublishers() {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -161,6 +161,7 @@ public class InsertsStreamRunner extends BasePerfRunner {
     @Override
     public CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
         final JsonObject properties,
+        final JsonObject sessionVariables,
         final Context context,
         final WorkerExecutor workerExecutor,
         final ApiSecurityContext apiSecurityContext,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -119,6 +119,7 @@ public class PullQueryRunner extends BasePerfRunner {
     @Override
     public synchronized CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
         final JsonObject properties,
+        final JsonObject sessionVariables,
         final Context context,
         final WorkerExecutor workerExecutor,
         final ApiSecurityContext apiSecurityContext,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -98,6 +98,7 @@ public class QueryStreamRunner extends BasePerfRunner {
     @Override
     public synchronized CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
         final JsonObject properties,
+        final JsonObject sessionVariables,
         final Context context,
         final WorkerExecutor workerExecutor,
         final ApiSecurityContext apiSecurityContext,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -155,6 +155,11 @@ public class RestApiTest {
               )
               .withAcl(
                   NORMAL_USER,
+                  resource(TOPIC, "Y"),
+                  ops(ALL)
+              )
+              .withAcl(
+                  NORMAL_USER,
                   resource(TOPIC, AGG_TABLE),
                   ops(ALL)
               )
@@ -681,7 +686,7 @@ public class RestApiTest {
     // Given:
     // When:
     makeKsqlRequestWithVariables(
-        "CREATE STREAM X AS SELECT * FROM " + PAGE_VIEW_STREAM + " WHERE USERID='${id}';",
+        "CREATE STREAM Y AS SELECT * FROM " + PAGE_VIEW_STREAM + " WHERE USERID='${id}';",
         ImmutableMap.of("id", "USER_1")
     );
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -55,8 +55,10 @@ import io.confluent.ksql.rest.entity.CommandId.Type;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatus.Status;
 import io.confluent.ksql.rest.entity.CommandStatuses;
+import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryStreamArgs;
 import io.confluent.ksql.rest.entity.ServerClusterId;
 import io.confluent.ksql.rest.entity.ServerInfo;
@@ -684,8 +686,9 @@ public class RestApiTest {
     );
 
     // Then:
-    final List<String> query = REST_APP.getPersistentQueries().stream()
-        .filter(q -> q.startsWith("CSAS_X_"))
+    final List<String> query = ((Queries) makeKsqlRequest("SHOW QUERIES;").get(0))
+        .getQueries().stream().map(q -> q.getQueryString())
+        .filter(q -> q.contains("WHERE (PAGEVIEW_KSTREAM.USERID = 'USER_1')"))
         .collect(Collectors.toList());
     assertThat(query.size(), is(1));
   }
@@ -715,8 +718,8 @@ public class RestApiTest {
     return serviceContext;
   }
 
-  private static void makeKsqlRequest(final String sql) {
-    RestIntegrationTestUtil.makeKsqlRequest(REST_APP, sql);
+  private static List<KsqlEntity> makeKsqlRequest(final String sql) {
+    return RestIntegrationTestUtil.makeKsqlRequest(REST_APP, sql);
   }
 
   private static void makeKsqlRequestWithVariables(final String sql, final Map<String, Object> variables) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.ServerClusterId;
 import io.confluent.ksql.rest.entity.ServerInfo;
@@ -89,6 +90,15 @@ public final class RestIntegrationTestUtil {
 
   public static List<KsqlEntity> makeKsqlRequest(final TestKsqlRestApp restApp, final String sql) {
     return makeKsqlRequest(restApp, sql, Optional.empty());
+  }
+
+  public static String makeKsqlRequestWithVariables(
+      final TestKsqlRestApp restApp, final String sql, final Map<String, Object> variables) {
+    final KsqlRequest request =
+        new KsqlRequest(sql, ImmutableMap.of(), ImmutableMap.of(), variables, null);
+
+    return rawRestRequest(restApp, HTTP_1_1, POST, "/ksql", request, KsqlMediaType.KSQL_V1_JSON.mediaType(),
+        Optional.empty()).body().toString();
   }
 
   static List<KsqlEntity> makeKsqlRequest(

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientUtilTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientUtilTest.java
@@ -184,7 +184,7 @@ public class KsqlClientUtilTest {
     // Then:
     assertThat(buff, is(notNullValue()));
     String expectedJson = "{\"ksql\":\"some ksql\",\"streamsProperties\":{\"auto.offset.reset\":\""
-        + "latest\"},\"requestProperties\":{},\"commandSequenceNumber\":21345}";
+        + "latest\"},\"requestProperties\":{},\"commandSequenceNumber\":21345,\"sessionVariables\":{}}";
     assertThat(new JsonObject(buff), is(new JsonObject(expectedJson)));
 
     // When:

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * Wraps the incoming {@link io.confluent.ksql.rest.entity.KsqlRequest} streamsProperties
@@ -35,6 +36,27 @@ public class SessionProperties {
   private final URL localUrl;
   private final boolean internalRequest;
   private final Map<String, String> sessionVariables;
+
+  /**
+   * @param mutableScopedProperties   The streamsProperties of the incoming request
+   * @param ksqlHostInfo              The ksqlHostInfo of the server that handles the request
+   * @param localUrl                  The url of the server that handles the request
+   * @param internalRequest           Flag indicating if request is from within the KSQL cluster
+   * @param sessionVariables          Initial session variables
+   */
+  public SessionProperties(
+      final Map<String, Object> mutableScopedProperties,
+      final KsqlHostInfo ksqlHostInfo,
+      final URL localUrl,
+      final boolean internalRequest,
+      final Map<String, Object> sessionVariables
+  ) {
+    this(mutableScopedProperties, ksqlHostInfo, localUrl, internalRequest);
+    if (sessionVariables != null) {
+      this.sessionVariables.putAll(sessionVariables.entrySet().stream()
+          .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toString())));
+    }
+  }
 
   /**
    * @param mutableScopedProperties   The streamsProperties of the incoming request

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/SessionProperties.java
@@ -51,11 +51,17 @@ public class SessionProperties {
       final boolean internalRequest,
       final Map<String, Object> sessionVariables
   ) {
-    this(mutableScopedProperties, ksqlHostInfo, localUrl, internalRequest);
-    if (sessionVariables != null) {
-      this.sessionVariables.putAll(sessionVariables.entrySet().stream()
-          .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toString())));
-    }
+    this.mutableScopedProperties =
+        new HashMap<>(Objects.requireNonNull(mutableScopedProperties, "mutableScopedProperties"));
+    this.ksqlHostInfo = Objects.requireNonNull(ksqlHostInfo, "ksqlHostInfo");
+    this.localUrl = Objects.requireNonNull(localUrl, "localUrl");
+    this.internalRequest = internalRequest;
+    this.sessionVariables = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    this.sessionVariables.putAll(
+        Objects.requireNonNull(sessionVariables, "sessionVariables")
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().toString())));
   }
 
   /**
@@ -70,12 +76,7 @@ public class SessionProperties {
       final URL localUrl,
       final boolean internalRequest
   ) {
-    this.mutableScopedProperties = 
-        new HashMap<>(Objects.requireNonNull(mutableScopedProperties, "mutableScopedProperties"));
-    this.ksqlHostInfo = Objects.requireNonNull(ksqlHostInfo, "ksqlHostInfo");
-    this.localUrl = Objects.requireNonNull(localUrl, "localUrl");
-    this.internalRequest = internalRequest;
-    this.sessionVariables = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    this(mutableScopedProperties, ksqlHostInfo, localUrl, internalRequest, Collections.EMPTY_MAP);
   }
 
   public Map<String, Object> getMutableScopedProperties() {

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -39,13 +39,24 @@ public class KsqlRequest {
   private final String ksql;
   private final ImmutableMap<String, Object> configOverrides;
   private final ImmutableMap<String, Object> requestProperties;
+  private final ImmutableMap<String, Object> sessionVariables;
   private final Optional<Long> commandSequenceNumber;
+
+  public KsqlRequest(
+      @JsonProperty("ksql") final String ksql,
+      @JsonProperty("streamsProperties") final Map<String, ?> configOverrides,
+      @JsonProperty("requestProperties") final Map<String, ?> requestProperties,
+      @JsonProperty("commandSequenceNumber") final Long commandSequenceNumber
+  ) {
+    this(ksql, configOverrides, requestProperties, null, commandSequenceNumber);
+  }
 
   @JsonCreator
   public KsqlRequest(
       @JsonProperty("ksql") final String ksql,
       @JsonProperty("streamsProperties") final Map<String, ?> configOverrides,
       @JsonProperty("requestProperties") final Map<String, ?> requestProperties,
+      @JsonProperty("sessionVariables") final Map<String, ?> sessionVariables,
       @JsonProperty("commandSequenceNumber") final Long commandSequenceNumber
   ) {
     this.ksql = ksql == null ? "" : ksql;
@@ -55,6 +66,9 @@ public class KsqlRequest {
     this.requestProperties = requestProperties == null
         ? ImmutableMap.of()
         : ImmutableMap.copyOf(serializeClassValues(requestProperties));
+    this.sessionVariables = sessionVariables == null
+        ? ImmutableMap.of()
+        : ImmutableMap.copyOf(serializeClassValues(sessionVariables));
     this.commandSequenceNumber = Optional.ofNullable(commandSequenceNumber);
   }
 
@@ -69,6 +83,10 @@ public class KsqlRequest {
 
   public Map<String, Object> getRequestProperties() {
     return coerceTypes(requestProperties);
+  }
+
+  public Map<String, Object> getSessionVariables() {
+    return sessionVariables;
   }
 
   public Optional<Long> getCommandSequenceNumber() {
@@ -89,6 +107,7 @@ public class KsqlRequest {
     return Objects.equals(ksql, that.ksql)
         && Objects.equals(configOverrides, that.configOverrides)
         && Objects.equals(requestProperties, that.requestProperties)
+        && Objects.equals(sessionVariables, that.sessionVariables)
         && Objects.equals(commandSequenceNumber, that.commandSequenceNumber);
   }
 
@@ -103,6 +122,7 @@ public class KsqlRequest {
         + "ksql='" + ksql + '\''
         + ", configOverrides=" + configOverrides
         + ", requestProperties=" + requestProperties
+        + ", sessionVariables=" + sessionVariables
         + ", commandSequenceNumber=" + commandSequenceNumber
         + '}';
   }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -113,7 +113,8 @@ public class KsqlRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(ksql, configOverrides, requestProperties, commandSequenceNumber);
+    return Objects.hash(ksql, configOverrides, requestProperties,
+        sessionVariables, commandSequenceNumber);
   }
 
   @Override

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStreamArgs.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStreamArgs.java
@@ -29,12 +29,16 @@ public class QueryStreamArgs {
 
   public final String sql;
   public final JsonObject properties;
+  public final JsonObject sessionVariables;
 
   public QueryStreamArgs(final @JsonProperty(value = "sql", required = true) String sql,
       final @JsonProperty(value = "properties")
-          Map<String, Object> properties) {
+          Map<String, Object> properties,
+      final @JsonProperty(value = "sessionVariables")
+          Map<String, Object> sessionVariables) {
     this.sql = Objects.requireNonNull(sql);
     this.properties = properties == null ? new JsonObject() : new JsonObject(properties);
+    this.sessionVariables = sessionVariables == null ? new JsonObject() : new JsonObject(sessionVariables);
   }
 
   @Override
@@ -42,6 +46,7 @@ public class QueryStreamArgs {
     return "QueryStreamArgs{"
         + "sql='" + sql + '\''
         + ", properties=" + properties
+        + ", sessionVariables=" + sessionVariables
         + '}';
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStreamArgs.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStreamArgs.java
@@ -38,7 +38,9 @@ public class QueryStreamArgs {
           Map<String, Object> sessionVariables) {
     this.sql = Objects.requireNonNull(sql);
     this.properties = properties == null ? new JsonObject() : new JsonObject(properties);
-    this.sessionVariables = sessionVariables == null ? new JsonObject() : new JsonObject(sessionVariables);
+    this.sessionVariables = sessionVariables == null
+        ? new JsonObject()
+        : new JsonObject(sessionVariables);
   }
 
   @Override

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -65,7 +65,8 @@ public class KsqlRequestTest {
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST + "\":true,"
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
-      + "\"commandSequenceNumber\":2}";
+      + "\"commandSequenceNumber\":2,"
+      + "\"sessionVariables\":{}}";
   private static final String A_JSON_REQUEST_WITH_NULL_COMMAND_NUMBER = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
@@ -77,7 +78,8 @@ public class KsqlRequestTest {
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST + "\":true,"
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
-      + "\"commandSequenceNumber\":null}";
+      + "\"commandSequenceNumber\":null,"
+      + "\"sessionVariables\":{}}";
 
   private static final ImmutableMap<String, Object> SOME_PROPS = ImmutableMap.of(
       ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -65,8 +65,8 @@ public class KsqlRequestTest {
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST + "\":true,"
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
-      + "\"commandSequenceNumber\":2,"
-      + "\"sessionVariables\":{}}";
+      + "\"sessionVariables\":{},"
+      + "\"commandSequenceNumber\":2}";
   private static final String A_JSON_REQUEST_WITH_NULL_COMMAND_NUMBER = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
@@ -78,8 +78,8 @@ public class KsqlRequestTest {
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST + "\":true,"
       + "\"" + KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING + "\":true"
       + "},"
-      + "\"commandSequenceNumber\":null,"
-      + "\"sessionVariables\":{}}";
+      + "\"sessionVariables\":{},"
+      + "\"commandSequenceNumber\":null}";
 
   private static final ImmutableMap<String, Object> SOME_PROPS = ImmutableMap.of(
       ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
@@ -109,6 +109,13 @@ public class KsqlRequestTest {
   public void shouldHandleNullProps() {
     assertThat(
         new KsqlRequest("sql", null, SOME_REQUEST_PROPS, SOME_COMMAND_NUMBER).getConfigOverrides(),
+        is(Collections.emptyMap()));
+  }
+
+  @Test
+  public void shouldHandleNullSessionVariables() {
+    assertThat(
+        new KsqlRequest("sql", SOME_PROPS, Collections.emptyMap(), null, SOME_COMMAND_NUMBER).getSessionVariables(),
         is(Collections.emptyMap()));
   }
 
@@ -168,12 +175,15 @@ public class KsqlRequestTest {
   public void shouldImplementHashCodeAndEqualsCorrectly() {
     new EqualsTester()
         .addEqualityGroup(new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, SOME_COMMAND_NUMBER),
-            new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, SOME_COMMAND_NUMBER))
+            new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, SOME_COMMAND_NUMBER),
+            new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, ImmutableMap.of(), SOME_COMMAND_NUMBER),
+            new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, null, SOME_COMMAND_NUMBER))
         .addEqualityGroup(
             new KsqlRequest("different-sql", SOME_PROPS, SOME_REQUEST_PROPS, SOME_COMMAND_NUMBER))
         .addEqualityGroup(
             new KsqlRequest("sql", ImmutableMap.of(), SOME_REQUEST_PROPS, SOME_COMMAND_NUMBER))
         .addEqualityGroup(new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, null))
+        .addEqualityGroup(new KsqlRequest("sql", SOME_PROPS, SOME_REQUEST_PROPS, ImmutableMap.of("", ""), null))
         .testEquals();
   }
 


### PR DESCRIPTION
### Description 
Adds an extra parameter, `sessionVariables` to the /query-stream and /ksql endpoints so that users can pass in a map of variable substitutions and use them in statements. For `/ksql`, `sessionVariables` is a map of initial variable values that can be modified with `define` and `undefine` statements.

This is a prerequisite for enabling variable substitutions in the java client.

### Testing done 
integration and unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

