### PR TITLE
chore: remove explicit rocksdbjni dependency as it's no longer needed (MINOR)

### DIFF
--- a/ksqldb-rocksdb-config-setter/pom.xml
+++ b/ksqldb-rocksdb-config-setter/pom.xml
@@ -35,12 +35,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.rocksdb</groupId>
-            <artifactId>rocksdbjni</artifactId>
-            <version>5.18.4</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### Description 

This PR reverts https://github.com/confluentinc/ksql/pull/7262, since we no longer need the explicit dependency anymore in light of https://github.com/apache/kafka/pull/10341.

### Testing done 

Will wait for Jenkins build to pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

