### PR TITLE
fix: Fixes ambiguous test mocks after streams change

### DIFF
--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -151,9 +151,9 @@ public class StreamStreamJoinBuilderTest {
     when(right.build(any(), eq(planInfo))).thenReturn(
         new KStreamHolder<>(rightKStream, RIGHT_SCHEMA, executionKeyFactory));
 
-    when(leftKStream.leftJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
-    when(leftKStream.outerJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
-    when(leftKStream.join(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
+    when(leftKStream.leftJoin(any(KStream.class), any(KsqlValueJoiner.class), any(), any(StreamJoined.class))).thenReturn(resultKStream);
+    when(leftKStream.outerJoin(any(KStream.class), any(KsqlValueJoiner.class), any(), any(StreamJoined.class))).thenReturn(resultKStream);
+    when(leftKStream.join(any(KStream.class), any(KsqlValueJoiner.class), any(), any(StreamJoined.class))).thenReturn(resultKStream);
 
     planBuilder = new KSPlanBuilder(
         buildContext,

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -121,8 +121,10 @@ public class StreamTableJoinBuilderTest {
     when(right.build(any(), eq(planInfo))).thenReturn(
         KTableHolder.materialized(rightKTable, RIGHT_SCHEMA, executionKeyFactory, materializationBuilder));
 
-    when(leftKStream.leftJoin(any(KTable.class), any(), any())).thenReturn(resultStream);
-    when(leftKStream.join(any(KTable.class), any(), any())).thenReturn(resultStream);
+    when(leftKStream.leftJoin(any(KTable.class), any(KsqlValueJoiner.class), any()))
+        .thenReturn(resultStream);
+    when(leftKStream.join(any(KTable.class), any(KsqlValueJoiner.class), any()))
+        .thenReturn(resultStream);
 
     planBuilder = new KSPlanBuilder(
         buildContext,


### PR DESCRIPTION
### Description 
The mock call are currently ambiguous and make a compilation error.  This makes the tests compile and pass.


### Testing done 
Ran tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

