### PR TITLE
Revert "test: fix QTT tests after upstream change"

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/5.5.0_1581572086154/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/5.5.0_1581572086154/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585182000596/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585182000596/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585912758104/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1585912758104/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1588893905811/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1588893905811/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1589910852463/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_AVRO/6.0.0_1589910852463/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/5.5.0_1581572086189/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/5.5.0_1581572086189/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585182000661/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585182000661/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585912758148/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1585912758148/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1588893905952/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1588893905952/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1589910852673/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_JSON/6.0.0_1589910852673/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/5.5.0_1581572086226/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/5.5.0_1581572086226/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585182000710/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585182000710/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585912758193/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1585912758193/spec.json
@@ -118,6 +118,20 @@
       "key" : 100,
       "value" : {
         "ID" : 100,
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "ID" : 100,
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1588893906070/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1588893906070/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1589910852780/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_string_table_-_PROTOBUF/6.0.0_1589910852780/spec.json
@@ -107,6 +107,18 @@
       "topic" : "S2",
       "key" : 100,
       "value" : {
+        "COLLECTED" : [ "baz" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 100,
+      "value" : {
         "COLLECTED" : [ "foo" ]
       }
     } ],


### PR DESCRIPTION
Reverts confluentinc/ksql#7294

Master is back to having 8 rows