### PR TITLE
fix: only list known connect worker properties when listing server props

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -142,7 +142,8 @@ public class ListPropertiesExecutorTest {
             + "offset.storage.topic=topic1\n"
             + "config.storage.topic=topic2\n"
             + "status.storage.topic=topic3\n"
-            + "producer.sasl.jaas.config=<potentially sensitive data that should not be shown>\n"
+            + "other.config=<potentially sensitive data that should not be shown>\n"
+            + "sasl.jaas.config=<potentially sensitive data that should not be shown even though it's a recognized config>\n"
     );
 
     // When:
@@ -162,9 +163,8 @@ public class ListPropertiesExecutorTest {
     assertThat(
         properties.getProperties(),
         hasItem(new Property("value.converter", "EMBEDDED CONNECT WORKER", "io.confluent.connect.avro.AvroConverter")));
-    assertThat(
-        toMap(properties),
-        not(hasKey("producer.sasl.jaas.config")));
+    assertThat(toMap(properties), not(hasKey("other.config")));
+    assertThat(toMap(properties), not(hasKey("sasl.jaas.config")));
   }
 
   private void givenConnectWorkerProperties(final String contents) throws Exception {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -31,17 +31,37 @@ import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.util.KsqlConfig;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ListPropertiesExecutorTest {
 
-  @Rule public final TemporaryEngine engine = new TemporaryEngine();
+  @Rule
+  public final TemporaryEngine engine = new TemporaryEngine();
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private String connectPropsFile;
+
+  @Before
+  public void setUp() {
+    connectPropsFile = Paths.get(folder.getRoot().getPath(), "connect.properties").toString();
+  }
 
   @Test
   public void shouldListProperties() {
@@ -58,14 +78,6 @@ public class ListPropertiesExecutorTest {
         toMap(properties),
         equalTo(engine.getKsqlConfig().getAllConfigPropsWithSecretsObfuscated()));
     assertThat(properties.getOverwrittenProperties(), is(empty()));
-  }
-
-  private Map<String, String> toMap(final PropertiesList properties) {
-    final Map<String, String> map = new HashMap<>();
-    for (final Property property : properties.getProperties()) {
-      map.put(property.getName(), property.getValue());
-    }
-    return map;
   }
 
   @Test
@@ -118,5 +130,58 @@ public class ListPropertiesExecutorTest {
     assertThat(
         properties.getProperties(),
         hasItem(new Property("ksql.streams.topic.min.insync.replicas", "KSQL", "2")));
+  }
+
+  @Test
+  public void shouldNotListUnrecognizedConnectProps() throws Exception {
+    // Given:
+    givenConnectWorkerProperties(
+        "group.id=list_properties_unit_test\n"
+            + "key.converter=io.confluent.connect.avro.AvroConverter\n"
+            + "value.converter=io.confluent.connect.avro.AvroConverter\n"
+            + "offset.storage.topic=topic1\n"
+            + "config.storage.topic=topic2\n"
+            + "status.storage.topic=topic3\n"
+            + "producer.sasl.jaas.config=<potentially sensitive data that should not be shown>\n"
+    );
+
+    // When:
+    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
+        engine.configure("LIST PROPERTIES;")
+            .withConfig(new KsqlConfig(ImmutableMap.of(
+                "ksql.connect.worker.config", connectPropsFile))),
+        mock(SessionProperties.class),
+        engine.getEngine(),
+        engine.getServiceContext()
+    ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(
+        properties.getProperties(),
+        hasItem(new Property("ksql.connect.worker.config", "KSQL", connectPropsFile)));
+    assertThat(
+        properties.getProperties(),
+        hasItem(new Property("value.converter", "EMBEDDED CONNECT WORKER", "io.confluent.connect.avro.AvroConverter")));
+    assertThat(
+        toMap(properties),
+        not(hasKey("producer.sasl.jaas.config")));
+  }
+
+  private void givenConnectWorkerProperties(final String contents) throws Exception {
+    assertThat(new File(connectPropsFile).createNewFile(), is(true));
+
+    try (PrintWriter out = new PrintWriter(connectPropsFile, Charset.defaultCharset().name())) {
+      out.println(contents);
+    } catch (FileNotFoundException | UnsupportedEncodingException e) {
+      Assert.fail("Failed to write connect worker config file: " + connectPropsFile);
+    }
+  }
+
+  private static Map<String, String> toMap(final PropertiesList properties) {
+    final Map<String, String> map = new HashMap<>();
+    for (final Property property : properties.getProperties()) {
+      map.put(property.getName(), property.getValue());
+    }
+    return map;
   }
 }


### PR DESCRIPTION
### Description 

When ksqlDB runs with embedded Connect via the `ksql.connect.worker.config` config, if a user lists server properties with `list properties;`, the entire contents of the connect worker config file is displayed in the output, including any potentially sensitive configs. This is in contrast to sensitive ksqlDB or Streams configs which are properly sanitized (displayed as `[hidden]`) in the properties listing output, including any/all UDF-specific configs. This PR fixes the issue for the connect worker configs by only displaying known connect worker properties (as specified by `DistributedConfig`) as we know these are safe to display.

### Testing done 

Unit test added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

