### PR TITLE
fix: only list known connect worker properties when listing server props (5.5.x)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
@@ -32,8 +32,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 
 public final class ListPropertiesExecutor {
 
@@ -90,9 +92,18 @@ public final class ListPropertiesExecutor {
       final ConfiguredStatement<ListProperties> statement) {
     final String configFile = statement.getConfig()
         .getString(KsqlConfig.CONNECT_WORKER_CONFIG_FILE_PROPERTY);
-    return !configFile.isEmpty()
-        ? Utils.propsToStringMap(getWorkerProps(configFile))
-        : Collections.emptyMap();
+
+    if (configFile.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    final Map<String, String> workerProps = Utils.propsToStringMap(getWorkerProps(configFile));
+    // only list known connect worker properties to avoid showing potentially sensitive data
+    // in other configs
+    final Set<String> allowList = new DistributedConfig(workerProps).values().keySet();
+    return workerProps.keySet().stream()
+        .filter(allowList::contains)
+        .collect(Collectors.toMap(k -> k, workerProps::get));
   }
 
   private static Properties getWorkerProps(final String configFile) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
@@ -35,10 +35,15 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ListPropertiesExecutor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ListPropertiesExecutor.class);
 
   private ListPropertiesExecutor() { }
 
@@ -110,7 +115,17 @@ public final class ListPropertiesExecutor {
   private static Set<String> embeddedConnectWorkerPropertiesAllowList(
       final Map<String, String> workerProps
   ) {
-    final DistributedConfig config = new DistributedConfig(workerProps);
+    final DistributedConfig config;
+    try {
+      config = new DistributedConfig(workerProps);
+    } catch (ConfigException e) {
+      LOGGER.warn("Could not create Connect worker config to validate properties; "
+          + "not displaying Connect worker properties as a result. Note that "
+          + "this should not happen if ksqlDB was able to start with embedded Connect. "
+          + "Error: {}", e.getMessage());
+      return Collections.emptySet();
+    }
+    
     return config.values().keySet().stream()
         .filter(k -> config.typeOf(k) != Type.PASSWORD)
         .collect(Collectors.toSet());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 
@@ -100,10 +101,19 @@ public final class ListPropertiesExecutor {
     final Map<String, String> workerProps = Utils.propsToStringMap(getWorkerProps(configFile));
     // only list known connect worker properties to avoid showing potentially sensitive data
     // in other configs
-    final Set<String> allowList = new DistributedConfig(workerProps).values().keySet();
+    final Set<String> allowList = embeddedConnectWorkerPropertiesAllowList(workerProps);
     return workerProps.keySet().stream()
         .filter(allowList::contains)
         .collect(Collectors.toMap(k -> k, workerProps::get));
+  }
+
+  private static Set<String> embeddedConnectWorkerPropertiesAllowList(
+      final Map<String, String> workerProps
+  ) {
+    final DistributedConfig config = new DistributedConfig(workerProps);
+    return config.values().keySet().stream()
+        .filter(k -> config.typeOf(k) != Type.PASSWORD)
+        .collect(Collectors.toSet());
   }
 
   private static Properties getWorkerProps(final String configFile) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -29,17 +29,37 @@ import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.util.KsqlConfig;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ListPropertiesExecutorTest {
 
-  @Rule public final TemporaryEngine engine = new TemporaryEngine();
+  @Rule
+  public final TemporaryEngine engine = new TemporaryEngine();
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private String connectPropsFile;
+
+  @Before
+  public void setUp() {
+    connectPropsFile = Paths.get(folder.getRoot().getPath(), "connect.properties").toString();
+  }
 
   @Test
   public void shouldListProperties() {
@@ -56,14 +76,6 @@ public class ListPropertiesExecutorTest {
         toMap(properties),
         equalTo(engine.getKsqlConfig().getAllConfigPropsWithSecretsObfuscated()));
     assertThat(properties.getOverwrittenProperties(), is(empty()));
-  }
-
-  private Map<String, String> toMap(final PropertiesList properties) {
-    final Map<String, String> map = new HashMap<>();
-    for (final Property property : properties.getProperties()) {
-      map.put(property.getName(), property.getValue());
-    }
-    return map;
   }
 
   @Test
@@ -98,5 +110,58 @@ public class ListPropertiesExecutorTest {
     assertThat(
         toMap(properties),
         not(hasKey(isIn(KsqlConfig.SSL_CONFIG_NAMES))));
+  }
+
+  @Test
+  public void shouldNotListUnrecognizedConnectProps() throws Exception {
+    // Given:
+    givenConnectWorkerProperties(
+        "group.id=list_properties_unit_test\n"
+            + "key.converter=io.confluent.connect.avro.AvroConverter\n"
+            + "value.converter=io.confluent.connect.avro.AvroConverter\n"
+            + "offset.storage.topic=topic1\n"
+            + "config.storage.topic=topic2\n"
+            + "status.storage.topic=topic3\n"
+            + "producer.sasl.jaas.config=<potentially sensitive data that should not be shown>\n"
+    );
+
+    // When:
+    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
+        engine.configure("LIST PROPERTIES;")
+            .withConfig(new KsqlConfig(ImmutableMap.of(
+                "ksql.connect.worker.config", connectPropsFile))),
+        ImmutableMap.of(),
+        engine.getEngine(),
+        engine.getServiceContext()
+    ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(
+        properties.getProperties(),
+        hasItem(new Property("ksql.connect.worker.config", "KSQL", connectPropsFile)));
+    assertThat(
+        properties.getProperties(),
+        hasItem(new Property("value.converter", "EMBEDDED CONNECT WORKER", "io.confluent.connect.avro.AvroConverter")));
+    assertThat(
+        toMap(properties),
+        not(hasKey("producer.sasl.jaas.config")));
+  }
+
+  private void givenConnectWorkerProperties(final String contents) throws Exception {
+    assertThat(new File(connectPropsFile).createNewFile(), is(true));
+
+    try (PrintWriter out = new PrintWriter(connectPropsFile, Charset.defaultCharset().name())) {
+      out.println(contents);
+    } catch (FileNotFoundException | UnsupportedEncodingException e) {
+      Assert.fail("Failed to write connect worker config file: " + connectPropsFile);
+    }
+  }
+
+  private static Map<String, String> toMap(final PropertiesList properties) {
+    final Map<String, String> map = new HashMap<>();
+    for (final Property property : properties.getProperties()) {
+      map.put(property.getName(), property.getValue());
+    }
+    return map;
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -122,7 +122,8 @@ public class ListPropertiesExecutorTest {
             + "offset.storage.topic=topic1\n"
             + "config.storage.topic=topic2\n"
             + "status.storage.topic=topic3\n"
-            + "producer.sasl.jaas.config=<potentially sensitive data that should not be shown>\n"
+            + "other.config=<potentially sensitive data that should not be shown>\n"
+            + "sasl.jaas.config=<potentially sensitive data that should not be shown even though it's a recognized config>\n"
     );
 
     // When:
@@ -142,9 +143,8 @@ public class ListPropertiesExecutorTest {
     assertThat(
         properties.getProperties(),
         hasItem(new Property("value.converter", "EMBEDDED CONNECT WORKER", "io.confluent.connect.avro.AvroConverter")));
-    assertThat(
-        toMap(properties),
-        not(hasKey("producer.sasl.jaas.config")));
+    assertThat(toMap(properties), not(hasKey("other.config")));
+    assertThat(toMap(properties), not(hasKey("sasl.jaas.config")));
   }
 
   private void givenConnectWorkerProperties(final String contents) throws Exception {


### PR DESCRIPTION
### Description 

Backport https://github.com/confluentinc/ksql/pull/7304 to an older branch.

### Testing done 

Unit test backported.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

