### PR TITLE
feat: enable variable substitution for inserts-stream endpoint

### DIFF
--- a/docs/developer-guide/ksqldb-rest-api/streaming-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/streaming-endpoint.md
@@ -155,6 +155,34 @@ In case of error, an error response (see below) is sent. For an error response f
     Acks can be returned in a different sequence compared with the order in
     which inserts were submitted. 
 
+Starting from 0.18, variable substitution can be applied by passing a map of variables and
+definitions to the `sessionVariables` argument of the body of the request and referencing variables
+by enclosing them in `${}`. For example, given the following request body and row,
+
+```
+{
+"target": "my-stream",
+"sessionVariables": {"value": "abc"}
+}
+
+```
+
+```
+{
+"col1" : "${value}defg",
+"col2": 2.3
+}
+```
+
+The data that would be written to the stream is 
+
+```
+{
+"col1" : "abcdefg",
+"col2": 2.3
+}
+```
+
 ## Example curl command
 
 ```bash

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
 
 public final class VariableSubstitutor {
@@ -64,6 +65,16 @@ public final class VariableSubstitutor {
     final String statementText = parsedStatement.getStatementText();
     final SqlSubstitutorVisitor visitor = new SqlSubstitutorVisitor(statementText, valueMap);
     return visitor.replace(parsedStatement.getStatement());
+  }
+
+  public static String substitute(
+      final String string,
+      final Map<String, String> valueMap
+  ) {
+    return StringSubstitutor.replace(
+        string, valueMap.entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey(), e -> sanitize(e.getValue())))
+    );
   }
 
   // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -240,6 +240,20 @@ public class VariableSubstitutorTest {
     assertThrowOnInvalidVariables(statements, variablesMap);
   }
 
+  @Test
+  public void shouldSubstituteVariablesInString() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("event", "birthday");
+    }}.build();
+
+    // When
+    final String substituted = VariableSubstitutor.substitute("Happy ${event} to you!", variablesMap);
+
+    // Then
+    assertThat(substituted, equalTo("Happy birthday to you!"));
+  }
+
   private void assertReplacedStatements(
       final List<Pair<String, String>> statements,
       final Map<String, String> variablesMap

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -46,6 +46,7 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.codec.BodyCodec;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -477,6 +478,63 @@ public class ApiTest extends BaseApiTest {
     assertThatEventually(() -> testEndpoints.getInsertsSubscriber().getRowsInserted(), is(rows));
     assertThatEventually(() -> testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
     assertThat(testEndpoints.getLastTarget(), is("test-stream"));
+    assertThat(testEndpoints.getInsertsSubscriber().isClosed(), is(true));
+  }
+
+  @Test
+  public void shouldInsertWithVariableSubstitution() throws Exception {
+
+    // Given
+    JsonObject variables = new JsonObject().put("a", "aaa").put("b", "bbb");
+    JsonObject properties = new JsonObject().put("${a}", "${b}");
+    JsonObject expectedProperties = new JsonObject().put("aaa", "bbb");
+    JsonObject params = new JsonObject()
+        .put("target", "test-stream")
+        .put("sessionVariables", variables)
+        .put("properties", properties);
+    Buffer requestBody = Buffer.buffer();
+    final List<JsonObject> rows = Collections.singletonList(new JsonObject()
+        .put("f_str", "${a}")
+        .put("f_int", 3)
+        .put("f_bool", false)
+        .put("f_long", 9L)
+        .put("f_double", 5.5555)
+        .put("f_decimal", 5.1)
+        .put("f_array", new JsonArray().add("${b}"))
+        .put("f_map", new JsonObject().put("${a}", "${b}"))
+        .put("f_struct", new JsonObject().put("${a}", "${b}"))
+        .putNull("f_null")
+    );
+    final List<JsonObject> expectedRows = Collections.singletonList(new JsonObject()
+        .put("f_str", "aaa")
+        .put("f_int", 3)
+        .put("f_bool", false)
+        .put("f_long", 9L)
+        .put("f_double", 5.5555)
+        .put("f_decimal", 5.1)
+        .put("f_array", new JsonArray().add("bbb"))
+        .put("f_map", new JsonObject().put("aaa", "bbb"))
+        .put("f_struct", new JsonObject().put("aaa", "bbb"))
+        .putNull("f_null")
+    );
+    requestBody.appendBuffer(params.toBuffer()).appendString("\n");
+    for (JsonObject row : rows) {
+      requestBody.appendBuffer(row.toBuffer()).appendString("\n");
+    }
+
+    // When
+    HttpResponse<Buffer> response = sendPostRequest("/inserts-stream", requestBody);
+
+    // Then
+    assertThat(response.statusCode(), is(200));
+    assertThat(response.statusMessage(), is("OK"));
+    String responseBody = response.bodyAsString();
+    InsertsResponse insertsResponse = new InsertsResponse(responseBody);
+    assertThat(insertsResponse.acks, hasSize(expectedRows.size()));
+    assertThatEventually(() -> testEndpoints.getInsertsSubscriber().getRowsInserted(), is(expectedRows));
+    assertThatEventually(() -> testEndpoints.getInsertsSubscriber().isCompleted(), is(true));
+    assertThat(testEndpoints.getLastTarget(), is("test-stream"));
+    assertThat(testEndpoints.getLastProperties(), is(expectedProperties));
     assertThat(testEndpoints.getInsertsSubscriber().isClosed(), is(true));
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.api.utils.ReceiveStream;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
+import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.serde.FormatFactory;
@@ -419,6 +420,48 @@ public class ApiIntegrationTest {
     for (long l = 0; l < numRows; l++) {
       assertThat(sequences.contains(l), is(true));
     }
+  }
+
+  @Test
+  public void shouldExecuteInsertsWithVariableSubstitution() {
+
+    // Given:
+    JsonObject properties = new JsonObject();
+    JsonObject sessionVariables = new JsonObject()
+        .put("stream", TEST_STREAM)
+        .put("v", "Value")
+        .put("a", "apple");
+    JsonObject requestBody = new JsonObject()
+        .put("target", "${stream}")
+        .put("properties", properties)
+        .put("sessionVariables", sessionVariables);
+    Buffer bodyBuffer = requestBody.toBuffer();
+    bodyBuffer.appendString("\n");
+
+    int numRows = 10;
+
+    for (int i = 0; i < numRows; i++) {
+      JsonObject row = new JsonObject()
+          .put("K", new JsonObject().put("F1", new JsonArray().add("my_key_" + i)))
+          .put("STR", "${v}_" + i)
+          .put("LONG", 1000 + i)
+          .put("DEC", i + 0.11) // JsonObject does not accept BigDecimal
+          .put("ARRAY", new JsonArray().add("${a}_" + i).add("b_" + i))
+          .put("MAP", new JsonObject().put("k1", "v1_" + i).put("k2", "v2_" + i))
+          .put("STRUCT", new JsonObject().put("F1", i))
+          .put("COMPLEX", COMPLEX_FIELD_VALUE);
+      bodyBuffer.appendBuffer(row.toBuffer()).appendString("\n");
+    }
+
+    // When:
+    HttpResponse<Buffer> response = sendRequest("/inserts-stream", bodyBuffer);
+
+    // Then:
+    assertThat(response.statusCode(), is(200));
+    QueryResponse queryResponse = executeQuery("SELECT STR, ARRAY FROM " + TEST_STREAM + " WHERE K=STRUCT(F1 := ARRAY['my_key_0']) EMIT CHANGES LIMIT 1;");
+    assertThat(queryResponse.rows.get(0).getString(0), is("Value_0"));
+    assertThat(queryResponse.rows.get(0).getJsonArray(1).getString(0), is("apple_0"));
+    assertThat(queryResponse.rows.get(0).getJsonArray(1).getString(1), is("b_0"));
   }
 
   @Test

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/InsertsStreamArgs.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/InsertsStreamArgs.java
@@ -29,12 +29,18 @@ public class InsertsStreamArgs {
 
   public final String target;
   public final JsonObject properties;
+  public final JsonObject sessionVariables;
 
   public InsertsStreamArgs(final @JsonProperty(value = "target", required = true) String target,
       final @JsonProperty(value = "properties")
-          Map<String, Object> properties) {
+          Map<String, Object> properties,
+      final @JsonProperty(value = "sessionVariables")
+          Map<String, Object> sessionVariables) {
     this.target = Objects.requireNonNull(target);
     this.properties = properties == null ? new JsonObject() : new JsonObject(properties);
+    this.sessionVariables = sessionVariables == null
+        ? new JsonObject()
+        : new JsonObject(sessionVariables);
   }
 
   @Override
@@ -42,6 +48,7 @@ public class InsertsStreamArgs {
     return "InsertsStreamArgs{"
         + "target='" + target + '\''
         + ", properties=" + properties
+        + ", sessionVariables=" + sessionVariables
         + '}';
   }
 }


### PR DESCRIPTION
### Description 
Adds `sessionVariables` to the `/inserts-stream` endpoint. Rows, properties and the stream name can be substituted.

### Testing done 
Added unit and integration tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

