### PR TITLE
feat: scatter gather task metadata for query descriptions

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -204,6 +204,7 @@ public final class ListQueriesExecutor {
       final QueryId queryId = q.getId();
 
       // If the query has already been discovered, add to the ksqlQueryHostStatus mapping
+      // and the streams metadata task set
       if (allResults.containsKey(queryId)) {
         for (Map.Entry<KsqlHostInfoEntity, KsqlQueryStatus> entry :
             q.getKsqlHostQueryStatus().entrySet()) {
@@ -211,6 +212,8 @@ public final class ListQueriesExecutor {
               .get(queryId)
               .updateKsqlHostQueryStatus(entry.getKey(), entry.getValue());
         }
+        
+        allResults.get(queryId).updateTaskMetadata(q.getTasksMetadata());
       } else {
         allResults.put(queryId, q);
       }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.QueryStatusCount;
 import io.confluent.ksql.rest.entity.RunningQuery;
+import io.confluent.ksql.rest.entity.StreamsTaskMetadata;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
@@ -62,6 +63,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.StreamsMetadata;
@@ -310,8 +312,11 @@ public class ListQueriesExecutorTest {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
     final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES EXTENDED;");
-    final PersistentQueryMetadata localMetadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
-    final PersistentQueryMetadata remoteMetadata = givenPersistentQuery("id", ERROR_QUERY_STATE);
+    
+    final StreamsTaskMetadata localTaskMetadata = mock(StreamsTaskMetadata.class);
+    final StreamsTaskMetadata remoteTaskMetadata = mock(StreamsTaskMetadata.class);
+    final PersistentQueryMetadata localMetadata = givenPersistentQuery("id", RUNNING_QUERY_STATE, Collections.singleton(localTaskMetadata));
+    final PersistentQueryMetadata remoteMetadata = givenPersistentQuery("id", ERROR_QUERY_STATE, Collections.singleton(remoteTaskMetadata));
 
     final KsqlEngine engine = mock(KsqlEngine.class);
     when(engine.getAllLiveQueries()).thenReturn(ImmutableList.of(localMetadata));
@@ -339,8 +344,10 @@ public class ListQueriesExecutorTest {
     ).orElseThrow(IllegalStateException::new);
 
     // Then
+    final QueryDescription mergedQueryDescription = QueryDescriptionFactory.forQueryMetadata(localMetadata, mergedMap);
+    mergedQueryDescription.updateTaskMetadata(Collections.singleton(remoteTaskMetadata));
     assertThat(queries.getQueryDescriptions(), 
-        containsInAnyOrder(QueryDescriptionFactory.forQueryMetadata(localMetadata, mergedMap)));
+        containsInAnyOrder(mergedQueryDescription));
   }
 
   @Test
@@ -447,6 +454,14 @@ public class ListQueriesExecutorTest {
       final String id,
       final KafkaStreams.State state
   ) {
+    return givenPersistentQuery(id, state, Collections.emptySet());
+  }
+
+  public static PersistentQueryMetadata givenPersistentQuery(
+      final String id,
+      final KafkaStreams.State state,
+      final Set<StreamsTaskMetadata> tasksMetadata
+  ) {
     final PersistentQueryMetadata metadata = mock(PersistentQueryMetadata.class);
     mockQuery(id, state, metadata);
     when(metadata.getQueryType()).thenReturn(KsqlConstants.KsqlQueryType.PERSISTENT);
@@ -456,6 +471,7 @@ public class ListQueriesExecutorTest {
         KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()), SerdeFeatures.of()));
     when(sinkTopic.getKafkaTopicName()).thenReturn(id);
     when(metadata.getResultTopic()).thenReturn(sinkTopic);
+    when(metadata.getTaskMetadata()).thenReturn(tasksMetadata);
 
     return metadata;
   }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -51,7 +51,7 @@ public class QueryDescription {
   private final Map<KsqlHostInfoEntity, KsqlQueryStatus> ksqlHostQueryStatus;
   private final KsqlQueryType queryType;
   private final List<QueryError> queryErrors;
-  private ImmutableSet<StreamsTaskMetadata> tasksMetadata;
+  private final Set<StreamsTaskMetadata> tasksMetadata;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   @SuppressWarnings("WeakerAccess") // Invoked via reflection
@@ -86,7 +86,7 @@ public class QueryDescription {
         new HashMap<>(Objects.requireNonNull(ksqlHostQueryStatus, "ksqlHostQueryStatus"));
     this.queryType = Objects.requireNonNull(queryType, "queryType");
     this.queryErrors = new ArrayList<>(Objects.requireNonNull(queryErrors, "queryErrors"));
-    this.tasksMetadata = ImmutableSet.copyOf(Objects.requireNonNull(tasksMetadata));
+    this.tasksMetadata = new HashSet<>(Objects.requireNonNull(tasksMetadata));
   }
 
   public QueryId getId() {
@@ -126,13 +126,11 @@ public class QueryDescription {
   }
 
   public void updateTaskMetadata(final Set<StreamsTaskMetadata> updatedMetadata) {
-    final Set<StreamsTaskMetadata> oldTaskMetadata = new HashSet<>(tasksMetadata);
-    oldTaskMetadata.addAll(updatedMetadata);
-    tasksMetadata = ImmutableSet.copyOf(oldTaskMetadata);
+    tasksMetadata.addAll(updatedMetadata);
   }
 
   public ImmutableSet<StreamsTaskMetadata> getTasksMetadata() {
-    return tasksMetadata;
+    return ImmutableSet.copyOf(tasksMetadata);
   }
 
   // kept for backwards compatibility

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,7 +51,7 @@ public class QueryDescription {
   private final Map<KsqlHostInfoEntity, KsqlQueryStatus> ksqlHostQueryStatus;
   private final KsqlQueryType queryType;
   private final List<QueryError> queryErrors;
-  private final Set<StreamsTaskMetadata> tasksMetadata;
+  private ImmutableSet<StreamsTaskMetadata> tasksMetadata;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   @SuppressWarnings("WeakerAccess") // Invoked via reflection
@@ -124,7 +125,13 @@ public class QueryDescription {
     return overriddenProperties;
   }
 
-  public Set<StreamsTaskMetadata> getTasksMetadata() {
+  public void updateTaskMetadata(final Set<StreamsTaskMetadata> updatedMetadata) {
+    final Set<StreamsTaskMetadata> oldTaskMetadata = new HashSet<>(tasksMetadata);
+    oldTaskMetadata.addAll(updatedMetadata);
+    tasksMetadata = ImmutableSet.copyOf(oldTaskMetadata);
+  }
+
+  public ImmutableSet<StreamsTaskMetadata> getTasksMetadata() {
     return tasksMetadata;
   }
 


### PR DESCRIPTION
### Description 
`show queries extended` now combines the task metadata information from remote hosts in the response.

If we ran a query where the source topic has two partitions and then got a QueryDescription of it, the description would only have 1 task metadata before this patch. Now it has both.

### Testing done 
Updated integration test

Sample response with two ksqlDB servers running

```
[
    {
        "@type": "query_descriptions",
        "statementText": "show queries extended;",
        "queryDescriptions": [
            {
                "id": "CSAS_TEST_3",
                "statementText": "CREATE STREAM TEST WITH (KAFKA_TOPIC='TEST', PARTITIONS=2, REPLICAS=1) AS SELECT *\nFROM PAGEVIEWS PAGEVIEWS\nEMIT CHANGES;",
                ...
                "ksqlHostQueryStatus": {
                    "192.168.86.31:8089": "RUNNING",
                    "192.168.86.31:8088": "RUNNING"
                },
                "queryType": "PERSISTENT",
                "queryErrors": [],
                "tasksMetadata": [
                    {
                        "taskId": "0_1",
                        "topicOffsets": [
                            {
                                "topicPartitionEntity": {
                                    "topic": "pageviews",
                                    "partition": 1
                                },
                                "endOffset": 0,
                                "committedOffset": 10949
                            }
                        ],
                        "timeCurrentIdlingStarted": null
                    },
                    {
                        "taskId": "0_0",
                        "topicOffsets": [
                            {
                                "topicPartitionEntity": {
                                    "topic": "pageviews",
                                    "partition": 0
                                },
                                "endOffset": 0,
                                "committedOffset": 11004
                            }
                        ],
                        "timeCurrentIdlingStarted": null
                    }
                ],
                "state": "RUNNING"
            }
        ],
        "warnings": []
    }
]
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

