### PR TITLE
docs: cherry-pick: add changelog for 0.16 (DOCS-7303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Change Log
 
+## [0.16.0](https://github.com/confluentinc/ksql/releases/tag/v0.16.0-ksqldb) (2021-03-15)
+
+### Features
+
+* **client:** add getInfo method to java client ([#7030](https://github.com/confluentinc/ksql/pull/7030)) ([b09f003](https://github.com/confluentinc/ksql/commit/b09f003f31e45080301f65d329b132fe71eeb78b))
+* add describe option to list streams/tables ([#6827](https://github.com/confluentinc/ksql/pull/6827)) ([26e3dea](https://github.com/confluentinc/ksql/commit/26e3deab8242df235f0541e7d2c90df5ed17b815))
+* add functions to support use of timestamp data type ([#6852](https://github.com/confluentinc/ksql/pull/6852)) ([2cee618](https://github.com/confluentinc/ksql/commit/2cee618ef8ca8a24768e0f7b1b88ccd2e5364248))
+* add standard deviation udf ([#6845](https://github.com/confluentinc/ksql/pull/6845)) ([f2fdbb3](https://github.com/confluentinc/ksql/commit/f2fdbb389d06aafc808493fe009719f202351728))
+* display precision and scale when describing DECIMAL columns ([#6872](https://github.com/confluentinc/ksql/pull/6872)) ([fb89998](https://github.com/confluentinc/ksql/commit/fb89998ede01922a4741448f37c7064aa966147e))
+* enable decimal for Protobuf ([#6884](https://github.com/confluentinc/ksql/pull/6884)) ([6b5877c](https://github.com/confluentinc/ksql/commit/6b5877c2910023263421b247824af4eadb7db640))
+* Make pull queries streamed asynchronously ([#6813](https://github.com/confluentinc/ksql/pull/6813)) ([b69e3f8](https://github.com/confluentinc/ksql/commit/b69e3f8e459c3d0a055ec0738ae71e58bda7b28c))
+* make UDAFs configurable and remove limit on COLLECT_LIST/SET ([#6851](https://github.com/confluentinc/ksql/pull/6851)) ([63ae169](https://github.com/confluentinc/ksql/commit/63ae169ab753aab980f0ee4cbf52fbe34291418d))
+* Rewrites pull query WHERE clause to be in DNF and allow more expressions  ([#6874](https://github.com/confluentinc/ksql/pull/6874)) ([b8e0c99](https://github.com/confluentinc/ksql/commit/b8e0c991a982229afd6d42dc8752a29a35fa937e))
+* Support timestamp protobuf serde ([#6927](https://github.com/confluentinc/ksql/pull/6927)) ([5ea1ce4](https://github.com/confluentinc/ksql/commit/5ea1ce4c9129260272608aa8d8263e22a23a9188))
+* timestamp support - casting, comparisons and serde ([#6806](https://github.com/confluentinc/ksql/pull/6806)) ([a27df46](https://github.com/confluentinc/ksql/commit/a27df465040bf3aa409ca34509c0117fadf8982a))
+
+
+
+### Bug Fixes
+
+* client/server SSL settings fail when 'ssl.key.password' is set ([#6763](https://github.com/confluentinc/ksql/pull/6763)) ([3e48540](https://github.com/confluentinc/ksql/commit/3e48540fbe1a02ed02faa667e424b225f9d7ba20))
+* do not log data on JSON deserialization errors (MINOR) ([#6930](https://github.com/confluentinc/ksql/pull/6930)) ([1834da6](https://github.com/confluentinc/ksql/commit/1834da678cf86e7cb333d57a9c97d1884d09d7af))
+* ff-4240-upgrade httpclient version ([#6935](https://github.com/confluentinc/ksql/pull/6935)) ([19f4d63](https://github.com/confluentinc/ksql/commit/19f4d632bc4c854904f366b359d4bf70a6f54d6d))
+* fix how the buffer limit check evaluates streams config ([#6876](https://github.com/confluentinc/ksql/pull/6876)) ([ad1cc2a](https://github.com/confluentinc/ksql/commit/ad1cc2aca3b3a51f6f9e3aee86b1f41de449ae15))
+* format cast arguments with passed context (6.0.x) ([#7032](https://github.com/confluentinc/ksql/pull/7032)) ([8c0d93d](https://github.com/confluentinc/ksql/commit/8c0d93db4ad94f820639ccb993dbc53a81175e53))
+* make formattimestamp and parsetimestamp default to utc ([#6954](https://github.com/confluentinc/ksql/pull/6954)) ([a5ea98a](https://github.com/confluentinc/ksql/commit/a5ea98affd13b99d17c21832c09394e45b1f86ac))
+* Make Select * avoid code gen for projections ([#6846](https://github.com/confluentinc/ksql/pull/6846)) ([0896b85](https://github.com/confluentinc/ksql/commit/0896b856a86c1f7b212d8b5ebe3f9140f5679cd6))
+* npe when getting topic configs ([#6946](https://github.com/confluentinc/ksql/pull/6946)) ([5e026d4](https://github.com/confluentinc/ksql/commit/5e026d4ad9d02629566593705e79d568296e96bd))
+* remove mutable subscriber field on an endpoint ([#6905](https://github.com/confluentinc/ksql/pull/6905)) ([98c7d73](https://github.com/confluentinc/ksql/commit/98c7d735c2506a0204ecce8d8861f07eb62d968d))
+* use the right name for fallback subject for transient queries ([#6821](https://github.com/confluentinc/ksql/pull/6821)) ([d044d64](https://github.com/confluentinc/ksql/commit/d044d645cefe6aba9ae495a47b3051413e55ff29)), closes [#6817](https://github.com/confluentinc/ksql/issues/6817)
+
+
 ## [0.15.0](https://github.com/confluentinc/ksql/releases/tag/v0.15.0-ksqldb) (2021-01-20)
 
 ### Highlights

--- a/docs/operate-and-deploy/changelog.md
+++ b/docs/operate-and-deploy/changelog.md
@@ -6,6 +6,12 @@ description: Lists changes to the ksqlDB codebase
 keywords: ksqldb, changelog
 ---
 
+Version 0.16.0
+--------------
+
+- [Announcing ksqlDB 0.16.0](https://www.confluent.io/blog/ksqldb-0-16-features-updates/)
+- [ksqlDB v0.16.0 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0160-2021-03-15)
+
 Version 0.15.0
 --------------
 


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/7227.