### PR TITLE
docs: add docs for /clusterStatus endpoint

### DIFF
--- a/docs/developer-guide/api.md
+++ b/docs/developer-guide/api.md
@@ -5,12 +5,13 @@ tagline: Run queries over HTTP
 description: Learn how to communicate with ksqlDB by using HTTP
 ---
 
-- [Introspect query status (/status endpoint)](ksqldb-rest-api/status-endpoint.md)
-- [Introspect server status (/info endpoint)](ksqldb-rest-api/info-endpoint.md)
 - [Execute a statement (/ksql endpoint)](ksqldb-rest-api/ksql-endpoint.md)
 - [Run a query (/query endpoint)](ksqldb-rest-api/query-endpoint.md)
 - [Run push and pull queries (/query-stream endpoint)](ksqldb-rest-api/streaming-endpoint.md)
 - [Terminate a cluster (/ksql/terminate endpoint)](ksqldb-rest-api/terminate-endpoint.md)
+- [Introspect query status (/status endpoint)](ksqldb-rest-api/status-endpoint.md)
+- [Introspect server status (/info endpoint)](ksqldb-rest-api/info-endpoint.md)
+- [Introspect cluster status (/clusterStatus endpoint)](ksqldb-rest-api/cluster-status-endpoint.md)
 - [Terminate a cluster (/is_valid_property)](ksqldb-rest-api/is_valid_property-endpoint.md)
 
 REST Endpoint
@@ -20,7 +21,7 @@ The default HTTP API endpoint is `http://0.0.0.0:8088/`.
 
 Change the server configuration that controls the HTTP API endpoint by
 setting the `listeners` parameter in the ksqlDB server config file. For
-more info, see [listeners](/reference/server-configuration#listeners).
+more info, see [listeners](../reference/server-configuration.md#listeners).
 To configure the endpoint to use HTTPS, see
 [Configure ksqlDB for HTTPS](../operate-and-deploy/installation/server-config/security.md#configure-ksqldb-for-https).
 

--- a/docs/developer-guide/ksqldb-rest-api/cluster-status-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/cluster-status-endpoint.md
@@ -1,0 +1,156 @@
+---
+layout: page
+title: Get the Status of the Servers in a ksqlDB Cluster 
+tagline: clusterStatus endpoint
+description: The `/clusterStatus` resource gives you the status of all servers in a ksqlDB cluster
+keywords: ksqldb, server, status, cluster
+---
+
+The `/clusterStatus` resource gives you information about the status of all
+ksqlDB servers in a ksqlDB cluster, which can be useful for troubleshooting. 
+Enable this endpoint by setting [`ksql.heartbeat.enable`](../../reference/server-configuration.md#ksqlheartbeatenable) 
+to `true`. Optionally, you can also set [`ksql.lag.reporting.enable`](../../reference/server-configuration.md#ksqllagreportingenable) 
+to `true` to have your ksqlDB servers report state store lag, which will 
+then also be returned with the response from the `/clusterStatus` endpoint.
+
+!!! note
+      ksqlDB servers in a cluster discover each other through persistent queries.
+      If you have no persistent queries running, then the `/clusterStatus` endpoint
+      will only contain info for the particular server that was queried, rather than
+      all servers in the cluster.  
+
+You can use the `curl` command to query the `/clusterStatus` endpoint
+for a particular server:
+
+```bash
+curl -sX GET "http://localhost:8088/clusterStatus" | jq '.'
+```
+
+The response object contains a `clusterStatus` field with the following
+information for each ksqlDB server (represented as `host:port`):
+
+- **hostAlive** (boolean): whether the server is alive, as determined by
+  heartbeats received by the queried server
+- **lastStatusUpdateMs** (long): epoch timestamp, in milliseconds, for when the
+  last status update was received for this server, by the queried server 
+- **activeStandbyPerQuery** (object): for each query ID, a collection of 
+  active and standy partitions and state stores on this server
+- **hostStoreLags** (object): state store lag information. Empty unless
+  `ksql.lag.reporting.enable` is set to `true`.
+- **hostStoreLags.stateStoreLags** (object): partition-level lag breakdown
+  for each state store.
+- **hostStoreLags.updateTimeMs** (long): epoch timestamp, in milliseconds, for when 
+  the last lag update was received for this server, by the queried server
+
+For a two-node cluster running a single `CREATE TABLE ... AS SELECT` query, 
+with lag reporting enabled, your output should resemble:
+
+```json
+{
+  "clusterStatus": {
+    "localhost:8088": {
+      "hostAlive": true,
+      "lastStatusUpdateMs": 1617609098808,
+      "activeStandbyPerQuery": {
+        "CTAS_MY_AGG_TABLE_3": {
+          "activeStores": [
+            "Aggregate-Aggregate-Materialize"
+          ],
+          "activePartitions": [
+            {
+              "topic": "my_stream",
+              "partition": 1
+            },
+            {
+              "topic": "my_stream",
+              "partition": 3
+            },
+            {
+              "topic": "_confluent-ksql-default_query_CTAS_MY_AGG_TABLE_3-Aggregate-GroupBy-repartition",
+              "partition": 1
+            },
+            {
+              "topic": "_confluent-ksql-default_query_CTAS_MY_AGG_TABLE_3-Aggregate-GroupBy-repartition",
+              "partition": 3
+            }
+          ],
+          "standByStores": [],
+          "standByPartitions": []
+        }
+      },
+      "hostStoreLags": {
+        "stateStoreLags": {
+          "_confluent-ksql-default_query_CTAS_MY_AGG_TABLE_3#Aggregate-Aggregate-Materialize": {
+            "lagByPartition": {
+              "1": {
+                "currentOffsetPosition": 0,
+                "endOffsetPosition": 0,
+                "offsetLag": 0
+              },
+              "3": {
+                "currentOffsetPosition": 0,
+                "endOffsetPosition": 0,
+                "offsetLag": 0
+              }
+            },
+            "size": 2
+          }
+        },
+        "updateTimeMs": 1617609168917
+      }
+    },
+    "other.ksqldb.host:8088": {
+      "hostAlive": true,
+      "lastStatusUpdateMs": 1617609172614,
+      "activeStandbyPerQuery": {
+        "CTAS_MY_AGG_TABLE_3": {
+          "activeStores": [
+            "Aggregate-Aggregate-Materialize"
+          ],
+          "activePartitions": [
+            {
+              "topic": "my_stream",
+              "partition": 0
+            },
+            {
+              "topic": "my_stream",
+              "partition": 2
+            },
+            {
+              "topic": "_confluent-ksql-default_query_CTAS_MY_AGG_TABLE_3-Aggregate-GroupBy-repartition",
+              "partition": 0
+            },
+            {
+              "topic": "_confluent-ksql-default_query_CTAS_MY_AGG_TABLE_3-Aggregate-GroupBy-repartition",
+              "partition": 2
+            }
+          ],
+          "standByStores": [],
+          "standByPartitions": []
+        }
+      },
+      "hostStoreLags": {
+        "stateStoreLags": {
+          "_confluent-ksql-default_query_CTAS_MY_AGG_TABLE_3#Aggregate-Aggregate-Materialize": {
+            "lagByPartition": {
+              "0": {
+                "currentOffsetPosition": 1,
+                "endOffsetPosition": 1,
+                "offsetLag": 0
+              },
+              "2": {
+                "currentOffsetPosition": 0,
+                "endOffsetPosition": 0,
+                "offsetLag": 0
+              }
+            },
+            "size": 2
+          }
+        },
+        "updateTimeMs": 1617609170111
+      }
+    }
+  }
+}
+```
+

--- a/docs/developer-guide/ksqldb-rest-api/cluster-status-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/cluster-status-endpoint.md
@@ -16,7 +16,7 @@ then also be returned with the response from the `/clusterStatus` endpoint.
 !!! note
       ksqlDB servers in a cluster discover each other through persistent queries.
       If you have no persistent queries running, then the `/clusterStatus` endpoint
-      will only contain info for the particular server that was queried, rather than
+      contains info for the particular server that was queried, rather than
       all servers in the cluster.  
 
 You can use the `curl` command to query the `/clusterStatus` endpoint

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -118,6 +118,13 @@ Controls the semantics of the SUBSTRING UDF. Refer to the SUBSTRING
 documentation in the [function](/developer-guide/ksqldb-reference/scalar-functions)
 guide for details.
 
+## `ksql.heartbeat.enable`
+
+If enabled, ksqlDB servers in the same ksqlDB cluster will send heartbeats to each
+other, to aid in faster failure detection for improved pull query routing.
+Also enables the [`/clusterStatus` endpoint](../developer-guide/ksqldb-rest-api/cluster-status-endpoint.md).
+Defaults to false.
+
 ## `ksql.internal.listener`
 
 The `ksql.internal.listener` setting controls the address bound for use by internal,
@@ -136,6 +143,13 @@ The number of replicas for the internal topics created by ksqlDB Server.
 The default is 1. Replicas for the record processing log topic should be
 configured separately. For more information, see
 [Processing Log](/reference/processing-log).
+
+## `ksql.lag.reporting.enable`
+
+If enabled, ksqlDB servers in the same ksqlDB cluster will send state store 
+lag information to each other as a form of heartbeat, for improved pull query routing.
+Only applicable if [`ksql.heartbeat.enable`](#ksqlheartbeatenable) is also set to `true`.
+Defaults to false.
 
 ## `ksql.logging.processing.topic.auto.create`
 

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -120,10 +120,10 @@ guide for details.
 
 ## `ksql.heartbeat.enable`
 
-If enabled, ksqlDB servers in the same ksqlDB cluster will send heartbeats to each
+If enabled, ksqlDB servers in the same ksqlDB cluster send heartbeats to each
 other, to aid in faster failure detection for improved pull query routing.
 Also enables the [`/clusterStatus` endpoint](../developer-guide/ksqldb-rest-api/cluster-status-endpoint.md).
-Defaults to false.
+The default is `false`.
 
 ## `ksql.internal.listener`
 
@@ -146,10 +146,10 @@ configured separately. For more information, see
 
 ## `ksql.lag.reporting.enable`
 
-If enabled, ksqlDB servers in the same ksqlDB cluster will send state store 
+If enabled, ksqlDB servers in the same ksqlDB cluster sends state-store 
 lag information to each other as a form of heartbeat, for improved pull query routing.
 Only applicable if [`ksql.heartbeat.enable`](#ksqlheartbeatenable) is also set to `true`.
-Defaults to false.
+The default is `false`.
 
 ## `ksql.logging.processing.topic.auto.create`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,11 +144,12 @@ nav:
     - Metrics: reference/metrics.md
     - REST API:
       - REST API Index: developer-guide/api.md # old reference topic, rename file to index.md
-      - Introspect query status: developer-guide/ksqldb-rest-api/status-endpoint.md
-      - Introspect server status: developer-guide/ksqldb-rest-api/info-endpoint.md
       - Execute a statement: developer-guide/ksqldb-rest-api/ksql-endpoint.md
       - Run a query: developer-guide/ksqldb-rest-api/query-endpoint.md
       - Run push and pull queries: developer-guide/ksqldb-rest-api/streaming-endpoint.md
+      - Introspect query status: developer-guide/ksqldb-rest-api/status-endpoint.md
+      - Introspect server status: developer-guide/ksqldb-rest-api/info-endpoint.md
+      - Introspect cluster status: developer-guide/ksqldb-rest-api/cluster-status-endpoint.md
       - Terminate a cluster: developer-guide/ksqldb-rest-api/terminate-endpoint.md
     - Clients:
       - Synopsis: developer-guide/ksqldb-clients/index.md


### PR DESCRIPTION
### Description 

The `/clusterStatus` endpoint is currently undocumented even though it's useful to users and mentioned in [this blog](https://www.confluent.io/blog/ksqldb-pull-queries-high-availability/). This PR adds docs for the endpoint, which has been around since January 2020.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

