### PR TITLE
test: retries for known flaky RestApiTest

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -48,6 +48,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.api.utils.QueryResponse;
 import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.CommandId.Action;
@@ -82,6 +83,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.MediaType;
@@ -191,6 +193,9 @@ public class RestApiTest {
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain.outerRule(TEST_HARNESS).around(REST_APP);
+
+  @Rule
+  public final Retry retry = Retry.of(5, AssertionError.class, 3, TimeUnit.SECONDS);
 
   @Rule
   public final Timeout timeout = Timeout.seconds(60);


### PR DESCRIPTION
### Description 

Add a retry around a known flaky test to help stabilize master build. I know this isn't the best thing to do, but I think we have a pretty good understanding about why this test is flaky (cc @AlanConfluent I believe you investigated this, can you comment here so that we have history recorded?)

### Testing done 

I see the following in the logs:
```
[2021-04-05 16:31:00,102] WARN Retrying test after 3 SECONDS due to: 
Expected: is "{\"row\":{\"columns\":[1,\"USER_1\"]}}]"
     but: was "{\"errorMessage\":{\"@type\":\"generic_error\",\"error_code\":50000,\"message\":\"Unable to execute pull query \\"SELECT COUNT, USERID from AGG_TABLE WHERE USERID='USER_1';\\". Error executing query locally at node http://localhost:64740/: Failed to get value from materialized table\"}}]" (io.confluent.ksql.integration.Retry:135)
```

And it passes afterwards

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

