### PR TITLE
fix: add quotes to connector and source names in java client

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -302,7 +302,7 @@ public class ClientImpl implements Client {
     makePostRequest(
         KSQL_ENDPOINT,
         new JsonObject()
-            .put("ksql", "describe " + sourceName + ";")
+            .put("ksql", "describe `" + sourceName + "`;")
             .put("sessionVariables", sessionVariables),
         cf,
         response -> handleSingleEntityResponse(
@@ -344,7 +344,7 @@ public class ClientImpl implements Client {
         KSQL_ENDPOINT,
         new JsonObject()
             .put("ksql",
-                String.format("CREATE %s CONNECTOR %s WITH (%s);", type, name, connectorConfigs))
+                String.format("CREATE %s CONNECTOR `%s` WITH (%s);", type, name, connectorConfigs))
             .put("sessionVariables", sessionVariables),
         cf,
         response -> handleSingleEntityResponse(
@@ -361,7 +361,7 @@ public class ClientImpl implements Client {
     makePostRequest(
         KSQL_ENDPOINT,
         new JsonObject()
-            .put("ksql", "drop connector " + name + ";")
+            .put("ksql", "drop connector `" + name + "`;")
             .put("sessionVariables", sessionVariables),
         cf,
         response -> handleSingleEntityResponse(
@@ -393,7 +393,7 @@ public class ClientImpl implements Client {
     makePostRequest(
         KSQL_ENDPOINT,
         new JsonObject()
-            .put("ksql", "describe connector " + name + ";")
+            .put("ksql", "describe connector `" + name + "`;")
             .put("sessionVariables", sessionVariables),
         cf,
         response -> handleSingleEntityResponse(

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -1484,7 +1484,7 @@ public class ClientTest extends BaseApiTest {
     javaClient.createConnector("name", true, Collections.EMPTY_MAP).get();
 
     // Then:
-    assertThat(testEndpoints.getLastSql(), is("CREATE SOURCE CONNECTOR name WITH ();"));
+    assertThat(testEndpoints.getLastSql(), is("CREATE SOURCE CONNECTOR `name` WITH ();"));
   }
 
   @Test
@@ -1497,7 +1497,7 @@ public class ClientTest extends BaseApiTest {
     javaClient.dropConnector("name").get();
 
     // Then:
-    assertThat(testEndpoints.getLastSql(), is("drop connector name;"));
+    assertThat(testEndpoints.getLastSql(), is("drop connector `name`;"));
   }
 
   @Test


### PR DESCRIPTION
### Description 
The functions `describeConnector`, `createConnector`, `dropConnector` and `describeSource` did not add quotes to the sql commands sent to the rest endpoints, so case sensitive names weren't preserved. 

### Testing done 
updated unit tests, integration test still passes

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

