### PR TITLE
chore: remove deprecated members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ logs/
 *.ipr
 .idea/
 
+# Maven wrapper
+.mvn/
+
 # VSCode data
 .vscode/
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedAdminClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedAdminClientTest.java
@@ -44,6 +44,7 @@ public final class SandboxedAdminClientTest {
       return TestMethods.builder(Admin.class)
           .ignore("close")
           .ignore("close", Duration.class)
+          .ignoreUnchecked("close", long.class, TimeUnit.class)
           .setDefault(ElectLeadersOptions.class, new ElectLeadersOptions())
           .setDefault(Optional.class, Optional.empty())
           .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedAdminClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedAdminClientTest.java
@@ -44,7 +44,6 @@ public final class SandboxedAdminClientTest {
       return TestMethods.builder(Admin.class)
           .ignore("close")
           .ignore("close", Duration.class)
-          .ignore("close", long.class, TimeUnit.class)
           .setDefault(ElectLeadersOptions.class, new ElectLeadersOptions())
           .setDefault(Optional.class, Optional.empty())
           .build();
@@ -77,11 +76,9 @@ public final class SandboxedAdminClientTest {
       sandboxedAdminClient = SandboxedAdminClient.createProxy();
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void shouldDoNothingOnClose() {
       sandboxedAdminClient.close();
-      sandboxedAdminClient.close(1, TimeUnit.MILLISECONDS);
       sandboxedAdminClient.close(Duration.ofMillis(1));
     }
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedConsumerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedConsumerTest.java
@@ -43,7 +43,6 @@ public final class SandboxedConsumerTest {
       return TestMethods.builder(Consumer.class)
           .ignore("unsubscribe")
           .ignore("close")
-          .ignore("close", long.class, TimeUnit.class)
           .ignore("close", Duration.class)
           .ignore("wakeup")
           .ignore("groupMetadata")
@@ -86,12 +85,6 @@ public final class SandboxedConsumerTest {
     @Test
     public void shouldDoNothingOnCloseWithNoArgs() {
       sandboxedConsumer.close();
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test
-    public void shouldDoNothingOnCloseWithTimeUnit() {
-      sandboxedConsumer.close(1, TimeUnit.MILLISECONDS);
     }
 
     @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedConsumerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedConsumerTest.java
@@ -44,6 +44,7 @@ public final class SandboxedConsumerTest {
           .ignore("unsubscribe")
           .ignore("close")
           .ignore("close", Duration.class)
+          .ignoreUnchecked("close", long.class, TimeUnit.class)
           .ignore("wakeup")
           .ignore("groupMetadata")
           .setDefault(TopicPartition.class, new TopicPartition("t", 1))

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedProducerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedProducerTest.java
@@ -45,6 +45,7 @@ public final class SandboxedProducerTest {
           .ignore("send", ProducerRecord.class)
           .ignore("send", ProducerRecord.class, Callback.class)
           .ignore("close")
+          .ignoreUnchecked("close", long.class, TimeUnit.class)
           .ignore("close", Duration.class)
           .build();
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedProducerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedProducerTest.java
@@ -45,7 +45,6 @@ public final class SandboxedProducerTest {
           .ignore("send", ProducerRecord.class)
           .ignore("send", ProducerRecord.class, Callback.class)
           .ignore("close")
-          .ignore("close", long.class, TimeUnit.class)
           .ignore("close", Duration.class)
           .build();
     }
@@ -82,11 +81,9 @@ public final class SandboxedProducerTest {
       sandboxedProducer.close();
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void shouldDoNothingOnClose() {
       sandboxedProducer.close();
-      sandboxedProducer.close(1, TimeUnit.MILLISECONDS);
       sandboxedProducer.close(Duration.ofMillis(1));
     }
   }

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
@@ -69,32 +69,36 @@ public final class TestMethods {
     private final Class<T> typeUnderTest;
     private final Set<MethodRef> blackList = new HashSet<>();
     private final Map<Class<?>, Object> defaults = new HashMap<>();
+
     public Builder(final Class<T> typeUnderTest) {
       this.typeUnderTest = Objects.requireNonNull(typeUnderTest, "typeUnderTest");
     }
 
     /**
-     * The purpose of this class is to provide a more general reference to the actual Method that we can
-     * use in the blacklist. Note that the equality algorithm is the same as Method's: class name, method name,
-     * and argument types. I expect this to be a valid equality algorithm for methods indefinitely because it's
-     * the same as the method overload resolution criteria specified in the Java language.
+     * The purpose of this class is to provide a more general reference to the actual Method
+     * that we can use in the blacklist. Note that the equality algorithm is the same as
+     * Method's: class name, method name, and argument types. I expect this to be a valid
+     * equality algorithm for methods indefinitely because it's the same as the method
+     * overload resolution criteria specified in the Java language.
      */
     public static class MethodRef {
       private final Class<?> clazz;
-      final String methodName;
-      final Class[] paramTypes;
+      private final String methodName;
+      private final Class<?>[] paramTypes;
 
-      public MethodRef(final Class<?> clazz, final String methodName, final Class[] paramTypes) {
+      public MethodRef(final Class<?> clazz, final String methodName, final Class<?>[] paramTypes) {
         this.clazz = clazz;
         this.methodName = methodName;
-        this.paramTypes = paramTypes;
+        this.paramTypes = Arrays.copyOf(paramTypes, paramTypes.length);
       }
 
       public MethodRef(final Method method) {
         this(method.getDeclaringClass(), method.getName(), method.getParameterTypes());
       }
 
-      public static Collection<MethodRef> refs(final Collection<? extends Method> declaredPublicMethods) {
+      public static Collection<MethodRef> refs(
+              final Collection<? extends Method> declaredPublicMethods
+      ) {
         final List<MethodRef> methodRefs = new ArrayList<>(declaredPublicMethods.size());
         for (final Method method : declaredPublicMethods) {
           methodRefs.add(new MethodRef(method));
@@ -104,10 +108,16 @@ public final class TestMethods {
 
       @Override
       public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        final MethodRef methodRef = (MethodRef) o;
-        return Objects.equals(clazz, methodRef.clazz) && Objects.equals(methodName, methodRef.methodName) && Arrays.equals(paramTypes, methodRef.paramTypes);
+        if (this == o) {
+          return true;
+        } else if (o == null || getClass() != o.getClass()) {
+          return false;
+        } else {
+          final MethodRef methodRef = (MethodRef) o;
+          return Objects.equals(clazz, methodRef.clazz)
+                  && Objects.equals(methodName, methodRef.methodName)
+                  && Arrays.equals(paramTypes, methodRef.paramTypes);
+        }
       }
 
       @Override
@@ -131,9 +141,11 @@ public final class TestMethods {
     }
 
     /**
-     * Exclude a certain method from the test cases without checking first that the method-to-ignore actually exists.
-     * This was added to let us keep "ignore" directives for methods that get deleted. Because of modular dependencies,
-     * it's not always possible to "atomically" remove a method from the declaration and the test all at once.
+     * Exclude a certain method from the test cases without checking first that the
+     * method-to-ignore actually exists. This was added to let us keep "ignore"
+     * directives for methods that get deleted. Because of modular dependencies,
+     * it's not always possible to "atomically" remove a method from the declaration
+     * and the test all at once.
      *
      * @param methodName the name of the method
      * @param paramTypes the types of the parameters to the method.

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
@@ -25,7 +25,15 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -65,6 +73,12 @@ public final class TestMethods {
       this.typeUnderTest = Objects.requireNonNull(typeUnderTest, "typeUnderTest");
     }
 
+    /**
+     * The purpose of this class is to provide a more general reference to the actual Method that we can
+     * use in the blacklist. Note that the equality algorithm is the same as Method's: class name, method name,
+     * and argument types. I expect this to be a valid equality algorithm for methods indefinitely because it's
+     * the same as the method overload resolution criteria specified in the Java language.
+     */
     public static class MethodRef {
       private final Class<?> clazz;
       final String methodName;


### PR DESCRIPTION
close(long, TimeUnit) has finally been removed,
so we can drop our tests that verified it was a no-op
in our testing subclasses.
