### PR TITLE
fix: add sessionVariables to /ksql endpoint validator

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -284,7 +284,8 @@ public class KsqlResource implements KsqlConfigurable {
               configProperties,
               localHost,
               localUrl,
-              requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST)
+              requestConfig.getBoolean(KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST),
+              request.getSessionVariables()
           ),
           request.getKsql()
       );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -691,8 +691,8 @@ public class RestApiTest {
     // Given:
     // When:
     makeKsqlRequestWithVariables(
-        "CREATE STREAM Y AS SELECT * FROM " + PAGE_VIEW_STREAM + " WHERE USERID='${id}';",
-        ImmutableMap.of("id", "USER_1")
+        "CREATE STREAM ${name} AS SELECT * FROM " + PAGE_VIEW_STREAM + " WHERE USERID='${id}';",
+        ImmutableMap.of("id", "USER_1", "name", "Y")
     );
 
     // Then:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1198,7 +1198,7 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldSupportVariableSubstitutionWithInitialVariables() {
+  public void shouldSupportVariableSubstitutionWithVariablesInRequest() {
     // Given:
     final String csasRaw = "CREATE STREAM ${streamName} AS SELECT * FROM ${fromStream};";
     final String csasSubstituted = "CREATE STREAM " + streamName + " AS SELECT * FROM test_stream;";

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1198,6 +1198,34 @@ public class KsqlResourceTest {
   }
 
   @Test
+  public void shouldSupportVariableSubstitutionWithInitialVariables() {
+    // Given:
+    final String csasRaw = "CREATE STREAM ${streamName} AS SELECT * FROM ${fromStream};";
+    final String csasSubstituted = "CREATE STREAM " + streamName + " AS SELECT * FROM test_stream;";
+
+
+    // When:
+    final List<CommandStatusEntity> results = makeMultipleRequest(
+        new KsqlRequest(
+            csasRaw,
+            emptyMap(),
+            emptyMap(),
+            ImmutableMap.of("streamName", streamName, "fromStream", "test_stream"),
+            null),
+        CommandStatusEntity.class);
+
+    // Then:
+    verify(commandStore).enqueueCommand(
+        argThat(is(commandIdWithString("stream/`" + streamName + "`/create"))),
+        argThat(is(commandWithStatement(csasSubstituted))),
+        any()
+    );
+
+    assertThat(results, hasSize(1));
+    assertThat(results.get(0).getStatementText(), is(csasSubstituted));
+  }
+
+  @Test
   public void shouldSupportSchemaInference() {
     // Given:
     givenMockEngine();


### PR DESCRIPTION
### Description 
Statements like `CREATE STREAM ${variable} ...` were failing when sent to the `/ksql` endpoint even if the request included the needed session variables because  the request validator was parsing the stream without first replacing the variables.

### Testing done 
Updated an integration test to catch this scenario, added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

