### PR TITLE
feat(migrations): support DEFINE and UNDEFINE statements

### DIFF
--- a/docs/operate-and-deploy/migrations-tool.md
+++ b/docs/operate-and-deploy/migrations-tool.md
@@ -51,6 +51,9 @@ types of ksqlDB statements:
 * `DEFINE <variable>`
 * `UNDEFINE <variable>`
 
+Any properties or variables set using the `SET`, `UNSET`, `DEFINE` and `UNDEFINE` are applied in the 
+current migration file only. They do not carry over to the next migration file.
+
 Requirements and Installation
 -----------------------------
 

--- a/docs/operate-and-deploy/migrations-tool.md
+++ b/docs/operate-and-deploy/migrations-tool.md
@@ -48,6 +48,8 @@ types of ksqlDB statements:
 * `DROP TYPE`
 * `SET <property>`
 * `UNSET <property>`
+* `DEFINE <variable>`
+* `UNDEFINE <variable>`
 
 Requirements and Installation
 -----------------------------

--- a/docs/operate-and-deploy/migrations-tool.md
+++ b/docs/operate-and-deploy/migrations-tool.md
@@ -52,7 +52,8 @@ types of ksqlDB statements:
 * `UNDEFINE <variable>`
 
 Any properties or variables set using the `SET`, `UNSET`, `DEFINE` and `UNDEFINE` are applied in the 
-current migration file only. They do not carry over to the next migration file.
+current migration file only. They do not carry over to the next migration file, even if multiple
+migration files are applied as part of the same `ksql-migrations apply` command
 
 Requirements and Installation
 -----------------------------

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
 
 public final class VariableSubstitutor {
@@ -55,6 +56,16 @@ public final class VariableSubstitutor {
 
       return variables;
     }
+  }
+
+  public static String substitute(
+      final String string,
+      final Map<String, String> valueMap
+  ) {
+    return StringSubstitutor.replace(
+        string, valueMap.entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey(), e -> sanitize(e.getValue())))
+    );
   }
 
   public static String substitute(

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -240,6 +240,20 @@ public class VariableSubstitutorTest {
     assertThrowOnInvalidVariables(statements, variablesMap);
   }
 
+  @Test
+  public void shouldSubstituteVariablesInString() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("event", "birthday");
+    }}.build();
+
+    // When
+    final String substituted = VariableSubstitutor.substitute("Happy ${event} to you!", variablesMap);
+
+    // Then
+    assertThat(substituted, equalTo("Happy birthday to you!"));
+  }
+
   private void assertReplacedStatements(
       final List<Pair<String, String>> statements,
       final Map<String, String> variablesMap

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -324,7 +324,7 @@ public class ApplyMigrationCommand extends BaseCommand {
   /**
    * If validateOnly is set to true, then this parses each of the commands but only executes
    * DEFINE/UNDEFINE commands (variables are needed for parsing INSERT INTO... VALUES, SET/UNSET
-   * and DEFINE commands). If validateOnly is set to fales, then each command will execute after
+   * and DEFINE commands). If validateOnly is set to false, then each command will execute after
    * parsing.
    */
   private void executeCommands(
@@ -370,9 +370,6 @@ public class ApplyMigrationCommand extends BaseCommand {
       final Map<String, Object> properties,
       final boolean defineUndefineOnly
   ) throws ExecutionException, InterruptedException {
-    if (!defineUndefineOnly) {
-      executeNonVariableCommands(command, ksqlClient, properties);
-    }
     if (command instanceof SqlDefineVariableCommand) {
       ksqlClient.define(
           ((SqlDefineVariableCommand) command).getVariable(),
@@ -380,6 +377,8 @@ public class ApplyMigrationCommand extends BaseCommand {
       );
     } else if (command instanceof SqlUndefineVariableCommand) {
       ksqlClient.undefine(((SqlUndefineVariableCommand) command).getVariable());
+    } else if (!defineUndefineOnly) {
+      executeNonVariableCommands(command, ksqlClient, properties);
     }
   }
 

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -48,7 +48,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class CommandParser {
+  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
   private static final String QUOTED_STRING_OR_WHITESPACE = "('([^']*|(''))*')|\\s+";
   private static final Pattern SET_PROPERTY = Pattern.compile(
       "\\s*SET\\s+'((?:[^']*|(?:''))*)'\\s*=\\s*'((?:[^']*|(?:''))*)'\\s*;\\s*",
@@ -331,13 +333,13 @@ public final class CommandParser {
       return StatementType.CREATE_CONNECTOR;
     } else if (isDropConnectorStatement(tokens)) {
       return StatementType.DROP_CONNECTOR;
-    } else if (tokens.size() > 0 && tokens.get(0).equals(SET)) {
+    } else if (isSetStatement(tokens)) {
       return StatementType.SET_PROPERTY;
-    } else if (tokens.size() > 0 && tokens.get(0).equals(UNSET)) {
+    } else if (isUnsetStatement(tokens)) {
       return StatementType.UNSET_PROPERTY;
-    } else if (tokens.size() > 0 && tokens.get(0).equals(DEFINE)) {
+    } else if (isDefineStatement(tokens)) {
       return StatementType.DEFINE_VARIABLE;
-    } else if (tokens.size() > 0 && tokens.get(0).equals(UNDEFINE)) {
+    } else if (isUndefineStatement(tokens)) {
       return StatementType.UNDEFINE_VARIABLE;
     } else {
       validateSupportedStatementType(tokens);
@@ -367,6 +369,22 @@ public final class CommandParser {
 
   private static boolean isDropConnectorStatement(final List<String> tokens) {
     return tokens.size() > 1 && tokens.get(0).equals(DROP) && tokens.get(1).equals(CONNECTOR);
+  }
+
+  private static boolean isSetStatement(final List<String> tokens) {
+    return tokens.size() > 0 && tokens.get(0).equals(SET);
+  }
+
+  private static boolean isUnsetStatement(final List<String> tokens) {
+    return tokens.size() > 0 && tokens.get(0).equals(UNSET);
+  }
+
+  private static boolean isDefineStatement(final List<String> tokens) {
+    return tokens.size() > 0 && tokens.get(0).equals(DEFINE);
+  }
+
+  private static boolean isUndefineStatement(final List<String> tokens) {
+    return tokens.size() > 0 && tokens.get(0).equals(UNDEFINE);
   }
 
   /**

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -202,6 +202,8 @@ public final class CommandParser {
   */
   public static SqlCommand transformToSqlCommand(
       final String sql, final Map<String, String> variables) {
+
+    // Splits the sql string into tokens(uppercased keyowords, identifiers and strings)
     final List<String> tokens = Arrays
         .stream(sql.toUpperCase().split(QUOTED_STRING_OR_WHITESPACE))
         .filter(s -> !s.isEmpty())
@@ -326,6 +328,9 @@ public final class CommandParser {
     return new SqlUndefineVariableCommand(sql, undefineVariableMatcher.group(1));
   }
 
+  /**
+   * Determines if a statement is supported and the type of command it is based on a list of tokens.
+   */
   private static StatementType getStatementType(final List<String> tokens) {
     if (isInsertValuesStatement(tokens)) {
       return StatementType.INSERT_VALUES;

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -229,7 +229,7 @@ public final class CommandParser {
   }
 
   private static SqlInsertValues getInsertValuesStatement(
-      final String sql, Map<String, String> variables) {
+      final String sql, final Map<String, String> variables) {
     final InsertValues parsedStatement;
     try {
       final String substituted = VariableSubstitutor.substitute(

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import com.github.rvesse.airline.SingleCommand;
@@ -89,7 +90,8 @@ public class ApplyMigrationCommandTest {
       + "UNSET 'auto.offset.reset';"
       + "CREATE STREAM MOO (A STRING) WITH (KAFKA_TOPIC='MOO', PARTITIONS=1, VALUE_FORMAT='DELIMITED');";
   private static final String DEFINE_COMMANDS = COMMAND
-      + "DEFINE str='abc';"
+      + "DEFINE pre='a';"
+      + "DEFINE str='${pre}bc';"
       + "SET '${str}'='yay';"
       + "CREATE STREAM ${str} AS SELECT * FROM FOO;"
       + "INSERT INTO FOO VALUES ('${str}');"
@@ -210,18 +212,14 @@ public class ApplyMigrationCommandTest {
   @Test
   public void shouldApplyDefineUndefineCommands() throws Exception {
     // Given:
-    final Map<String, Object> variables = ImmutableMap.of("str", "abc");
+    final Map<String, Object> variables = ImmutableMap.of("pre", "a", "str", "abc");
     command = PARSER.parse("-n");
     createMigrationFile(1, NAME, migrationsDir, DEFINE_COMMANDS);
     when(versionQueryResult.get()).thenReturn(ImmutableList.of());
     when(ksqlClient.getVariables()).thenReturn(
-        ImmutableMap.of(),
-        ImmutableMap.of(),
-        variables,
-        variables,
-        variables,
-        variables,
-        ImmutableMap.of()
+        ImmutableMap.of(), ImmutableMap.of(), variables, variables, variables, variables, variables,
+        variables, variables, variables, variables, variables, variables, variables, variables,
+        variables, variables, ImmutableMap.of()
     );
 
     // When:
@@ -234,6 +232,7 @@ public class ApplyMigrationCommandTest {
 
     verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED, () -> {
       inOrder.verify(ksqlClient).executeStatement(COMMAND, new HashMap<>());
+      inOrder.verify(ksqlClient).define("pre", "a");
       inOrder.verify(ksqlClient).define("str", "abc");
       inOrder.verify(ksqlClient).executeStatement(eq("CREATE STREAM ${str} AS SELECT * FROM FOO;"), propCaptor.capture());
       assertThat(propCaptor.getValue().size(), is(1));
@@ -242,6 +241,34 @@ public class ApplyMigrationCommandTest {
       inOrder.verify(ksqlClient).undefine("str");
       inOrder.verify(ksqlClient).insertInto("`FOO`", new KsqlObject(ImmutableMap.of("`A`", "${str}")));
     });
+    inOrder.verify(ksqlClient).close();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldResetVariablesBetweenMigrations() throws Exception {
+    // Given:
+    final Map<String, Object> variables = ImmutableMap.of("cat", "pat");
+    command = PARSER.parse("-a");
+    createMigrationFile(1, NAME, migrationsDir, "DEFINE cat='pat';");
+    createMigrationFile(2, NAME, migrationsDir, "INSERT INTO FOO VALUES ('${cat}');");
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of());
+    when(ksqlClient.getVariables()).thenReturn(ImmutableMap.of(), ImmutableMap.of(), variables, ImmutableMap.of());
+    givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
+    assertThat(result, is(0));
+    final InOrder inOrder = inOrder(ksqlClient);
+    inOrder.verify(ksqlClient, times(2)).getVariables();
+    inOrder.verify(ksqlClient).define("cat", "pat");
+    inOrder.verify(ksqlClient).getVariables();
+    inOrder.verify(ksqlClient).undefine("cat");
+    inOrder.verify(ksqlClient).getVariables();
+    inOrder.verify(ksqlClient).insertInto("`FOO`", new KsqlObject(ImmutableMap.of("`A`", "${cat}")));
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -352,7 +379,7 @@ public class ApplyMigrationCommandTest {
     final InOrder inOrder = inOrder(ksqlClient);
     verifyMigratedVersion(inOrder, 1, "<none>", MigrationState.MIGRATED);
     inOrder.verify(ksqlClient).close();
-    Mockito.verify(ksqlClient, Mockito.times(1)).executeStatement(COMMAND, new HashMap<>());
+    Mockito.verify(ksqlClient, times(1)).executeStatement(COMMAND, new HashMap<>());
   }
 
   @Test
@@ -392,9 +419,9 @@ public class ApplyMigrationCommandTest {
 
     // Then:
     assertThat(result, is(1));
-    Mockito.verify(ksqlClient, Mockito.times(3)).executeQuery(any());
-    Mockito.verify(ksqlClient, Mockito.times(0)).executeStatement(any(), any());
-    Mockito.verify(ksqlClient, Mockito.times(0)).insertInto(any(), any());
+    Mockito.verify(ksqlClient, times(3)).executeQuery(any());
+    Mockito.verify(ksqlClient, times(0)).executeStatement(any(), any());
+    Mockito.verify(ksqlClient, times(0)).insertInto(any(), any());
   }
 
   @Test
@@ -433,9 +460,28 @@ public class ApplyMigrationCommandTest {
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
+    assertThat(result, is(0));
+    Mockito.verify(ksqlClient, times(0)).executeStatement(any(), any());
+    Mockito.verify(ksqlClient, times(0)).insertInto(any(), any());
+  }
+
+  @Test
+  public void shouldThrowErrorOnParsingFailure() throws Exception {
+    // Given:
+    command = PARSER.parse("-n");
+    createMigrationFile(1, NAME, migrationsDir, "SHOW TABLES;");
+    when(versionQueryResult.get()).thenReturn(ImmutableList.of());
+
+    // When:
+    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+        Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
+
+    // Then:
     assertThat(result, is(1));
-    Mockito.verify(ksqlClient, Mockito.times(0)).executeStatement(any(), any());
-    Mockito.verify(ksqlClient, Mockito.times(0)).insertInto(any(), any());
+    final InOrder inOrder = inOrder(ksqlClient);
+    verifyMigratedVersion(
+        inOrder, 1, "<none>", MigrationState.ERROR,
+        Optional.of("Failed to parse sql: SHOW TABLES;. Error: 'SHOW' statements are not supported."), () -> {});
   }
 
   @Test

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -137,35 +137,41 @@ public class CommandParserTest {
 
   @Test
   public void shouldParseSetUnsetStatements() {
-    List<SqlCommand> commands = parse("SET 'foo.property'='bar';UNSET 'foo.property';");
+    List<SqlCommand> commands = parse("SeT 'foo.property'='bar';UnSET 'foo.property';");
     assertThat(commands.size(), is(2));
     assertThat(commands.get(0), instanceOf(SqlPropertyCommand.class));
-    assertThat(commands.get(0).getCommand(), is("SET 'foo.property'='bar';"));
+    assertThat(commands.get(0).getCommand(), is("SeT 'foo.property'='bar';"));
     assertThat(((SqlPropertyCommand) commands.get(0)).isSetCommand(), is(true));
     assertThat(((SqlPropertyCommand) commands.get(0)).getProperty(), is("foo.property"));
     assertThat(((SqlPropertyCommand) commands.get(0)).getValue().get(), is("bar"));
     assertThat(commands.get(1), instanceOf(SqlPropertyCommand.class));
-    assertThat(commands.get(1).getCommand(), is("UNSET 'foo.property';"));
+    assertThat(commands.get(1).getCommand(), is("UnSET 'foo.property';"));
     assertThat(((SqlPropertyCommand) commands.get(1)).isSetCommand(), is(false));
     assertThat(((SqlPropertyCommand) commands.get(1)).getProperty(), is("foo.property"));
     assertTrue(!((SqlPropertyCommand) commands.get(1)).getValue().isPresent());
   }
 
   @Test
-  public void shouldParseSetUnsetStatementsWithVariables() {
-    List<SqlCommand> commands = parse("SET '${name}'='${value}';UNSET '${name}';",
+  public void shouldParseSetStatementsWithVariables() {
+    List<SqlCommand> commands = parse("SET '${name}'='${value}';",
         ImmutableMap.of("name", "foo.property", "value", "bar"));
-    assertThat(commands.size(), is(2));
+    assertThat(commands.size(), is(1));
     assertThat(commands.get(0), instanceOf(SqlPropertyCommand.class));
     assertThat(commands.get(0).getCommand(), is("SET '${name}'='${value}';"));
     assertThat(((SqlPropertyCommand) commands.get(0)).isSetCommand(), is(true));
     assertThat(((SqlPropertyCommand) commands.get(0)).getProperty(), is("foo.property"));
     assertThat(((SqlPropertyCommand) commands.get(0)).getValue().get(), is("bar"));
-    assertThat(commands.get(1), instanceOf(SqlPropertyCommand.class));
-    assertThat(commands.get(1).getCommand(), is("UNSET '${name}';"));
-    assertThat(((SqlPropertyCommand) commands.get(1)).isSetCommand(), is(false));
-    assertThat(((SqlPropertyCommand) commands.get(1)).getProperty(), is("foo.property"));
-    assertTrue(!((SqlPropertyCommand) commands.get(1)).getValue().isPresent());
+  }
+
+  @Test
+  public void shouldParseUnsetStatementsWithVariables() {
+    List<SqlCommand> commands = parse("UnSeT '${name}';",
+        ImmutableMap.of("name", "foo.property"));
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0), instanceOf(SqlPropertyCommand.class));
+    assertThat(((SqlPropertyCommand) commands.get(0)).isSetCommand(), is(false));
+    assertThat(((SqlPropertyCommand) commands.get(0)).getProperty(), is("foo.property"));
+    assertTrue(!((SqlPropertyCommand) commands.get(0)).getValue().isPresent());
   }
 
   @Test
@@ -340,7 +346,7 @@ public class CommandParserTest {
   @Test
   public void shouldParseDropConnectorStatement() {
     // Given:
-    final String dropConnector = "DROP CONNECTOR `jdbc-connector` ;"; // The space at the end is to make sure that the regex doesn't capture it as a part of the name
+    final String dropConnector = "DRoP CONNEcTOR `jdbc-connector` ;"; // The space at the end is to make sure that the regex doesn't capture it as a part of the name
 
     // When:
     List<SqlCommand> commands = parse(dropConnector);
@@ -383,17 +389,32 @@ public class CommandParserTest {
   @Test
   public void shouldParseDefineStatement() {
     // Given:
-    final String undefineVar = "DEFINE var = 'foo';";
+    final String defineVar = "DEFINE var = 'foo';";
 
     // When:
-    List<SqlCommand> commands = parse(undefineVar);
+    List<SqlCommand> commands = parse(defineVar);
 
     // Then:
     assertThat(commands.size(), is(1));
-    assertThat(commands.get(0).getCommand(), is(undefineVar));
+    assertThat(commands.get(0).getCommand(), is(defineVar));
     assertThat(commands.get(0), instanceOf(SqlDefineVariableCommand.class));
     assertThat(((SqlDefineVariableCommand) commands.get(0)).getVariable(), is("var"));
     assertThat(((SqlDefineVariableCommand) commands.get(0)).getValue(), is("foo"));
+  }
+
+  @Test
+  public void shouldDefineStatementWithVariable() {
+    // Given:
+    final String defineVar = "DEFiNe word = 'walk${suffix}';";
+
+    // When:
+    List<SqlCommand> commands = parse(defineVar, ImmutableMap.of("suffix", "ing"));
+
+    // Then:
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0), instanceOf(SqlDefineVariableCommand.class));
+    assertThat(((SqlDefineVariableCommand) commands.get(0)).getVariable(), is("word"));
+    assertThat(((SqlDefineVariableCommand) commands.get(0)).getValue(), is("walking"));
   }
 
   @Test


### PR DESCRIPTION
### Description 
^^^

Previously, the tool parsed each command, collected them and then executed them. Because the variables are tracked in the java client, but SET/UNSET/INSERT VALUES don't do variable substitution through the client, the flow was refactored to parse commands and then execute them one by one.

### Testing done 
unit + integration

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

