### PR TITLE
chore: drop ignoreUnchecked for deprecated members

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedAdminClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedAdminClientTest.java
@@ -44,7 +44,6 @@ public final class SandboxedAdminClientTest {
       return TestMethods.builder(Admin.class)
           .ignore("close")
           .ignore("close", Duration.class)
-          .ignoreUnchecked("close", long.class, TimeUnit.class)
           .setDefault(ElectLeadersOptions.class, new ElectLeadersOptions())
           .setDefault(Optional.class, Optional.empty())
           .build();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedConsumerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedConsumerTest.java
@@ -44,7 +44,6 @@ public final class SandboxedConsumerTest {
           .ignore("unsubscribe")
           .ignore("close")
           .ignore("close", Duration.class)
-          .ignoreUnchecked("close", long.class, TimeUnit.class)
           .ignore("wakeup")
           .ignore("groupMetadata")
           .setDefault(TopicPartition.class, new TopicPartition("t", 1))

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedProducerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedProducerTest.java
@@ -45,7 +45,6 @@ public final class SandboxedProducerTest {
           .ignore("send", ProducerRecord.class)
           .ignore("send", ProducerRecord.class, Callback.class)
           .ignore("close")
-          .ignoreUnchecked("close", long.class, TimeUnit.class)
           .ignore("close", Duration.class)
           .build();
     }


### PR DESCRIPTION
Follow up to https://github.com/confluentinc/ksql/pull/7363 .

Once we feel all builds will see the upstream changes, we
no longer need to use ignoreUnchecked for the dropped close methods.