### PR TITLE
fix: source key format compatibility with non primitive types (#7337)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -25,7 +25,9 @@ import io.confluent.ksql.execution.streams.StepSchemaResolver;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.InternalFormats;
 import io.confluent.ksql.serde.KeyFormat;
@@ -34,6 +36,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class SchemaKGroupedStream {
 
@@ -85,7 +88,7 @@ public class SchemaKGroupedStream {
     } else {
       keyFormat = SerdeFeaturesFactory.sanitizeKeyFormat(
           this.keyFormat,
-          schema.key().size(),
+          toSqlTypes(schema.key()),
           false
       );
       step = ExecutionStepFactory.streamAggregate(
@@ -112,9 +115,13 @@ public class SchemaKGroupedStream {
             keyFormat.getFormatInfo(),
             keyFormat.getFeatures(),
             windowExpression.getKsqlWindowExpression().getWindowInfo()),
-        schema.key().size(),
+        toSqlTypes(schema.key()),
         false
     );
+  }
+
+  protected List<SqlType> toSqlTypes(final List<Column> columns) {
+    return columns.stream().map(Column::type).collect(Collectors.toList());
   }
 
   LogicalSchema resolveSchema(final ExecutionStep<?> step) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -185,7 +185,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
 
     final KeyFormat newKeyFormat = SerdeFeaturesFactory.sanitizeKeyFormat(
         forceInternalKeyFormat.orElse(keyFormat),
-        keyExpression.size(),
+        toSqlTypes(keyExpression),
         false // logical schema changes are not supported
     );
 
@@ -225,7 +225,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     // the key format directly (as opposed to the logic in SchemaKStream)
     final KeyFormat groupedKeyFormat = SerdeFeaturesFactory.sanitizeKeyFormat(
         KeyFormat.nonWindowed(keyFormat.getFormatInfo(), keyFormat.getFeatures()),
-        groupByExpressions.size(),
+        toSqlTypes(groupByExpressions),
         true
     );
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/serde/SerdeFeaturesFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/serde/SerdeFeaturesFactoryTest.java
@@ -29,15 +29,22 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
+import io.confluent.ksql.schema.ksql.types.SqlBaseType;
+import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.delimited.DelimitedFormat;
 import io.confluent.ksql.serde.json.JsonFormat;
 import io.confluent.ksql.serde.kafka.KafkaFormat;
 import io.confluent.ksql.serde.none.NoneFormat;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,8 +64,8 @@ public class SerdeFeaturesFactoryTest {
       .valueColumn(ColumnName.of("f1"), SqlTypes.DOUBLE)
       .build();
 
-  private static final List<ColumnName> SINGLE_COLUMN_NAME = ImmutableList.of(ColumnName.of("bob"));
-  private static final List<ColumnName> MULTI_FIELD_NAMES = ImmutableList.of(ColumnName.of("bob"), ColumnName.of("vic"));
+  private static final List<SqlType> MULTI_SQL_TYPES = ImmutableList.of(SqlPrimitiveType.of(SqlBaseType.INTEGER),SqlPrimitiveType.of(SqlBaseType.BOOLEAN));
+  private static final List<SqlType> SINGLE_SQL_TYPE = ImmutableList.of(SqlPrimitiveType.of(SqlBaseType.INTEGER));
 
   private KsqlConfig ksqlConfig;
 
@@ -267,7 +274,7 @@ public class SerdeFeaturesFactoryTest {
         SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 2, true);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, MULTI_SQL_TYPES, true);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
@@ -282,7 +289,7 @@ public class SerdeFeaturesFactoryTest {
         SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 0, true);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, Collections.emptyList(), true);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
@@ -297,7 +304,7 @@ public class SerdeFeaturesFactoryTest {
         SerdeFeatures.of());
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 1, true);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, SINGLE_SQL_TYPE, true);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
@@ -312,7 +319,7 @@ public class SerdeFeaturesFactoryTest {
         SerdeFeatures.of(SerdeFeature.WRAP_SINGLES));
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 1, true);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, SINGLE_SQL_TYPE, true);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
@@ -327,7 +334,7 @@ public class SerdeFeaturesFactoryTest {
         SerdeFeatures.of());
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 2, true);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, MULTI_SQL_TYPES, true);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
@@ -342,7 +349,7 @@ public class SerdeFeaturesFactoryTest {
         SerdeFeatures.of());
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 2, true);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, MULTI_SQL_TYPES, true);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
@@ -360,7 +367,7 @@ public class SerdeFeaturesFactoryTest {
         SerdeFeatures.of(SerdeFeature.WRAP_SINGLES));
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 2, true);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, MULTI_SQL_TYPES, true);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(formatInfo));
@@ -368,14 +375,14 @@ public class SerdeFeaturesFactoryTest {
   }
 
   @Test
-  public void shouldNotConvertFormatForMulticolKeysWhenSanitizingIfNotMultiColumn() {
+  public void shouldNotConvertFormatWhenSanitizingWithSingleColumnAndSupportedPrimitiveType() {
     // Given:
     final KeyFormat format = KeyFormat.nonWindowed(
         FormatInfo.of(KafkaFormat.NAME),
         SerdeFeatures.of());
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 1, true);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, SINGLE_SQL_TYPE, true);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(KafkaFormat.NAME)));
@@ -390,10 +397,115 @@ public class SerdeFeaturesFactoryTest {
         SerdeFeatures.of());
 
     // When:
-    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, 2, false);
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, MULTI_SQL_TYPES, false);
 
     // Then:
     assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(KafkaFormat.NAME)));
     assertThat(sanitized.getFeatures(), equalTo(SerdeFeatures.of()));
+  }
+
+  @Test
+  public void shouldConvertKafkaFormatForSingleKeyWithNonPrimitiveType() {
+    // Given:
+    final KeyFormat format = KeyFormat.nonWindowed(
+        FormatInfo.of(KafkaFormat.NAME),
+        SerdeFeatures.of());
+
+    // When:
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, ImmutableList.of(SqlTypes.struct().build()), true);
+
+    // Then:
+    assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
+    assertThat(sanitized.getFeatures(), equalTo(SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES)));
+  }
+
+  @Test
+  public void shouldConvertKafkaFormatForSingleKeyWithUnsupportedPrimitiveType() {
+    // Given:
+    final KeyFormat format = KeyFormat.nonWindowed(
+        FormatInfo.of(KafkaFormat.NAME),
+        SerdeFeatures.of());
+
+    // When:
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, ImmutableList.of(SqlPrimitiveType.of(SqlBaseType.BOOLEAN)), true);
+
+    // Then:
+    assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
+    assertThat(sanitized.getFeatures(), equalTo(SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES)));
+  }
+
+  @Test
+  public void shouldConvertDelimitedFormatForSingleKeyWithNonPrimitiveType() {
+    // Given:
+    final KeyFormat format = KeyFormat.nonWindowed(
+        FormatInfo.of(DelimitedFormat.NAME),
+        SerdeFeatures.of());
+
+    // When:
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, ImmutableList.of(SqlTypes.struct().build()), true);
+
+    // Then:
+    assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
+    assertThat(sanitized.getFeatures(), equalTo(SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES)));
+  }
+
+  @Test
+  public void shouldConvertDelimitedFormatForMultiColKeyWithNonPrimitiveType() {
+    // Given:
+    final KeyFormat format = KeyFormat.nonWindowed(
+        FormatInfo.of(DelimitedFormat.NAME),
+        SerdeFeatures.of());
+
+    // When:
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, ImmutableList.of(SqlTypes.struct().build(), SqlPrimitiveType.of(SqlBaseType.INTEGER)), true);
+
+    // Then:
+    assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
+    assertThat(sanitized.getFeatures(), equalTo(SerdeFeatures.of()));
+  }
+
+  @Test
+  public void shouldNotConvertDelimitedFormatForMulticolKeysWithPrimitiveTypes() {
+    // Given:
+    final KeyFormat format = KeyFormat.nonWindowed(
+        FormatInfo.of(DelimitedFormat.NAME),
+        SerdeFeatures.of());
+
+    // When:
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, MULTI_SQL_TYPES, true);
+
+    // Then:
+    assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(DelimitedFormat.NAME)));
+    assertThat(sanitized.getFeatures(), equalTo(SerdeFeatures.of()));
+  }
+
+  @Test
+  public void shouldNotConvertDelimitedFormatForSingleKeyWithPrimitiveType() {
+    // Given:
+    final KeyFormat format = KeyFormat.nonWindowed(
+        FormatInfo.of(DelimitedFormat.NAME),
+        SerdeFeatures.of());
+
+    // When:
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, SINGLE_SQL_TYPE, true);
+
+    // Then:
+    assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(DelimitedFormat.NAME)));
+    assertThat(sanitized.getFeatures(), equalTo(SerdeFeatures.of()));
+  }
+
+  @Test
+  public void shouldConvertNoneFormatForSingleKeyWithNonPrimitiveType() {
+    // Given:
+    final KeyFormat format = KeyFormat.nonWindowed(
+        FormatInfo.of(NoneFormat.NAME),
+        SerdeFeatures.of());
+
+    // When:
+    final KeyFormat sanitized = SerdeFeaturesFactory.sanitizeKeyFormat(format, ImmutableList.of(SqlTypes.struct().build()), true);
+
+    // Then:
+    assertThat(sanitized.getFormatInfo(), equalTo(FormatInfo.of(JsonFormat.NAME)));
+    assertThat(sanitized.getFeatures(), equalTo(SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES)));
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -362,7 +362,7 @@ public class TestExecutor implements Closeable {
     try {
       key = topicInfo.getKeySerializer().serialize(rec.topic(), rec.key());
     } catch (final Exception e) {
-      throw new AssertionError("Failed to serialize value: " + e.getMessage()
+      throw new AssertionError("Failed to serialize key: " + e.getMessage()
           + System.lineSeparator()
           + "rec: " + rec,
           e

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_JSON_format_conversion/7.0.0_1617994288429/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_JSON_format_conversion/7.0.0_1617994288429/plan.json
@@ -1,0 +1,191 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (F1 INTEGER KEY, F2 DECIMAL(2, 1)) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', PARTITIONS=1, VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`F1` INTEGER KEY, `F2` DECIMAL(2, 1)",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT\n  TEST.F2 KEY,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F2\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`KEY` DECIMAL(2, 1) KEY, `TOTAL` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`F1` INTEGER KEY, `F2` DECIMAL(2, 1)"
+                },
+                "keyColumnNames" : [ "F1" ],
+                "selectExpressions" : [ "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "JSON"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                },
+                "keyFeatures" : [ "UNWRAP_SINGLES" ]
+              },
+              "groupByExpressions" : [ "F2" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "JSON"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              },
+              "keyFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "nonAggregateColumns" : [ "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "keyColumnNames" : [ "KEY" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS TOTAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "keyFeatures" : [ "UNWRAP_SINGLES" ]
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_JSON_format_conversion/7.0.0_1617994288429/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_JSON_format_conversion/7.0.0_1617994288429/spec.json
@@ -1,0 +1,206 @@
+{
+  "version" : "7.0.0",
+  "timestamp" : 1617994288429,
+  "path" : "query-validation-tests/group-by.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`F2` DECIMAL(2, 1) KEY, `F2` DECIMAL(2, 1), `ROWTIME` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`F1` INTEGER KEY, `F2` DECIMAL(2, 1)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`F2` DECIMAL(2, 1) KEY, `F2` DECIMAL(2, 1), `ROWTIME` BIGINT, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`KEY` DECIMAL(2, 1) KEY, `TOTAL` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "multiple expressions - KAFKA to non-supported decimal key format with JSON format conversion",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : null
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "f2" : "1"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "1"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 2.0,
+      "value" : {
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 4.0,
+      "value" : {
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1.0,
+      "value" : {
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2.0,
+      "value" : {
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 4.0,
+      "value" : {
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1.0,
+      "value" : {
+        "TOTAL" : 2
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM TEST (f1 INT KEY, f2 DECIMAL(2, 1)) WITH (kafka_topic='test_topic', value_format='JSON', partitions=1);", "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT f2 AS key, COUNT(*) AS total FROM TEST GROUP BY f2;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`KEY` DECIMAL(2, 1) KEY, `TOTAL` BIGINT",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`F1` INTEGER KEY, `F2` DECIMAL(2, 1)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 1
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_JSON_format_conversion/7.0.0_1617994288429/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_JSON_format_conversion/7.0.0_1617994288429/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_favored_explicit_AVRO_format_conversion/7.0.0_1617994288525/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_favored_explicit_AVRO_format_conversion/7.0.0_1617994288525/plan.json
@@ -1,0 +1,197 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (F1 INTEGER KEY, F2 DECIMAL(2, 1)) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', PARTITIONS=1, VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`F1` INTEGER KEY, `F2` DECIMAL(2, 1)",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT WITH (KEY_FORMAT='AVRO') AS SELECT\n  TEST.F2 KEY,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F2\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`KEY` DECIMAL(2, 1) KEY, `TOTAL` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "AVRO",
+          "properties" : {
+            "fullSchemaName" : "io.confluent.ksql.avro_schemas.OutputKey"
+          }
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`F1` INTEGER KEY, `F2` DECIMAL(2, 1)"
+                },
+                "keyColumnNames" : [ "F1" ],
+                "selectExpressions" : [ "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "JSON"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                },
+                "keyFeatures" : [ "UNWRAP_SINGLES" ]
+              },
+              "groupByExpressions" : [ "F2" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "JSON"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              },
+              "keyFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "nonAggregateColumns" : [ "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "keyColumnNames" : [ "KEY" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS TOTAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "io.confluent.ksql.avro_schemas.OutputKey"
+            }
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "keyFeatures" : [ "UNWRAP_SINGLES" ]
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_favored_explicit_AVRO_format_conversion/7.0.0_1617994288525/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_favored_explicit_AVRO_format_conversion/7.0.0_1617994288525/spec.json
@@ -1,0 +1,218 @@
+{
+  "version" : "7.0.0",
+  "timestamp" : 1617994288525,
+  "path" : "query-validation-tests/group-by.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`F2` DECIMAL(2, 1) KEY, `F2` DECIMAL(2, 1), `ROWTIME` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`F1` INTEGER KEY, `F2` DECIMAL(2, 1)",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`F2` DECIMAL(2, 1) KEY, `F2` DECIMAL(2, 1), `ROWTIME` BIGINT, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`KEY` DECIMAL(2, 1) KEY, `TOTAL` BIGINT",
+      "keyFormat" : {
+        "format" : "AVRO",
+        "properties" : {
+          "fullSchemaName" : "io.confluent.ksql.avro_schemas.OutputKey"
+        },
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "multiple expressions - KAFKA to non-supported decimal key format with favored explicit AVRO format conversion",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : null
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "f2" : "1"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "1"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 2.0,
+      "value" : {
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 4.0,
+      "value" : {
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1.0,
+      "value" : {
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2.0,
+      "value" : {
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 4.0,
+      "value" : {
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1.0,
+      "value" : {
+        "TOTAL" : 2
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM TEST (f1 INT KEY, f2 DECIMAL(2, 1)) WITH (kafka_topic='test_topic', value_format='JSON', partitions=1);", "CREATE TABLE OUTPUT WITH (KEY_FORMAT='AVRO') AS SELECT f2 AS key, COUNT(*) AS total FROM TEST GROUP BY f2;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`KEY` DECIMAL(2, 1) KEY, `TOTAL` BIGINT",
+        "keyFormat" : {
+          "format" : "AVRO"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`F1` INTEGER KEY, `F2` DECIMAL(2, 1)",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 1
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "AVRO",
+            "properties" : {
+              "fullSchemaName" : "io.confluent.ksql.avro_schemas.OutputKey"
+            },
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4,
+          "keySchema" : {
+            "type" : "bytes",
+            "scale" : 1,
+            "precision" : 2,
+            "logicalType" : "decimal"
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_favored_explicit_AVRO_format_conversion/7.0.0_1617994288525/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_non-supported_decimal_key_format_with_favored_explicit_AVRO_format_conversion/7.0.0_1617994288525/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_struct_key_format/7.0.0_1617994288298/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_struct_key_format/7.0.0_1617994288298/plan.json
@@ -1,0 +1,191 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (F1 INTEGER KEY, F2 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', PARTITIONS=1, VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`F1` INTEGER KEY, `F2` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT\n  STRUCT(F1:=TEST.F1, F2:=TEST.F2) K,\n  AS_VALUE(STRUCT(F1:=TEST.F1, F2:=TEST.F2)) KEY,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY STRUCT(F1:=TEST.F1, F2:=TEST.F2)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRUCT<`F1` INTEGER, `F2` INTEGER> KEY, `KEY` STRUCT<`F1` INTEGER, `F2` INTEGER>, `TOTAL` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`F1` INTEGER KEY, `F2` INTEGER"
+                },
+                "keyColumnNames" : [ "F1" ],
+                "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "JSON"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                },
+                "keyFeatures" : [ "UNWRAP_SINGLES" ]
+              },
+              "groupByExpressions" : [ "STRUCT(F1:=F1, F2:=F2)" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "JSON"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              },
+              "keyFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "nonAggregateColumns" : [ "F1", "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "AS_VALUE(STRUCT(F1:=F1, F2:=F2)) AS KEY", "KSQL_AGG_VARIABLE_0 AS TOTAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "keyFeatures" : [ "UNWRAP_SINGLES" ]
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_struct_key_format/7.0.0_1617994288298/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_struct_key_format/7.0.0_1617994288298/spec.json
@@ -1,0 +1,261 @@
+{
+  "version" : "7.0.0",
+  "timestamp" : 1617994288298,
+  "path" : "query-validation-tests/group-by.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`KSQL_COL_0` STRUCT<`F1` INTEGER, `F2` INTEGER> KEY, `F1` INTEGER, `F2` INTEGER, `ROWTIME` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`F1` INTEGER KEY, `F2` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`KSQL_COL_0` STRUCT<`F1` INTEGER, `F2` INTEGER> KEY, `F1` INTEGER, `F2` INTEGER, `ROWTIME` BIGINT, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRUCT<`F1` INTEGER, `F2` INTEGER> KEY, `KEY` STRUCT<`F1` INTEGER, `F2` INTEGER>, `TOTAL` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "multiple expressions - KAFKA to struct key format",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : null
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "f2" : "1"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : {
+        "f2" : "1"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : 1,
+        "F2" : 2
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : 1,
+          "F2" : 2
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : 2,
+        "F2" : 4
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : 2,
+          "F2" : 4
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : 1,
+        "F2" : null
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : 1,
+          "F2" : null
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : null,
+        "F2" : 1
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : null,
+          "F2" : 1
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : 1,
+        "F2" : 2
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : 1,
+          "F2" : 2
+        },
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : 2,
+        "F2" : 4
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : 2,
+          "F2" : 4
+        },
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : 2,
+        "F2" : 1
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : 2,
+          "F2" : 1
+        },
+        "TOTAL" : 1
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', value_format='JSON', partitions=1);", "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT STRUCT(f1:=f1, f2:=f2) AS k, as_value(struct(f1:=f1, f2:=f2)) AS key, COUNT(*) AS total FROM TEST GROUP BY STRUCT(f1:=f1, f2:=f2);" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`K` STRUCT<`F1` INTEGER, `F2` INTEGER> KEY, `KEY` STRUCT<`F1` INTEGER, `F2` INTEGER>, `TOTAL` BIGINT",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`F1` INTEGER KEY, `F2` INTEGER",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 1
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_struct_key_format/7.0.0_1617994288298/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_KAFKA_to_struct_key_format/7.0.0_1617994288298/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column,_non-primitive_format/7.0.0_1617994288755/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column,_non-primitive_format/7.0.0_1617994288755/plan.json
@@ -1,0 +1,187 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (F1 STRING KEY, F2 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='DELIMITED', PARTITIONS=1, VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`F1` STRING KEY, `F2` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "DELIMITED"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT\n  STRUCT(F1:=TEST.F1, F2:=TEST.F2) K1,\n  TEST.F1 K2,\n  AS_VALUE(STRUCT(F1:=TEST.F1, F2:=TEST.F2)) KEY,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY STRUCT(F1:=TEST.F1, F2:=TEST.F2), TEST.F1\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K1` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `K2` STRING KEY, `KEY` STRUCT<`F1` STRING, `F2` INTEGER>, `TOTAL` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "DELIMITED"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`F1` STRING KEY, `F2` INTEGER"
+                },
+                "keyColumnNames" : [ "F1" ],
+                "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "JSON"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "STRUCT(F1:=F1, F2:=F2)", "F1" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "JSON"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "F1", "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "keyColumnNames" : [ "K1", "K2" ],
+          "selectExpressions" : [ "AS_VALUE(STRUCT(F1:=F1, F2:=F2)) AS KEY", "KSQL_AGG_VARIABLE_0 AS TOTAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column,_non-primitive_format/7.0.0_1617994288755/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column,_non-primitive_format/7.0.0_1617994288755/spec.json
@@ -1,0 +1,260 @@
+{
+  "version" : "7.0.0",
+  "timestamp" : 1617994288755,
+  "path" : "query-validation-tests/group-by.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`KSQL_COL_0` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `F1` STRING KEY, `F1` STRING, `F2` INTEGER, `ROWTIME` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`F1` STRING KEY, `F2` INTEGER",
+      "keyFormat" : {
+        "format" : "DELIMITED"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`KSQL_COL_0` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `F1` STRING KEY, `F1` STRING, `F2` INTEGER, `ROWTIME` BIGINT, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K1` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `K2` STRING KEY, `KEY` STRUCT<`F1` STRING, `F2` INTEGER>, `TOTAL` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "multiple expressions - delimited key format to multi-column, non-primitive format",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : null
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "f2" : "1"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "1"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K1" : {
+          "F1" : "a",
+          "F2" : 2
+        },
+        "K2" : "a"
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "a",
+          "F2" : 2
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K1" : {
+          "F1" : "b",
+          "F2" : 4
+        },
+        "K2" : "b"
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "b",
+          "F2" : 4
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K1" : {
+          "F1" : "a",
+          "F2" : null
+        },
+        "K2" : "a"
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "a",
+          "F2" : null
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K1" : {
+          "F1" : "a",
+          "F2" : 2
+        },
+        "K2" : "a"
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "a",
+          "F2" : 2
+        },
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K1" : {
+          "F1" : "b",
+          "F2" : 4
+        },
+        "K2" : "b"
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "b",
+          "F2" : 4
+        },
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K1" : {
+          "F1" : "b",
+          "F2" : 1
+        },
+        "K2" : "b"
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "b",
+          "F2" : 1
+        },
+        "TOTAL" : 1
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM TEST (f1 STRING KEY, f2 INT) WITH (kafka_topic='test_topic', key_format='DELIMITED', value_format='JSON', partitions=1);", "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT STRUCT(f1:=f1, f2:=f2) AS k1, f1 as k2, as_value(struct(f1:=f1, f2:=f2)) AS key, COUNT(*) AS total FROM TEST GROUP BY STRUCT(f1:=f1, f2:=f2), f1;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`K1` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `K2` STRING KEY, `KEY` STRUCT<`F1` STRING, `F2` INTEGER>, `TOTAL` BIGINT",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`F1` STRING KEY, `F2` INTEGER",
+        "keyFormat" : {
+          "format" : "DELIMITED"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "DELIMITED"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 1
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column,_non-primitive_format/7.0.0_1617994288755/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column,_non-primitive_format/7.0.0_1617994288755/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column_primitive_format/7.0.0_1617994288625/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column_primitive_format/7.0.0_1617994288625/plan.json
@@ -1,0 +1,187 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (F1 STRING KEY, F2 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='DELIMITED', PARTITIONS=1, VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`F1` STRING KEY, `F2` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "DELIMITED"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  TEST.F1 K1,\n  TEST.F2 K2,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K1` STRING KEY, `K2` INTEGER KEY, `TOTAL` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "DELIMITED"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "DELIMITED"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`F1` STRING KEY, `F2` INTEGER"
+                },
+                "keyColumnNames" : [ "F1" ],
+                "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "DELIMITED"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "F1", "F2" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "DELIMITED"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "F1", "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "keyColumnNames" : [ "K1", "K2" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS TOTAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "DELIMITED"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column_primitive_format/7.0.0_1617994288625/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column_primitive_format/7.0.0_1617994288625/spec.json
@@ -1,0 +1,194 @@
+{
+  "version" : "7.0.0",
+  "timestamp" : 1617994288625,
+  "path" : "query-validation-tests/group-by.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`F1` STRING KEY, `F2` INTEGER KEY, `F1` STRING, `F2` INTEGER, `ROWTIME` BIGINT",
+      "keyFormat" : {
+        "format" : "DELIMITED"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`F1` STRING KEY, `F2` INTEGER",
+      "keyFormat" : {
+        "format" : "DELIMITED"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`F1` STRING KEY, `F2` INTEGER KEY, `F1` STRING, `F2` INTEGER, `ROWTIME` BIGINT, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "DELIMITED"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K1` STRING KEY, `K2` INTEGER KEY, `TOTAL` BIGINT",
+      "keyFormat" : {
+        "format" : "DELIMITED"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "multiple expressions - delimited key format to multi-column primitive format",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : null
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "f2" : "1"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "1"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "a,2",
+      "value" : {
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "b,4",
+      "value" : {
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "a,2",
+      "value" : {
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "b,4",
+      "value" : {
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "b,1",
+      "value" : {
+        "TOTAL" : 1
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM TEST (f1 STRING KEY, f2 INT) WITH (kafka_topic='test_topic', key_format='DELIMITED', value_format='JSON', partitions=1);", "CREATE TABLE OUTPUT AS SELECT f1 AS k1, f2 AS k2, COUNT(*) AS total FROM TEST GROUP BY f1, f2;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`K1` STRING KEY, `K2` INTEGER KEY, `TOTAL` BIGINT",
+        "keyFormat" : {
+          "format" : "DELIMITED"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`F1` STRING KEY, `F2` INTEGER",
+        "keyFormat" : {
+          "format" : "DELIMITED"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "DELIMITED"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 1
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "DELIMITED"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "DELIMITED"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "DELIMITED"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column_primitive_format/7.0.0_1617994288625/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_multi-column_primitive_format/7.0.0_1617994288625/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_struct_format/7.0.0_1617994288873/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_struct_format/7.0.0_1617994288873/plan.json
@@ -1,0 +1,191 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (F1 STRING KEY, F2 INTEGER) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='DELIMITED', PARTITIONS=1, VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`F1` STRING KEY, `F2` INTEGER",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "DELIMITED"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT\n  STRUCT(F1:=TEST.F1, F2:=TEST.F2) K,\n  AS_VALUE(STRUCT(F1:=TEST.F1, F2:=TEST.F2)) KEY,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY STRUCT(F1:=TEST.F1, F2:=TEST.F2)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `KEY` STRUCT<`F1` STRING, `F2` INTEGER>, `TOTAL` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "DELIMITED"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`F1` STRING KEY, `F2` INTEGER"
+                },
+                "keyColumnNames" : [ "F1" ],
+                "selectExpressions" : [ "F1 AS F1", "F2 AS F2", "ROWTIME AS ROWTIME" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "JSON"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                },
+                "keyFeatures" : [ "UNWRAP_SINGLES" ]
+              },
+              "groupByExpressions" : [ "STRUCT(F1:=F1, F2:=F2)" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "JSON"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              },
+              "keyFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "nonAggregateColumns" : [ "F1", "F2", "ROWTIME" ],
+            "aggregationFunctions" : [ "COUNT(ROWTIME)" ]
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "AS_VALUE(STRUCT(F1:=F1, F2:=F2)) AS KEY", "KSQL_AGG_VARIABLE_0 AS TOTAL" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "keyFeatures" : [ "UNWRAP_SINGLES" ]
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_struct_format/7.0.0_1617994288873/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_struct_format/7.0.0_1617994288873/spec.json
@@ -1,0 +1,261 @@
+{
+  "version" : "7.0.0",
+  "timestamp" : 1617994288873,
+  "path" : "query-validation-tests/group-by.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`KSQL_COL_0` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `F1` STRING, `F2` INTEGER, `ROWTIME` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`F1` STRING KEY, `F2` INTEGER",
+      "keyFormat" : {
+        "format" : "DELIMITED"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`KSQL_COL_0` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `F1` STRING, `F2` INTEGER, `ROWTIME` BIGINT, `KSQL_AGG_VARIABLE_0` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `KEY` STRUCT<`F1` STRING, `F2` INTEGER>, `TOTAL` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "multiple expressions - delimited key format to struct format",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : null
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "f2" : "1"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "a",
+      "value" : {
+        "f2" : "2"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "4"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "b",
+      "value" : {
+        "f2" : "1"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : "a",
+        "F2" : 2
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "a",
+          "F2" : 2
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : "b",
+        "F2" : 4
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "b",
+          "F2" : 4
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : "a",
+        "F2" : null
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "a",
+          "F2" : null
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : null,
+        "F2" : 1
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : null,
+          "F2" : 1
+        },
+        "TOTAL" : 1
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : "a",
+        "F2" : 2
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "a",
+          "F2" : 2
+        },
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : "b",
+        "F2" : 4
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "b",
+          "F2" : 4
+        },
+        "TOTAL" : 2
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : {
+        "F1" : "b",
+        "F2" : 1
+      },
+      "value" : {
+        "KEY" : {
+          "F1" : "b",
+          "F2" : 1
+        },
+        "TOTAL" : 1
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM TEST (f1 STRING KEY, f2 INT) WITH (kafka_topic='test_topic', key_format='DELIMITED', value_format='JSON', partitions=1);", "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT STRUCT(f1:=f1, f2:=f2) AS k, as_value(struct(f1:=f1, f2:=f2)) AS key, COUNT(*) AS total FROM TEST GROUP BY STRUCT(f1:=f1, f2:=f2);" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`K` STRUCT<`F1` STRING, `F2` INTEGER> KEY, `KEY` STRUCT<`F1` STRING, `F2` INTEGER>, `TOTAL` BIGINT",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`F1` STRING KEY, `F2` INTEGER",
+        "keyFormat" : {
+          "format" : "DELIMITED"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "DELIMITED"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 1
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_struct_format/7.0.0_1617994288873/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/group-by_-_multiple_expressions_-_delimited_key_format_to_struct_format/7.0.0_1617994288873/topology
@@ -1,0 +1,40 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-FILTER-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-FILTER-0000000003 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> Aggregate-GroupBy-repartition-filter
+      <-- KSTREAM-FILTER-0000000003
+    Processor: Aggregate-GroupBy-repartition-filter (stores: [])
+      --> Aggregate-GroupBy-repartition-sink
+      <-- Aggregate-GroupBy
+    Sink: Aggregate-GroupBy-repartition-sink (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy-repartition-filter
+
+  Sub-topology: 1
+    Source: Aggregate-GroupBy-repartition-source (topics: [Aggregate-GroupBy-repartition])
+      --> KSTREAM-AGGREGATE-0000000005
+    Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-GroupBy-repartition-source
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000005
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000011
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000011 (stores: [])
+      --> KSTREAM-SINK-0000000012
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000012 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000011
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -573,6 +573,199 @@
       }
     },
     {
+      "name": "multiple expressions - KAFKA to struct key format",
+      "statements": [
+        "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', value_format='JSON', partitions=1);",
+        "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT STRUCT(f1:=f1, f2:=f2) AS k, as_value(struct(f1:=f1, f2:=f2)) AS key, COUNT(*) AS total FROM TEST GROUP BY STRUCT(f1:=f1, f2:=f2);"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 1, "value": {"f2": null}},
+        {"topic": "test_topic", "key": 1, "value": null},
+        {"topic": "test_topic", "key": null, "value": {"f2": "1"}},
+        {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "1"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"F1": 1, "F2": 2}, "value": {"KEY": {"F1":1,"F2":2}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"F1": 2, "F2": 4}, "value": {"KEY": {"F1":2,"F2":4}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"F1": 1, "F2": null}, "value": {"KEY": {"F1":1,"F2":null}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"F1": null, "F2": 1}, "value": {"KEY": {"F1":null,"F2":1}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"F1": 1, "F2": 2}, "value": {"KEY": {"F1":1,"F2":2}, "TOTAL": 2}},
+        {"topic": "OUTPUT", "key": {"F1": 2, "F2": 4}, "value": {"KEY": {"F1":2,"F2":4}, "TOTAL": 2}},
+        {"topic": "OUTPUT", "key": {"F1": 2, "F2": 1}, "value": {"KEY": {"F1":2,"F2":1}, "TOTAL": 1}}
+      ]
+    },
+    {
+      "name": "multiple expressions - KAFKA to non-supported decimal key format",
+      "statements": [
+        "CREATE STREAM TEST (f1 INT KEY, f2 DECIMAL(2, 1)) WITH (kafka_topic='test_topic', value_format='JSON', partitions=1);",
+        "CREATE TABLE OUTPUT AS SELECT f2 AS key, COUNT(*) AS total FROM TEST GROUP BY f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`KEY` DECIMAL(2, 1) KEY], features=[]}\nreason: The 'KAFKA' format does not support type 'DECIMAL'\nStatement: CREATE TABLE OUTPUT AS SELECT\n  TEST.F2 KEY,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F2\nEMIT CHANGES"
+      }
+    },
+    {
+      "name": "multiple expressions - KAFKA to non-supported decimal key format with JSON format conversion",
+      "statements": [
+        "CREATE STREAM TEST (f1 INT KEY, f2 DECIMAL(2, 1)) WITH (kafka_topic='test_topic', value_format='JSON', partitions=1);",
+        "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT f2 AS key, COUNT(*) AS total FROM TEST GROUP BY f2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 1, "value": {"f2": null}},
+        {"topic": "test_topic", "key": 1, "value": null},
+        {"topic": "test_topic", "key": null, "value": {"f2": "1"}},
+        {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "1"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2.0, "value": {"TOTAL": 1}},
+        {"topic": "OUTPUT", "key": 4.0, "value": {"TOTAL": 1}},
+        {"topic": "OUTPUT", "key": 1.0, "value": {"TOTAL": 1}},
+        {"topic": "OUTPUT", "key": 2.0, "value": {"TOTAL": 2}},
+        {"topic": "OUTPUT", "key": 4.0, "value": {"TOTAL": 2}},
+        {"topic": "OUTPUT", "key": 1.0, "value": {"TOTAL": 2}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "JSON"},
+            "schema": "KEY DECIMAL(2, 1) KEY, TOTAL BIGINT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "multiple expressions - KAFKA to non-supported decimal key format with favored explicit AVRO format conversion",
+      "statements": [
+        "CREATE STREAM TEST (f1 INT KEY, f2 DECIMAL(2, 1)) WITH (kafka_topic='test_topic', value_format='JSON', partitions=1);",
+        "CREATE TABLE OUTPUT WITH (KEY_FORMAT='AVRO') AS SELECT f2 AS key, COUNT(*) AS total FROM TEST GROUP BY f2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 1, "value": {"f2": null}},
+        {"topic": "test_topic", "key": 1, "value": null},
+        {"topic": "test_topic", "key": null, "value": {"f2": "1"}},
+        {"topic": "test_topic", "key": 1, "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": 2, "value": {"f2": "1"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2.0, "value": {"TOTAL": 1}},
+        {"topic": "OUTPUT", "key": 4.0, "value": {"TOTAL": 1}},
+        {"topic": "OUTPUT", "key": 1.0, "value": {"TOTAL": 1}},
+        {"topic": "OUTPUT", "key": 2.0, "value": {"TOTAL": 2}},
+        {"topic": "OUTPUT", "key": 4.0, "value": {"TOTAL": 2}},
+        {"topic": "OUTPUT", "key": 1.0, "value": {"TOTAL": 2}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "AVRO"},
+            "schema": "KEY DECIMAL(2, 1) KEY, TOTAL BIGINT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "JSON format to KAFKA key format with unsupported multiple column",
+      "statements": [
+        "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', key_format='JSON', value_format='JSON', partitions=1);",
+        "CREATE TABLE OUTPUT WITH (KEY_FORMAT='KAFKA') AS SELECT f1 AS k1, f2 AS k2, COUNT(*) AS total FROM TEST GROUP BY f1, f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`K1` INTEGER KEY, `K2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`K1` INTEGER KEY, `K2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT WITH (KEY_FORMAT='KAFKA') AS SELECT\n  TEST.F1 K1,\n  TEST.F2 K2,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
+      }
+    },
+    {
+      "name": "multiple expressions - delimited key format to multi-column primitive format",
+      "statements": [
+        "CREATE STREAM TEST (f1 STRING KEY, f2 INT) WITH (kafka_topic='test_topic', key_format='DELIMITED', value_format='JSON', partitions=1);",
+        "CREATE TABLE OUTPUT AS SELECT f1 AS k1, f2 AS k2, COUNT(*) AS total FROM TEST GROUP BY f1, f2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "a", "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": "a", "value": {"f2": null}},
+        {"topic": "test_topic", "key": "a", "value": null},
+        {"topic": "test_topic", "key": null, "value": {"f2": "1"}},
+        {"topic": "test_topic", "key": "a", "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "1"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"a,2", "value": {"TOTAL": 1}},
+        {"topic": "OUTPUT", "key":"b,4", "value": {"TOTAL": 1}},
+        {"topic": "OUTPUT", "key":"a,2", "value": {"TOTAL": 2}},
+        {"topic": "OUTPUT", "key":"b,4", "value": {"TOTAL": 2}},
+        {"topic": "OUTPUT", "key":"b,1", "value": {"TOTAL": 1}}
+      ]
+    },
+    {
+      "name": "multiple expressions - delimited key format to multi-column, non-primitive format",
+      "statements": [
+        "CREATE STREAM TEST (f1 STRING KEY, f2 INT) WITH (kafka_topic='test_topic', key_format='DELIMITED', value_format='JSON', partitions=1);",
+        "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT STRUCT(f1:=f1, f2:=f2) AS k1, f1 as k2, as_value(struct(f1:=f1, f2:=f2)) AS key, COUNT(*) AS total FROM TEST GROUP BY STRUCT(f1:=f1, f2:=f2), f1;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "a", "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": "a", "value": {"f2": null}},
+        {"topic": "test_topic", "key": "a", "value": null},
+        {"topic": "test_topic", "key": null, "value": {"f2": "1"}},
+        {"topic": "test_topic", "key": "a", "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "1"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"K1": {"F1": "a", "F2": 2}, "K2": "a"}, "value": {"KEY": {"F1":"a","F2":2}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"K1": {"F1": "b", "F2": 4}, "K2": "b"}, "value": {"KEY": {"F1":"b","F2":4}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"K1": {"F1": "a", "F2": null}, "K2": "a"}, "value": {"KEY": {"F1":"a","F2":null}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"K1": {"F1": "a", "F2": 2}, "K2": "a"}, "value": {"KEY": {"F1":"a","F2":2}, "TOTAL": 2}},
+        {"topic": "OUTPUT", "key": {"K1": {"F1": "b", "F2": 4}, "K2": "b"}, "value": {"KEY": {"F1":"b","F2":4}, "TOTAL": 2}},
+        {"topic": "OUTPUT", "key": {"K1": {"F1": "b", "F2": 1}, "K2": "b"}, "value": {"KEY": {"F1":"b","F2":1}, "TOTAL": 1}}
+      ]
+    },
+    {
+      "name": "multiple expressions - delimited key format to struct format",
+      "statements": [
+        "CREATE STREAM TEST (f1 STRING KEY, f2 INT) WITH (kafka_topic='test_topic', key_format='DELIMITED', value_format='JSON', partitions=1);",
+        "CREATE TABLE OUTPUT WITH (KEY_FORMAT='JSON') AS SELECT STRUCT(f1:=f1, f2:=f2) AS k, as_value(struct(f1:=f1, f2:=f2)) AS key, COUNT(*) AS total FROM TEST GROUP BY STRUCT(f1:=f1, f2:=f2);"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "a", "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": "a", "value": {"f2": null}},
+        {"topic": "test_topic", "key": "a", "value": null},
+        {"topic": "test_topic", "key": null, "value": {"f2": "1"}},
+        {"topic": "test_topic", "key": "a", "value": {"f2": "2"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "4"}},
+        {"topic": "test_topic", "key": "b", "value": {"f2": "1"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"F1": "a", "F2": 2}, "value": {"KEY": {"F1":"a","F2":2}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"F1": "b", "F2": 4}, "value": {"KEY": {"F1":"b","F2":4}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"F1": "a", "F2": null}, "value": {"KEY": {"F1":"a","F2":null}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"F1": null, "F2": 1}, "value": {"KEY": {"F1":null,"F2":1}, "TOTAL": 1}},
+        {"topic": "OUTPUT", "key": {"F1": "a", "F2": 2}, "value": {"KEY": {"F1":"a","F2":2}, "TOTAL": 2}},
+        {"topic": "OUTPUT", "key": {"F1": "b", "F2": 4}, "value": {"KEY": {"F1":"b","F2":4}, "TOTAL": 2}},
+        {"topic": "OUTPUT", "key": {"F1": "b", "F2": 1}, "value": {"KEY": {"F1":"b","F2":1}, "TOTAL": 1}}
+      ]
+    },
+    {
       "name": "multiple expressions - windowed",
       "statements": [
         "CREATE STREAM TEST (f1 INT KEY, f2 INT) WITH (kafka_topic='test_topic', format='JSON');",

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
@@ -141,4 +142,11 @@ public interface Format {
       boolean isKey
   );
 
+  /**
+   * Check whether given sql type is supported by this format.
+   *
+   * @param type given sql key type
+   * @return true if the given sql type is supported
+   */
+  boolean supportsKeyType(SqlType type);
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KeyFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/KeyFormat.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.model.WindowType;
+
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Map;

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
@@ -19,6 +19,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SimpleColumn;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.SchemaTranslator;
 import io.confluent.ksql.serde.SerdeFeature;
@@ -240,5 +241,10 @@ public abstract class ConnectFormat implements Format {
     public void close() {
       inner.close();
     }
+  }
+
+  @Override
+  public boolean supportsKeyType(final SqlType type) {
+    return true;
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/DelimitedFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/DelimitedFormat.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.serde.delimited;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.Delimiter;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatProperties;
@@ -80,5 +82,10 @@ public final class DelimitedFormat implements Format {
 
   private static Delimiter getDelimiter(final Map<String, String> formatProperties) {
     return Delimiter.parse(formatProperties.getOrDefault(DELIMITER, DEFAULT_DELIMITER));
+  }
+
+  @Override
+  public boolean supportsKeyType(final SqlType type) {
+    return type instanceof SqlPrimitiveType;
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaFormat.java
@@ -18,6 +18,9 @@ package io.confluent.ksql.serde.kafka;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatProperties;
 import io.confluent.ksql.serde.SerdeFeature;
@@ -58,5 +61,12 @@ public class KafkaFormat implements Format {
     SerdeUtils.throwOnUnsupportedFeatures(schema.features(), supportedFeatures());
 
     return KafkaSerdeFactory.createSerde(schema);
+  }
+
+  @Override
+  public boolean supportsKeyType(final SqlType type) {
+    return type instanceof SqlPrimitiveType
+               && KafkaSerdeFactory.containsSerde(
+        SchemaConverters.sqlToJavaConverter().toJavaType(type.baseType()));
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
@@ -47,6 +47,10 @@ public final class KafkaSerdeFactory {
   private KafkaSerdeFactory() {
   }
 
+  public static boolean containsSerde(final Class<?> javaType) {
+    return SERDE.containsKey(javaType);
+  }
+
   static Serde<List<?>> createSerde(final PersistenceSchema schema) {
     final List<SimpleColumn> columns = schema.columns();
     if (columns.isEmpty()) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/none/NoneFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/none/NoneFormat.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.serde.none;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatProperties;
 import io.confluent.ksql.serde.SerdeUtils;
@@ -56,5 +57,10 @@ public class NoneFormat implements Format {
     }
 
     return new KsqlVoidSerde<>();
+  }
+
+  @Override
+  public boolean supportsKeyType(final SqlType type) {
+    return false;
   }
 }


### PR DESCRIPTION
This patch tries to fix the wrong behavior we spotted in #7242, where the conversion to struct key format should work when the source stream key format is KafkaFormat.

In addition, we expanded the fix and addressed the potential conversion failure for DelimitedFormat case as well.

Reviewers: Victoria Xia <victoria.xia@confluent.io>, Almog Gavra <agavra@confluent.io>, Guozhang Wang <wangguoz@gmail.com>

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

