### PR TITLE
chore: log any errors that happen for pull queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -232,7 +232,7 @@ final class EngineExecutor {
             pullPlannerOptions.debugString(),
             loc);
       } else {
-        LOG.warn("Failure to execute pull query. {} {}",
+        LOG.error("Failure to execute pull query. {} {}",
             routingOptions.debugString(),
             pullPlannerOptions.debugString(),
             e);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.engine;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 
+import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.analyzer.QueryAnalyzer;
@@ -67,10 +69,13 @@ import io.confluent.ksql.util.PlanSummary;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Executor of {@code PreparedStatement} within a specific {@code EngineContext} and using a
@@ -85,6 +90,8 @@ import java.util.stream.Collectors;
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 final class EngineExecutor {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
+
+  private static final Logger LOG = LoggerFactory.getLogger(EngineExecutor.class);
 
   private final EngineContext engineContext;
   private final ServiceContext serviceContext;
@@ -205,6 +212,33 @@ final class EngineExecutor {
           Optional.ofNullable(finalSourceType).orElse(PullSourceType.UNKNOWN),
           Optional.ofNullable(finalPlanType).orElse(PullPhysicalPlanType.UNKNOWN),
           Optional.ofNullable(finalRoutingNodeType).orElse(RoutingNodeType.UNKNOWN)));
+
+      final String stmtLower = statement.getStatementText().toLowerCase(Locale.ROOT);
+      final String messageLower = e.getMessage().toLowerCase(Locale.ROOT);
+      final String stackLower = Throwables.getStackTraceAsString(e).toLowerCase(Locale.ROOT);
+
+      // do not include the statement text in the default logs as it may contain sensitive
+      // information - the exception which is returned to the user below will contain
+      // the contents of the query
+      if (messageLower.contains(stmtLower) || stackLower.contains(stmtLower)) {
+        final StackTraceElement loc = Iterables
+            .getLast(Throwables.getCausalChain(e))
+            .getStackTrace()[0];
+        LOG.error("Failure to execute pull query {} {}, not logging the error message since it "
+            + "contains the query string, which may contain sensitive information. If you "
+            + "see this LOG message, please submit a GitHub ticket and we will scrub "
+            + "the statement text from the error at {}",
+            routingOptions.debugString(),
+            pullPlannerOptions.debugString(),
+            loc);
+      } else {
+        LOG.warn("Failure to execute pull query. {} {}",
+            routingOptions.debugString(),
+            pullPlannerOptions.debugString(),
+            e);
+      }
+      LOG.debug("Failed pull query text {}, {}", statement.getStatementText(), e);
+
       throw new KsqlStatementException(
           e.getMessage() == null
               ? "Server Error" + Arrays.toString(e.getStackTrace())

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/PullPlannerOptions.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/PullPlannerOptions.java
@@ -20,4 +20,16 @@ public interface PullPlannerOptions {
   boolean getTableScansEnabled();
 
   boolean getInterpreterEnabled();
+
+  /**
+   * @return a human readable representation of the {@code PullPlannerOptions},
+   *         used to debug requests
+   */
+  default String debugString() {
+    return "PullPlannerOptions{"
+        + "tableScansEnabled: " + getTableScansEnabled()
+        + ", interpreterEnabled: " + getInterpreterEnabled()
+        + "}";
+  }
+
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/HARoutingTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
@@ -314,8 +315,7 @@ public class HARoutingTest {
     verify(pullPhysicalPlan).execute(eq(ImmutableList.of(location1, location3)), any(), any());
     verify(ksqlClient, times(2)).makeQueryRequest(eq(node2.location()), any(), any(), any(), any());
 
-    assertThat(e.getCause().getMessage(), containsString("Unable to execute pull query: \"foo\". "
-                                                  + "Exhausted standby hosts to try."));
+    assertThat(e.getCause().getMessage(), containsString("Exhausted standby hosts to try."));
   }
 
   @Test
@@ -332,8 +332,7 @@ public class HARoutingTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString(
-        "Unable to execute pull query \"foo\". All nodes are dead or exceed max allowed lag."));
+    assertThat(e.getMessage(), containsString("All nodes are dead or exceed max allowed lag."));
   }
 
   @Test
@@ -365,7 +364,7 @@ public class HARoutingTest {
 
     // Then:
     assertThat(pullQueryQueue.size(), is(0));
-    assertThat(e.getMessage(), containsString("Row Error!"));
+    assertThat(Throwables.getRootCause(e).getMessage(), containsString("Row Error!"));
   }
 
   @Test
@@ -394,7 +393,7 @@ public class HARoutingTest {
 
     // Then:
     assertThat(pullQueryQueue.size(), is(0));
-    assertThat(e.getMessage(), containsString("Authentication Error"));
+    assertThat(Throwables.getRootCause(e).getMessage(), containsString("Authentication Error"));
   }
 
   @Test
@@ -423,7 +422,7 @@ public class HARoutingTest {
 
     // Then:
     assertThat(pullQueryQueue.size(), is(0));
-    assertThat(e.getMessage(),
+    assertThat(Throwables.getRootCause(e).getMessage(),
         containsString("empty response from forwarding call, expected a header row"));
   }
 
@@ -456,7 +455,7 @@ public class HARoutingTest {
 
     // Then:
     assertThat(pullQueryQueue.size(), is(0));
-    assertThat(e.getMessage(),
+    assertThat(Throwables.getRootCause(e).getMessage(),
         containsString("Schemas logicalSchema2 from host node2 differs from schema logicalSchema"));
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/RoutingOptions.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/RoutingOptions.java
@@ -29,4 +29,17 @@ public interface RoutingOptions {
   boolean getIsDebugRequest();
 
   Set<Integer> getPartitions();
+
+  /**
+   * @return a human readable representation of the routing options, used
+   *         to debug requests
+   */
+  default String debugString() {
+    return "RoutingOptions{"
+        + "maxOffsetLagAllowed: " + getMaxOffsetLagAllowed()
+        + ", isSkipForwardRequest: " + getIsSkipForwardRequest()
+        + ", isDebugRequest: " + getIsDebugRequest()
+        + ", partitions: " + getPartitions()
+        + "}";
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <scala.version>2.13.2</scala.version>
         <apache.io.version>2.6</apache.io.version>
         <io.confluent.ksql.version>7.0.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.0.0-245</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
     </properties>
 


### PR DESCRIPTION
### Description 

We recently noticed that a ksqlDB user was receiving erroneous responses to pull query requests. However, nothing relating to these errors was visible in the logs. We should ensure that we log any error a user receives in response to a command they've issued (whether from the UI or CLI) so that we can proactively investigate any unusual error activity.

### Testing done 

Without this change, the following exception was returned but never present in the logs. I also made sure that errors that contain the error message get logged properly:

```
[2021-04-16 09:01:47,141] ERROR Failure to execute pull query, not logging the error message since it contains the query string, which may contain sensitive information. If you see this LOG message, please submit a GitHub ticket and we will scrub the statement text from the error at io.confluent.ksql.physical.pull.HARouting.handlePullQuery(HARouting.java:121) (io.confluent.ksql.engine.EngineExecutor:220)
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

