### PR TITLE
chore: disable daily jenkins job for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@ def baseConfig = {
     dockerRepos = ['confluentinc/ksqldb-cli', 'confluentinc/ksqldb-server']
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
     dockerScan = true
-    cron = '@daily'
     maven_packages_url = "https://jenkins-confluent-packages-beta-maven.s3-us-west-2.amazonaws.com"
     dockerPullDeps = ['confluentinc/cp-base-new']
     kafka_tutorials_branch = 'ksqldb-latest'


### PR DESCRIPTION
### Description 
Per internal discusison, stop the ksql-db-release job from building nightly since we're experiencing frequent test failures. This should be re-enabled (likely with new configs) via https://confluentinc.atlassian.net/browse/KQE-196 when this branch has been moved to its own repo
### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

