### PR TITLE
chore: fix jenkins file to work with new image name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -345,7 +345,7 @@ def job = {
             withDockerServer([uri: dockerHost()]) {
                 config.dockerRepos.eachWithIndex { dockerRepo, index ->
                     dockerArtifact = config.dockerArtifacts[index]
-                    sh "docker tag ${config.dockerRegistry}${dockerArtifact}:${config.docker_tag} ${config.dockerRegistry}${dockerRepo}:${config.docker_tag}"
+                    sh "docker tag ${config.dockerRegistry}${dockerArtifact}:${config.docker_tag}-1 ${config.dockerRegistry}${dockerRepo}:${config.docker_tag}"
                 }
             }
         }


### PR DESCRIPTION
### Description 
looks like we changed the naming strategy for the docker images in build_images: https://github.com/confluentinc/ksql/blob/ksql-db-release/build-packages.sh#L57 but we didn't update the jenkins file so it's looking for images that don't exist 
### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

