### PR TITLE
fix: update functional tests to latest TopologyTestDriver api

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -67,6 +67,7 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -81,7 +82,6 @@ import org.apache.kafka.streams.TopologyTestDriver;
 import org.hamcrest.StringDescription;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
-@SuppressWarnings("deprecation")
 public final class TestExecutorUtil {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
@@ -119,7 +119,7 @@ public final class TestExecutorUtil {
       final TopologyTestDriver topologyTestDriver = new TopologyTestDriver(
           topology,
           streamsProperties,
-          0);
+          Instant.ofEpochMilli(0L));
       final List<Topic> sourceTopics = persistentQueryAndSources.getSources()
           .stream()
           .map(dataSource -> {


### PR DESCRIPTION
### Description 
AK -> CCS kafka sync has happened which caused us to
break. This updates the TestExecutor in ksqldb-functional-tests to the latest API

### Testing done 
So far it compiles. Running the functional tests on my local machine to verify I haven't changed behaviour

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

