### PR TITLE
build: use proper artifact version during release builds

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -92,7 +92,7 @@ for cmd in "${REQUIRED_UTILS[@]}"; do
     fi
 done
 
-echo "FULL_VERSION=${FULL_VERSION} VERSION=${VERSION} RELEASE=${RELEASE} UPSTREAM_VERSION=${UPSTREAM_VERSION}"
+echo "FULL_VERSION=${FULL_VERSION} VERSION=${VERSION} RELEASE=${RELEASE} MAVEN_ARTIFACT_VERSION=${MAVEN_ARTIFACT_VERSION} UPSTREAM_VERSION=${UPSTREAM_VERSION}"
 cd "${WORKSPACE}"
 work_branch="debian-${FULL_VERSION}"
 git checkout -b "${work_branch}"
@@ -125,7 +125,7 @@ git diff | cat
 
 # Commit changes
 git add maven-settings.xml
-git commit -a -m "build: Setting project version ${FULL_VERSION} and parent version ${UPSTREAM_VERSION}."
+git commit -a -m "build: Setting project version ${MAVEN_ARTIFACT_VERSION} and parent version ${UPSTREAM_VERSION}."
 
 # We run things through fakeroot, which causes issues with finding an .m2/repository location to write. We set the homedir where it does
 # have write access too to get around that.
@@ -142,7 +142,7 @@ fakeroot make PACKAGE_TYPE=rpm "VERSION=${FULL_VERSION}" "RPM_VERSION=${VERSION}
 
 # Build Archive
 echo "Building Archive packages"
-fakeroot make PACKAGE_TYPE=archive "VERSION=${FULL_VERSION}" -f debian/Makefile archive
+fakeroot make PACKAGE_TYPE=archive "VERSION=${MAVEN_ARTIFACT_VERSION}" -f debian/Makefile archive
 
 # Collect output
 mkdir -p "${WORKSPACE}/output"


### PR DESCRIPTION
### Description 

Same as https://github.com/confluentinc/ksql/pull/7406 but more targeted. This PR fixes the bug with the maven and docker artifact versions, and leaves the deb, rpm, and archive versions as is. @andrewegel is it correct for the archive version to be the save as the deb and rpm versions, or should it match the maven and docker versions instead?

### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

