### PR TITLE
chore: allow collect_* to be configured with string values

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
@@ -30,8 +30,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.metrics.Metrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class UdafFactoryInvoker implements FunctionSignature {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UdafFactoryInvoker.class);
 
   private final FunctionName functionName;
   private final ParamType aggregateArgType;
@@ -110,6 +114,7 @@ class UdafFactoryInvoker implements FunctionSignature {
       }
       return function;
     } catch (final Exception e) {
+      LOG.error("Failed to invoke UDAF factory method", e);
       throw new KsqlException("Failed to invoke UDAF factory method", e);
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
@@ -74,7 +74,13 @@ public final class CollectListUdaf {
     @Override
     public void configure(final Map<String, ?> map) {
       final Object limit = map.get(LIMIT_CONFIG);
-      this.limit = (limit == null) ? this.limit : ((Number) limit).intValue();
+      if (limit != null) {
+        if (limit instanceof Number) {
+          this.limit = ((Number) limit).intValue();
+        } else if (limit instanceof String) {
+          this.limit = Integer.parseInt((String) limit);
+        }
+      }
 
       if (this.limit < 0) {
         this.limit = Integer.MAX_VALUE;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectSetUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectSetUdaf.java
@@ -72,7 +72,13 @@ public final class CollectSetUdaf {
     @Override
     public void configure(final Map<String, ?> map) {
       final Object limit = map.get(LIMIT_CONFIG);
-      this.limit = (limit == null) ? this.limit : ((Number) limit).intValue();
+      if (limit != null) {
+        if (limit instanceof Number) {
+          this.limit = ((Number) limit).intValue();
+        } else if (limit instanceof String) {
+          this.limit = Integer.parseInt((String) limit);
+        }
+      }
 
       if (this.limit < 0) {
         this.limit = Integer.MAX_VALUE;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
@@ -79,6 +79,21 @@ public class CollectListUdafTest {
   }
 
   @Test
+  public void shouldRespectSizeLimitString() {
+    final TableUdaf<Integer, List<Integer>, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
+    ((Configurable) udaf).configure(ImmutableMap.of(CollectListUdaf.LIMIT_CONFIG, "10"));
+
+    List<Integer> runningList = udaf.initialize();
+    for (int i = 1; i < 25; i++) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, hasSize(10));
+    assertThat(runningList, hasItem(1));
+    assertThat(runningList, hasItem(10));
+    assertThat(runningList, not(hasItem(11)));
+  }
+
+  @Test
   public void shouldIgnoreNegativeLimit() {
     final TableUdaf<Integer, List<Integer>, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
     ((Configurable) udaf).configure(ImmutableMap.of(CollectListUdaf.LIMIT_CONFIG, -10));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectSetUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectSetUdafTest.java
@@ -77,6 +77,20 @@ public class CollectSetUdafTest {
   }
 
   @Test
+  public void shouldRespectSizeLimitString() {
+    final Udaf<Integer, List<Integer>, List<Integer>> udaf = CollectSetUdaf.createCollectSetInt();
+    ((Configurable) udaf).configure(ImmutableMap.of(CollectSetUdaf.LIMIT_CONFIG, "1000"));
+    List<Integer> runningList = udaf.initialize();
+    for (int i = 1; i < 2500; i++) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, hasSize(1000));
+    assertThat(runningList, hasItem(1));
+    assertThat(runningList, hasItem(1000));
+    assertThat(runningList, not(hasItem(1001)));
+  }
+
+  @Test
   public void shouldIgnoreNegativeLimit() {
     final Udaf<Integer, List<Integer>, List<Integer>> udaf = CollectSetUdaf.createCollectSetInt();
     ((Configurable) udaf).configure(ImmutableMap.of(CollectSetUdaf.LIMIT_CONFIG, -1));


### PR DESCRIPTION
### Description 

The properties file by default sets the properties as strings, not integers, so the old mechanism of casting to a number doesn't work.

### Testing done 

Unit test + local testing

```
ksql> create stream foo (id int) with (kafka_topic='a', format='json', partitions=1);

 Message
----------------
 Stream created
----------------
ksql> insert into foo (id) values (1);
ksql> insert into foo (id) values (1);
ksql> insert into foo (id) values (1);
ksql> insert into foo (id) values (1);
ksql> insert into foo (id) values (1);
ksql> insert into foo (id) values (1);
ksql> select collect_list(id) from foo group by id emit changes;
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|KSQL_COL_0                                                                                                                                                           |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|[1, 1, 1, 1]                                                                                                                                                         |
^CQuery terminated
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

