### PR TITLE
chore: fix error message for unsupport legacy statements version (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -307,7 +307,7 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
 
   private static void throwUnsupportedStatementError() {
     throw new KsqlException("This version of ksqlDB does not support executing "
-        + "statements submitted prior to ksqlDB 0.8.0 or Confluent Platform ksqlDB 5.0. "
+        + "statements submitted prior to ksqlDB 0.8.0 or Confluent Platform ksqlDB 5.5. "
         + "Please see the upgrading guide to upgrade.");
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -491,7 +491,7 @@ public class InteractiveStatementExecutorTest {
     // Then
     assertThat(e.getMessage(), containsString(
         "This version of ksqlDB does not support executing statements submitted prior to ksqlDB "
-            + "0.8.0 or Confluent Platform ksqlDB 5.0. Please see the upgrading guide to upgrade."));
+            + "0.8.0 or Confluent Platform ksqlDB 5.5. Please see the upgrading guide to upgrade."));
   }
 
   @Test
@@ -515,7 +515,7 @@ public class InteractiveStatementExecutorTest {
     // Then
     assertThat(e.getMessage(), containsString(
         "This version of ksqlDB does not support executing statements submitted prior to ksqlDB "
-            + "0.8.0 or Confluent Platform ksqlDB 5.0. Please see the upgrading guide to upgrade."));
+            + "0.8.0 or Confluent Platform ksqlDB 5.5. Please see the upgrading guide to upgrade."));
   }
 
   @Test
@@ -539,7 +539,7 @@ public class InteractiveStatementExecutorTest {
     // Then
     assertThat(e.getMessage(), containsString(
         "This version of ksqlDB does not support executing statements submitted prior to ksqlDB "
-            + "0.8.0 or Confluent Platform ksqlDB 5.0. Please see the upgrading guide to upgrade."));
+            + "0.8.0 or Confluent Platform ksqlDB 5.5. Please see the upgrading guide to upgrade."));
   }
 
   @Test


### PR DESCRIPTION
### Description 

As the title says. CP 5.5 was when execution plans were first introduced, not CP 5.0. This PR fixes the typo to avoid confusion. 

### Testing done 

Non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

