### PR TITLE
chore: fix rpm packaging to pick up correct maven version

### DIFF
--- a/build-packages.sh
+++ b/build-packages.sh
@@ -138,7 +138,7 @@ git-buildpackage -us -uc --git-debian-branch="${work_branch}" --git-upstream-tre
 
 # Build RPM
 echo "Building RPM packages"
-fakeroot make PACKAGE_TYPE=rpm "VERSION=${FULL_VERSION}" "RPM_VERSION=${VERSION}" "REVISION=${RELEASE}" -f debian/Makefile rpm
+fakeroot make PACKAGE_TYPE=rpm "VERSION=${VERSION}" "RPM_VERSION=${VERSION}" "REVISION=${RELEASE}" -f debian/Makefile rpm
 
 # Build Archive
 echo "Building Archive packages"


### PR DESCRIPTION
we've got an image mix up, maven is 0.XX.0 and RPM is picking up 0.XX.0-1. Error from Jenkins here:

`[2021-04-22T22:12:06.765Z] Building RPM packages [2021-04-22T22:12:06.765Z] mkdir -p RPM_BUILDING/BUILD [2021-04-22T22:12:06.765Z] mkdir -p RPM_BUILDING/RPMS [2021-04-22T22:12:06.765Z] mkdir -p RPM_BUILDING/SOURCES [2021-04-22T22:12:06.765Z] mkdir -p RPM_BUILDING/SPECS [2021-04-22T22:12:06.765Z] mkdir -p RPM_BUILDING/SRPMS [2021-04-22T22:12:06.765Z] # Safety precatuion to avoid removing of root dir when DESTDIR or PREFIX is not set, for wathever reason [2021-04-22T22:12:06.765Z] if [[ "/home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr" =~ ^/usr* ]] || [[ "/home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr" == / ]] || [[ "/home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr" == "" ]]; then echo "DESTDIR=/home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD/ or PREFIX=/usr is weird"; exit 1 ; fi [2021-04-22T22:12:06.765Z] rm -rf /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr [2021-04-22T22:12:06.765Z] mkdir -p /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr [2021-04-22T22:12:06.765Z] mkdir -p /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr/bin [2021-04-22T22:12:06.765Z] mkdir -p /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr/share/java/ksqldb [2021-04-22T22:12:06.765Z] mkdir -p /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//etc/ksqldb [2021-04-22T22:12:06.765Z] for svc in debian/*.service ; do \ [2021-04-22T22:12:06.765Z] install -D -m 644 -o root -g root -D $svc /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//lib/systemd/system/$(basename $svc) ; \ [2021-04-22T22:12:06.765Z] done [2021-04-22T22:12:06.765Z] pushd "ksqldb-package/target/ksqldb-package-0.17.0-1-package" ; \ [2021-04-22T22:12:06.765Z] find bin/ -type f | grep -v README[.]rpm | xargs -I XXX install -D -m 755 -o root -g root XXX /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr/XXX ;\ [2021-04-22T22:12:06.765Z] find share/ -type f | grep -v README[.]rpm | xargs -I XXX install -D -m 644 -o root -g root XXX /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//usr/XXX ; \ [2021-04-22T22:12:06.765Z] pushd etc/ksqldb/ ; \ [2021-04-22T22:12:06.765Z] find . -type f | grep -v README[.]rpm | xargs -I XXX install -D -m 644 -o root -g root XXX /home/jenkins/workspace/onfluentinc_ksql_ksql-db-release/ksql-db/BUILD//etc/ksqldb/XXX [2021-04-22T22:12:06.765Z] /bin/bash: line 0: pushd: ksqldb-package/target/ksqldb-package-0.17.0-1-package: No such file or directory [2021-04-22T22:12:06.765Z] find: share/': No such file or directory
[2021-04-22T22:12:06.765Z] /bin/bash: line 3: pushd: etc/ksqldb/: No such file or directory`
