### PR TITLE
fix: worker-poll tasks shouldn't block main loop

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasAuthProvider.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasAuthProvider.java
@@ -96,6 +96,7 @@ public class JaasAuthProvider implements AuthProvider {
 
     server.getWorkerExecutor().executeBlocking(
         p -> getUser(contextName, username, password, allowedRoles, p),
+        false,
         resultHandler
     );
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/KsqlAuthorizationProviderHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/KsqlAuthorizationProviderHandler.java
@@ -57,6 +57,7 @@ public class KsqlAuthorizationProviderHandler implements Handler<RoutingContext>
 
     workerExecutor.<Void>executeBlocking(
         promise -> authorize(promise, routingContext),
+        false,
         ar -> handleAuthorizeResult(ar, routingContext));
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/JaasAuthProviderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/JaasAuthProviderTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -253,11 +254,11 @@ public class JaasAuthProviderTest {
     when(server.getWorkerExecutor()).thenReturn(worker);
     doAnswer(invocation -> {
       final Handler<Promise<User>> blockingCodeHandler = invocation.getArgument(0);
-      final Handler<AsyncResult<User>> resultHandler = invocation.getArgument(1);
+      final Handler<AsyncResult<User>> resultHandler = invocation.getArgument(2);
       final Promise<User> promise = Promise.promise();
       promise.future().onComplete(resultHandler);
       blockingCodeHandler.handle(promise);
       return null;
-    }).when(worker).executeBlocking(any(), false, any());
+    }).when(worker).executeBlocking(any(), eq(false), any());
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/JaasAuthProviderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/auth/JaasAuthProviderTest.java
@@ -258,6 +258,6 @@ public class JaasAuthProviderTest {
       promise.future().onComplete(resultHandler);
       blockingCodeHandler.handle(promise);
       return null;
-    }).when(worker).executeBlocking(any(), any());
+    }).when(worker).executeBlocking(any(), false, any());
   }
 }


### PR DESCRIPTION
### Description 
Fixes a call to execute a task on the worker pool that still may block main event-loop
execution. See https://github.com/confluentinc/ksql/issues/7358 for more information.

### Testing done 
Just ran the tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

