### PR TITLE
feat: Adds Scalable Push Query physical operators

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/AbstractPhysicalOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/AbstractPhysicalOperator.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical.pull.operators;
+package io.confluent.ksql.physical.common.operators;
 
 import io.confluent.ksql.planner.plan.PlanNode;
 import java.util.List;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/PhysicalOperatorUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/PhysicalOperatorUtil.java
@@ -13,16 +13,16 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical.pull.operators;
+package io.confluent.ksql.physical.common.operators;
 
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.streams.materialization.TableRow;
 import java.util.List;
 
-final class PullPhysicalOperatorUtil {
+final class PhysicalOperatorUtil {
 
-  private PullPhysicalOperatorUtil() {
+  private PhysicalOperatorUtil() {
 
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/ProjectOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/ProjectOperator.java
@@ -26,7 +26,7 @@ import io.confluent.ksql.execution.transform.select.SelectValueMapperFactory;
 import io.confluent.ksql.execution.transform.select.SelectValueMapperFactory.SelectValueMapperFactorySupplier;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.planner.plan.PlanNode;
-import io.confluent.ksql.planner.plan.PullProjectNode;
+import io.confluent.ksql.planner.plan.QueryProjectNode;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.ArrayList;
@@ -38,7 +38,7 @@ public class ProjectOperator extends AbstractPhysicalOperator implements UnaryPh
 
   private final ProcessingLogger logger;
   private final SelectValueMapperFactorySupplier selectValueMapperFactorySupplier;
-  private final PullProjectNode logicalNode;
+  private final QueryProjectNode logicalNode;
 
   private AbstractPhysicalOperator child;
   private TableRow row;
@@ -46,7 +46,7 @@ public class ProjectOperator extends AbstractPhysicalOperator implements UnaryPh
 
   public ProjectOperator(
       final ProcessingLogger logger,
-      final PullProjectNode logicalNode
+      final QueryProjectNode logicalNode
   ) {
     this(
         logger,
@@ -58,7 +58,7 @@ public class ProjectOperator extends AbstractPhysicalOperator implements UnaryPh
   @VisibleForTesting
   ProjectOperator(
       final ProcessingLogger logger,
-      final PullProjectNode logicalNode,
+      final QueryProjectNode logicalNode,
       final SelectValueMapperFactorySupplier selectValueMapperFactorySupplier
   ) {
     this.logger = Objects.requireNonNull(logger, "logger");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/ProjectOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/ProjectOperator.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical.pull.operators;
+package io.confluent.ksql.physical.common.operators;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.GenericRow;
@@ -89,7 +89,7 @@ public class ProjectOperator extends AbstractPhysicalOperator implements UnaryPh
       return null;
     }
 
-    final GenericRow intermediate = PullPhysicalOperatorUtil.getIntermediateRow(
+    final GenericRow intermediate = PhysicalOperatorUtil.getIntermediateRow(
         row, logicalNode.getAddAdditionalColumnsToIntermediateSchema());
 
     if (logicalNode.getIsSelectStar()) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/SelectOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/SelectOperator.java
@@ -26,14 +26,14 @@ import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.transform.sqlpredicate.SqlPredicate;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.planner.plan.PlanNode;
-import io.confluent.ksql.planner.plan.PullFilterNode;
+import io.confluent.ksql.planner.plan.QueryFilterNode;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 public class SelectOperator extends AbstractPhysicalOperator implements UnaryPhysicalOperator {
 
-  private final PullFilterNode logicalNode;
+  private final QueryFilterNode logicalNode;
   private final ProcessingLogger logger;
   private final SqlPredicate predicate;
 
@@ -41,13 +41,13 @@ public class SelectOperator extends AbstractPhysicalOperator implements UnaryPhy
   private KsqlTransformer<Object, Optional<GenericRow>> transformer;
   private TableRow row;
 
-  public SelectOperator(final PullFilterNode logicalNode, final ProcessingLogger logger) {
+  public SelectOperator(final QueryFilterNode logicalNode, final ProcessingLogger logger) {
     this(logicalNode, logger, SqlPredicate::new);
   }
 
   @VisibleForTesting
   SelectOperator(
-      final PullFilterNode logicalNode,
+      final QueryFilterNode logicalNode,
       final ProcessingLogger logger,
       final SqlPredicateFactory predicateFactory
   ) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/SelectOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/SelectOperator.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical.pull.operators;
+package io.confluent.ksql.physical.common.operators;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.GenericRow;
@@ -80,7 +80,7 @@ public class SelectOperator extends AbstractPhysicalOperator implements UnaryPhy
   }
 
   private Optional<TableRow> transformRow(final TableRow tableRow) {
-    final GenericRow intermediate = PullPhysicalOperatorUtil.getIntermediateRow(
+    final GenericRow intermediate = PhysicalOperatorUtil.getIntermediateRow(
         tableRow, logicalNode.getAddAdditionalColumnsToIntermediateSchema());
     return transformer.transform(
         tableRow.key(),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/UnaryPhysicalOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/common/operators/UnaryPhysicalOperator.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical.pull.operators;
+package io.confluent.ksql.physical.common.operators;
 
 /**
  * Represents a physical operator of the physical plan that has a single child.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlan.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlKey;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlPartitionLocation;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
-import io.confluent.ksql.physical.pull.operators.AbstractPhysicalOperator;
+import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
 import io.confluent.ksql.physical.pull.operators.DataSourceOperator;
 import io.confluent.ksql.planner.plan.KeyConstraint;
 import io.confluent.ksql.planner.plan.KeyConstraint.ConstraintOperator;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlanBuilder.java
@@ -42,8 +42,8 @@ import io.confluent.ksql.planner.plan.LookupConstraint;
 import io.confluent.ksql.planner.plan.NonKeyConstraint;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.planner.plan.PlanNode;
-import io.confluent.ksql.planner.plan.PullFilterNode;
-import io.confluent.ksql.planner.plan.PullProjectNode;
+import io.confluent.ksql.planner.plan.QueryFilterNode;
+import io.confluent.ksql.planner.plan.QueryProjectNode;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -109,10 +109,10 @@ public class PullPhysicalPlanBuilder {
     AbstractPhysicalOperator rootPhysicalOp = null;
     while (true) {
       AbstractPhysicalOperator currentPhysicalOp = null;
-      if (currentLogicalNode instanceof PullProjectNode) {
-        currentPhysicalOp = translateProjectNode((PullProjectNode)currentLogicalNode);
-      } else if (currentLogicalNode instanceof PullFilterNode) {
-        currentPhysicalOp = translateFilterNode((PullFilterNode) currentLogicalNode);
+      if (currentLogicalNode instanceof QueryProjectNode) {
+        currentPhysicalOp = translateProjectNode((QueryProjectNode)currentLogicalNode);
+      } else if (currentLogicalNode instanceof QueryFilterNode) {
+        currentPhysicalOp = translateFilterNode((QueryFilterNode) currentLogicalNode);
         seenSelectOperator = true;
       } else if (currentLogicalNode instanceof DataSourceNode) {
         currentPhysicalOp = translateDataSourceNode(
@@ -154,7 +154,7 @@ public class PullPhysicalPlanBuilder {
         dataSourceOperator);
   }
 
-  private ProjectOperator translateProjectNode(final PullProjectNode logicalNode) {
+  private ProjectOperator translateProjectNode(final QueryProjectNode logicalNode) {
     final ProcessingLogger logger = processingLogContext
         .getLoggerFactory()
         .getLogger(
@@ -168,7 +168,7 @@ public class PullPhysicalPlanBuilder {
     );
   }
 
-  private SelectOperator translateFilterNode(final PullFilterNode logicalNode) {
+  private SelectOperator translateFilterNode(final QueryFilterNode logicalNode) {
     lookupConstraints = logicalNode.getLookupConstraints();
 
     final ProcessingLogger logger = processingLogContext

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedTableLookupOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedTableLookupOperator.java
@@ -21,6 +21,8 @@ import io.confluent.ksql.execution.streams.materialization.Locator.KsqlKey;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlPartitionLocation;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.Row;
+import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
+import io.confluent.ksql.physical.common.operators.UnaryPhysicalOperator;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import java.util.Iterator;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperator.java
@@ -24,7 +24,7 @@ import io.confluent.ksql.physical.common.operators.UnaryPhysicalOperator;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.KeyConstraint.KeyConstraintKey;
 import io.confluent.ksql.planner.plan.PlanNode;
-import io.confluent.ksql.planner.plan.PullFilterNode.WindowBounds;
+import io.confluent.ksql.planner.plan.QueryFilterNode.WindowBounds;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperator.java
@@ -19,6 +19,8 @@ import io.confluent.ksql.execution.streams.materialization.Locator.KsqlKey;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlPartitionLocation;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.WindowedRow;
+import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
+import io.confluent.ksql.physical.common.operators.UnaryPhysicalOperator;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.KeyConstraint.KeyConstraintKey;
 import io.confluent.ksql.planner.plan.PlanNode;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/TableScanOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/TableScanOperator.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.physical.pull.operators;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlPartitionLocation;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.Row;
+import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
+import io.confluent.ksql.physical.common.operators.UnaryPhysicalOperator;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import java.util.Iterator;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WindowedTableScanOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WindowedTableScanOperator.java
@@ -19,6 +19,8 @@ import com.google.common.collect.Range;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlPartitionLocation;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.WindowedRow;
+import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
+import io.confluent.ksql.physical.common.operators.UnaryPhysicalOperator;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import java.util.Iterator;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.physical.scalablepush;
+
+import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
+import io.confluent.ksql.physical.pull.PullPhysicalPlan;
+import io.confluent.ksql.physical.scalablepush.operators.PushDataSourceOperator;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.reactive.BufferedPublisher;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.VertxUtils;
+import io.vertx.core.Context;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a physical plan for a scalable push query. The execution of the plan is done async
+ * on a {@link Context} so that running queries don't need to use dedicated threads. This is
+ * especially important since push queries tend to be long-running. This should allow scalable push
+ * queries to have many concurrent requests.
+ */
+public class PushPhysicalPlan {
+  // Subscribers always demand one row, so it shouldn't be that any buffering is required in
+  // practice.
+  private static final int CAPACITY = Integer.MAX_VALUE;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PullPhysicalPlan.class);
+
+  private final AbstractPhysicalOperator root;
+
+  private final LogicalSchema schema;
+  private final QueryId queryId;
+  private final ScalablePushRegistry scalablePushRegistry;
+  private final PushDataSourceOperator dataSourceOperator;
+  private final Context context;
+  private volatile boolean closed = false;
+  private long timer = -1;
+
+  public PushPhysicalPlan(
+      final AbstractPhysicalOperator root,
+      final LogicalSchema schema,
+      final QueryId queryId,
+      final ScalablePushRegistry scalablePushRegistry,
+      final PushDataSourceOperator dataSourceOperator,
+      final Context context
+  ) {
+    this.root = Objects.requireNonNull(root, "root");
+    this.schema = Objects.requireNonNull(schema, "schema");
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+    this.scalablePushRegistry =
+        Objects.requireNonNull(scalablePushRegistry, "scalablePushRegistry");
+    this.dataSourceOperator = dataSourceOperator;
+    this.context = context;
+  }
+
+  public BufferedPublisher<List<?>> execute() {
+    final Publisher publisher = new Publisher(context);
+    context.runOnContext(v -> open(publisher));
+    return publisher;
+  }
+
+  public boolean isClosed() {
+    return closed;
+  }
+
+  private void maybeNext(final Publisher publisher) {
+    List<?> row;
+    while ((row = (List<?>)next()) != null) {
+      if (dataSourceOperator.droppedRows()) {
+        closeInternal();
+        publisher.reportDroppedRows();
+        break;
+      } else {
+        publisher.accept(row);
+      }
+    }
+    if (!closed) {
+      if (timer >= 0) {
+        context.owner().cancelTimer(timer);
+      }
+      // Schedule another batch async
+      timer = context.owner()
+          .setTimer(100, timerId -> context.runOnContext(v -> maybeNext(publisher)));
+    } else {
+      publisher.close();
+    }
+  }
+
+  private void open(final Publisher publisher) {
+    VertxUtils.checkContext(context);
+    dataSourceOperator.setNewRowCallback(() -> context.runOnContext(v -> maybeNext(publisher)));
+    root.open();
+    maybeNext(publisher);
+  }
+
+  private Object next() {
+    VertxUtils.checkContext(context);
+    return root.next();
+  }
+
+  public void close() {
+    context.runOnContext(v -> closeInternal());
+  }
+
+  private void closeInternal() {
+    VertxUtils.checkContext(context);
+    closed = true;
+    root.close();
+  }
+
+  public AbstractPhysicalOperator getRoot() {
+    return root;
+  }
+
+  public QueryId getQueryId() {
+    return queryId;
+  }
+
+  public LogicalSchema getOutputSchema() {
+    return schema;
+  }
+
+  public ScalablePushRegistry getScalablePushRegistry() {
+    return scalablePushRegistry;
+  }
+
+  public static class Publisher extends BufferedPublisher<List<?>> {
+
+    public Publisher(final Context ctx) {
+      super(ctx, CAPACITY);
+    }
+
+    public void reportDroppedRows() {
+      sendError(new RuntimeException("Dropped rows"));
+    }
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilder.java
@@ -160,7 +160,7 @@ public class PushPhysicalPlanBuilder {
     final ScalablePushRegistry scalablePushRegistry =
         persistentQueryMetadata.getScalablePushRegistry()
         .orElseThrow(() -> new IllegalStateException("Scalable push registry cannot be found"));
-    return new PeekStreamOperator(scalablePushRegistry, logicalNode);
+    return new PeekStreamOperator(scalablePushRegistry, logicalNode, queryId);
   }
 
   private QueryId uniqueQueryId() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"; you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -13,33 +13,21 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical.pull;
+package io.confluent.ksql.physical.scalablepush;
 
-import io.confluent.ksql.analyzer.ImmutableAnalysis;
-import io.confluent.ksql.analyzer.PullQueryValidator;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
 import io.confluent.ksql.execution.context.QueryLoggerUtil.QueryType;
-import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
-import io.confluent.ksql.metastore.model.DataSource;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
 import io.confluent.ksql.physical.common.operators.ProjectOperator;
 import io.confluent.ksql.physical.common.operators.SelectOperator;
-import io.confluent.ksql.physical.pull.PullPhysicalPlan.PullPhysicalPlanType;
-import io.confluent.ksql.physical.pull.PullPhysicalPlan.PullSourceType;
-import io.confluent.ksql.physical.pull.operators.DataSourceOperator;
-import io.confluent.ksql.physical.pull.operators.KeyedTableLookupOperator;
-import io.confluent.ksql.physical.pull.operators.KeyedWindowedTableLookupOperator;
-import io.confluent.ksql.physical.pull.operators.TableScanOperator;
-import io.confluent.ksql.physical.pull.operators.WindowedTableScanOperator;
+import io.confluent.ksql.physical.scalablepush.operators.PeekStreamOperator;
+import io.confluent.ksql.physical.scalablepush.operators.PushDataSourceOperator;
 import io.confluent.ksql.planner.LogicalPlanNode;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.KsqlBareOutputNode;
-import io.confluent.ksql.planner.plan.LookupConstraint;
-import io.confluent.ksql.planner.plan.NonKeyConstraint;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.PullFilterNode;
@@ -47,8 +35,7 @@ import io.confluent.ksql.planner.plan.PullProjectNode;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
-import java.util.Collections;
-import java.util.List;
+import io.vertx.core.Context;
 import java.util.Objects;
 
 /**
@@ -57,25 +44,17 @@ import java.util.Objects;
  * The logical plan should consist of Project, Filter and DataSource nodes only.
  */
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
-@SuppressWarnings("UnstableApiUsage")
-public class PullPhysicalPlanBuilder {
+public class PushPhysicalPlanBuilder {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private final ProcessingLogContext processingLogContext;
-  private final Stacker contextStacker;
   private final PersistentQueryMetadata persistentQueryMetadata;
+  private final Stacker contextStacker;
   private final QueryId queryId;
-  private final Materialization mat;
 
-  private List<LookupConstraint> lookupConstraints;
-  private PullPhysicalPlanType pullPhysicalPlanType;
-  private PullSourceType pullSourceType;
-  private boolean seenSelectOperator = false;
-
-  public PullPhysicalPlanBuilder(
+  public PushPhysicalPlanBuilder(
       final ProcessingLogContext processingLogContext,
-      final PersistentQueryMetadata persistentQueryMetadata,
-      final ImmutableAnalysis analysis
+      final PersistentQueryMetadata persistentQueryMetadata
   ) {
     this.processingLogContext = Objects.requireNonNull(
         processingLogContext, "processingLogContext");
@@ -83,9 +62,6 @@ public class PullPhysicalPlanBuilder {
         persistentQueryMetadata, "persistentQueryMetadata");
     this.contextStacker = new Stacker();
     queryId = uniqueQueryId();
-    mat = this.persistentQueryMetadata
-        .getMaterialization(queryId, contextStacker)
-        .orElseThrow(() -> notMaterializedException(getSourceName(analysis)));
   }
 
   /**
@@ -93,15 +69,18 @@ public class PullPhysicalPlanBuilder {
    * @param logicalPlanNode the logical plan root node
    * @return the root node of the tree of physical operators
    */
-  public PullPhysicalPlan buildPullPhysicalPlan(final LogicalPlanNode logicalPlanNode) {
-    DataSourceOperator dataSourceOperator = null;
+  public PushPhysicalPlan buildPushPhysicalPlan(
+      final LogicalPlanNode logicalPlanNode,
+      final Context context
+  ) {
+    PushDataSourceOperator dataSourceOperator = null;
 
     final OutputNode outputNode = logicalPlanNode.getNode()
         .orElseThrow(() -> new IllegalArgumentException("Need an output node to build a plan"));
 
     if (!(outputNode instanceof KsqlBareOutputNode)) {
-      throw new KsqlException("Pull queries expect the root of the logical plan to be a "
-                                  + "KsqlBareOutputNode.");
+      throw new KsqlException("Push queries expect the root of the logical plan to be a "
+          + "KsqlBareOutputNode.");
     }
     // We skip KsqlBareOutputNode in the translation since it only applies the LIMIT
     PlanNode currentLogicalNode = outputNode.getSource();
@@ -113,15 +92,14 @@ public class PullPhysicalPlanBuilder {
         currentPhysicalOp = translateProjectNode((PullProjectNode)currentLogicalNode);
       } else if (currentLogicalNode instanceof PullFilterNode) {
         currentPhysicalOp = translateFilterNode((PullFilterNode) currentLogicalNode);
-        seenSelectOperator = true;
       } else if (currentLogicalNode instanceof DataSourceNode) {
         currentPhysicalOp = translateDataSourceNode(
             (DataSourceNode) currentLogicalNode);
-        dataSourceOperator = (DataSourceOperator)currentPhysicalOp;
+        dataSourceOperator = (PushDataSourceOperator) currentPhysicalOp;
       } else {
         throw new KsqlException(String.format(
-            "Error in translating logical to physical plan for pull queries: unrecognized logical"
-                + " node %s.", currentLogicalNode));
+            "Error in translating logical to physical plan for scalable push queries:"
+                + " unrecognized logical node %s.", currentLogicalNode));
       }
 
       if (prevPhysicalOp == null) {
@@ -135,23 +113,21 @@ public class PullPhysicalPlanBuilder {
         break;
       }
       if (currentLogicalNode.getSources().size() > 1) {
-        throw new KsqlException("Pull queries do not support joins or nested sub-queries yet.");
+        throw new KsqlException("Push queries do not support joins or nested sub-queries yet.");
       }
       currentLogicalNode = currentLogicalNode.getSources().get(0);
     }
 
     if (dataSourceOperator == null) {
-      throw new IllegalStateException("DataSourceOperator cannot be null in Pull physical plan");
+      throw new IllegalStateException("DataSourceOperator cannot be null in Push physical plan");
     }
-    return new PullPhysicalPlan(
+    return new PushPhysicalPlan(
         rootPhysicalOp,
         (rootPhysicalOp).getLogicalNode().getSchema(),
         queryId,
-        lookupConstraints,
-        pullPhysicalPlanType,
-        pullSourceType,
-        mat,
-        dataSourceOperator);
+        dataSourceOperator.getScalablePushRegistry(),
+        dataSourceOperator,
+        context);
   }
 
   private ProjectOperator translateProjectNode(final PullProjectNode logicalNode) {
@@ -163,14 +139,12 @@ public class PullPhysicalPlanBuilder {
         );
 
     return new ProjectOperator(
-      logger,
-      logicalNode
+        logger,
+        logicalNode
     );
   }
 
   private SelectOperator translateFilterNode(final PullFilterNode logicalNode) {
-    lookupConstraints = logicalNode.getLookupConstraints();
-
     final ProcessingLogger logger = processingLogContext
         .getLoggerFactory()
         .getLogger(
@@ -183,50 +157,13 @@ public class PullPhysicalPlanBuilder {
   private AbstractPhysicalOperator translateDataSourceNode(
       final DataSourceNode logicalNode
   ) {
-    boolean isTableScan = false;
-    if (!seenSelectOperator) {
-      lookupConstraints = Collections.emptyList();
-      isTableScan = true;
-    } else if (lookupConstraints.stream().anyMatch(lc -> lc instanceof NonKeyConstraint)) {
-      isTableScan = true;
-    }
-    pullSourceType = logicalNode.isWindowed()
-        ? PullSourceType.WINDOWED : PullSourceType.NON_WINDOWED;
-    if (isTableScan) {
-      pullPhysicalPlanType = PullPhysicalPlanType.TABLE_SCAN;
-      if (!logicalNode.isWindowed()) {
-        return new TableScanOperator(mat, logicalNode);
-      } else {
-        return new WindowedTableScanOperator(mat, logicalNode);
-      }
-    }
-    pullPhysicalPlanType = PullPhysicalPlanType.KEY_LOOKUP;
-    if (!logicalNode.isWindowed()) {
-      return new KeyedTableLookupOperator(mat, logicalNode);
-    } else {
-      return new KeyedWindowedTableLookupOperator(mat, logicalNode);
-    }
+    final ScalablePushRegistry scalablePushRegistry =
+        persistentQueryMetadata.getScalablePushRegistry()
+        .orElseThrow(() -> new IllegalStateException("Scalable push registry cannot be found"));
+    return new PeekStreamOperator(scalablePushRegistry, logicalNode);
   }
 
   private QueryId uniqueQueryId() {
     return new QueryId("query_" + System.currentTimeMillis());
-  }
-
-  private KsqlException notMaterializedException(final SourceName sourceTable) {
-    final String tableName = sourceTable.text();
-    return new KsqlException(
-        "The " + sourceTable + " table isn't queryable. To derive a queryable table, "
-                + "you can do 'CREATE TABLE QUERYABLE_"
-                + tableName
-                + " AS SELECT * FROM "
-                + tableName
-                + "'."
-                + PullQueryValidator.PULL_QUERY_SYNTAX_HELP
-    );
-  }
-
-  private SourceName getSourceName(final ImmutableAnalysis analysis) {
-    final DataSource source = analysis.getFrom().getDataSource();
-    return source.getName();
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.physical.scalablepush.ProcessingQueue;
 import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.PlanNode;
+import io.confluent.ksql.query.QueryId;
 import java.util.List;
 
 /**
@@ -34,11 +35,12 @@ public class PeekStreamOperator extends AbstractPhysicalOperator implements Push
 
   public PeekStreamOperator(
       final ScalablePushRegistry scalablePushRegistry,
-      final DataSourceNode logicalNode
+      final DataSourceNode logicalNode,
+      final QueryId queryId
   ) {
     this.scalablePushRegistry = scalablePushRegistry;
     this.logicalNode = logicalNode;
-    this.processingQueue = new ProcessingQueue();
+    this.processingQueue = new ProcessingQueue(queryId);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.physical.scalablepush.operators;
+
+import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
+import io.confluent.ksql.physical.scalablepush.ProcessingQueue;
+import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
+import io.confluent.ksql.planner.plan.DataSourceNode;
+import io.confluent.ksql.planner.plan.PlanNode;
+import java.util.List;
+
+/**
+ * A physical operator which utilizes a {@link ScalablePushRegistry} to register for output rows.
+ * These are then fed to the upstream operators.
+ */
+public class PeekStreamOperator extends AbstractPhysicalOperator implements PushDataSourceOperator {
+
+  private final DataSourceNode logicalNode;
+  private final ScalablePushRegistry scalablePushRegistry;
+  private final ProcessingQueue processingQueue;
+
+  public PeekStreamOperator(
+      final ScalablePushRegistry scalablePushRegistry,
+      final DataSourceNode logicalNode
+  ) {
+    this.scalablePushRegistry = scalablePushRegistry;
+    this.logicalNode = logicalNode;
+    this.processingQueue = new ProcessingQueue();
+  }
+
+  @Override
+  public void open() {
+    scalablePushRegistry.register(processingQueue);
+  }
+
+  @Override
+  public Object next() {
+    return processingQueue.poll();
+  }
+
+  @Override
+  public void close() {
+    processingQueue.close();
+    scalablePushRegistry.unregister(processingQueue);
+  }
+
+  @Override
+  public PlanNode getLogicalNode() {
+    return logicalNode;
+  }
+
+  @Override
+  public void addChild(final AbstractPhysicalOperator child) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public AbstractPhysicalOperator getChild(final int index) {
+    return null;
+  }
+
+  @Override
+  public List<AbstractPhysicalOperator> getChildren() {
+    return null;
+  }
+
+  @Override
+  public ScalablePushRegistry getScalablePushRegistry() {
+    return scalablePushRegistry;
+  }
+
+  @Override
+  public void setNewRowCallback(final Runnable newRowCallback) {
+    processingQueue.setNewRowCallback(newRowCallback);
+  }
+
+  @Override
+  public boolean droppedRows() {
+    return processingQueue.hasDroppedRows();
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PushDataSourceOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PushDataSourceOperator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.physical.scalablepush.operators;
+
+import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
+
+/**
+ * Represents a data source for a scalable push query
+ */
+public interface PushDataSourceOperator {
+  ScalablePushRegistry getScalablePushRegistry();
+
+  // Since push queries are pushed and not pulled, it needs to call back on the operator to tell it
+  // when data can be read.
+  void setNewRowCallback(Runnable newRowCallback);
+
+  // If rows have been dropped.
+  boolean droppedRows();
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -70,8 +70,8 @@ import io.confluent.ksql.planner.plan.PlanNodeId;
 import io.confluent.ksql.planner.plan.PreJoinProjectNode;
 import io.confluent.ksql.planner.plan.PreJoinRepartitionNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
-import io.confluent.ksql.planner.plan.PullFilterNode;
-import io.confluent.ksql.planner.plan.PullProjectNode;
+import io.confluent.ksql.planner.plan.QueryFilterNode;
+import io.confluent.ksql.planner.plan.QueryProjectNode;
 import io.confluent.ksql.planner.plan.SelectionUtil;
 import io.confluent.ksql.planner.plan.SingleSourcePlanNode;
 import io.confluent.ksql.planner.plan.SuppressNode;
@@ -200,7 +200,7 @@ public class LogicalPlanner {
 
       validator.validateFilterExpression(whereExpression);
 
-      currentNode = new PullFilterNode(
+      currentNode = new QueryFilterNode(
           new PlanNodeId("WhereFilter"),
           currentNode,
           whereExpression,
@@ -210,11 +210,11 @@ public class LogicalPlanner {
           pullPlannerOptions);
     } else {
       if (!pullPlannerOptions.getTableScansEnabled()) {
-        throw PullFilterNode.invalidWhereClauseException("Missing WHERE clause", isWindowed);
+        throw QueryFilterNode.invalidWhereClauseException("Missing WHERE clause", isWindowed);
       }
     }
 
-    currentNode = new PullProjectNode(
+    currentNode = new QueryProjectNode(
         new PlanNodeId("Project"),
         currentNode,
         analysis.getSelectItems(),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KeyConstraint.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/KeyConstraint.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.planner.plan;
 
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlKey;
-import io.confluent.ksql.planner.plan.PullFilterNode.WindowBounds;
+import io.confluent.ksql.planner.plan.QueryFilterNode.WindowBounds;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryFilterNode.java
@@ -64,8 +64,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PullFilterNode extends SingleSourcePlanNode {
-  private static final Logger LOG = LoggerFactory.getLogger(PullFilterNode.class);
+public class QueryFilterNode extends SingleSourcePlanNode {
+  private static final Logger LOG = LoggerFactory.getLogger(QueryFilterNode.class);
 
   private static final Set<Type> VALID_WINDOW_BOUND_COMPARISONS = ImmutableSet.of(
       Type.EQUAL,
@@ -93,7 +93,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
   private final PullPlannerOptions pullPlannerOptions;
   private final boolean requiresTableScan;
 
-  public PullFilterNode(
+  public QueryFilterNode(
       final PlanNodeId id,
       final PlanNode source,
       final Expression predicate,
@@ -126,7 +126,7 @@ public class PullFilterNode extends SingleSourcePlanNode {
 
     // Compiling expression into byte code/interpreting the expression
     this.addAdditionalColumnsToIntermediateSchema = shouldAddAdditionalColumnsInSchema();
-    this.intermediateSchema = PullLogicalPlanUtil.buildIntermediateSchema(
+    this.intermediateSchema = QueryLogicalPlanUtil.buildIntermediateSchema(
         source.getSchema().withoutPseudoAndKeyColsInValue(),
         addAdditionalColumnsToIntermediateSchema, isWindowed);
     compiledWhereClause = getExpressionEvaluator(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryLogicalPlanUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryLogicalPlanUtil.java
@@ -17,9 +17,9 @@ package io.confluent.ksql.planner.plan;
 
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 
-final class PullLogicalPlanUtil {
+final class QueryLogicalPlanUtil {
 
-  private PullLogicalPlanUtil(){
+  private QueryLogicalPlanUtil(){
 
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryProjectNode.java
@@ -62,7 +62,7 @@ import java.util.stream.Collectors;
  * part else add them to the value part.
  * </ul>
  */
-public class PullProjectNode extends ProjectNode {
+public class QueryProjectNode extends ProjectNode {
 
   private final Projection projection;
   private final ImmutableList<SelectExpression> selectExpressions;
@@ -74,7 +74,7 @@ public class PullProjectNode extends ProjectNode {
   private final boolean isSelectStar;
   private final boolean addAdditionalColumnsToIntermediateSchema;
 
-  public PullProjectNode(
+  public QueryProjectNode(
       final PlanNodeId id,
       final PlanNode source,
       final List<SelectItem> selectItems,
@@ -93,7 +93,7 @@ public class PullProjectNode extends ProjectNode {
     this.isSelectStar = isSelectStar();
     this.addAdditionalColumnsToIntermediateSchema = shouldAddAdditionalColumnsInSchema();
     this.outputSchema = buildOutputSchema(metaStore);
-    this.intermediateSchema = PullLogicalPlanUtil.buildIntermediateSchema(
+    this.intermediateSchema = QueryLogicalPlanUtil.buildIntermediateSchema(
           source.getSchema(),
           addAdditionalColumnsToIntermediateSchema,
           isWindowed

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/common/operators/ProjectOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/common/operators/ProjectOperatorTest.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.execution.transform.select.SelectValueMapper;
 import io.confluent.ksql.execution.transform.select.SelectValueMapperFactory.SelectValueMapperFactorySupplier;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.planner.plan.PullProjectNode;
+import io.confluent.ksql.planner.plan.QueryProjectNode;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -97,7 +97,7 @@ public class ProjectOperatorTest {
   @Mock
   private SelectValueMapperFactorySupplier selectValueMapperFactorySupplier;
   @Mock
-  private PullProjectNode logicalNode;
+  private QueryProjectNode logicalNode;
   @Mock
   private AbstractPhysicalOperator child;
   @Mock

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/common/operators/ProjectOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/common/operators/ProjectOperatorTest.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical.pull.operators;
+package io.confluent.ksql.physical.common.operators;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/common/operators/SelectOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/common/operators/SelectOperatorTest.java
@@ -31,7 +31,7 @@ import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.transform.sqlpredicate.SqlPredicate;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.planner.plan.PullFilterNode;
+import io.confluent.ksql.planner.plan.QueryFilterNode;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -96,7 +96,7 @@ public class SelectOperatorTest {
   @Mock
   private SqlPredicate sqlPredicate;
   @Mock
-  private PullFilterNode logicalNode;
+  private QueryFilterNode logicalNode;
 
   @Test
   public void shouldSelectKeyNonWindowed() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/common/operators/SelectOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/common/operators/SelectOperatorTest.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical.pull.operators;
+package io.confluent.ksql.physical.common.operators;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperatorTest.java
@@ -32,7 +32,7 @@ import io.confluent.ksql.execution.streams.materialization.WindowedRow;
 import io.confluent.ksql.execution.streams.materialization.ks.KsLocator;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.KeyConstraint.KeyConstraintKey;
-import io.confluent.ksql.planner.plan.PullFilterNode.WindowBounds;
+import io.confluent.ksql.planner.plan.QueryFilterNode.WindowBounds;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilderTest.java
@@ -23,8 +23,8 @@ import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.KsqlBareOutputNode;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.planner.plan.PlanNode;
-import io.confluent.ksql.planner.plan.PullFilterNode;
-import io.confluent.ksql.planner.plan.PullProjectNode;
+import io.confluent.ksql.planner.plan.QueryFilterNode;
+import io.confluent.ksql.planner.plan.QueryProjectNode;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
@@ -55,9 +55,9 @@ public class PushPhysicalPlanBuilderTest {
   @Mock
   private KsqlBareOutputNode ksqlBareOutputNode;
   @Mock
-  private PullProjectNode projectNode;
+  private QueryProjectNode projectNode;
   @Mock
-  private PullFilterNode filterNode;
+  private QueryFilterNode filterNode;
   @Mock
   private DataSourceNode dataSourceNode;
   @Mock

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilderTest.java
@@ -1,0 +1,197 @@
+package io.confluent.ksql.physical.scalablepush;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.transform.ExpressionEvaluator;
+import io.confluent.ksql.logging.processing.ProcessingLogContext;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
+import io.confluent.ksql.physical.common.operators.ProjectOperator;
+import io.confluent.ksql.physical.common.operators.SelectOperator;
+import io.confluent.ksql.physical.scalablepush.operators.PeekStreamOperator;
+import io.confluent.ksql.planner.LogicalPlanNode;
+import io.confluent.ksql.planner.plan.DataSourceNode;
+import io.confluent.ksql.planner.plan.KsqlBareOutputNode;
+import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.planner.plan.PlanNode;
+import io.confluent.ksql.planner.plan.PullFilterNode;
+import io.confluent.ksql.planner.plan.PullProjectNode;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.vertx.core.Context;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PushPhysicalPlanBuilderTest {
+
+  @Mock
+  private ProcessingLogContext logContext;
+  @Mock
+  private ProcessingLoggerFactory processingLoggerFactory;
+  @Mock
+  private ProcessingLogger processingLogger;
+  @Mock
+  private PersistentQueryMetadata persistentQueryMetadata;
+  @Mock
+  private Context context;
+  @Mock
+  private LogicalPlanNode logicalPlanNode;
+  @Mock
+  private KsqlBareOutputNode ksqlBareOutputNode;
+  @Mock
+  private PullProjectNode projectNode;
+  @Mock
+  private PullFilterNode filterNode;
+  @Mock
+  private DataSourceNode dataSourceNode;
+  @Mock
+  private ScalablePushRegistry scalablePushRegistry;
+  @Mock
+  private Expression rewrittenExpression;
+  @Mock
+  private ExpressionEvaluator expressionEvaluator;
+  @Mock
+  private LogicalSchema logicalSchema;
+
+  @Before
+  public void setUp() {
+    when(logContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
+    when(processingLoggerFactory.getLogger(any())).thenReturn(processingLogger);
+    when(logicalPlanNode.getNode()).thenReturn(Optional.of(ksqlBareOutputNode));
+    when(ksqlBareOutputNode.getSource()).thenReturn(projectNode);
+    when(projectNode.getSources()).thenReturn(ImmutableList.of(filterNode));
+    when(filterNode.getSources()).thenReturn(ImmutableList.of(dataSourceNode));
+    when(persistentQueryMetadata.getScalablePushRegistry())
+        .thenReturn(Optional.of(scalablePushRegistry));
+
+    when(filterNode.getRewrittenPredicate()).thenReturn(rewrittenExpression);
+    when(filterNode.getCompiledWhereClause()).thenReturn(expressionEvaluator);
+    when(expressionEvaluator.getExpressionType()).thenReturn(SqlTypes.BOOLEAN);
+    when(projectNode.getSchema()).thenReturn(logicalSchema);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldBuildPhysicalPlan() {
+    // Given:
+    final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
+        persistentQueryMetadata);
+
+    // When:
+    final PushPhysicalPlan pushPhysicalPlan =
+        builder.buildPushPhysicalPlan(logicalPlanNode, context);
+
+    // Then:
+    assertThat(pushPhysicalPlan.getRoot(), isA((Class) ProjectOperator.class));
+    final ProjectOperator projectOperator = (ProjectOperator) pushPhysicalPlan.getRoot();
+    assertThat(projectOperator.getChild(), isA((Class) SelectOperator.class));
+    final SelectOperator selectOperator = (SelectOperator) projectOperator.getChild();
+    assertThat(selectOperator.getChild(), isA((Class) PeekStreamOperator.class));
+    assertThat(pushPhysicalPlan.getScalablePushRegistry(), is(scalablePushRegistry));
+  }
+
+  @Test
+  public void shouldThrowOnNoOutputNode() {
+    // Given:
+    when(logicalPlanNode.getNode()).thenReturn(Optional.empty());
+    final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
+        persistentQueryMetadata);
+
+    // When:
+    final Exception e = assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.buildPushPhysicalPlan(logicalPlanNode, context)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Need an output node to build a plan"));
+  }
+
+  @Test
+  public void shouldThrowOnNotBareOutputNode() {
+    // Given:
+    when(logicalPlanNode.getNode()).thenReturn(Optional.of(mock(OutputNode.class)));
+    final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
+        persistentQueryMetadata);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> builder.buildPushPhysicalPlan(logicalPlanNode, context)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Push queries expect the root of the logical plan to be a "
+            + "KsqlBareOutputNode."));
+  }
+
+  @Test
+  public void shouldThrowOnUnknownLogicalNode() {
+    // Given:
+    when(ksqlBareOutputNode.getSource()).thenReturn(mock(PlanNode.class));
+    final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
+        persistentQueryMetadata);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> builder.buildPushPhysicalPlan(logicalPlanNode, context)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("unrecognized logical node"));
+  }
+
+  @Test
+  public void shouldThrowOnMultipleSources() {
+    // Given:
+    when(projectNode.getSources()).thenReturn(ImmutableList.of(filterNode, dataSourceNode));
+    final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
+        persistentQueryMetadata);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> builder.buildPushPhysicalPlan(logicalPlanNode, context)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Push queries do not support joins or nested sub-queries yet"));
+  }
+
+  @Test
+  public void shouldThrowOnNoDataSourceOperator() {
+    // Given:
+    when(filterNode.getSources()).thenReturn(ImmutableList.of());
+    final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
+        persistentQueryMetadata);
+
+    // When:
+    final Exception e = assertThrows(
+        IllegalStateException.class,
+        () -> builder.buildPushPhysicalPlan(logicalPlanNode, context)
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("DataSourceOperator cannot be null in Push physical plan"));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
@@ -1,0 +1,174 @@
+package io.confluent.ksql.physical.scalablepush;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
+import io.confluent.ksql.physical.scalablepush.operators.PushDataSourceOperator;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.reactive.BufferedPublisher;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PushPhysicalPlanTest {
+
+  private static final List<?> ROW1 = ImmutableList.of(1, "abc");
+  private static final List<?> ROW2 = ImmutableList.of(2, "def");
+
+  @Mock
+  private AbstractPhysicalOperator root;
+  @Mock
+  private LogicalSchema logicalSchema;
+  @Mock
+  private QueryId queryId;
+  @Mock
+  private ScalablePushRegistry scalablePushRegistry;
+  @Mock
+  private PushDataSourceOperator pushDataSourceOperator;
+  @Captor
+  private ArgumentCaptor<Runnable> runnableCaptor;
+
+  private Vertx vertx;
+  private Context context;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+    context = vertx.getOrCreateContext();
+  }
+
+  @After
+  public void tearDown() {
+    if (vertx != null) {
+      vertx.close();
+    }
+  }
+
+  @Test
+  public void shouldPublishRows() throws InterruptedException {
+    final PushPhysicalPlan pushPhysicalPlan = new PushPhysicalPlan(root, logicalSchema, queryId,
+        scalablePushRegistry, pushDataSourceOperator, context);
+    doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
+    when(pushDataSourceOperator.droppedRows()).thenReturn(false);
+
+    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
+    final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
+    publisher.subscribe(subscriber);
+
+    context.owner().setPeriodic(50, timerId -> {
+      if (runnableCaptor.getValue() == null) {
+        return;
+      }
+      when(root.next()).thenReturn(ROW1, ROW2, null);
+
+      runnableCaptor.getValue().run();
+      runnableCaptor.getValue().run();
+
+      context.owner().cancelTimer(timerId);
+    });
+
+    while (subscriber.getValues().size() < 2) {
+      Thread.sleep(100);
+    }
+  }
+
+  @Test
+  public void shouldStopOnDroppedRows() throws InterruptedException {
+    final PushPhysicalPlan pushPhysicalPlan = new PushPhysicalPlan(root, logicalSchema, queryId,
+        scalablePushRegistry, pushDataSourceOperator, context);
+    doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
+    when(pushDataSourceOperator.droppedRows()).thenReturn(false, true);
+
+    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
+    final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
+    publisher.subscribe(subscriber);
+
+    context.owner().setPeriodic(50, timerId -> {
+      if (runnableCaptor.getValue() == null) {
+        return;
+      }
+      when(root.next()).thenReturn(ROW1, ROW2, null);
+
+      runnableCaptor.getValue().run();
+      runnableCaptor.getValue().run();
+
+      context.owner().cancelTimer(timerId);
+    });
+
+    while (subscriber.getError() == null) {
+      Thread.sleep(100);
+    }
+
+    assertThat(subscriber.getError().getMessage(), containsString("Dropped rows"));
+    assertThat(subscriber.getValues().size(), is(1));
+    assertThat(subscriber.getValues().get(0), is(ROW1));
+    assertThat(pushPhysicalPlan.isClosed(), is(true));
+  }
+
+  public static class TestSubscriber<T> implements Subscriber<T> {
+
+    private Subscription sub;
+    private boolean completed;
+    private Throwable error;
+    private final List<T> values = new ArrayList<>();
+
+    public TestSubscriber() {
+    }
+
+    @Override
+    public synchronized void onSubscribe(final Subscription sub) {
+      this.sub = sub;
+      sub.request(1);
+    }
+
+    @Override
+    public synchronized void onNext(final T value) {
+      values.add(value);
+      sub.request(1);
+    }
+
+    @Override
+    public synchronized void onError(final Throwable t) {
+      this.error = t;
+    }
+
+    @Override
+    public synchronized void onComplete() {
+      this.completed = true;
+    }
+
+    public synchronized boolean isCompleted() {
+      return completed;
+    }
+
+    public synchronized Throwable getError() {
+      return error;
+    }
+
+    public synchronized List<T> getValues() {
+      return ImmutableList.copyOf(values);
+    }
+
+    public synchronized Subscription getSub() {
+      return sub;
+    }
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
@@ -10,6 +10,7 @@ import io.confluent.ksql.execution.streams.materialization.TableRow;
 import io.confluent.ksql.physical.scalablepush.ProcessingQueue;
 import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
 import io.confluent.ksql.planner.plan.DataSourceNode;
+import io.confluent.ksql.query.QueryId;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -19,6 +20,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PeekStreamOperatorTest {
+
+  private static final QueryId QUERY_ID = new QueryId("foo");
 
   @Mock
   private ScalablePushRegistry registry;
@@ -36,7 +39,7 @@ public class PeekStreamOperatorTest {
   @Test
   public void shouldGetRowsFromOperator() {
     // Given:
-    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode);
+    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID);
     locator.setNewRowCallback(newRowCallback);
 
     // When:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
@@ -1,0 +1,57 @@
+package io.confluent.ksql.physical.scalablepush.operators;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.confluent.ksql.execution.streams.materialization.TableRow;
+import io.confluent.ksql.physical.scalablepush.ProcessingQueue;
+import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
+import io.confluent.ksql.planner.plan.DataSourceNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PeekStreamOperatorTest {
+
+  @Mock
+  private ScalablePushRegistry registry;
+  @Mock
+  private DataSourceNode dataSourceNode;
+  @Captor
+  private ArgumentCaptor<ProcessingQueue> processingQueueCaptor;
+  @Mock
+  private TableRow row1;
+  @Mock
+  private TableRow row2;
+  @Mock
+  private Runnable newRowCallback;
+
+  @Test
+  public void shouldGetRowsFromOperator() {
+    // Given:
+    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode);
+    locator.setNewRowCallback(newRowCallback);
+
+    // When:
+    locator.open();
+
+    // Then:
+    verify(registry, times(1)).register(processingQueueCaptor.capture());
+    final ProcessingQueue processingQueue = processingQueueCaptor.getValue();
+    processingQueue.offer(row1);
+    processingQueue.offer(row2);
+    assertThat(locator.next(), is(row1));
+    assertThat(locator.next(), is(row2));
+    assertThat(locator.next(), nullValue());
+    verify(newRowCallback, times(2)).run();
+    locator.close();
+    verify(registry, times(1)).unregister(processingQueue);
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryFilterNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryFilterNodeTest.java
@@ -43,8 +43,8 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.planner.PullPlannerOptions;
-import io.confluent.ksql.planner.plan.PullFilterNode.WindowBounds;
-import io.confluent.ksql.planner.plan.PullFilterNode.WindowBounds.WindowRange;
+import io.confluent.ksql.planner.plan.QueryFilterNode.WindowBounds;
+import io.confluent.ksql.planner.plan.QueryFilterNode.WindowBounds.WindowRange;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
@@ -59,7 +59,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PullFilterNodeTest {
+public class QueryFilterNodeTest {
 
   private static final PlanNodeId NODE_ID = new PlanNodeId("1");
   private static final ColumnName K = ColumnName.of("K");
@@ -102,7 +102,7 @@ public class PullFilterNodeTest {
         new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
         new IntegerLiteral(1)
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -135,7 +135,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -158,7 +158,7 @@ public class PullFilterNodeTest {
         new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
         new ArithmeticUnaryExpression(Optional.empty(), Sign.MINUS, new IntegerLiteral(1))
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -197,7 +197,7 @@ public class PullFilterNodeTest {
         keyExp1,
         keyExp2
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -229,7 +229,7 @@ public class PullFilterNodeTest {
             ImmutableList.of(new IntegerLiteral(1), new IntegerLiteral(2))
         )
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -262,7 +262,7 @@ public class PullFilterNodeTest {
         new UnqualifiedColumnReferenceExp(ColumnName.of("K")),
         new IntegerLiteral(1)
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -301,7 +301,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -346,7 +346,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -391,7 +391,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -436,7 +436,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -481,7 +481,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -526,7 +526,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -571,7 +571,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -616,7 +616,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -661,7 +661,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -717,7 +717,7 @@ public class PullFilterNodeTest {
         expressionA,
         windowEnd
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -767,7 +767,7 @@ public class PullFilterNodeTest {
         keyExp,
         windowStart
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -813,7 +813,7 @@ public class PullFilterNodeTest {
         expression1,
         expression2
     );
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,
@@ -845,7 +845,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -898,7 +898,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -927,7 +927,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -970,7 +970,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -992,7 +992,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1019,7 +1019,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1071,7 +1071,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1098,7 +1098,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1130,7 +1130,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1166,7 +1166,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1217,7 +1217,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1269,7 +1269,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1305,7 +1305,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1354,7 +1354,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1401,7 +1401,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1437,7 +1437,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1484,7 +1484,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1520,7 +1520,7 @@ public class PullFilterNodeTest {
     // When:
     final KsqlException e = assertThrows(
         KsqlException.class,
-        () -> new PullFilterNode(
+        () -> new QueryFilterNode(
             NODE_ID,
             source,
             expression,
@@ -1537,7 +1537,7 @@ public class PullFilterNodeTest {
   @SuppressWarnings("unchecked")
   private void expectTableScan(final Expression expression, final boolean windowed) {
     // Given:
-    PullFilterNode filterNode = new PullFilterNode(
+    QueryFilterNode filterNode = new QueryFilterNode(
         NODE_ID,
         source,
         expression,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryProjectNodeTest.java
@@ -51,7 +51,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PullProjectNodeTest {
+public class QueryProjectNodeTest {
 
   private static final PlanNodeId NODE_ID = new PlanNodeId("1");
   private static final ColumnName K = ColumnName.of("K");
@@ -113,7 +113,7 @@ public class PullProjectNodeTest {
     when(analysis.getSelectColumnNames()).thenReturn(ImmutableSet.of(ColumnName.of("K")));
 
     // When:
-    final PullProjectNode projectNode = new PullProjectNode(
+    final QueryProjectNode projectNode = new QueryProjectNode(
         NODE_ID,
         source,
         selects,
@@ -137,7 +137,7 @@ public class PullProjectNodeTest {
     when(analysis.getSelectColumnNames()).thenReturn(ImmutableSet.of(ColumnName.of("K")));
 
     // When:
-    final PullProjectNode projectNode = new PullProjectNode(
+    final QueryProjectNode projectNode = new QueryProjectNode(
         NODE_ID,
         source,
         selects,
@@ -160,7 +160,7 @@ public class PullProjectNodeTest {
     when(keyFormat.isWindowed()).thenReturn(false);
 
     // When:
-    final PullProjectNode projectNode = new PullProjectNode(
+    final QueryProjectNode projectNode = new QueryProjectNode(
         NODE_ID,
         source,
         selects,
@@ -182,7 +182,7 @@ public class PullProjectNodeTest {
     when(keyFormat.isWindowed()).thenReturn(false);
 
     // When:
-    final PullProjectNode projectNode = new PullProjectNode(
+    final QueryProjectNode projectNode = new QueryProjectNode(
         NODE_ID,
         source,
         selects,
@@ -217,7 +217,7 @@ public class PullProjectNodeTest {
         .add((new SingleColumn(K_REF, Optional.of(K)))).build();
 
     // When:
-    final PullProjectNode projectNode = new PullProjectNode(
+    final QueryProjectNode projectNode = new QueryProjectNode(
         NODE_ID,
         source,
         selects,
@@ -254,7 +254,7 @@ public class PullProjectNodeTest {
         .add((new SingleColumn(COL0_REF, Optional.of(COL0)))).build();
 
     // When:
-    final PullProjectNode projectNode = new PullProjectNode(
+    final QueryProjectNode projectNode = new QueryProjectNode(
         NODE_ID,
         source,
         selects,
@@ -283,7 +283,7 @@ public class PullProjectNodeTest {
     when(analysis.getSelectColumnNames()).thenReturn(ImmutableSet.of());
 
     // When:
-    final PullProjectNode projectNode = new PullProjectNode(
+    final QueryProjectNode projectNode = new QueryProjectNode(
         NODE_ID,
         source,
         selects,


### PR DESCRIPTION
### Description 
This adds the Scalable Push Query physical operators.  It introduces an operator `PeekStreamOperator` which registers a `ProcessingQueue` with the `ScalablePushRegistry`. This new operator is combined with existing pull query operators such as `ProjectOperator` and `SelectOperator` to create a full query execution.  These operators are created with newly introduced `PushPhysicalPlanBuilder`, which then creates a `PushPhysicalPlan` which actually does the execution.

Note that `PushPhysicalPlan` executes async on a Vert.x `Context`.  The idea is that all of the passing of rows doesn't require any dedicated threads, and so many requests can be executing at once and be long-running without taxing threadpools.

Also, this PR includes moving those common operators that are now used by both pull and push to a common package.

### Testing done 
Ran unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

