### PR TITLE
feat: made class to compute essential meta-data

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -154,6 +154,12 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_WRAP_SINGLE_VALUES =
       "ksql.persistence.wrap.single.values";
 
+  public static final String KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE =
+      "ksql.ccloud.queryanonymizer.cluster_namespace";
+  private static final String KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE_TAG =
+      "Namespace used in the query anonymization process, representing cluster id and "
+          + "organization id respectively. For example, 'clusterid.orgid'.";
+
   public static final String KSQL_CUSTOM_METRICS_TAGS = "ksql.metrics.tags.custom";
   private static final String KSQL_CUSTOM_METRICS_TAGS_DOC =
       "A list of tags to be included with emitted JMX metrics, formatted as a string of key:value "
@@ -688,6 +694,12 @@ public class KsqlConfig extends AbstractConfig {
             "",
             ConfigDef.Importance.LOW,
             KSQL_CUSTOM_METRICS_TAGS_DOC
+        ).define(
+            KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE,
+            ConfigDef.Type.STRING,
+            KSQL_SERVICE_ID_CONFIG,
+            ConfigDef.Importance.LOW,
+            KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE_TAG
         ).define(
             KSQL_CUSTOM_METRICS_EXTENSION,
             ConfigDef.Type.CLASS,

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/QueryMetaDataCollector.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/QueryMetaDataCollector.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.joda.time.DateTime;
+
+public final class QueryMetaDataCollector {
+
+  private QueryMetaDataCollector() {}
+
+  public static ImmutableMap<String, String> buildMetaData(
+      final KsqlConfig config,
+      final String nonAnonQuery,
+      final String anonQuery) {
+
+    // get metadata from control plane
+    final Map<String, String> metaData = new HashMap<>();
+    final String clusterNamespace = config
+        .getString(KsqlConfig.KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE);
+
+    metaData.put("cluster_namespace", clusterNamespace);
+    metaData.put("id", getQueryId(nonAnonQuery, clusterNamespace));
+    metaData.put("structurally_similar_id", getStructurallySimilarId(anonQuery, clusterNamespace));
+    metaData.put("time_of_creation", DateTime.now().toString());
+
+    return ImmutableMap.copyOf(metaData);
+  }
+
+  private static String getQueryId(final String query, final String namespace) {
+    final String genericQuery = getGenericQueryForm(query);
+    final String namespacePlusQuery = namespace + genericQuery;
+
+    return UUID.nameUUIDFromBytes(namespacePlusQuery.getBytes()).toString();
+  }
+
+  private static String getStructurallySimilarId(final String query, final String namespace) {
+    final String namespacePlusQuery = namespace + query;
+
+    return UUID.nameUUIDFromBytes(namespacePlusQuery.getBytes()).toString();
+  }
+
+  private static String getGenericQueryForm(final String query) {
+    return query.replaceAll("[\\n\\t ]", "");
+  }
+}

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/util/QueryMetaDataCollectorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/util/QueryMetaDataCollectorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class QueryMetaDataCollectorTest {
+  private KsqlConfig ksqlConfig;
+
+  @Before
+  public void setUp() {
+    // initialize ksql config
+    Map<String, String> ksqlConfigMap = new HashMap<>();
+    ksqlConfigMap.put(KsqlConfig.KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE,
+        "testData.testData");
+    ksqlConfig = new KsqlConfig(ksqlConfigMap);
+  }
+
+  @Test
+  public void shouldGetCorrectClusterNamespaceData() {
+    // Given:
+    final Map<String, String> metaData = QueryMetaDataCollector.buildMetaData(ksqlConfig,
+        "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, "
+            + "longitude DOUBLE)\nWITH (kafka_topic='locations', value_format='json', "
+            + "partitions=1);", "TEST");
+
+    // Then:
+    Assert.assertEquals("testData.testData",
+        metaData.get("cluster_namespace"));
+  }
+
+  @Test
+  public void sameQueryInSameClusterAndOrgGetsSameId() {
+    // Given:
+    final String query1 = "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, longitude "
+        + "DOUBLE)\nWITH (kafka_topic='locations', value_format='json', partitions=1);";
+    final String query2 = "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, "
+        + "longitude DOUBLE) WITH (kafka_topic='locations', value_format='json', partitions=1);";
+
+    // When:
+    final String queryId1 = QueryMetaDataCollector
+        .buildMetaData(ksqlConfig, query1, "TEST").get("id");
+    final String queryId2 = QueryMetaDataCollector
+        .buildMetaData(ksqlConfig, query2, "TEST").get("id");
+
+    // Then:
+    Assert.assertEquals(queryId1, queryId2);
+  }
+
+  @Test
+  public void sameQueryWithDifferentClusterOrOrgGetsDifferentId() {
+    // Given:
+    final String query = "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, longitude "
+        + "DOUBLE)\nWITH (kafka_topic='locations', value_format='json', partitions=1);";
+    Map<String, String> ksqlConfigMap2 = new HashMap<>();
+    ksqlConfigMap2.put(KsqlConfig.KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE, "pc_id:testData2,org_id:testData");
+    final KsqlConfig ksqlConfig2 = new KsqlConfig(ksqlConfigMap2);
+
+
+    // When:
+    final String queryId1 = QueryMetaDataCollector
+        .buildMetaData(ksqlConfig, query, "TEST").get("id");
+    final String queryId2 = QueryMetaDataCollector
+        .buildMetaData(ksqlConfig2, query, "TEST").get("id");
+
+
+    // Then:
+    Assert.assertNotEquals(queryId1, queryId2);
+  }
+
+  @Test
+  public void queriesWithSameAnonFormShouldGetSameStructurallySimilarId() {
+    // Given:
+    final String query1 = "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE) "
+        + "WITH (kafka_topic='locations', value_format='json', partitions=1);";
+    final String query2 = "CREATE STREAM my_stream (userId VARCHAR, performance DOUBLE) "
+        + "WITH (kafka_topic='user_performance', value_format='json', partitions=2);";
+    final String anonQuery = "CREATE STREAM stream1 (column1 VARCHAR, column2 DOUBLE) WITH "
+        + "(kafka_topic=['string'], value_format=['string'], partitions='0';";
+
+    // When:
+    final String id1 = QueryMetaDataCollector
+        .buildMetaData(ksqlConfig, query1, anonQuery)
+        .get("structurally_similar_id");
+    final String id2 = QueryMetaDataCollector
+        .buildMetaData(ksqlConfig, query2, anonQuery)
+        .get("structurally_similar_id");
+
+    // Then:
+    Assert.assertEquals(id1, id2);
+  }
+
+  @Test
+  public void queriesWithDifferentAnonFormShouldGetSameStructurallySimilarId() {
+    // Given:
+    final String anonQuery1 = "CREATE STREAM stream1 (column1 VARCHAR, column2 DOUBLE) WITH "
+        + "(kafka_topic=['string'], value_format=['string'], partitions='0';";
+    final String anonQuery2 = "CREATE STREAM stream1 (column1 VARCHAR, column2 INT) WITH "
+        + "(kafka_topic=['string'], value_format=['string'], partitions='0';";
+
+    // When:
+    final String id1 = QueryMetaDataCollector
+        .buildMetaData(ksqlConfig, "TEST", anonQuery1)
+        .get("structurally_similar_id");
+    final String id2 = QueryMetaDataCollector
+        .buildMetaData(ksqlConfig, "TEST", anonQuery2)
+        .get("structurally_similar_id");
+
+    // Then:
+    Assert.assertNotEquals(id1, id2);
+  }
+}


### PR DESCRIPTION
### Description 
We want to be able to filter the anonymized queries according to things such as physical cluster, organization and time created. For this we need to get/generate the relevant meta-data. The organization and physical cluster id is picked up from the control plane via a metric set [here](https://github.com/confluentinc/cc-spec-ksql/pull/233).

### Testing done 
Unit tests to make sure metadata gets computed as expected.

### References
jira: [KCI-342](https://confluentinc.atlassian.net/browse/KCI-342)
cc-structs-ksql update: [PR-223](https://github.com/confluentinc/cc-spec-ksql/pull/233)
cc-scheduler-service update: [PR-2240](https://github.com/confluentinc/cc-scheduler-service/pull/2240)
protobuff update: [PR-1507](https://github.com/confluentinc/cc-structs/pull/1507)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

