### PR TITLE
feat: made class to compute essential meta-data

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -154,6 +154,12 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_WRAP_SINGLE_VALUES =
       "ksql.persistence.wrap.single.values";
 
+  public static final String KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE =
+      "ksql.ccloud.queryanonymizer.cluster_namespace";
+  private static final String KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE_TAG =
+      "Namespace used in the query anonymization process, representing cluster id and "
+          + "organization id respectively. For example, 'clusterid.orgid'.";
+
   public static final String KSQL_CUSTOM_METRICS_TAGS = "ksql.metrics.tags.custom";
   private static final String KSQL_CUSTOM_METRICS_TAGS_DOC =
       "A list of tags to be included with emitted JMX metrics, formatted as a string of key:value "
@@ -688,6 +694,12 @@ public class KsqlConfig extends AbstractConfig {
             "",
             ConfigDef.Importance.LOW,
             KSQL_CUSTOM_METRICS_TAGS_DOC
+        ).define(
+            KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE,
+            ConfigDef.Type.STRING,
+            KSQL_SERVICE_ID_CONFIG,
+            ConfigDef.Importance.LOW,
+            KSQL_CCLOUD_QUERYANONYMIZER_CLUSTER_NAMESPACE_TAG
         ).define(
             KSQL_CUSTOM_METRICS_EXTENSION,
             ConfigDef.Type.CLASS,

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/QueryGuid.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/QueryGuid.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public final class QueryGuid {
+  private final String clusterNamespace;
+  private final String queryUuid;
+  private final String anonQueryUuid;
+  private final LocalDateTime timeOfCreation;
+
+  public QueryGuid(final String namespace, final String nonAnonQuery, final String anonQuery) {
+    this.clusterNamespace = namespace;
+    this.queryUuid = computeQueryId(nonAnonQuery, clusterNamespace);
+    this.anonQueryUuid = computeQueryId(anonQuery, "");
+    this.timeOfCreation = LocalDateTime.now();
+  }
+
+  public String getClusterNamespace() {
+    return this.clusterNamespace;
+  }
+
+  public String getQueryUuid() {
+    return this.queryUuid;
+  }
+
+  public String getAnonQueryUuid() {
+    return this.anonQueryUuid;
+  }
+
+  public LocalDateTime getTimeOfCreation() {
+    return this.timeOfCreation;
+  }
+
+  private static String computeQueryId(final String query, final String namespace) {
+    final String genericQuery = getGenericQueryForm(query);
+    final String namespacePlusQuery = namespace + genericQuery;
+
+    return UUID.nameUUIDFromBytes(namespacePlusQuery.getBytes(StandardCharsets.UTF_8)).toString();
+  }
+
+  private static String getGenericQueryForm(final String query) {
+    return query.replaceAll("[\\n\\t ]", "");
+  }
+}

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/util/QueryGuidTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/util/QueryGuidTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import java.time.LocalDateTime;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueryGuidTest {
+
+  @Test
+  public void shouldGetCorrectClusterNamespace() {
+    // Given:
+    final QueryGuid metaData = new QueryGuid("testData.testData",
+        "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, "
+            + "longitude DOUBLE)\nWITH (kafka_topic='locations', value_format='json', "
+            + "partitions=1);", "TEST");
+
+    // Then:
+    Assert.assertEquals("testData.testData", metaData.getClusterNamespace());
+  }
+
+  @Test
+  public void sameQueryInSameClusterAndOrgGetsSameId() {
+    // Given:
+    final String query1 = "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, longitude "
+        + "DOUBLE)\nWITH (kafka_topic='locations', value_format='json', partitions=1);";
+    final String query2 = "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, "
+        + "longitude DOUBLE) WITH (kafka_topic='locations', value_format='json', partitions=1);";
+
+    // When:
+    final String queryId1 =
+        new QueryGuid("testData.testData", query1, "TEST").getQueryUuid();
+    final String queryId2 =
+        new QueryGuid("testData.testData", query2, "TEST").getQueryUuid();
+
+    // Then:
+    Assert.assertEquals(queryId1, queryId2);
+  }
+
+  @Test
+  public void sameQueryWithDifferentClusterOrOrgGetsDifferentId() {
+    // Given:
+    final String query = "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, longitude "
+        + "DOUBLE)\nWITH (kafka_topic='locations', value_format='json', partitions=1);";
+
+    // When:
+    final String queryId1 =
+        new QueryGuid("testData.testData", query, "TEST").getQueryUuid();
+    final String queryId2 =
+        new QueryGuid("testData2.testData", query, "TEST").getQueryUuid();
+
+    // Then:
+    Assert.assertNotEquals(queryId1, queryId2);
+  }
+
+  @Test
+  public void queriesWithSameAnonFormShouldGetSameStructurallySimilarId() {
+    // Given:
+    final String query1 = "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE) "
+        + "WITH (kafka_topic='locations', value_format='json', partitions=1);";
+    final String query2 = "CREATE STREAM my_stream (userId VARCHAR, performance DOUBLE) "
+        + "WITH (kafka_topic='user_performance', value_format='json', partitions=2);";
+    final String anonQuery = "CREATE STREAM stream1 (column1 VARCHAR, column2 DOUBLE) WITH "
+        + "(kafka_topic=['string'], value_format=['string'], partitions='0';";
+
+    // When:
+    final String id1 =
+        new QueryGuid("testData.testData", query1, anonQuery).getAnonQueryUuid();
+    final String id2 =
+        new QueryGuid("testData.testData", query2, anonQuery).getAnonQueryUuid();
+
+    // Then:
+    Assert.assertEquals(id1, id2);
+  }
+
+  @Test
+  public void queriesWithDifferentAnonFormShouldGetSameStructurallySimilarId() {
+    // Given:
+    final String anonQuery1 = "CREATE STREAM stream1 (column1 VARCHAR, column2 DOUBLE) WITH "
+        + "(kafka_topic=['string'], value_format=['string'], partitions='0';";
+    final String anonQuery2 = "CREATE STREAM stream1 (column1 VARCHAR, column2 INT) WITH "
+        + "(kafka_topic=['string'], value_format=['string'], partitions='0';";
+
+    // When:
+    final String id1 =
+        new QueryGuid("testData.testData", "TEST", anonQuery1)
+        .getAnonQueryUuid();
+    final String id2 =
+        new QueryGuid("testData.testData", "TEST", anonQuery2)
+        .getAnonQueryUuid();
+
+    // Then:
+    Assert.assertNotEquals(id1, id2);
+  }
+
+  @Test
+  public void queriesGetCorrectTimeOfCreation() {
+    // Given:
+    final QueryGuid metaData = new QueryGuid("testData.testData",
+        "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, "
+            + "longitude DOUBLE)\nWITH (kafka_topic='locations', value_format='json', "
+            + "partitions=1);", "TEST");
+
+    // Then:
+    Assert.assertEquals(LocalDateTime.now(), metaData.getTimeOfCreation());
+  }
+
+  @Test
+  public void handlesEmptyNamespaceCorrectly() {
+    // Given:
+    final QueryGuid metaData = new QueryGuid("",
+        "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, "
+            + "longitude DOUBLE)\nWITH (kafka_topic='locations', value_format='json', "
+            + "partitions=1);", "TEST");
+
+    // Then:
+    Assert.assertEquals("", metaData.getClusterNamespace());
+    Assert.assertNotEquals("", metaData.getQueryUuid());
+    Assert.assertNotEquals("", metaData.getAnonQueryUuid());
+    Assert.assertEquals(LocalDateTime.now(), metaData.getTimeOfCreation());
+  }
+
+  @Test
+  public void handlesEmptyQueryCorrectly() {
+    // Given:
+    final QueryGuid metaData = new QueryGuid("testData.testData",
+        "", "TEST");
+
+    // Then:
+    Assert.assertEquals("testData.testData", metaData.getClusterNamespace());
+    Assert.assertNotEquals("", metaData.getQueryUuid());
+    Assert.assertNotEquals("", metaData.getAnonQueryUuid());
+    Assert.assertEquals(LocalDateTime.now(), metaData.getTimeOfCreation());
+  }
+
+  @Test
+  public void handlesEmptyAnonQueryCorrectly() {
+    // Given:
+    final QueryGuid metaData = new QueryGuid("testData.testData",
+        "CREATE STREAM my_stream (profileId VARCHAR, latitude DOUBLE, "
+            + "longitude DOUBLE)\nWITH (kafka_topic='locations', value_format='json', "
+            + "partitions=1);", "TEST");
+
+    // Then:
+    Assert.assertEquals("testData.testData", metaData.getClusterNamespace());
+    Assert.assertNotEquals("", metaData.getQueryUuid());
+    Assert.assertNotEquals("", metaData.getAnonQueryUuid());
+    Assert.assertEquals(LocalDateTime.now(), metaData.getTimeOfCreation());
+  }
+}


### PR DESCRIPTION
### Description 
We want to be able to filter the anonymized queries according to things such as physical cluster, organization and time created. For this we need to get/generate the relevant meta-data. The organization and physical cluster id is picked up from the control plane via a metric set [here](https://github.com/confluentinc/cc-spec-ksql/pull/233).

### Testing done 
Unit tests to make sure metadata gets computed as expected.

### References
jira: [KCI-342](https://confluentinc.atlassian.net/browse/KCI-342)
cc-structs-ksql update: [PR-223](https://github.com/confluentinc/cc-spec-ksql/pull/233)
cc-scheduler-service update: [PR-2240](https://github.com/confluentinc/cc-scheduler-service/pull/2240)
protobuff update: [PR-1507](https://github.com/confluentinc/cc-structs/pull/1507)
old pr that was closed accidentally: [PR-7425](https://github.com/confluentinc/ksql/pull/7425)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

