### PR TITLE
chore: upgrade guava to 30.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <commons-text.version>1.8</commons-text.version>
         <csv.version>1.4</csv.version>
         <lang3.version>3.3.1</lang3.version>
-        <guava.version>24.1.1-jre</guava.version>
+        <guava.version>30.1.1-jre</guava.version>
         <protobuf.version>3.11.1</protobuf.version>
         <retrying.version>2.0.0</retrying.version>
         <inject.version>1</inject.version>


### PR DESCRIPTION
### Description 
Upgrade Guava library from 24.1.1 to 30.1.1 to fix CVE-2020-8908.

### Testing done 
No code added

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

