### PR TITLE
fix: Fixes org.mock-server to be 5.11.2 to utilize newer netty

### DIFF
--- a/ksqldb-version-metrics-client/pom.xml
+++ b/ksqldb-version-metrics-client/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>3.10.4</version>
+            <version>5.11.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <version>3.10.4</version>
+            <version>5.11.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
+++ b/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.version.metrics;
 
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.Matchers.is;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
@@ -27,13 +28,13 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.mockserver.integration.ClientAndProxy;
+import org.mockserver.integration.ClientAndServer;
 import org.mockserver.socket.PortFactory;
 
 public class VersionCheckerIntegrationTest {
 
   private static int proxyPort;
-  private static ClientAndProxy clientAndProxy;
+  private static ClientAndServer mockServer;
 
   @Rule
   public final Timeout timeout = Timeout.builder()
@@ -44,7 +45,7 @@ public class VersionCheckerIntegrationTest {
   @BeforeClass
   public static void startProxy() {
     proxyPort = PortFactory.findFreePort();
-    clientAndProxy = ClientAndProxy.startClientAndProxy(proxyPort);
+    mockServer = startClientAndServer(proxyPort);
   }
 
   @Test
@@ -64,7 +65,7 @@ public class VersionCheckerIntegrationTest {
 
     assertThatEventually("Version not submitted", () -> {
           try {
-            clientAndProxy.verify(request().withPath("/ksql/anon").withMethod("POST"));
+            mockServer.verify(request().withPath("/ksql/anon").withMethod("POST"));
             return true;
           } catch (final AssertionError e) {
             return false;


### PR DESCRIPTION
### Description 
Fixes test and the build.

### Testing done 
Ran test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

