### PR TITLE
chore: Override dependencies: netty -> 4.1.49.Final, jersey-common -> 2.31

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -335,8 +335,8 @@ final class AdminResponseHandlers {
           source.getString("valueFormat"),
           formatQueries(source.getJsonArray("readQueries")),
           formatQueries(source.getJsonArray("writeQueries")),
-          Optional.ofNullable(source.getString("timestamp")),
-          Optional.ofNullable(source.getString("windowType")),
+          Optional.ofNullable(emptyToNull(source.getString("timestamp"))),
+          Optional.ofNullable(emptyToNull(source.getString("windowType"))),
           source.getString("statement"),
           source.getJsonArray("sourceConstraints").stream()
               .map(o -> (String)o)
@@ -345,5 +345,9 @@ final class AdminResponseHandlers {
     } catch (Exception e) {
       return Optional.empty();
     }
+  }
+
+  private static String emptyToNull(final String str) {
+    return str == null ? null : (str.isEmpty() ? null : str);
   }
 }

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -35,7 +35,6 @@
         <cli.main-class>${main-class}</cli.main-class>
         <docker.skip-build>true</docker.skip-build>
         <docker.skip-test>true</docker.skip-test>
-        <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>
     </properties>
 
     <dependencies>
@@ -130,7 +129,6 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-version}</version>
         </dependency>
 
         <dependency>

--- a/ksqldb-version-metrics-client/pom.xml
+++ b/ksqldb-version-metrics-client/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>5.11.2</version>
+            <version>3.10.4</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <version>5.11.2</version>
+            <version>3.10.4</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
+++ b/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.version.metrics;
 
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.Matchers.is;
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
@@ -28,13 +27,13 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.mockserver.integration.ClientAndServer;
+import org.mockserver.integration.ClientAndProxy;
 import org.mockserver.socket.PortFactory;
 
 public class VersionCheckerIntegrationTest {
 
   private static int proxyPort;
-  private static ClientAndServer mockServer;
+  private static ClientAndProxy clientAndProxy;
 
   @Rule
   public final Timeout timeout = Timeout.builder()
@@ -45,7 +44,7 @@ public class VersionCheckerIntegrationTest {
   @BeforeClass
   public static void startProxy() {
     proxyPort = PortFactory.findFreePort();
-    mockServer = startClientAndServer(proxyPort);
+    clientAndProxy = ClientAndProxy.startClientAndProxy(proxyPort);
   }
 
   @Test
@@ -65,7 +64,7 @@ public class VersionCheckerIntegrationTest {
 
     assertThatEventually("Version not submitted", () -> {
           try {
-            mockServer.verify(request().withPath("/ksql/anon").withMethod("POST"));
+            clientAndProxy.verify(request().withPath("/ksql/anon").withMethod("POST"));
             return true;
           } catch (final AssertionError e) {
             return false;

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.1</vertx.version>
+        <vertx.version>3.9.7</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -140,6 +140,10 @@
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
         <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
+        <!-- We normally get this from common, but Vertx is built against 4.1.60.Final -->
+        <netty.version>4.1.60.Final</netty.version>
+        <!-- This matches the version in common -->
+        <netty-codec-http2-version>4.1.63.Final</netty-codec-http2-version>
     </properties>
 
     <dependencyManagement>
@@ -523,7 +527,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>${netty.version}</version>
+                <version>${netty-codec-http2-version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.7</vertx.version>
+        <vertx.version>3.9.1</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -139,11 +139,11 @@
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
-        <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
-        <!-- We normally get this from common, but Vertx is built against 4.1.60.Final -->
-        <netty.version>4.1.60.Final</netty.version>
+        <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>
+        <!-- We normally get this from common, but Vertx is built against 4.1.49.Final -->
+        <netty.version>4.1.49.Final</netty.version>
         <!-- This matches the version in common -->
-        <netty-codec-http2-version>4.1.63.Final</netty-codec-http2-version>
+        <netty-codec-http2-version>4.1.49.Final</netty-codec-http2-version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
+        <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>
     </properties>
 
     <dependencyManagement>
@@ -474,6 +475,90 @@
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-reflect</artifactId>
                 <version>${scala.version}</version>
+            </dependency>
+
+            <!-- Explicitly override all netty artifacts to get the version we want. Doing netty-all
+             doesn't seem to correctly override its individual dependencies, so all are enumerated
+             here -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-all</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-socks</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative-boringssl-static</artifactId>
+                <version>${netty-tcnative-version}</version>
             </dependency>
 
             <!-- Required for running tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.7</vertx.version>
+        <vertx.version>3.9.1</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -140,8 +140,8 @@
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
         <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
-        <!-- We normally get this from common, but Vertx is built against 4.1.60.Final -->
-        <netty.version>4.1.60.Final</netty.version>
+        <!-- We normally get this from common, but Vertx is built against 4.1.49 -->
+        <netty.version>4.1.49.Final</netty.version>
         <!-- This matches the version in common -->
         <netty-codec-http2-version>4.1.63.Final</netty-codec-http2-version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.1</vertx.version>
+        <vertx.version>3.9.7</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -140,8 +140,8 @@
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
         <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
-        <!-- We normally get this from common, but Vertx is built against 4.1.49 -->
-        <netty.version>4.1.49.Final</netty.version>
+        <!-- We normally get this from common, but Vertx is built against 4.1.60.Final -->
+        <netty.version>4.1.60.Final</netty.version>
         <!-- This matches the version in common -->
         <netty-codec-http2-version>4.1.63.Final</netty-codec-http2-version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <scala.version>2.13.2</scala.version>
         <apache.io.version>2.6</apache.io.version>
         <io.confluent.ksql.version>7.0.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>7.0.0-290</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
         <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
-        <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
     </properties>
 
     <dependencyManagement>
@@ -480,11 +480,6 @@
             <!-- Explicitly override all netty artifacts to get the version we want. Doing netty-all
              doesn't seem to correctly override its individual dependencies, so all are enumerated
              here -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <scala.version>2.13.2</scala.version>
         <apache.io.version>2.6</apache.io.version>
         <io.confluent.ksql.version>7.0.0-0</io.confluent.ksql.version>
-        <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
+        <io.confluent.schema-registry.version>7.0.0-290</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
         <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>
@@ -144,6 +144,8 @@
         <netty.version>4.1.49.Final</netty.version>
         <!-- This matches the version in common -->
         <netty-codec-http2-version>4.1.49.Final</netty-codec-http2-version>
+        <!-- Brought in by both schema registry and connect, we need to pick a version -->
+        <jersey-common>2.31</jersey-common>
     </properties>
 
     <dependencyManagement>
@@ -558,6 +560,11 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>${netty-tcnative-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-common</artifactId>
+                <version>${jersey-common}</version>
             </dependency>
 
             <!-- Required for running tests -->


### PR DESCRIPTION
### Description 
This is effectively a rollback to our previous version of netty since the update to 4.1.63.Final in common is breaking master.  Also pins jersey-common and fixes a small bug breaking master

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

