### PR TITLE
chore: refactor QueryMetadata and PersistentQueryMetadata

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryApplicationId;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
@@ -227,7 +228,7 @@ final class QueryExecutor {
         .map(userErrorClassifiers::and)
         .orElse(userErrorClassifiers);
 
-    return new PersistentQueryMetadata(
+    return new PersistentQueryMetadataImpl(
         statementText,
         querySchema,
         sources,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -30,8 +30,10 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
-import io.confluent.ksql.util.SandboxedPersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadataImpl;
+import io.confluent.ksql.util.SandboxedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.SandboxedTransientQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Collection;
@@ -84,10 +86,10 @@ public class QueryRegistryImpl implements QueryRegistry {
     insertQueries = new ConcurrentHashMap<>();
     original.allLiveQueries.forEach(query -> {
       if (query instanceof PersistentQueryMetadata) {
-        final PersistentQueryMetadata sandboxed = SandboxedPersistentQueryMetadata.of(
-            (PersistentQueryMetadata) query,
+        final PersistentQueryMetadata sandboxed = SandboxedPersistentQueryMetadataImpl.of(
+            (PersistentQueryMetadataImpl) query,
             new ListenerImpl()
-        );
+                                                                                         );
         persistentQueries.put(sandboxed.getQueryId(), sandboxed);
         allLiveQueries.add(sandboxed);
       } else {
@@ -332,7 +334,7 @@ public class QueryRegistryImpl implements QueryRegistry {
     );
   }
 
-  private class ListenerImpl implements QueryMetadata.Listener {
+  private class ListenerImpl implements QueryMetadataImpl.Listener {
     @Override
     public void onError(final QueryMetadata queryMetadata, final QueryError error) {
       eventListeners.forEach(l -> l.onError(queryMetadata, error));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -32,7 +32,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
-import io.confluent.ksql.util.QueryMetadataImpl;
 import io.confluent.ksql.util.SandboxedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.SandboxedTransientQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
@@ -89,7 +88,7 @@ public class QueryRegistryImpl implements QueryRegistry {
         final PersistentQueryMetadata sandboxed = SandboxedPersistentQueryMetadataImpl.of(
             (PersistentQueryMetadataImpl) query,
             new ListenerImpl()
-                                                                                         );
+        );
         persistentQueries.put(sandboxed.getQueryId(), sandboxed);
         allLiveQueries.add(sandboxed);
       } else {
@@ -334,7 +333,7 @@ public class QueryRegistryImpl implements QueryRegistry {
     );
   }
 
-  private class ListenerImpl implements QueryMetadataImpl.Listener {
+  private class ListenerImpl implements QueryMetadata.Listener {
     @Override
     public void onError(final QueryMetadata queryMetadata, final QueryError error) {
       eventListeners.forEach(l -> l.onError(queryMetadata, error));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -15,9 +15,6 @@
 
 package io.confluent.ksql.util;
 
-import static java.util.Objects.requireNonNull;
-
-import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.plan.ExecutionStep;
@@ -25,195 +22,43 @@ import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
-import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.KafkaStreamsBuilder;
-import io.confluent.ksql.query.MaterializationProviderBuilderFactory;
-import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
-/**
- * Metadata of a persistent query, e.g. {@code CREATE STREAM FOO AS SELECT * FROM BAR;}.
- */
-public class PersistentQueryMetadata extends QueryMetadata {
+import java.util.Optional;
 
-  private final DataSource sinkDataSource;
-  private final QuerySchemas schemas;
-  private final PhysicalSchema resultSchema;
-  private final ExecutionStep<?> physicalPlan;
-  private final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
-      materializationProviderBuilder;
+public interface PersistentQueryMetadata extends QueryMetadata {
 
-  private Optional<MaterializationProvider> materializationProvider;
-  private ProcessingLogger processingLogger;
+  DataSource.DataSourceType getDataSourceType();
 
-  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
-  public PersistentQueryMetadata(
-      final String statementString,
-      final PhysicalSchema schema,
-      final Set<SourceName> sourceNames,
-      final DataSource sinkDataSource,
-      final String executionPlan,
-      final QueryId id,
-      final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
-          materializationProviderBuilder,
-      final String queryApplicationId,
-      final Topology topology,
-      final KafkaStreamsBuilder kafkaStreamsBuilder,
-      final QuerySchemas schemas,
-      final Map<String, Object> streamsProperties,
-      final Map<String, Object> overriddenProperties,
-      final long closeTimeout,
-      final QueryErrorClassifier errorClassifier,
-      final ExecutionStep<?> physicalPlan,
-      final int maxQueryErrorsQueueSize,
-      final ProcessingLogger processingLogger,
-      final long retryBackoffInitialMs,
-      final long retryBackoffMaxMs,
-      final Listener listener
-  ) {
-    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
-    super(
-        statementString,
-        schema.logicalSchema(),
-        sourceNames,
-        executionPlan,
-        queryApplicationId,
-        topology,
-        kafkaStreamsBuilder,
-        streamsProperties,
-        overriddenProperties,
-        closeTimeout,
-        id,
-        errorClassifier,
-        maxQueryErrorsQueueSize,
-        retryBackoffInitialMs,
-        retryBackoffMaxMs,
-        listener
-    );
-    this.sinkDataSource = requireNonNull(sinkDataSource, "sinkDataSource");
-    this.schemas = requireNonNull(schemas, "schemas");
-    this.resultSchema = requireNonNull(schema, "schema");
-    this.physicalPlan = requireNonNull(physicalPlan, "physicalPlan");
-    this.materializationProviderBuilder =
-        requireNonNull(materializationProviderBuilder, "materializationProviderBuilder");
-    this.processingLogger = requireNonNull(processingLogger, "processingLogger");
-  }
+  KsqlTopic getResultTopic();
 
-  // for creating sandbox instances
-  protected PersistentQueryMetadata(
-      final PersistentQueryMetadata original,
-      final Listener listener
-  ) {
-    super(original, listener);
-    this.sinkDataSource = original.getSink();
-    this.schemas = original.schemas;
-    this.resultSchema = original.resultSchema;
-    this.materializationProvider = original.materializationProvider;
-    this.physicalPlan = original.physicalPlan;
-    this.materializationProviderBuilder = original.materializationProviderBuilder;
-    this.processingLogger = original.processingLogger;
-  }
+  SourceName getSinkName();
 
-  @Override
-  public void initialize() {
-    // initialize the first KafkaStreams
-    super.initialize();
-    setUncaughtExceptionHandler(this::uncaughtHandler);
+  QuerySchemas getQuerySchemas();
 
-    this.materializationProvider = materializationProviderBuilder
-        .flatMap(builder -> builder.apply(getKafkaStreams(), getTopology()));
-  }
+  PhysicalSchema getPhysicalSchema();
 
-  @Override
-  protected StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
-          final Throwable error
-  ) {
-    final StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse response =
-            super.uncaughtHandler(error);
+  ExecutionStep<?> getPhysicalPlan();
 
-    processingLogger.error(KafkaStreamsThreadError.of(
-        "Unhandled exception caught in streams thread", Thread.currentThread(), error));
-    return response;
-  }
+  DataSource getSink();
 
-  public DataSourceType getDataSourceType() {
-    return sinkDataSource.getDataSourceType();
-  }
+  ProcessingLogger getProcessingLogger();
 
-  public KsqlTopic getResultTopic() {
-    return sinkDataSource.getKsqlTopic();
-  }
-
-  public SourceName getSinkName() {
-    return sinkDataSource.getName();
-  }
-
-  public QuerySchemas getQuerySchemas() {
-    return schemas;
-  }
-
-  public PhysicalSchema getPhysicalSchema() {
-    return resultSchema;
-  }
-
-  public ExecutionStep<?> getPhysicalPlan() {
-    return physicalPlan;
-  }
-
-  public DataSource getSink() {
-    return sinkDataSource;
-  }
-
-  @VisibleForTesting
-  Optional<MaterializationProvider> getMaterializationProvider() {
-    return materializationProvider;
-  }
-
-  @VisibleForTesting
-  public ProcessingLogger getProcessingLogger() {
-    return processingLogger;
-  }
-
-  public Optional<Materialization> getMaterialization(
+  Optional<Materialization> getMaterialization(
       final QueryId queryId,
-      final QueryContext.Stacker contextStacker
-  ) {
-    return materializationProvider.map(builder -> builder.build(queryId, contextStacker));
-  }
+      final QueryContext.Stacker contextStacker);
 
-  public synchronized void restart() {
-    if (isClosed()) {
-      throw new IllegalStateException(String.format(
-          "Query with application id %s is already closed, cannot restart.",
-          getQueryApplicationId()));
-    }
+  void restart();
 
-    closeKafkaStreams();
+  void stop();
 
-    final KafkaStreams newKafkaStreams = buildKafkaStreams();
-    materializationProvider = materializationProviderBuilder.flatMap(
-        builder -> builder.apply(newKafkaStreams, getTopology()));
+  StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
+      final Throwable error
+                                                                                         );
 
-    resetKafkaStreams(newKafkaStreams);
-    start();
-  }
-
-  /**
-   * Stops the query without cleaning up the external resources
-   * so that it can be resumed when we call {@link #start()}.
-   *
-   * @see #close()
-   */
-  public synchronized void stop() {
-    doClose(false);
-  }
+  Optional<MaterializationProvider>  getMaterializationProvider();
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -58,7 +58,7 @@ public interface PersistentQueryMetadata extends QueryMetadata {
 
   StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
       final Throwable error
-                                                                                         );
+  );
 
   Optional<MaterializationProvider>  getMaterializationProvider();
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -26,9 +26,8 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
-import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
-
 import java.util.Optional;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
 public interface PersistentQueryMetadata extends QueryMetadata {
 
@@ -49,15 +48,16 @@ public interface PersistentQueryMetadata extends QueryMetadata {
   ProcessingLogger getProcessingLogger();
 
   Optional<Materialization> getMaterialization(
-      final QueryId queryId,
-      final QueryContext.Stacker contextStacker);
+      QueryId queryId,
+      QueryContext.Stacker contextStacker
+  );
 
   void restart();
 
   void stop();
 
   StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
-      final Throwable error
+      Throwable error
   );
 
   Optional<MaterializationProvider>  getMaterializationProvider();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.streams.materialization.Materialization;
+import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.KafkaStreamsBuilder;
+import io.confluent.ksql.query.MaterializationProviderBuilderFactory;
+import io.confluent.ksql.query.QueryErrorClassifier;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.query.QuerySchemas;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+
+/**
+ * Metadata of a persistent query, e.g. {@code CREATE STREAM FOO AS SELECT * FROM BAR;}.
+ */
+public class PersistentQueryMetadataImpl
+    extends QueryMetadataImpl implements PersistentQueryMetadata {
+
+  private final DataSource sinkDataSource;
+  private final QuerySchemas schemas;
+  private final PhysicalSchema resultSchema;
+  private final ExecutionStep<?> physicalPlan;
+  private final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
+      materializationProviderBuilder;
+
+  private Optional<MaterializationProvider> materializationProvider;
+  private ProcessingLogger processingLogger;
+
+  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
+  public PersistentQueryMetadataImpl(
+      final String statementString,
+      final PhysicalSchema schema,
+      final Set<SourceName> sourceNames,
+      final DataSource sinkDataSource,
+      final String executionPlan,
+      final QueryId id,
+      final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
+          materializationProviderBuilder,
+      final String queryApplicationId,
+      final Topology topology,
+      final KafkaStreamsBuilder kafkaStreamsBuilder,
+      final QuerySchemas schemas,
+      final Map<String, Object> streamsProperties,
+      final Map<String, Object> overriddenProperties,
+      final long closeTimeout,
+      final QueryErrorClassifier errorClassifier,
+      final ExecutionStep<?> physicalPlan,
+      final int maxQueryErrorsQueueSize,
+      final ProcessingLogger processingLogger,
+      final long retryBackoffInitialMs,
+      final long retryBackoffMaxMs,
+      final QueryMetadata.Listener listener
+  ) {
+    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
+    super(
+        statementString,
+        schema.logicalSchema(),
+        sourceNames,
+        executionPlan,
+        queryApplicationId,
+        topology,
+        kafkaStreamsBuilder,
+        streamsProperties,
+        overriddenProperties,
+        closeTimeout,
+        id,
+        errorClassifier,
+        maxQueryErrorsQueueSize,
+        retryBackoffInitialMs,
+        retryBackoffMaxMs,
+        listener
+    );
+    this.sinkDataSource = requireNonNull(sinkDataSource, "sinkDataSource");
+    this.schemas = requireNonNull(schemas, "schemas");
+    this.resultSchema = requireNonNull(schema, "schema");
+    this.physicalPlan = requireNonNull(physicalPlan, "physicalPlan");
+    this.materializationProviderBuilder =
+        requireNonNull(materializationProviderBuilder, "materializationProviderBuilder");
+    this.processingLogger = requireNonNull(processingLogger, "processingLogger");
+  }
+
+  // for creating sandbox instances
+  protected PersistentQueryMetadataImpl(
+      final PersistentQueryMetadataImpl original,
+      final QueryMetadata.Listener listener
+  ) {
+    super(original, listener);
+    this.sinkDataSource = original.getSink();
+    this.schemas = original.schemas;
+    this.resultSchema = original.resultSchema;
+    this.materializationProvider = original.materializationProvider;
+    this.physicalPlan = original.physicalPlan;
+    this.materializationProviderBuilder = original.materializationProviderBuilder;
+    this.processingLogger = original.processingLogger;
+  }
+
+  @Override
+  public void initialize() {
+    // initialize the first KafkaStreams
+    super.initialize();
+    setUncaughtExceptionHandler(this::uncaughtHandler);
+
+    this.materializationProvider = materializationProviderBuilder
+        .flatMap(builder -> builder.apply(getKafkaStreams(), getTopology()));
+  }
+
+  @Override
+  public StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
+      final Throwable error
+  ) {
+    final StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse response =
+            super.uncaughtHandler(error);
+
+    processingLogger.error(KafkaStreamsThreadError.of(
+        "Unhandled exception caught in streams thread", Thread.currentThread(), error));
+    return response;
+  }
+
+  public DataSourceType getDataSourceType() {
+    return sinkDataSource.getDataSourceType();
+  }
+
+  public KsqlTopic getResultTopic() {
+    return sinkDataSource.getKsqlTopic();
+  }
+
+  public SourceName getSinkName() {
+    return sinkDataSource.getName();
+  }
+
+  public QuerySchemas getQuerySchemas() {
+    return schemas;
+  }
+
+  public PhysicalSchema getPhysicalSchema() {
+    return resultSchema;
+  }
+
+  public ExecutionStep<?> getPhysicalPlan() {
+    return physicalPlan;
+  }
+
+  public DataSource getSink() {
+    return sinkDataSource;
+  }
+
+  @VisibleForTesting
+  public Optional<MaterializationProvider> getMaterializationProvider() {
+    return materializationProvider;
+  }
+
+  @VisibleForTesting
+  public ProcessingLogger getProcessingLogger() {
+    return processingLogger;
+  }
+
+  public Optional<Materialization> getMaterialization(
+      final QueryId queryId,
+      final QueryContext.Stacker contextStacker
+  ) {
+    return materializationProvider.map(builder -> builder.build(queryId, contextStacker));
+  }
+
+  public synchronized void restart() {
+    if (isClosed()) {
+      throw new IllegalStateException(String.format(
+          "Query with application id %s is already closed, cannot restart.",
+          getQueryApplicationId()));
+    }
+
+    closeKafkaStreams();
+
+    final KafkaStreams newKafkaStreams = buildKafkaStreams();
+    materializationProvider = materializationProviderBuilder.flatMap(
+        builder -> builder.apply(newKafkaStreams, getTopology()));
+
+    resetKafkaStreams(newKafkaStreams);
+    start();
+  }
+
+  /**
+   * Stops the query without cleaning up the external resources
+   * so that it can be resumed when we call {@link #start()}.
+   *
+   * @see #close()
+   */
+  public synchronized void stop() {
+    doClose(false);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -39,7 +39,7 @@ public interface QueryMetadata {
 
   String getStatementString();
 
-  void setUncaughtExceptionHandler(final StreamsUncaughtExceptionHandler handler);
+  void setUncaughtExceptionHandler(StreamsUncaughtExceptionHandler handler);
 
   KafkaStreams.State getState();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -20,16 +20,15 @@ import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.StreamsTaskMetadata;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.state.StreamsMetadata;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public interface QueryMetadata {
   void initialize();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -15,442 +15,79 @@
 
 package io.confluent.ksql.util;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
-import com.google.common.base.Ticker;
-import com.google.common.collect.EvictingQueue;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryError;
-import io.confluent.ksql.query.QueryError.Type;
-import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.StreamsTaskMetadata;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
-import java.time.Duration;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.LagInfo;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.apache.kafka.streams.state.StreamsMetadata;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Queue;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KafkaStreams.State;
-import org.apache.kafka.streams.LagInfo;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
-import org.apache.kafka.streams.state.StreamsMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+public interface QueryMetadata {
+  void initialize();
 
-public abstract class QueryMetadata {
+  Set<StreamsTaskMetadata> getTaskMetadata();
 
-  private static final Logger LOG = LoggerFactory.getLogger(QueryMetadata.class);
+  Map<String, Object> getOverriddenProperties();
 
-  private final String statementString;
-  private final String executionPlan;
-  private final String queryApplicationId;
-  private final Topology topology;
-  private final KafkaStreamsBuilder kafkaStreamsBuilder;
-  private final Map<String, Object> streamsProperties;
-  private final Map<String, Object> overriddenProperties;
-  private final Set<SourceName> sourceNames;
-  private final LogicalSchema logicalSchema;
-  private final Duration closeTimeout;
-  private final QueryId queryId;
-  private final QueryErrorClassifier errorClassifier;
-  private final TimeBoundedQueue queryErrors;
-  private final RetryEvent retryEvent;
-  private final Listener listener;
+  String getStatementString();
 
-  private boolean everStarted = false;
-  protected boolean closed = false;
-  private StreamsUncaughtExceptionHandler uncaughtExceptionHandler = this::uncaughtHandler;
-  private KafkaStreams kafkaStreams;
-  private boolean initialized = false;
+  void setUncaughtExceptionHandler(final StreamsUncaughtExceptionHandler handler);
 
-  private static final Ticker CURRENT_TIME_MILLIS_TICKER = new Ticker() {
-    @Override
-    public long read() {
-      return System.currentTimeMillis();
-    }
-  };
+  KafkaStreams.State getState();
 
-  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
-  @VisibleForTesting
-  QueryMetadata(
-      final String statementString,
-      final LogicalSchema logicalSchema,
-      final Set<SourceName> sourceNames,
-      final String executionPlan,
-      final String queryApplicationId,
-      final Topology topology,
-      final KafkaStreamsBuilder kafkaStreamsBuilder,
-      final Map<String, Object> streamsProperties,
-      final Map<String, Object> overriddenProperties,
-      final long closeTimeout,
-      final QueryId queryId,
-      final QueryErrorClassifier errorClassifier,
-      final int maxQueryErrorsQueueSize,
-      final long baseWaitingTimeMs,
-      final long retryBackoffMaxMs,
-      final Listener listener
-  ) {
-    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
-    this.statementString = Objects.requireNonNull(statementString, "statementString");
-    this.executionPlan = Objects.requireNonNull(executionPlan, "executionPlan");
-    this.queryApplicationId = Objects.requireNonNull(queryApplicationId, "queryApplicationId");
-    this.topology = Objects.requireNonNull(topology, "kafkaTopicClient");
-    this.kafkaStreamsBuilder = Objects.requireNonNull(kafkaStreamsBuilder, "kafkaStreamsBuilder");
-    this.streamsProperties =
-        ImmutableMap.copyOf(
-            Objects.requireNonNull(streamsProperties, "streamsPropeties"));
-    this.overriddenProperties =
-        ImmutableMap.copyOf(
-            Objects.requireNonNull(overriddenProperties, "overriddenProperties"));
-    this.listener = Objects.requireNonNull(listener, "listener");
-    this.sourceNames = Objects.requireNonNull(sourceNames, "sourceNames");
-    this.logicalSchema = Objects.requireNonNull(logicalSchema, "logicalSchema");
-    this.closeTimeout = Duration.ofMillis(closeTimeout);
-    this.queryId = Objects.requireNonNull(queryId, "queryId");
-    this.errorClassifier = Objects.requireNonNull(errorClassifier, "errorClassifier");
-    this.queryErrors = new TimeBoundedQueue(Duration.ofHours(1), maxQueryErrorsQueueSize);
-    this.retryEvent = new RetryEvent(
-        queryId,
-        baseWaitingTimeMs,
-        retryBackoffMaxMs,
-        CURRENT_TIME_MILLIS_TICKER
-    );
+  boolean isError();
+
+  String getExecutionPlan();
+
+  String getQueryApplicationId();
+
+  Topology getTopology();
+
+  Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLags();
+
+  Collection<StreamsMetadata> getAllMetadata();
+
+  Map<String, Object> getStreamsProperties();
+
+  LogicalSchema getLogicalSchema();
+
+  Set<SourceName> getSourceNames();
+
+  boolean hasEverBeenStarted();
+
+  QueryId getQueryId();
+
+  KsqlConstants.KsqlQueryType getQueryType();
+
+  String getTopologyDescription();
+
+  List<QueryError> getQueryErrors();
+
+  KafkaStreams getKafkaStreams();
+
+  void close();
+
+  void start() ;
+
+  interface RetryEvent {
+
+    long nextRestartTimeMs();
+
+    int getNumRetries();
+
+    void backOff();
   }
 
-  // Used for sandboxing
-  QueryMetadata(final QueryMetadata other, final Listener listener) {
-    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
-    this.statementString = other.getStatementString();
-    this.kafkaStreams = other.getKafkaStreams();
-    this.executionPlan = other.getExecutionPlan();
-    this.queryApplicationId = other.getQueryApplicationId();
-    this.topology = other.getTopology();
-    this.kafkaStreamsBuilder = other.kafkaStreamsBuilder;
-    this.streamsProperties = other.getStreamsProperties();
-    this.overriddenProperties = other.getOverriddenProperties();
-    this.sourceNames = other.getSourceNames();
-    this.logicalSchema = other.getLogicalSchema();
-    this.closeTimeout = other.closeTimeout;
-    this.queryId = other.getQueryId();
-    this.errorClassifier = other.errorClassifier;
-    this.uncaughtExceptionHandler = other.uncaughtExceptionHandler;
-    this.everStarted = other.everStarted;
-    this.queryErrors = new TimeBoundedQueue(Duration.ZERO, 0);
-    this.retryEvent = new RetryEvent(
-        other.getQueryId(),
-        0,
-        0,
-        new Ticker() {
-          @Override
-          public long read() {
-            return 0;
-          }
-        }
-    );
-    this.listener
-        = Objects.requireNonNull(listener, "stopListeners");
-  }
-
-  public void initialize() {
-    // initialize the first KafkaStreams
-    resetKafkaStreams(kafkaStreamsBuilder.build(topology, streamsProperties));
-    this.initialized = true;
-  }
-
-  protected StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
-      final Throwable e
-  ) {
-    QueryError.Type errorType = Type.UNKNOWN;
-    try {
-      errorType = errorClassifier.classify(e);
-    } catch (final Exception classificationException) {
-      LOG.error("Error classifying unhandled exception", classificationException);
-    } finally {
-      // If error classification throws then we consider the error to be an UNKNOWN error.
-      // We notify listeners and add the error to the errors queue in the finally block to ensure
-      // all listeners and consumers of the error queue (e.g. the API) can see the error. Similarly,
-      // log in finally block to make sure that if there's ever an error in the classification
-      // we still get this in our logs.
-      final QueryError queryError =
-          new QueryError(
-              System.currentTimeMillis(),
-              Throwables.getStackTraceAsString(e),
-              errorType
-          );
-      listener.onError(this, queryError);
-      queryErrors.add(queryError);
-      LOG.error(
-          "Unhandled exception caught in streams thread {}. ({})",
-          Thread.currentThread().getName(),
-          errorType,
-          e
-      );
-    }
-    retryEvent.backOff();
-    return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
-  }
-
-  public Set<StreamsTaskMetadata> getTaskMetadata() {
-    return kafkaStreams.localThreadsMetadata()
-                       .stream()
-                       .flatMap(t -> t.activeTasks().stream())
-                       .map(StreamsTaskMetadata::fromStreamsTaskMetadata)
-                       .collect(Collectors.toSet());
-  }
-
-  public Map<String, Object> getOverriddenProperties() {
-    return overriddenProperties;
-  }
-
-  public String getStatementString() {
-    return statementString;
-  }
-
-  public void setUncaughtExceptionHandler(final StreamsUncaughtExceptionHandler handler) {
-    this.uncaughtExceptionHandler = handler;
-    kafkaStreams.setUncaughtExceptionHandler(handler);
-  }
-
-  public State getState() {
-    return kafkaStreams.state();
-  }
-
-  public boolean isError() {
-    return getState() == State.ERROR;
-  }
-
-  public String getExecutionPlan() {
-    return executionPlan;
-  }
-
-  public String getQueryApplicationId() {
-    return queryApplicationId;
-  }
-
-  public Topology getTopology() {
-    return topology;
-  }
-
-  public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLags() {
-    try {
-      return kafkaStreams.allLocalStorePartitionLags();
-    } catch (IllegalStateException | StreamsException e) {
-      LOG.error(e.getMessage());
-      return ImmutableMap.of();
-    }
-  }
-
-  public Collection<StreamsMetadata> getAllMetadata() {
-    try {
-      return ImmutableList.copyOf(kafkaStreams.allMetadata());
-    } catch (IllegalStateException e) {
-      LOG.error(e.getMessage());
-    }
-    return ImmutableList.of();
-  }
-
-  public Map<String, Object> getStreamsProperties() {
-    return streamsProperties;
-  }
-
-  public LogicalSchema getLogicalSchema() {
-    return logicalSchema;
-  }
-
-  public Set<SourceName> getSourceNames() {
-    return sourceNames;
-  }
-
-  public boolean hasEverBeenStarted() {
-    return everStarted;
-  }
-
-  public QueryId getQueryId() {
-    return queryId;
-  }
-
-  public KsqlQueryType getQueryType() {
-    return KsqlQueryType.PERSISTENT;
-  }
-
-  public String getTopologyDescription() {
-    return topology.describe().toString();
-  }
-
-  public List<QueryError> getQueryErrors() {
-    return queryErrors.toImmutableList();
-  }
-
-  protected boolean isClosed() {
-    return closed;
-  }
-
-  public KafkaStreams getKafkaStreams() {
-    return kafkaStreams;
-  }
-
-  Listener getListener() {
-    return listener;
-  }
-
-  protected void resetKafkaStreams(final KafkaStreams kafkaStreams) {
-    this.kafkaStreams = kafkaStreams;
-    setUncaughtExceptionHandler(uncaughtExceptionHandler);
-    kafkaStreams.setStateListener((b, a) -> listener.onStateChange(this, b, a));
-  }
-
-  protected void closeKafkaStreams() {
-    if (initialized) {
-      kafkaStreams.close(closeTimeout);
-      if (!getState().equals(State.NOT_RUNNING)) {
-        LOG.warn(
-            "query has not terminated even after close. "
-                + "This may happen when streams threads are hung. State: " + getState()
-        );
-      }
-    }
-  }
-
-  protected KafkaStreams buildKafkaStreams() {
-    return kafkaStreamsBuilder.build(topology, streamsProperties);
-  }
-
-  /**
-   * Closes the {@code QueryMetadata} and cleans up any of
-   * the resources associated with it (e.g. internal topics,
-   * schemas, etc...).
-   */
-  public void close() {
-    doClose(true);
-    listener.onClose(this);
-  }
-
-  void doClose(final boolean cleanUp) {
-    closed = true;
-    closeKafkaStreams();
-
-    if (cleanUp) {
-      kafkaStreams.cleanUp();
-    }
-  }
-
-  public static class TimeBoundedQueue {
-    private final Duration duration;
-    private final Queue<QueryError> queue;
-
-    TimeBoundedQueue(final Duration duration, final int capacity) {
-      queue = EvictingQueue.create(capacity);
-      this.duration = duration;
-    }
-
-    public void add(final QueryError e) {
-      queue.add(e);
-      evict();
-    }
-
-    public List<QueryError> toImmutableList() {
-      evict();
-      return ImmutableList.copyOf(queue);
-    }
-    
-    private void evict() {
-      while (queue.peek() != null) {
-        if (queue.peek().getTimestamp() > System.currentTimeMillis() - duration.toMillis()) {
-          break;
-        }
-        queue.poll();
-      }
-    }
-
-  }
-
-  public void start() {
-    if (!initialized) {
-      throw new KsqlException(
-          String.format(
-              "Failed to initialize query %s before starting it",
-              queryApplicationId));
-    }
-    LOG.info("Starting query with application id: {}", queryApplicationId);
-    everStarted = true;
-    listener.onStateChange(this, kafkaStreams.state(), kafkaStreams.state());
-    kafkaStreams.start();
-  }
-
-  public static class RetryEvent {
-    private final Ticker ticker;
-    private final QueryId queryId;
-
-    private int numRetries = 0;
-    private long waitingTimeMs;
-    private long expiryTimeMs;
-    private long retryBackoffMaxMs;
-
-    RetryEvent(
-            final QueryId queryId,
-            final long baseWaitingTimeMs,
-            final long retryBackoffMaxMs,
-            final Ticker ticker
-    ) {
-      this.ticker = ticker;
-      this.queryId = queryId;
-
-      final long now = ticker.read();
-
-      this.waitingTimeMs = baseWaitingTimeMs;
-      this.retryBackoffMaxMs = retryBackoffMaxMs;
-      this.expiryTimeMs = now + baseWaitingTimeMs;
-    }
-
-    public long nextRestartTimeMs() {
-      return expiryTimeMs;
-    }
-
-    public int getNumRetries() {
-      return numRetries;
-    }
-
-    public void backOff() {
-      numRetries++;
-
-      final long now = ticker.read();
-
-      this.waitingTimeMs = getWaitingTimeMs();
-
-      try {
-        Thread.sleep(this.waitingTimeMs);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-
-      LOG.info("Restarting query {} (attempt #{})", queryId, numRetries);
-
-      // Math.max() prevents overflow if now is Long.MAX_VALUE (found just in tests)
-      this.expiryTimeMs = Math.max(now, now + waitingTimeMs);
-    }
-
-    private long getWaitingTimeMs() {
-      if ((waitingTimeMs * 2) < retryBackoffMaxMs) {
-        return waitingTimeMs * 2;
-      } else {
-        return retryBackoffMaxMs;
-      }
-    }
-  }
-
-  public interface Listener {
+  interface Listener {
     /**
      * This method will be called whenever the underlying application
      * throws an uncaught exception.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -449,21 +449,4 @@ public class QueryMetadataImpl implements QueryMetadata {
       }
     }
   }
-
-  public interface ListenerImpl extends Listener {
-    /**
-     * This method will be called whenever the underlying application
-     * throws an uncaught exception.
-     *
-     * @param error the error that occurred
-     */
-    void onError(QueryMetadata queryMetadata, QueryError error);
-
-    void onStateChange(
-        QueryMetadata queryMetadata,
-        KafkaStreams.State before,
-        KafkaStreams.State after);
-
-    void onClose(QueryMetadata queryMetadata);
-  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.common.base.Ticker;
+import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.KafkaStreamsBuilder;
+import io.confluent.ksql.query.QueryError;
+import io.confluent.ksql.query.QueryError.Type;
+import io.confluent.ksql.query.QueryErrorClassifier;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.StreamsTaskMetadata;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.LagInfo;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.apache.kafka.streams.state.StreamsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QueryMetadataImpl implements QueryMetadata {
+
+  private static final Logger LOG = LoggerFactory.getLogger(QueryMetadataImpl.class);
+
+  private final String statementString;
+  private final String executionPlan;
+  private final String queryApplicationId;
+  private final Topology topology;
+  private final KafkaStreamsBuilder kafkaStreamsBuilder;
+  private final Map<String, Object> streamsProperties;
+  private final Map<String, Object> overriddenProperties;
+  private final Set<SourceName> sourceNames;
+  private final LogicalSchema logicalSchema;
+  private final Duration closeTimeout;
+  private final QueryId queryId;
+  private final QueryErrorClassifier errorClassifier;
+  private final TimeBoundedQueue queryErrors;
+  private final RetryEvent retryEvent;
+  private final Listener listener;
+
+  private boolean everStarted = false;
+  protected boolean closed = false;
+  private StreamsUncaughtExceptionHandler uncaughtExceptionHandler = this::uncaughtHandler;
+  private KafkaStreams kafkaStreams;
+  private boolean initialized = false;
+
+  private static final Ticker CURRENT_TIME_MILLIS_TICKER = new Ticker() {
+    @Override
+    public long read() {
+      return System.currentTimeMillis();
+    }
+  };
+
+  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
+  @VisibleForTesting
+  QueryMetadataImpl(
+      final String statementString,
+      final LogicalSchema logicalSchema,
+      final Set<SourceName> sourceNames,
+      final String executionPlan,
+      final String queryApplicationId,
+      final Topology topology,
+      final KafkaStreamsBuilder kafkaStreamsBuilder,
+      final Map<String, Object> streamsProperties,
+      final Map<String, Object> overriddenProperties,
+      final long closeTimeout,
+      final QueryId queryId,
+      final QueryErrorClassifier errorClassifier,
+      final int maxQueryErrorsQueueSize,
+      final long baseWaitingTimeMs,
+      final long retryBackoffMaxMs,
+      final Listener listener
+  ) {
+    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
+    this.statementString = Objects.requireNonNull(statementString, "statementString");
+    this.executionPlan = Objects.requireNonNull(executionPlan, "executionPlan");
+    this.queryApplicationId = Objects.requireNonNull(queryApplicationId, "queryApplicationId");
+    this.topology = Objects.requireNonNull(topology, "kafkaTopicClient");
+    this.kafkaStreamsBuilder = Objects.requireNonNull(kafkaStreamsBuilder, "kafkaStreamsBuilder");
+    this.streamsProperties =
+        ImmutableMap.copyOf(
+            Objects.requireNonNull(streamsProperties, "streamsPropeties"));
+    this.overriddenProperties =
+        ImmutableMap.copyOf(
+            Objects.requireNonNull(overriddenProperties, "overriddenProperties"));
+    this.listener = Objects.requireNonNull(listener, "listener");
+    this.sourceNames = Objects.requireNonNull(sourceNames, "sourceNames");
+    this.logicalSchema = Objects.requireNonNull(logicalSchema, "logicalSchema");
+    this.closeTimeout = Duration.ofMillis(closeTimeout);
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+    this.errorClassifier = Objects.requireNonNull(errorClassifier, "errorClassifier");
+    this.queryErrors = new TimeBoundedQueue(Duration.ofHours(1), maxQueryErrorsQueueSize);
+    this.retryEvent = new RetryEvent(
+        queryId,
+        baseWaitingTimeMs,
+        retryBackoffMaxMs,
+        CURRENT_TIME_MILLIS_TICKER
+    );
+  }
+
+  // Used for sandboxing
+  QueryMetadataImpl(final QueryMetadataImpl other, final Listener listener) {
+    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
+    this.statementString = other.getStatementString();
+    this.kafkaStreams = other.getKafkaStreams();
+    this.executionPlan = other.getExecutionPlan();
+    this.queryApplicationId = other.getQueryApplicationId();
+    this.topology = other.getTopology();
+    this.kafkaStreamsBuilder = other.kafkaStreamsBuilder;
+    this.streamsProperties = other.getStreamsProperties();
+    this.overriddenProperties = other.getOverriddenProperties();
+    this.sourceNames = other.getSourceNames();
+    this.logicalSchema = other.getLogicalSchema();
+    this.closeTimeout = other.closeTimeout;
+    this.queryId = other.getQueryId();
+    this.errorClassifier = other.errorClassifier;
+    this.uncaughtExceptionHandler = other.uncaughtExceptionHandler;
+    this.everStarted = other.everStarted;
+    this.queryErrors = new TimeBoundedQueue(Duration.ZERO, 0);
+    this.retryEvent = new RetryEvent(
+        other.getQueryId(),
+        0,
+        0,
+        new Ticker() {
+          @Override
+          public long read() {
+            return 0;
+          }
+        }
+    );
+    this.listener
+        = Objects.requireNonNull(listener, "stopListeners");
+  }
+
+  public void initialize() {
+    // initialize the first KafkaStreams
+    resetKafkaStreams(kafkaStreamsBuilder.build(topology, streamsProperties));
+    this.initialized = true;
+  }
+
+  protected StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
+      final Throwable e
+  ) {
+    QueryError.Type errorType = Type.UNKNOWN;
+    try {
+      errorType = errorClassifier.classify(e);
+    } catch (final Exception classificationException) {
+      LOG.error("Error classifying unhandled exception", classificationException);
+    } finally {
+      // If error classification throws then we consider the error to be an UNKNOWN error.
+      // We notify listeners and add the error to the errors queue in the finally block to ensure
+      // all listeners and consumers of the error queue (e.g. the API) can see the error. Similarly,
+      // log in finally block to make sure that if there's ever an error in the classification
+      // we still get this in our logs.
+      final QueryError queryError =
+          new QueryError(
+              System.currentTimeMillis(),
+              Throwables.getStackTraceAsString(e),
+              errorType
+          );
+      listener.onError(this, queryError);
+      queryErrors.add(queryError);
+      LOG.error(
+          "Unhandled exception caught in streams thread {}. ({})",
+          Thread.currentThread().getName(),
+          errorType,
+          e
+      );
+    }
+    retryEvent.backOff();
+    return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
+  }
+
+  public Set<StreamsTaskMetadata> getTaskMetadata() {
+    return kafkaStreams.localThreadsMetadata()
+                       .stream()
+                       .flatMap(t -> t.activeTasks().stream())
+                       .map(StreamsTaskMetadata::fromStreamsTaskMetadata)
+                       .collect(Collectors.toSet());
+  }
+
+  public Map<String, Object> getOverriddenProperties() {
+    return overriddenProperties;
+  }
+
+  public String getStatementString() {
+    return statementString;
+  }
+
+  public void setUncaughtExceptionHandler(final StreamsUncaughtExceptionHandler handler) {
+    this.uncaughtExceptionHandler = handler;
+    kafkaStreams.setUncaughtExceptionHandler(handler);
+  }
+
+  public State getState() {
+    return kafkaStreams.state();
+  }
+
+  public boolean isError() {
+    return getState() == State.ERROR;
+  }
+
+  public String getExecutionPlan() {
+    return executionPlan;
+  }
+
+  public String getQueryApplicationId() {
+    return queryApplicationId;
+  }
+
+  public Topology getTopology() {
+    return topology;
+  }
+
+  public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLags() {
+    try {
+      return kafkaStreams.allLocalStorePartitionLags();
+    } catch (IllegalStateException | StreamsException e) {
+      LOG.error(e.getMessage());
+      return ImmutableMap.of();
+    }
+  }
+
+  public Collection<StreamsMetadata> getAllMetadata() {
+    try {
+      return ImmutableList.copyOf(kafkaStreams.allMetadata());
+    } catch (IllegalStateException e) {
+      LOG.error(e.getMessage());
+    }
+    return ImmutableList.of();
+  }
+
+  public Map<String, Object> getStreamsProperties() {
+    return streamsProperties;
+  }
+
+  public LogicalSchema getLogicalSchema() {
+    return logicalSchema;
+  }
+
+  public Set<SourceName> getSourceNames() {
+    return sourceNames;
+  }
+
+  public boolean hasEverBeenStarted() {
+    return everStarted;
+  }
+
+  public QueryId getQueryId() {
+    return queryId;
+  }
+
+  public KsqlQueryType getQueryType() {
+    return KsqlQueryType.PERSISTENT;
+  }
+
+  public String getTopologyDescription() {
+    return topology.describe().toString();
+  }
+
+  public List<QueryError> getQueryErrors() {
+    return queryErrors.toImmutableList();
+  }
+
+  protected boolean isClosed() {
+    return closed;
+  }
+
+  public KafkaStreams getKafkaStreams() {
+    return kafkaStreams;
+  }
+
+  Listener getListener() {
+    return listener;
+  }
+
+  protected void resetKafkaStreams(final KafkaStreams kafkaStreams) {
+    this.kafkaStreams = kafkaStreams;
+    setUncaughtExceptionHandler(uncaughtExceptionHandler);
+    kafkaStreams.setStateListener((b, a) -> listener.onStateChange(this, b, a));
+  }
+
+  protected void closeKafkaStreams() {
+    if (initialized) {
+      kafkaStreams.close(closeTimeout);
+      if (!getState().equals(State.NOT_RUNNING)) {
+        LOG.warn(
+            "query has not terminated even after close. "
+                + "This may happen when streams threads are hung. State: " + getState()
+        );
+      }
+    }
+  }
+
+  protected KafkaStreams buildKafkaStreams() {
+    return kafkaStreamsBuilder.build(topology, streamsProperties);
+  }
+
+  /**
+   * Closes the {@code QueryMetadata} and cleans up any of
+   * the resources associated with it (e.g. internal topics,
+   * schemas, etc...).
+   */
+  public void close() {
+    doClose(true);
+    listener.onClose(this);
+  }
+
+  void doClose(final boolean cleanUp) {
+    closed = true;
+    closeKafkaStreams();
+
+    if (cleanUp) {
+      kafkaStreams.cleanUp();
+    }
+  }
+
+  public static class TimeBoundedQueue {
+    private final Duration duration;
+    private final Queue<QueryError> queue;
+
+    TimeBoundedQueue(final Duration duration, final int capacity) {
+      queue = EvictingQueue.create(capacity);
+      this.duration = duration;
+    }
+
+    public void add(final QueryError e) {
+      queue.add(e);
+      evict();
+    }
+
+    public List<QueryError> toImmutableList() {
+      evict();
+      return ImmutableList.copyOf(queue);
+    }
+    
+    private void evict() {
+      while (queue.peek() != null) {
+        if (queue.peek().getTimestamp() > System.currentTimeMillis() - duration.toMillis()) {
+          break;
+        }
+        queue.poll();
+      }
+    }
+
+  }
+
+  public void start() {
+    if (!initialized) {
+      throw new KsqlException(
+          String.format(
+              "Failed to initialize query %s before starting it",
+              queryApplicationId));
+    }
+    LOG.info("Starting query with application id: {}", queryApplicationId);
+    everStarted = true;
+    listener.onStateChange(this, kafkaStreams.state(), kafkaStreams.state());
+    kafkaStreams.start();
+  }
+
+  public static class RetryEvent implements QueryMetadata.RetryEvent {
+    private final Ticker ticker;
+    private final QueryId queryId;
+
+    private int numRetries = 0;
+    private long waitingTimeMs;
+    private long expiryTimeMs;
+    private long retryBackoffMaxMs;
+
+    RetryEvent(
+            final QueryId queryId,
+            final long baseWaitingTimeMs,
+            final long retryBackoffMaxMs,
+            final Ticker ticker
+    ) {
+      this.ticker = ticker;
+      this.queryId = queryId;
+
+      final long now = ticker.read();
+
+      this.waitingTimeMs = baseWaitingTimeMs;
+      this.retryBackoffMaxMs = retryBackoffMaxMs;
+      this.expiryTimeMs = now + baseWaitingTimeMs;
+    }
+
+    public long nextRestartTimeMs() {
+      return expiryTimeMs;
+    }
+
+    public int getNumRetries() {
+      return numRetries;
+    }
+
+    public void backOff() {
+      numRetries++;
+
+      final long now = ticker.read();
+
+      this.waitingTimeMs = getWaitingTimeMs();
+
+      try {
+        Thread.sleep(this.waitingTimeMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+
+      LOG.info("Restarting query {} (attempt #{})", queryId, numRetries);
+
+      // Math.max() prevents overflow if now is Long.MAX_VALUE (found just in tests)
+      this.expiryTimeMs = Math.max(now, now + waitingTimeMs);
+    }
+
+    private long getWaitingTimeMs() {
+      if ((waitingTimeMs * 2) < retryBackoffMaxMs) {
+        return waitingTimeMs * 2;
+      } else {
+        return retryBackoffMaxMs;
+      }
+    }
+  }
+
+  public interface ListenerImpl extends Listener {
+    /**
+     * This method will be called whenever the underlying application
+     * throws an uncaught exception.
+     *
+     * @param error the error that occurred
+     */
+    void onError(QueryMetadata queryMetadata, QueryError error);
+
+    void onStateChange(
+        QueryMetadata queryMetadata,
+        KafkaStreams.State before,
+        KafkaStreams.State after);
+
+    void onClose(QueryMetadata queryMetadata);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImpl.java
@@ -19,17 +19,17 @@ package io.confluent.ksql.util;
  * Sandboxed {@link PersistentQueryMetadata} that prevents to modify the state of the internal
  * {@link org.apache.kafka.streams.KafkaStreams}.
  */
-public final class SandboxedPersistentQueryMetadata extends PersistentQueryMetadata {
-  public static SandboxedPersistentQueryMetadata of(
-      final PersistentQueryMetadata queryMetadata,
-      final Listener listener
+public final class SandboxedPersistentQueryMetadataImpl extends PersistentQueryMetadataImpl {
+  public static SandboxedPersistentQueryMetadataImpl of(
+      final PersistentQueryMetadataImpl queryMetadata,
+      final QueryMetadata.Listener listener
   ) {
-    return new SandboxedPersistentQueryMetadata(queryMetadata, listener);
+    return new SandboxedPersistentQueryMetadataImpl(queryMetadata, listener);
   }
 
-  private SandboxedPersistentQueryMetadata(
-      final PersistentQueryMetadata queryMetadata,
-      final Listener listener
+  private SandboxedPersistentQueryMetadataImpl(
+      final PersistentQueryMetadataImpl queryMetadata,
+      final QueryMetadata.Listener listener
   ) {
     super(queryMetadata, listener);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedTransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedTransientQueryMetadata.java
@@ -33,7 +33,7 @@ public final class SandboxedTransientQueryMetadata extends TransientQueryMetadat
 
   public static SandboxedTransientQueryMetadata of(
       final TransientQueryMetadata queryMetadata,
-      final Listener listener
+      final QueryMetadata.Listener listener
   ) {
     return new SandboxedTransientQueryMetadata(
         Objects.requireNonNull(queryMetadata, "queryMetadata"),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -32,7 +32,7 @@ import org.apache.kafka.streams.Topology;
 /**
  * Metadata of a transient query, e.g. {@code SELECT * FROM FOO;}.
  */
-public class TransientQueryMetadata extends QueryMetadata {
+public class TransientQueryMetadata extends QueryMetadataImpl {
 
   public enum ResultType {
     STREAM,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -78,7 +78,7 @@ import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 
-import io.confluent.ksql.util.SandboxedPersistentQueryMetadata;
+import io.confluent.ksql.util.SandboxedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.SandboxedTransientQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.IOException;
@@ -980,7 +980,7 @@ public class KsqlEngineTest {
         if (q instanceof TransientQueryMetadata) {
           assertTrue(sq instanceof SandboxedTransientQueryMetadata);
         } else {
-          assertTrue(sq instanceof SandboxedPersistentQueryMetadata);
+          assertTrue(sq instanceof SandboxedPersistentQueryMetadataImpl);
         }
       }
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -54,6 +54,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.QueryMetadataImpl;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Collections;
 import java.util.List;
@@ -178,7 +179,7 @@ public class QueryExecutorTest {
   @Mock
   private SessionConfig config;
   @Mock
-  private QueryMetadata.Listener queryListener;
+  private QueryMetadataImpl.ListenerImpl queryListener;
   @Captor
   private ArgumentCaptor<Map<String, Object>> propertyCaptor;
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -179,7 +179,7 @@ public class QueryExecutorTest {
   @Mock
   private SessionConfig config;
   @Mock
-  private QueryMetadataImpl.ListenerImpl queryListener;
+  private QueryMetadata.Listener queryListener;
   @Captor
   private ArgumentCaptor<Map<String, Object>> propertyCaptor;
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.query.QueryRegistryImpl.QueryExecutorFactory;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Map;
@@ -330,7 +331,7 @@ public class QueryRegistryImplTest {
       boolean createAs
   ) {
     final QueryId queryId = new QueryId(id);
-    final PersistentQueryMetadata query = mock(PersistentQueryMetadata.class);
+    final PersistentQueryMetadata query = mock(PersistentQueryMetadataImpl.class);
     final DataSource sinkSource = mock(DataSource.class);
     when(sinkSource.getName()).thenReturn(SourceName.of(sink));
     when(query.getQueryId()).thenReturn(queryId);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -105,7 +105,7 @@ public class PersistentQueryMetadataTest {
         .thenReturn(Optional.of(materializationProvider));
     when(kafkaStreams.state()).thenReturn(State.NOT_RUNNING);
 
-    query = new PersistentQueryMetadata(
+    query = new PersistentQueryMetadataImpl(
         SQL,
         physicalSchema,
         Collections.emptySet(),

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -41,7 +41,6 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
-import io.confluent.ksql.util.QueryMetadata.Listener;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
@@ -79,7 +78,7 @@ public class QueryMetadataTest {
   @Mock
   private KafkaStreams kafkaStreams;
   @Mock
-  private Listener listener;
+  private QueryMetadataImpl.Listener listener;
   @Mock
   private QueryErrorClassifier classifier;
   @Captor
@@ -87,7 +86,7 @@ public class QueryMetadataTest {
   @Mock
   private Ticker ticker;
 
-  private QueryMetadata query;
+  private QueryMetadataImpl query;
 
   @Before
   public void setup() {
@@ -95,7 +94,7 @@ public class QueryMetadataTest {
     when(classifier.classify(any())).thenReturn(Type.UNKNOWN);
     when(kafkaStreams.state()).thenReturn(State.NOT_RUNNING);
 
-    query = new QueryMetadata(
+    query = new QueryMetadataImpl(
         "foo",
         SOME_SCHEMA,
         SOME_SOURCES,
@@ -231,7 +230,7 @@ public class QueryMetadataTest {
     when(ticker.read()).thenReturn(now);
 
     // When:
-    final QueryMetadata.RetryEvent retryEvent = new QueryMetadata.RetryEvent(
+    final QueryMetadataImpl.RetryEvent retryEvent = new QueryMetadataImpl.RetryEvent(
             QUERY_ID,
             RETRY_BACKOFF_INITIAL_MS,
             RETRY_BACKOFF_MAX_MS,
@@ -250,7 +249,7 @@ public class QueryMetadataTest {
     when(ticker.read()).thenReturn(now);
 
     // When:
-    final QueryMetadata.RetryEvent retryEvent = new QueryMetadata.RetryEvent(
+    final QueryMetadataImpl.RetryEvent retryEvent = new QueryMetadataImpl.RetryEvent(
             QUERY_ID,
             RETRY_BACKOFF_INITIAL_MS,
             RETRY_BACKOFF_MAX_MS,
@@ -271,7 +270,7 @@ public class QueryMetadataTest {
     when(ticker.read()).thenReturn(now);
 
     // When:
-    final QueryMetadata.RetryEvent retryEvent = new QueryMetadata.RetryEvent(
+    final QueryMetadataImpl.RetryEvent retryEvent = new QueryMetadataImpl.RetryEvent(
             QUERY_ID,
             RETRY_BACKOFF_INITIAL_MS,
             RETRY_BACKOFF_MAX_MS,
@@ -288,7 +287,7 @@ public class QueryMetadataTest {
   @Test
   public void shouldEvictBasedOnTime() {
     // Given:
-    final QueryMetadata.TimeBoundedQueue queue = new QueryMetadata.TimeBoundedQueue(Duration.ZERO, 1);
+    final QueryMetadataImpl.TimeBoundedQueue queue = new QueryMetadataImpl.TimeBoundedQueue(Duration.ZERO, 1);
     queue.add(new QueryError(System.currentTimeMillis(), "test", Type.SYSTEM));
 
     //Then:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImplTest.java
@@ -97,7 +97,7 @@ public class SandboxedPersistentQueryMetadataImplTest {
     when(materializationProviderBuilder.apply(kafkaStreams, topology))
         .thenReturn(Optional.of(materializationProvider));
 
-    final PersistentQueryMetadata query = new PersistentQueryMetadataImpl(
+    final PersistentQueryMetadataImpl query = new PersistentQueryMetadataImpl(
         SQL,
         physicalSchema,
         Collections.emptySet(),

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImplTest.java
@@ -46,7 +46,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SandboxedPersistentQueryMetadataTest {
+public class SandboxedPersistentQueryMetadataImplTest {
   private static final String SQL = "sql";
   private static final String EXECUTION_PLAN = "execution plan";
   private static final QueryId QUERY_ID = new QueryId("queryId");
@@ -87,7 +87,8 @@ public class SandboxedPersistentQueryMetadataTest {
   @Mock
   private Listener sandboxListener;
 
-  private SandboxedPersistentQueryMetadata sandbox;
+  private PersistentQueryMetadataImpl query;
+  private SandboxedPersistentQueryMetadataImpl sandbox;
 
   @Before
   public void setUp() {
@@ -96,7 +97,7 @@ public class SandboxedPersistentQueryMetadataTest {
     when(materializationProviderBuilder.apply(kafkaStreams, topology))
         .thenReturn(Optional.of(materializationProvider));
 
-    final PersistentQueryMetadata query = new PersistentQueryMetadata(
+    final PersistentQueryMetadata query = new PersistentQueryMetadataImpl(
         SQL,
         physicalSchema,
         Collections.emptySet(),
@@ -122,7 +123,7 @@ public class SandboxedPersistentQueryMetadataTest {
 
     query.initialize();
 
-    sandbox = SandboxedPersistentQueryMetadata.of(query, sandboxListener);
+    sandbox = SandboxedPersistentQueryMetadataImpl.of(query, sandboxListener);
     reset(kafkaStreams);
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImplTest.java
@@ -87,7 +87,6 @@ public class SandboxedPersistentQueryMetadataImplTest {
   @Mock
   private Listener sandboxListener;
 
-  private PersistentQueryMetadataImpl query;
   private SandboxedPersistentQueryMetadataImpl sandbox;
 
   @Before

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedTransientQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedTransientQueryMetadataTest.java
@@ -66,7 +66,6 @@ public class SandboxedTransientQueryMetadataTest {
     when(original.getSourceNames()).thenReturn(SOURCE_NAMES);
     when(original.getExecutionPlan()).thenReturn(PLAN);
     when(original.getQueryApplicationId()).thenReturn(APP_ID);
-    when(original.getResultType()).thenReturn(RESULT_TYPE);
     when(original.getLogicalSchema()).thenReturn(schema);
     when(original.getTopology()).thenReturn(topology);
     sandboxed = SandboxedTransientQueryMetadata.of(original, listener);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata.ResultType;
@@ -148,7 +149,7 @@ public class QueryDescriptionFactoryTest {
 
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery, Collections.emptyMap());
 
-    persistentQuery = new PersistentQueryMetadata(
+    persistentQuery = new PersistentQueryMetadataImpl(
         SQL_TEXT,
         PhysicalSchema.from(PERSISTENT_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of()),
         SOURCE_NAMES,


### PR DESCRIPTION
In order to make bin packed Queries easier to implement I refactored the current version.

Now I can just implement the PersistantQueryMetadata interface and drop it in place. This will make the feature flag logic and change over much easier.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

