### PR TITLE
feat: support for NOT NULL

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -328,7 +328,8 @@ final class AdminResponseHandlers {
               .map(f -> new FieldInfoImpl(
                   f.getString("name"),
                   new ColumnTypeImpl(f.getJsonObject("schema").getString("type")),
-                  "KEY".equals(f.getString("type"))))
+                  "KEY".equals(f.getString("type")),
+                   f.getJsonObject("schema").getBoolean("optional")))
               .collect(Collectors.toList()),
           source.getString("topic"),
           source.getString("keyFormat"),

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/FieldInfoImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/FieldInfoImpl.java
@@ -24,11 +24,14 @@ public final class FieldInfoImpl implements FieldInfo {
   private final String name;
   private final ColumnType type;
   private final boolean isKey;
+  private final boolean isOptional;
 
-  FieldInfoImpl(final String name, final ColumnType type, final boolean isKey) {
+  FieldInfoImpl(final String name, final ColumnType type, final boolean isKey,
+                final boolean isOptional) {
     this.name = Objects.requireNonNull(name, "name");
     this.type = Objects.requireNonNull(type, "type");
     this.isKey = isKey;
+    this.isOptional = isOptional;
   }
 
   @Override
@@ -47,6 +50,11 @@ public final class FieldInfoImpl implements FieldInfo {
   }
 
   @Override
+  public boolean isOptional() {
+    return isOptional;
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
@@ -57,12 +65,13 @@ public final class FieldInfoImpl implements FieldInfo {
     final FieldInfoImpl fieldInfo = (FieldInfoImpl) o;
     return name.equals(fieldInfo.name)
         && type.equals(fieldInfo.type)
-        && isKey == fieldInfo.isKey;
+        && isKey == fieldInfo.isKey
+        && isOptional == fieldInfo.isOptional;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, type, isKey);
+    return Objects.hash(name, type, isKey, isOptional);
   }
 
   @Override
@@ -71,6 +80,7 @@ public final class FieldInfoImpl implements FieldInfo {
         + "name='" + name + '\''
         + ", type=" + type
         + ", isKey=" + isKey
+        + ", isOptional=" + isOptional
         + '}';
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -1375,8 +1375,8 @@ public class ClientTest extends BaseApiTest {
                 KsqlQueryType.PERSISTENT)),
             Collections.emptyList(),
             ImmutableList.of(
-                new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.of(FieldType.KEY)),
-                new FieldInfo("f2", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty())),
+                new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null, true), Optional.of(FieldType.KEY)),
+                new FieldInfo("f2", new SchemaInfo(SqlBaseType.INTEGER, null, null, false), Optional.empty())),
             "TABLE",
             "",
             "",
@@ -1405,9 +1405,11 @@ public class ClientTest extends BaseApiTest {
     assertThat(description.fields().get(0).name(), is("f1"));
     assertThat(description.fields().get(0).type().getType(), is(ColumnType.Type.STRING));
     assertThat(description.fields().get(0).isKey(), is(true));
+    assertThat(description.fields().get(0).isOptional(), is(true));
     assertThat(description.fields().get(1).name(), is("f2"));
     assertThat(description.fields().get(1).type().getType(), is(ColumnType.Type.INTEGER));
     assertThat(description.fields().get(1).isKey(), is(false));
+    assertThat(description.fields().get(1).isOptional(), is(false));
     assertThat(description.topic(), is("topic"));
     assertThat(description.keyFormat(), is("KAFKA"));
     assertThat(description.valueFormat(), is("JSON"));

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/FieldInfoImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/FieldInfoImplTest.java
@@ -24,17 +24,30 @@ public class FieldInfoImplTest {
   public void shouldImplementHashCodeAndEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false),
-            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)
+            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true),
+            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false,true)
         )
         .addEqualityGroup(
-            new FieldInfoImpl("f2", new ColumnTypeImpl("STRING"), false)
+            new FieldInfoImpl("f2", new ColumnTypeImpl("STRING"), false, true)
         )
         .addEqualityGroup(
-            new FieldInfoImpl("f1", new ColumnTypeImpl("BOOLEAN"), false)
+            new FieldInfoImpl("f1", new ColumnTypeImpl("BOOLEAN"), false,true)
         )
         .addEqualityGroup(
-            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), true)
+            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), true,true)
+        )
+        .addEqualityGroup(
+            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, false),
+            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false,false)
+        )
+        .addEqualityGroup(
+            new FieldInfoImpl("f2", new ColumnTypeImpl("STRING"), false, false)
+        )
+        .addEqualityGroup(
+            new FieldInfoImpl("f1", new ColumnTypeImpl("BOOLEAN"), false,false)
+        )
+        .addEqualityGroup(
+            new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), true,false)
         )
         .testEquals();
   }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/SourceDescriptionImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/SourceDescriptionImplTest.java
@@ -30,7 +30,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -45,7 +45,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -62,7 +62,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "other_name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -79,7 +79,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "other_type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -96,7 +96,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("other_f", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("other_f", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -113,7 +113,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("INTEGER"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("INTEGER"), false,true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -130,7 +130,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "other_topic",
                 "keyFormat",
                 "valueFormat",
@@ -147,7 +147,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "other_keyFormat",
                 "valueFormat",
@@ -164,7 +164,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "other_valueFormat",
@@ -181,7 +181,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -197,7 +197,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -213,7 +213,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -230,7 +230,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",
@@ -247,7 +247,7 @@ public class SourceDescriptionImplTest {
             new SourceDescriptionImpl(
                 "name",
                 "type",
-                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false)),
+                Collections.singletonList(new FieldInfoImpl("f1", new ColumnTypeImpl("STRING"), false, true)),
                 "topic",
                 "keyFormat",
                 "valueFormat",

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -359,7 +359,7 @@ public class ConsoleTest {
             ImmutableList.of(
                 new FieldInfo(
                     "name",
-                    new SchemaInfo(SqlBaseType.STRING, ImmutableList.of(), null),
+                    new SchemaInfo(SqlBaseType.STRING, ImmutableList.of(), null, true),
                     Optional.empty())),
             ImmutableSet.of("source"),
             ImmutableSet.of("sink"),
@@ -661,17 +661,18 @@ public class ConsoleTest {
             "typeB", new SchemaInfo(
                 SqlBaseType.ARRAY,
                 null,
-                new SchemaInfo(SqlBaseType.STRING, null, null)),
+                new SchemaInfo(SqlBaseType.STRING, null, null, false), false),
             "typeA", new SchemaInfo(
                 SqlBaseType.STRUCT,
                 ImmutableList.of(
-                    new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())),
-                null),
+                    new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null, false), Optional.empty())),
+                null, false),
             "typeC", new SchemaInfo(
                 SqlBaseType.DECIMAL,
                 null,
                 null,
-                ImmutableMap.of("precision", 10, "scale", 9)
+                ImmutableMap.of("precision", 10, "scale", 9),
+                true
             )
         ))
     ));

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -72,7 +72,6 @@ public final class DecimalUtil {
     validateParameters(precision, scale);
     return org.apache.kafka.connect.data.Decimal
         .builder(scale)
-        .optional()
         .parameter(PRECISION_FIELD, Integer.toString(precision));
   }
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/json/StructSerializationModuleTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/json/StructSerializationModuleTest.java
@@ -50,7 +50,7 @@ public class StructSerializationModuleTest {
       .field("ITEMID", Schema.INT64_SCHEMA)
       .field("NAME", Schema.STRING_SCHEMA)
       .field("CATEGORY", categorySchema)
-      .field("COST", DecimalUtil.builder(4, 2).build())
+      .field("COST", DecimalUtil.builder(4, 2).optional().build())
       .optional().build();
 
   private ObjectMapper objectMapper;

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/connect/SqlSchemaFormatterTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/connect/SqlSchemaFormatterTest.java
@@ -98,8 +98,8 @@ public class SqlSchemaFormatterTest {
 
   @Test
   public void shouldFormatDecimal() {
-    assertThat(DEFAULT.format(DecimalUtil.builder(2, 1).build()), is("DECIMAL(2, 1)"));
-    assertThat(STRICT.format(DecimalUtil.builder(2, 1).build()), is("DECIMAL(2, 1)"));
+    assertThat(DEFAULT.format(DecimalUtil.builder(2, 1).optional().build()), is("DECIMAL(2, 1)"));
+    assertThat(STRICT.format(DecimalUtil.builder(2, 1).optional().build()), is("DECIMAL(2, 1)"));
   }
 
   @Test

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 @SuppressWarnings("ConstantConditions")
 public class DecimalUtilTest {
 
-  private static final Schema DECIMAL_SCHEMA = DecimalUtil.builder(2, 1).build();
+  private static final Schema DECIMAL_SCHEMA = DecimalUtil.builder(2, 1).optional().build();
 
   @Test
   public void shouldBuildCorrectSchema() {
@@ -49,7 +49,7 @@ public class DecimalUtilTest {
   @Test
   public void shouldCopyBuilder() {
     // When:
-    final Schema copy = DecimalUtil.builder(DECIMAL_SCHEMA).build();
+    final Schema copy = DecimalUtil.builder(DECIMAL_SCHEMA).optional().build();
 
     // Then:
     assertThat(copy, is(DECIMAL_SCHEMA));

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -1128,6 +1128,30 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "JSON does not support the following configs: [fullSchemaName]"
       }
+    },
+    {
+      "name": "not null - missing require field `b` doesn't insert in topic `input_topic`",
+      "statements": [
+        "CREATE STREAM INPUT (a string not null, b string not null) WITH (kafka_topic='input_topic', value_format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "topics": [
+        {
+          "name": "input_topic",
+          "valueSchema": {
+            "name": "inputValue", 
+            "type": "record", 
+            "namespace": "io.confluent.ksql.avro_schemas", 
+            "fields": [ 
+              { "name": "a", "type": [ "null", "string" ], "default": null },
+              { "name": "b", "type": [ "null", "string" ], "default": null }
+            ]},
+          "valueFormat": "AVRO"
+        }
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"a": "foo"}}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/insert-into.json
@@ -209,6 +209,333 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Result schema is `K` STRING KEY, `DATA_1` STRING, `DATA_2` STRING, `DATA_3` STRING\nSink schema is `K` STRING KEY, `DATA_1` STRING, `DATA_2` STRING"
       }
+    },
+    {
+      "name": "fails when not inserting value to a VARCHAR NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data VARCHAR NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: STRING"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a STRING NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data STRING NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: STRING"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a INT32 NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data INT NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: INT32"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a BOOLEAN NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data BOOLEAN NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: BOOLEAN"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a BIGINT NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data BIGINT NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: INT64"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a DOUBLE NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data DOUBLE NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: FLOAT64"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a DECIMAL NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data DECIMAL(20,10) NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar') ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: BYTES"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a ARRAY<STRING> NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data ARRAY<STRING> NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar') ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: ARRAY"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a MAP<STRING, INT> NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data MAP<STRING, INT> NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar') ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: MAP"
+      }
+    },
+    {
+      "name": "fails when not inserting value to a MAP<STRING, INT NOT NULL> NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data MAP<STRING, INT NOT NULL> NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K, data) VALUES ('bar', MAP('key':=null)) ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Failed to insert values into 'SOURCE1'. Invalid insert value: Cannot construct a map with all NULL values (see https://github.com/confluentinc/ksql/issues/4239). As a workaround, you may cast a NULL value to the desired type.. expression:MAP('key':=null), schema:"
+      }
+    },
+    {
+      "name": "fails when inserting null to a STRUCT<a VARCHAR, b INT> NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, data STRUCT<a VARCHAR, b INT> NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (K) VALUES ('bar') ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"DATA\", schema type: STRUCT"
+      }
+    },
+    {
+      "name": "fails when inserting null to a STRUCT<a VARCHAR, b INT NOT NULL> NOT NULL column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (data STRUCT<a VARCHAR, b INTEGER NOT NULL, c DOUBLE NOT NULL> NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (data) VALUES (STRUCT(a:='a')) ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Failed to insert values into 'SOURCE1'. Could not serialize value: [ Struct{A=a} ]. Failed to prepare Struct value field 'DATA' for serialization. This could happen if the value was produced by a user-defined function where the schema has non-optional return types."
+      }
+    },
+    {
+      "name": "fails when inserting null to a MAP<STRING, STRUCT<a VARCHAR, b INT NOT NULL>> column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (data MAP<STRING, STRUCT<a VARCHAR, b INT NOT NULL>>) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (data) VALUES (MAP('key':=STRUCT(a:='a'))) ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"B\", schema type: INT32"
+      }
+    },
+    {
+      "name": "fails when inserting null to a ARRAY<STRUCT<a VARCHAR, b INT NOT NULL>> column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (data ARRAY<STRUCT<a VARCHAR, b INT NOT NULL>>) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (data) VALUES (ARRAY[STRUCT(a:='a')]) ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"B\", schema type: INT32"
+      }
+    },
+    {
+      "name": "fails when inserting null to a ARRAY<STRUCT<a VARCHAR NOT NULL, b INT NULL, c DOUBLE NOT NULL>> column",
+      "statements": [
+        "CREATE STREAM SOURCE1 (data ARRAY<STRUCT<a VARCHAR, b INT NULL, c DOUBLE NOT NULL>>) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "INSERT INTO SOURCE1 (data) VALUES (ARRAY[STRUCT(b:=1)]) ;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"C\", schema type: FLOAT64"
+      }
+    },
+    {
+      "name": "insert null into NOT NULL field fails the insert",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 VARCHAR NOT NULL, v2 STRING NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v2) VALUES ('string');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Invalid value: null used for required field: \"V1\", schema type: STRING"
+      }
+    },
+    {
+      "name": "insert primitives VARCHAR NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 VARCHAR NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES ('varchar1');"
+      ],
+      "inputs": [
+        {"topic": "insert-source",  "value": {"v1" : "varchar2" }}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": "varchar1" }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": "varchar2" }}
+      ]
+    },
+    {
+      "name": "insert values to STRING NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 STRING NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES ('string1');"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": "string2"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": "string1" }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": "string2" }}
+      ]
+    },
+    {
+      "name": "insert values to INT NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 INT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES (1);"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 1 }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 2 }}
+      ]
+    },
+    {
+      "name": "insert values to INTEGER NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 INTEGER NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES (1);"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 1 }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 2 }}
+      ]
+    },
+    {
+      "name": "insert values to DOUBLE NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 DOUBLE NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES (1.0);"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": 2.0}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 1.0 }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 2.0 }}
+      ]
+    },
+    {
+      "name": "insert values to BIGINT NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 BIGINT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES (1);"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 1 }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 2 }}
+      ]
+    },
+    {
+      "name": "insert values to BOOLEAN NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 BOOLEAN NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES (true);"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": false}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": true }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": false }}
+      ]
+    },
+    {
+      "name": "insert values to DECIMAL NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 DECIMAL(6,4) NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES (1);"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 1.0000 }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": 2.0000 }}
+      ]
+    },
+    {
+      "name": "insert values to MAP NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 MAP<STRING, INTEGER NULL> NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES (MAP('k':=1));"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": {"k": 2}}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": {"k": 1} }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": {"k": 2} }}
+      ]
+    },
+    {
+      "name": "insert values to ARRAY NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 ARRAY<INTEGER> NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;",
+        "INSERT INTO OUTPUT (v1) VALUES (ARRAY[1]);"
+      ],
+      "inputs": [
+        {"topic": "insert-source", "value": {"v1": [2]}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"V1": [1] }},
+        {"topic": "OUTPUT", "key": null, "value": {"V1": [2] }}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
@@ -259,6 +259,40 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Invalid comparison expression 'null' in join '(L.A = null)'. Each side of the join comparision must contain references from exactly one source."
       }
+    },
+    {
+      "name": "null values in column NOT NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 INT NOT NULL, v2 STRING) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;"
+      ],
+      "inputs": [
+        {"topic": "insert-source",  "value": {"v1":  1, "v2": "v2"}},
+        {"topic": "insert-source",  "value": {"v1":  null, "v2": "v2"}},
+        {"topic": "insert-source",  "value": {"v2": "v2"}}
+      ],
+      "outputs": [
+        {"topic": "insert-source", "key":null,  "value": {"v1":  1, "v2": "v2"}},
+        {"topic": "insert-source", "key":null,  "value": {"v1":  null, "v2": "v2"}},
+        {"topic": "insert-source", "key":null,  "value": {"v2": "v2"}}
+      ]
+    },
+    {
+      "name": "null values in column NOT NULL DELIMITED",
+      "statements": [
+        "CREATE STREAM SOURCE1 (v1 INT NOT NULL, v2 STRING) WITH (kafka_topic='insert-source', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;"
+      ],
+      "inputs": [
+        {"topic": "insert-source",  "value": "1, 'bob'"},
+        {"topic": "insert-source",  "value": "'bob'"},
+        {"topic": "insert-source",  "value": "'bob'"}
+      ],
+      "outputs": [
+        {"topic": "insert-source", "key":null,  "value": "1, 'bob'"},
+        {"topic": "insert-source", "key":null,  "value": "'bob'"},
+        {"topic": "insert-source", "key":null,  "value": "'bob'"}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/select.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/select.json
@@ -107,6 +107,42 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Line: 3, Col: 3: SELECT column 'I.BOB' cannot be resolved."
       }
+    },
+    {
+      "name": "value column NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (data INT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;"
+      ],
+      "inputs": [
+        {"topic": "insert-source",  "value": {"data":  1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"DATA": 1}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "data INT NULL"}
+        ]
+      }
+    },
+    {
+      "name": "value column NOT NULL",
+      "statements": [
+        "CREATE STREAM SOURCE1 (data INT NOT NULL) WITH (kafka_topic='insert-source', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM SOURCE1;"
+      ],
+      "inputs": [
+        {"topic": "insert-source",  "value": {"data":  1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"DATA": 1}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "data INT NOT NULL"}
+        ]
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/udf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/udf.json
@@ -87,6 +87,23 @@
           }
         ]
       }
+    },
+    {
+      "name": "struct args, UDFs that returns non-optional data types ",
+      "statements": [
+        "CREATE STREAM INPUT (col0 VARCHAR) WITH (kafka_topic='test_topic', value_format='AVRO');",
+        "CREATE STREAM OUTPUT AS SELECT test_udtf(1) as col0 FROM INPUT EMIT CHANGES;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"col0":  "mytest"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"COL0": {"TEST1": "1", "TEST2": "2"}}}
+      ],
+      "expectedException": {
+        "type": "org.apache.kafka.streams.errors.StreamsException",
+        "message": "Error encountered sending record to topic OUTPUT for task 0_0 due to:\norg.apache.kafka.common.errors.SerializationException: Failed to prepare Struct value field 'COL0' for serialization. This could happen if the value was produced by a user-defined function where the schema has non-optional return types."
+      }
     }
   ]
 }

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -324,11 +324,11 @@ booleanValue
     ;
 
 type
-    : type ARRAY
-    | ARRAY '<' type '>'
-    | MAP '<' type ',' type '>'
-    | STRUCT '<' (identifier type (',' identifier type)*)? '>'
-    | DECIMAL '(' number ',' number ')'
+    : type ARRAY constraint?
+    | ARRAY '<' type '>' constraint?
+    | MAP '<' type ',' type '>' constraint?
+    | STRUCT '<' (identifier type (',' identifier type)*)? '>' constraint?
+    | DECIMAL '(' number ',' number ')' constraint?
     | baseType ('(' typeParameter (',' typeParameter)* ')')?
     ;
 
@@ -337,7 +337,12 @@ typeParameter
     ;
 
 baseType
-    : identifier
+    : identifier constraint?
+    ;
+
+constraint
+    : NOT NULL
+    | NULL
     ;
 
 whenClause

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/schema/ksql/SqlTypeParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/schema/ksql/SqlTypeParserTest.java
@@ -11,7 +11,11 @@ import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
+
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,99 +37,172 @@ public class SqlTypeParserTest {
   public void shouldGetTypeFromVarchar() {
     // Given:
     final String schemaString = "VARCHAR";
+    final String schemaStringWithNull = "VARCHAR NULL";
+    final String schemaStringRequired = "VARCHAR NOT NULL";
 
     // When:
     final Type type = parser.parse(schemaString);
+    final Type typeWithNull = parser.parse(schemaStringWithNull);
+    final Type typeRequired = parser.parse(schemaStringRequired);
 
     // Then:
     assertThat(type, is(new Type(SqlTypes.STRING)));
+    assertThat(type.getSqlType().isOptional(), is(true));
+    assertThat(typeWithNull, is(new Type(SqlTypes.STRING)));
+    assertThat(typeWithNull.getSqlType().isOptional(), is(true));
+    assertThat(typeRequired, is(new Type(SqlTypes.STRING.required())));
+    assertThat(typeRequired.getSqlType().isOptional(), is(false));
   }
 
   @Test
   public void shouldGetTypeFromDecimal() {
     // Given:
     final String schemaString = "DECIMAL(2, 1)";
+    final String schemaStringWithNull = "DECIMAL(2, 1) NULL";
+    final String schemaStringRequired = "DECIMAL(2, 1) NOT NULL";
 
     // When:
     final Type type = parser.parse(schemaString);
+    final Type typeWithNull = parser.parse(schemaStringWithNull);
+    final Type typeRequired = parser.parse(schemaStringRequired);
 
     // Then:
     assertThat(type, is(new Type(SqlTypes.decimal(2, 1))));
+    assertThat(type.getSqlType().isOptional(), is(true));
+    assertThat(typeWithNull, is(new Type(SqlTypes.decimal(2, 1))));
+    assertThat(typeWithNull.getSqlType().isOptional(), is(true));
+    assertThat(typeRequired, is(new Type(SqlTypes.decimal(2, 1).required())));
+    assertThat(typeRequired.getSqlType().isOptional(), is(false));
   }
 
   @Test
   public void shouldGetTypeFromStringArray() {
     // Given:
     final String schemaString = "ARRAY<VARCHAR>";
+    final String schemaStringWithNull = "ARRAY<VARCHAR> NULL";
+    final String schemaStringRequired = "ARRAY<VARCHAR> NOT NULL";
 
     // When:
     final Type type = parser.parse(schemaString);
+    final Type typeWithNull = parser.parse(schemaStringWithNull);
+    final Type typeRequired = parser.parse(schemaStringRequired);
 
     // Then:
     assertThat(type, is(new Type(SqlTypes.array(SqlTypes.STRING))));
+    assertThat(type.getSqlType().isOptional(), is(true));
+    assertThat(typeWithNull, is(new Type(SqlTypes.array(SqlTypes.STRING))));
+    assertThat(typeWithNull.getSqlType().isOptional(), is(true));
+    assertThat(typeRequired, is(new Type(SqlTypes.array(SqlTypes.STRING).required())));
+    assertThat(typeRequired.getSqlType().isOptional(), is(false));
   }
 
   @Test
   public void shouldGetTypeFromIntArray() {
     // Given:
     final String schemaString = "ARRAY<INT>";
+    final String schemaStringWithNull = "ARRAY<INT> NULL";
+    final String schemaStringRequired = "ARRAY<INT> NOT NULL";
 
     // When:
     final Type type = parser.parse(schemaString);
+    final Type typeWithNull = parser.parse(schemaStringWithNull);
+    final Type typeRequired = parser.parse(schemaStringRequired);
 
     // Then:
     assertThat(type, is(new Type(SqlTypes.array(SqlTypes.INTEGER))));
+    assertThat(type.getSqlType().isOptional(), is(true));
+    assertThat(typeWithNull, is(new Type(SqlTypes.array(SqlTypes.INTEGER))));
+    assertThat(typeWithNull.getSqlType().isOptional(), is(true));
+    assertThat(typeRequired, is(new Type(SqlTypes.array(SqlTypes.INTEGER).required())));
+    assertThat(typeRequired.getSqlType().isOptional(), is(false));
   }
 
   @Test
   public void shouldGetTypeFromMap() {
     // Given:
     final String schemaString = "MAP<BIGINT, INT>";
+    final String schemaStringWithNull = "MAP<BIGINT, INT> NULL";
+    final String schemaStringRequired = "MAP<BIGINT, INT NOT NULL> NOT NULL";
 
     // When:
     final Type type = parser.parse(schemaString);
+    final Type typeWithNull = parser.parse(schemaStringWithNull);
+    final Type typeRequired = parser.parse(schemaStringRequired);
 
     // Then:
     assertThat(type, is(new Type(SqlTypes.map(SqlTypes.BIGINT, SqlTypes.INTEGER))));
+    assertThat(type.getSqlType().isOptional(), is(true));
+    assertThat(typeWithNull, is(new Type(SqlTypes.map(SqlTypes.BIGINT, SqlTypes.INTEGER))));
+    assertThat(typeWithNull.getSqlType().isOptional(), is(true));
+    assertThat(typeRequired, is(new Type(SqlTypes.map(SqlTypes.BIGINT, SqlTypes.INTEGER.required()).required())));
+    assertThat(typeRequired.getSqlType().isOptional(), is(false));
   }
 
   @Test
   public void shouldGetTypeFromStruct() {
     // Given:
     final String schemaString = "STRUCT<A VARCHAR>";
+    final String schemaStringWithNull = "STRUCT<A VARCHAR> NULL";
+    final String schemaStringRequired = "STRUCT<A VARCHAR> NOT NULL";
 
     // When:
     final Type type = parser.parse(schemaString);
+    final Type typeWithNull = parser.parse(schemaStringWithNull);
+    final Type typeRequired = parser.parse(schemaStringRequired);
 
     // Then:
     assertThat(type, is(new Type(SqlTypes.struct().field("A", SqlTypes.STRING).build())));
+    assertThat(type.getSqlType().isOptional(), is(true));
+    assertThat(typeWithNull, is(new Type(SqlTypes.struct().field("A", SqlTypes.STRING).build())));
+    assertThat(typeWithNull.getSqlType().isOptional(), is(true));
+    assertThat(typeRequired, is(new Type(SqlTypes.struct().field("A", SqlTypes.STRING).build().required())));
+    assertThat(typeRequired.getSqlType().isOptional(), is(false));
   }
 
   @Test
   public void shouldGetTypeFromEmptyStruct() {
     // Given:
     final String schemaString = SqlTypes.struct().build().toString();
+    final String schemaStringRequired = SqlTypes.struct().build().required().toString();
 
     // When:
     final Type type = parser.parse(schemaString);
+    final Type typeRequired = parser.parse(schemaStringRequired);
 
     // Then:
     assertThat(type, is(new Type(SqlTypes.struct().build())));
+    assertThat(type.getSqlType().isOptional(), is(true));
+    assertThat(typeRequired, is(new Type(SqlTypes.struct().build().required())));
+    assertThat(typeRequired.getSqlType().isOptional(), is(false));
   }
 
   @Test
   public void shouldGetTypeFromStructWithTwoFields() {
     // Given:
     final String schemaString = "STRUCT<A VARCHAR, B INT>";
+    final String schemaStringWithNull = "STRUCT<A VARCHAR, B INT> NULL";
+    final String schemaStringRequired = "STRUCT<A VARCHAR NOT NULL, B INT> NOT NULL";
 
     // When:
     final Type type = parser.parse(schemaString);
+    final Type typeWithNull = parser.parse(schemaStringWithNull);
+    final Type typeRequired = parser.parse(schemaStringRequired);
 
     // Then:
     assertThat(type, is(new Type(SqlStruct.builder()
         .field("A", SqlTypes.STRING)
         .field("B", SqlTypes.INTEGER)
         .build())));
+    assertThat(typeWithNull, is(new Type(SqlStruct.builder()
+            .field("A", SqlTypes.STRING)
+            .field("B", SqlTypes.INTEGER)
+            .build())));
+    assertThat(typeWithNull.getSqlType().isOptional(), is(true));
+    assertThat(typeRequired, is(new Type(SqlStruct.builder()
+            .field("A", SqlTypes.STRING.required())
+            .field("B", SqlTypes.INTEGER)
+            .build().required())));
+    assertThat(typeRequired.getSqlType().isOptional(), is(false));
   }
 
   @Test

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -69,19 +69,19 @@ public final class EntityUtil {
   private static final class Converter implements SqlTypeWalker.Visitor<SchemaInfo, FieldInfo> {
 
     public SchemaInfo visitType(final SqlType schema) {
-      return new SchemaInfo(schema.baseType(), null, null);
+      return new SchemaInfo(schema.baseType(), null, null, schema.isOptional());
     }
 
     public SchemaInfo visitArray(final SqlArray type, final SchemaInfo element) {
-      return new SchemaInfo(SqlBaseType.ARRAY, null, element);
+      return new SchemaInfo(SqlBaseType.ARRAY, null, element, type.isOptional());
     }
 
     public SchemaInfo visitMap(final SqlMap type, final SchemaInfo key, final SchemaInfo value) {
-      return new SchemaInfo(SqlBaseType.MAP, null, value);
+      return new SchemaInfo(SqlBaseType.MAP, null, value, type.isOptional());
     }
 
     public SchemaInfo visitStruct(final SqlStruct type, final List<? extends FieldInfo> fields) {
-      return new SchemaInfo(SqlBaseType.STRUCT, fields, null);
+      return new SchemaInfo(SqlBaseType.STRUCT, fields, null, type.isOptional());
     }
 
     public FieldInfo visitField(final Field field, final SchemaInfo type) {
@@ -93,7 +93,7 @@ public final class EntityUtil {
               SqlBaseType.DECIMAL,
               null,
               null,
-              type.toParametersMap()
+              type.toParametersMap(), type.isOptional()
       );
     }
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -72,12 +72,16 @@ public class QueryDescriptionFactoryTest {
   private static final LogicalSchema TRANSIENT_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("field3"), SqlTypes.INTEGER.required())
+      .valueColumn(ColumnName.of("field4"), SqlTypes.STRING.required())
       .build();
 
   private static final LogicalSchema PERSISTENT_SCHEMA = LogicalSchema.builder()
       .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("field3"), SqlTypes.INTEGER.required())
+      .valueColumn(ColumnName.of("field4"), SqlTypes.STRING.required())
       .build();
 
   private static final Map<String, Object> STREAMS_PROPS = Collections.singletonMap("k1", "v1");
@@ -219,16 +223,20 @@ public class QueryDescriptionFactoryTest {
   @Test
   public void shouldExposeValueFieldsForTransientQueries() {
     assertThat(transientQueryDescription.getFields(), contains(
-        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty()),
-        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())));
+        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null, true), Optional.empty()),
+        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null,true), Optional.empty()),
+        new FieldInfo("field3", new SchemaInfo(SqlBaseType.INTEGER, null, null,false), Optional.empty()),
+        new FieldInfo("field4", new SchemaInfo(SqlBaseType.STRING, null, null,false), Optional.empty())));
   }
 
   @Test
   public void shouldExposeAllFieldsForPersistentQueries() {
     assertThat(persistentQueryDescription.getFields(), contains(
-        new FieldInfo("k0", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.of(FieldType.KEY)),
-        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty()),
-        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())));
+        new FieldInfo("k0", new SchemaInfo(SqlBaseType.STRING, null, null,true), Optional.of(FieldType.KEY)),
+        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null,true), Optional.empty()),
+        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null,true), Optional.empty()),
+        new FieldInfo("field3", new SchemaInfo(SqlBaseType.INTEGER, null, null,false), Optional.empty()),
+        new FieldInfo("field4", new SchemaInfo(SqlBaseType.STRING, null, null,false), Optional.empty())));
   }
 
   @Test
@@ -264,6 +272,7 @@ public class QueryDescriptionFactoryTest {
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("ROWTIME"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("field3"), SqlTypes.STRING.required())
         .build();
 
     transientQuery = new TransientQueryMetadata(
@@ -291,9 +300,10 @@ public class QueryDescriptionFactoryTest {
 
     // Then:
     assertThat(transientQueryDescription.getFields(), contains(
-        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty()),
-        new FieldInfo("ROWTIME", new SchemaInfo(SqlBaseType.BIGINT, null, null), Optional.empty()),
-        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())));
+        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null,true), Optional.empty()),
+        new FieldInfo("ROWTIME", new SchemaInfo(SqlBaseType.BIGINT, null, null,true), Optional.empty()),
+        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null,true), Optional.empty()),
+        new FieldInfo("field3", new SchemaInfo(SqlBaseType.STRING, null, null,false), Optional.empty())));
   }
 
   @Test
@@ -303,6 +313,7 @@ public class QueryDescriptionFactoryTest {
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("field3"), SqlTypes.STRING.required())
         .build();
 
     transientQuery = new TransientQueryMetadata(
@@ -330,8 +341,9 @@ public class QueryDescriptionFactoryTest {
 
     // Then:
     assertThat(transientQueryDescription.getFields(), contains(
-        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty()),
-        new FieldInfo("ROWKEY", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty()),
-        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.empty())));
+        new FieldInfo("field1", new SchemaInfo(SqlBaseType.INTEGER, null, null,true), Optional.empty()),
+        new FieldInfo("ROWKEY", new SchemaInfo(SqlBaseType.STRING, null, null,true), Optional.empty()),
+        new FieldInfo("field2", new SchemaInfo(SqlBaseType.STRING, null, null,true), Optional.empty()),
+        new FieldInfo("field3", new SchemaInfo(SqlBaseType.STRING, null, null,false), Optional.empty())));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.hasSize;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.rest.entity.FieldInfo;
 import io.confluent.ksql.rest.entity.FieldInfo.FieldType;
+import io.confluent.ksql.rest.entity.SchemaInfo;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -73,6 +74,7 @@ public class EntityUtilTest {
     assertThat(fields.get(0).getName(), equalTo("field"));
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("MAP"));
     assertThat(fields.get(0).getSchema().getFields(), equalTo(Optional.empty()));
+    assertThat(fields.get(0).getSchema().isOptional(), equalTo(true));
     assertThat(fields.get(0).getSchema().getMemberSchema().get().getTypeName(),
         equalTo("INTEGER"));
   }
@@ -113,6 +115,7 @@ public class EntityUtilTest {
     assertThat(fields.get(0).getName(), equalTo("field"));
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("ARRAY"));
     assertThat(fields.get(0).getSchema().getFields(), equalTo(Optional.empty()));
+    assertThat(fields.get(0).getSchema().isOptional(), equalTo(true));
     assertThat(fields.get(0).getSchema().getMemberSchema().get().getTypeName(),
         equalTo("BIGINT"));
   }
@@ -134,10 +137,12 @@ public class EntityUtilTest {
     assertThat(fields.get(0).getName(), equalTo("field"));
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("STRUCT"));
     assertThat(fields.get(0).getSchema().getFields().get().size(), equalTo(1));
+    assertThat(fields.get(0).getSchema().isOptional(), equalTo(true));
     final FieldInfo inner = fields.get(0).getSchema().getFields().get().get(0);
     assertThat(inner.getSchema().getTypeName(), equalTo("STRING"));
     assertThat(inner.getType(), equalTo(Optional.empty()));
     assertThat(fields.get(0).getSchema().getMemberSchema(), equalTo(Optional.empty()));
+    assertThat(fields.get(0).getSchema().isOptional(), equalTo(true));
   }
 
   @Test
@@ -155,8 +160,10 @@ public class EntityUtilTest {
     assertThat(fields, hasSize(2));
     assertThat(fields.get(0).getName(), equalTo("field1"));
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("INTEGER"));
+    assertThat(fields.get(0).getSchema().isOptional(), equalTo(true));
     assertThat(fields.get(1).getName(), equalTo("field2"));
     assertThat(fields.get(1).getSchema().getTypeName(), equalTo("BIGINT"));
+    assertThat(fields.get(1).getSchema().isOptional(), equalTo(true));
   }
 
   @Test
@@ -246,6 +253,7 @@ public class EntityUtilTest {
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo(schemaName));
     assertThat(fields.get(0).getSchema().getFields(), equalTo(Optional.empty()));
     assertThat(fields.get(0).getSchema().getMemberSchema(), equalTo(Optional.empty()));
+    assertThat(fields.get(0).getSchema().isOptional(), equalTo(true));
     assertThat(fields.get(0).getType(), equalTo(Optional.empty()));
   }
 }

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SchemaDescriptionFormatTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SchemaDescriptionFormatTest.java
@@ -48,20 +48,23 @@ public class SchemaDescriptionFormatTest {
         "    \"schema\": {\n" +
         "      \"type\": \"INTEGER\",\n" +
         "      \"fields\": null,\n" +
-        "      \"memberSchema\": null\n" +
+        "      \"memberSchema\": null,\n" +
+        "      \"optional\": true\n" +
         "    }\n" +
         "  },\n" +
         "  {\n" +
         "    \"name\": \"l1struct\",\n" +
         "    \"schema\": {\n" +
         "      \"type\": \"STRUCT\",\n" +
+        "      \"optional\": true,\n" +
         "      \"fields\": [\n" +
         "        {\n" +
         "          \"name\": \"l2string\",\n" +
         "          \"schema\": {\n" +
         "            \"type\": \"STRING\",\n" +
         "            \"fields\": null,\n" +
-        "            \"memberSchema\": null\n" +
+        "            \"memberSchema\": null,\n" +
+        "            \"optional\": true\n" +
         "          }\n" +
         "        },\n" +
         "        {\n" +
@@ -69,7 +72,8 @@ public class SchemaDescriptionFormatTest {
         "          \"schema\": {\n" +
         "            \"type\": \"INTEGER\",\n" +
         "            \"fields\": null,\n" +
-        "            \"memberSchema\": null\n" +
+        "            \"memberSchema\": null,\n" +
+        "            \"optional\": true\n" +
         "          }\n" +
         "        }\n" +
         "      ],\n" +
@@ -88,7 +92,7 @@ public class SchemaDescriptionFormatTest {
     assertThat(
         deserialized.get(0).getSchema(),
         equalTo(
-            new SchemaInfo(SqlBaseType.INTEGER, null, null)));
+            new SchemaInfo(SqlBaseType.INTEGER, null, null, true)));
     assertThat(deserialized.get(1).getName(), equalTo("l1struct"));
     final SchemaInfo structSchema = deserialized.get(1).getSchema();
     assertThat(structSchema.getType(), equalTo(SqlBaseType.STRUCT));
@@ -98,12 +102,12 @@ public class SchemaDescriptionFormatTest {
     assertThat(
         structSchema.getFields().get().get(0).getSchema(),
         equalTo(
-            new SchemaInfo(SqlBaseType.STRING, null, null)));
+            new SchemaInfo(SqlBaseType.STRING, null, null, true)));
     assertThat(structSchema.getFields().get().get(1).getName(), equalTo("l2integer"));
     assertThat(
         structSchema.getFields().get().get(1).getSchema(),
         equalTo(
-            new SchemaInfo(SqlBaseType.INTEGER, null, null)));
+            new SchemaInfo(SqlBaseType.INTEGER, null, null, true)));
 
     shouldSerializeCorrectly(descriptionString, deserialized);
   }
@@ -115,10 +119,12 @@ public class SchemaDescriptionFormatTest {
         "    \"name\": \"mapfield\",\n" +
         "    \"schema\": {\n" +
         "      \"type\": \"MAP\",\n" +
+        "      \"optional\": true,\n" +
         "      \"memberSchema\": {\n" +
         "        \"type\": \"STRING\",\n" +
         "        \"memberSchema\": null,\n" +
-        "        \"fields\": null\n" +
+        "        \"fields\": null,\n" +
+        "        \"optional\": true\n" +
         "      },\n" +
         "      \"fields\": null\n" +
         "    }\n" +
@@ -138,7 +144,7 @@ public class SchemaDescriptionFormatTest {
             new SchemaInfo(
                 SqlBaseType.MAP,
                 null,
-                new SchemaInfo(SqlBaseType.STRING, null, null))));
+                new SchemaInfo(SqlBaseType.STRING, null, null, true ),true)));
 
     shouldSerializeCorrectly(descriptionString, deserialized);
   }
@@ -150,10 +156,12 @@ public class SchemaDescriptionFormatTest {
         "    \"name\": \"arrayfield\",\n" +
         "    \"schema\": {\n" +
         "      \"type\": \"ARRAY\",\n" +
+        "      \"optional\": true,\n" +
         "      \"memberSchema\": {\n" +
         "        \"type\": \"STRING\",\n" +
         "        \"memberSchema\": null,\n" +
-        "        \"fields\": null\n" +
+        "        \"fields\": null,\n" +
+        "        \"optional\": true\n" +
         "      },\n" +
         "      \"fields\": null\n" +
         "    }\n" +
@@ -173,7 +181,7 @@ public class SchemaDescriptionFormatTest {
             new SchemaInfo(
                 SqlBaseType.ARRAY,
                 null,
-                new SchemaInfo(SqlBaseType.STRING, null, null))));
+                new SchemaInfo(SqlBaseType.STRING, null, null,true),true)));
 
     shouldSerializeCorrectly(descriptionString, deserialized);
   }

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SchemaInfoTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/SchemaInfoTest.java
@@ -16,9 +16,9 @@ public class SchemaInfoTest {
             SqlBaseType.DECIMAL,
             null,
             null,
-            ImmutableMap.of("precision", 10, "scale", 9)
+            ImmutableMap.of("precision", 10, "scale", 9), false
     );
-    assertThat(schemaInfo.toTypeString(), equalTo("DECIMAL(10, 9)"));
+    assertThat(schemaInfo.toTypeString(), equalTo("DECIMAL(10, 9) NOT NULL"));
   }
 
   @Test
@@ -26,8 +26,8 @@ public class SchemaInfoTest {
     final SchemaInfo schemaInfo= new SchemaInfo(
             SqlBaseType.DECIMAL,
             null,
-            null
+            null, false
     );
-    assertThat(schemaInfo.toTypeString(), equalTo("DECIMAL"));
+    assertThat(schemaInfo.toTypeString(), equalTo("DECIMAL NOT NULL"));
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
@@ -192,9 +192,7 @@ public abstract class ConnectFormat implements Format {
           throw new SerializationException(
               "Failed to prepare Struct value field '" + field.name() + "' for serialization. "
                   + "This could happen if the value was produced by a user-defined function "
-                  + "where the schema has non-optional return types. ksqlDB requires all "
-                  + "schemas to be optional at all levels of the Struct: the Struct itself, "
-                  + "schemas for all fields within the Struct, and so on.",
+                  + "where the schema has non-optional return types.",
               e);
         }
       }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -899,7 +899,7 @@ public class KsqlAvroSerializerTest {
         LogicalTypes.decimal(4, 2));
 
     shouldSerializeFieldTypeCorrectly(
-        DecimalUtil.builder(4, 2).build(),
+        DecimalUtil.builder(4, 2).optional().build(),
         value,
         DECIMAL_SCHEMA,
         bytes

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectFormatTest.java
@@ -162,9 +162,7 @@ public class ConnectFormatTest {
     assertThat(e.getMessage(), is(
         "Failed to prepare Struct value field 'bob' for serialization. "
             + "This could happen if the value was produced by a user-defined function "
-            + "where the schema has non-optional return types. ksqlDB requires all "
-            + "schemas to be optional at all levels of the Struct: the Struct itself, "
-            + "schemas for all fields within the Struct, and so on."
+            + "where the schema has non-optional return types."
     ));
   }
 

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlArray.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlArray.java
@@ -27,12 +27,17 @@ public final class SqlArray extends SqlType {
   private final SqlType itemType;
 
   public static SqlArray of(final SqlType itemType) {
-    return new SqlArray(itemType);
+    return new SqlArray(itemType, true);
   }
 
-  private SqlArray(final SqlType itemType) {
-    super(SqlBaseType.ARRAY);
+  private SqlArray(final SqlType itemType, final boolean optional) {
+    super(SqlBaseType.ARRAY, optional);
     this.itemType = requireNonNull(itemType, "itemType");
+  }
+
+  @Override
+  public SqlArray required() {
+    return new SqlArray(itemType, false);
   }
 
   public SqlType getItemType() {
@@ -48,12 +53,13 @@ public final class SqlArray extends SqlType {
       return false;
     }
     final SqlArray array = (SqlArray) o;
-    return Objects.equals(itemType, array.itemType);
+    return Objects.equals(itemType, array.itemType)
+           && Objects.equals(isOptional(), array.isOptional());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(itemType);
+    return Objects.hash(itemType, isOptional());
   }
 
   @Override
@@ -63,6 +69,7 @@ public final class SqlArray extends SqlType {
 
   @Override
   public String toString(final FormatOptions formatOptions) {
-    return "ARRAY<" + itemType.toString(formatOptions) + '>';
+    return "ARRAY<" + itemType.toString(formatOptions) + '>'
+            + (!this.isOptional() ? " NOT NULL" : "");
   }
 }

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlConstraint.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,31 +13,11 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.api.client;
+package io.confluent.ksql.schema.ksql.types;
 
 /**
- * Represents a field/column of a ksqlDB stream/table.
+ * The SQL constraints supported by KSQL.
  */
-public interface FieldInfo {
-
-  /**
-   * @return name of this field
-   */
-  String name();
-
-  /**
-   * @return type of this field
-   */
-  ColumnType type();
-
-  /**
-   * @return whether this field is a key field, rather than a value field
-   */
-  boolean isKey();
-
-  /**
-   * @return whether this field is a optional field or not
-   */
-  boolean isOptional();
-
+public enum SqlConstraint {
+  NULL, NOTNULL
 }

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlDecimal.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlDecimal.java
@@ -31,11 +31,16 @@ public final class SqlDecimal extends SqlType {
 
 
   public static SqlDecimal of(final int precision, final int scale) {
-    return new SqlDecimal(precision, scale);
+    return new SqlDecimal(precision, scale, true);
   }
 
-  private SqlDecimal(final int precision, final int scale) {
-    super(SqlBaseType.DECIMAL);
+  @Override
+  public SqlDecimal required() {
+    return new SqlDecimal(precision, scale, false);
+  }
+
+  private SqlDecimal(final int precision, final int scale, final boolean optional) {
+    super(SqlBaseType.DECIMAL, optional);
     this.precision = precision;
     this.scale = scale;
 
@@ -70,17 +75,19 @@ public final class SqlDecimal extends SqlType {
     }
     final SqlDecimal that = (SqlDecimal) o;
     return precision == that.precision
-        && scale == that.scale;
+        && scale == that.scale
+        && isOptional() == that.isOptional();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(precision, scale);
+    return Objects.hash(precision, scale, isOptional());
   }
 
   @Override
   public String toString() {
-    return "DECIMAL(" + precision + ", " + scale + ')';
+    return "DECIMAL(" + precision + ", " + scale + ')'
+            + (!this.isOptional() ? " NOT NULL" : "");
   }
 
   @Override

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlMap.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlMap.java
@@ -28,11 +28,16 @@ public final class SqlMap extends SqlType {
   private final SqlType valueType;
 
   public static SqlMap of(final SqlType keyType, final SqlType valueType) {
-    return new SqlMap(keyType, valueType);
+    return new SqlMap(keyType, valueType, true);
   }
 
-  private SqlMap(final SqlType keyType, final SqlType valueType) {
-    super(SqlBaseType.MAP);
+  @Override
+  public SqlMap required() {
+    return new SqlMap(keyType, valueType, false);
+  }
+
+  private SqlMap(final SqlType keyType, final SqlType valueType, final boolean optional) {
+    super(SqlBaseType.MAP, optional);
     this.keyType = requireNonNull(keyType, "keyType");
     this.valueType = requireNonNull(valueType, "valueType");
   }
@@ -55,12 +60,13 @@ public final class SqlMap extends SqlType {
     }
     final SqlMap map = (SqlMap) o;
     return Objects.equals(keyType, map.keyType)
-        && Objects.equals(valueType, map.valueType);
+        && Objects.equals(valueType, map.valueType)
+        && Objects.equals(isOptional(), map.isOptional());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(keyType, valueType);
+    return Objects.hash(keyType, valueType, isOptional());
   }
 
   @Override
@@ -73,6 +79,7 @@ public final class SqlMap extends SqlType {
     return "MAP<"
         + keyType.toString(formatOptions) + ", "
         + valueType.toString(formatOptions)
-        + '>';
+        + '>'
+        + (!this.isOptional() ? " NOT NULL" : "");
   }
 }

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
@@ -31,12 +31,12 @@ public final class SqlPrimitiveType extends SqlType {
 
   private static final ImmutableMap<SqlBaseType, SqlPrimitiveType> TYPES =
       ImmutableMap.<SqlBaseType, SqlPrimitiveType>builder()
-          .put(SqlBaseType.BOOLEAN, new SqlPrimitiveType(SqlBaseType.BOOLEAN))
-          .put(SqlBaseType.INTEGER, new SqlPrimitiveType(SqlBaseType.INTEGER))
-          .put(SqlBaseType.BIGINT, new SqlPrimitiveType(SqlBaseType.BIGINT))
-          .put(SqlBaseType.DOUBLE, new SqlPrimitiveType(SqlBaseType.DOUBLE))
-          .put(SqlBaseType.STRING, new SqlPrimitiveType(SqlBaseType.STRING))
-          .put(SqlBaseType.TIMESTAMP, new SqlPrimitiveType(SqlBaseType.TIMESTAMP))
+          .put(SqlBaseType.BOOLEAN, new SqlPrimitiveType(SqlBaseType.BOOLEAN, true))
+          .put(SqlBaseType.INTEGER, new SqlPrimitiveType(SqlBaseType.INTEGER, true))
+          .put(SqlBaseType.BIGINT, new SqlPrimitiveType(SqlBaseType.BIGINT, true))
+          .put(SqlBaseType.DOUBLE, new SqlPrimitiveType(SqlBaseType.DOUBLE, true))
+          .put(SqlBaseType.STRING, new SqlPrimitiveType(SqlBaseType.STRING,true))
+          .put(SqlBaseType.TIMESTAMP, new SqlPrimitiveType(SqlBaseType.TIMESTAMP, true))
           .build();
 
   private static final ImmutableSet<String> PRIMITIVE_TYPE_NAMES = ImmutableSet.<String>builder()
@@ -73,8 +73,13 @@ public final class SqlPrimitiveType extends SqlType {
     return primitive;
   }
 
-  private SqlPrimitiveType(final SqlBaseType baseType) {
-    super(baseType);
+  @Override
+  public SqlPrimitiveType required() {
+    return new SqlPrimitiveType(this.baseType(), false);
+  }
+
+  private SqlPrimitiveType(final SqlBaseType baseType, final boolean optional) {
+    super(baseType, optional);
   }
 
   @Override
@@ -87,17 +92,18 @@ public final class SqlPrimitiveType extends SqlType {
     }
 
     final SqlPrimitiveType that = (SqlPrimitiveType) o;
-    return Objects.equals(this.baseType(), that.baseType());
+    return Objects.equals(this.baseType(), that.baseType())
+           && Objects.equals(this.isOptional(), that.isOptional());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(baseType());
+    return Objects.hash(baseType(), isOptional());
   }
 
   @Override
   public String toString() {
-    return baseType().toString();
+    return baseType().toString() + (!this.isOptional() ? " NOT NULL" : "");
   }
 
   @Override

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlType.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlType.java
@@ -26,14 +26,23 @@ import java.util.Objects;
 public abstract class SqlType {
 
   private final SqlBaseType baseType;
+  private final boolean optional;
 
-  SqlType(final SqlBaseType baseType) {
+  SqlType(final SqlBaseType baseType, final Boolean optional) {
     this.baseType = Objects.requireNonNull(baseType, "baseType");
+    this.optional = Objects.requireNonNull(optional, "optional");
+
   }
 
   public SqlBaseType baseType() {
     return baseType;
   }
+
+  public boolean isOptional() {
+    return optional;
+  }
+
+  public abstract SqlType required();
 
   public abstract String toString(FormatOptions formatOptions);
 }

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlArrayTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlArrayTest.java
@@ -32,17 +32,26 @@ public class SqlArrayTest {
         .addEqualityGroup(SqlArray.of(SOME_TYPE), SqlArray.of(SOME_TYPE))
         .addEqualityGroup(SqlArray.of(SqlPrimitiveType.of(SqlBaseType.BOOLEAN)))
         .addEqualityGroup(SqlMap.of(SqlTypes.STRING, SqlTypes.BOOLEAN))
+        .addEqualityGroup(SqlArray.of(SOME_TYPE.required()).required(), SqlArray.of(SOME_TYPE.required()).required())
+        .addEqualityGroup(SqlArray.of(SqlPrimitiveType.of(SqlBaseType.BOOLEAN).required()).required())
+        .addEqualityGroup(SqlMap.of(SqlTypes.STRING.required(), SqlTypes.BOOLEAN.required()).required())
         .testEquals();
   }
 
   @Test
   public void shouldReturnSqlType() {
     assertThat(SqlArray.of(SOME_TYPE).baseType(), is(SqlBaseType.ARRAY));
+    assertThat(SqlArray.of(SOME_TYPE).isOptional(), is(true));
+    assertThat(SqlArray.of(SOME_TYPE).required().baseType(), is(SqlBaseType.ARRAY));
+    assertThat(SqlArray.of(SOME_TYPE).required().isOptional(), is(false));
   }
 
   @Test
   public void shouldReturnValueType() {
     assertThat(SqlArray.of(SOME_TYPE).getItemType(), is(SOME_TYPE));
+    assertThat(SqlArray.of(SOME_TYPE).getItemType().isOptional(), is(true));
+    assertThat(SqlArray.of(SOME_TYPE.required()).getItemType(), is(SOME_TYPE.required()));
+    assertThat(SqlArray.of(SOME_TYPE.required()).getItemType().isOptional(), is(false));
   }
 
   @Test
@@ -51,6 +60,16 @@ public class SqlArrayTest {
         "ARRAY<"
             + SOME_TYPE.toString()
             + ">"
+    ));
+    assertThat(SqlArray.of(SOME_TYPE.required()).toString(), is(
+            "ARRAY<"
+                    + SOME_TYPE.toString() + " NOT NULL"
+                    + ">"
+    ));
+    assertThat(SqlArray.of(SOME_TYPE).required().toString(), is(
+            "ARRAY<"
+                    + SOME_TYPE.toString()
+                    + "> NOT NULL"
     ));
   }
 }

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlDecimalTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlDecimalTest.java
@@ -36,22 +36,30 @@ public class SqlDecimalTest {
         .addEqualityGroup(SqlDecimal.of(10, 2), SqlDecimal.of(10, 2))
         .addEqualityGroup(SqlDecimal.of(11, 2))
         .addEqualityGroup(SqlDecimal.of(10, 3))
+        .addEqualityGroup(SqlDecimal.of(10, 2).required(), SqlDecimal.of(10, 2).required())
+        .addEqualityGroup(SqlDecimal.of(11, 2).required())
+        .addEqualityGroup(SqlDecimal.of(10, 3).required())
         .testEquals();
   }
 
   @Test
   public void shouldReturnBaseType() {
     MatcherAssert.assertThat(SqlDecimal.of(10, 2).baseType(), Matchers.is(SqlBaseType.DECIMAL));
+    MatcherAssert.assertThat(SqlDecimal.of(10, 2).isOptional(), Matchers.is(true));
+    MatcherAssert.assertThat(SqlDecimal.of(10, 2).required().baseType(), Matchers.is(SqlBaseType.DECIMAL));
+    MatcherAssert.assertThat(SqlDecimal.of(10, 2).required().isOptional(), Matchers.is(false));
   }
 
   @Test
   public void shouldReturnPrecision() {
     assertThat(SqlDecimal.of(10, 2).getPrecision(), is(10));
+    assertThat(SqlDecimal.of(10, 2).required().getPrecision(), is(10));
   }
 
   @Test
   public void shouldReturnScale() {
     assertThat(SqlDecimal.of(10, 2).getScale(), is(2));
+    assertThat(SqlDecimal.of(10, 2).required().getScale(), is(2));
   }
 
   @Test(expected = SchemaException.class)
@@ -72,6 +80,8 @@ public class SqlDecimalTest {
   @Test
   public void shouldImplementToString() {
     assertThat(SqlDecimal.of(10, 2).toString(), is("DECIMAL(10, 2)"));
+    assertThat(SqlDecimal.of(10, 2).required().toString(), is("DECIMAL(10, 2) NOT NULL"));
+
   }
 
   @Test
@@ -83,6 +93,8 @@ public class SqlDecimalTest {
             .put(TestCase.of(SqlTypes.decimal(2, 2), SqlTypes.decimal(2, 1)), SqlTypes.decimal(4, 2))
             .put(TestCase.of(SqlTypes.decimal(2, 1), SqlTypes.decimal(3, 2)), SqlTypes.decimal(4, 2))
             .put(TestCase.of(SqlTypes.decimal(3, 2), SqlTypes.decimal(2, 1)), SqlTypes.decimal(4, 2))
+            .put(TestCase.of(SqlTypes.decimal(3, 1).required(), SqlTypes.decimal(2, 1).required()), SqlTypes.decimal(4, 1))
+            .put(TestCase.of(SqlTypes.decimal(3, 1).required(), SqlTypes.decimal(2, 2)), SqlTypes.decimal(5, 2))
             .build();
 
     testCases.forEach((in, expected) -> {
@@ -103,6 +115,8 @@ public class SqlDecimalTest {
             .put(TestCase.of(SqlTypes.decimal(2, 2), SqlTypes.decimal(2, 1)), SqlTypes.decimal(4, 2))
             .put(TestCase.of(SqlTypes.decimal(2, 1), SqlTypes.decimal(3, 2)), SqlTypes.decimal(4, 2))
             .put(TestCase.of(SqlTypes.decimal(3, 2), SqlTypes.decimal(2, 1)), SqlTypes.decimal(4, 2))
+            .put(TestCase.of(SqlTypes.decimal(3, 1).required(), SqlTypes.decimal(2, 1).required()), SqlTypes.decimal(4, 1))
+            .put(TestCase.of(SqlTypes.decimal(3, 3).required(), SqlTypes.decimal(2, 1)), SqlTypes.decimal(5, 3))
             .build();
 
     inputToExpected.forEach((in, expected) -> {
@@ -122,6 +136,8 @@ public class SqlDecimalTest {
             .put(TestCase.of(SqlTypes.decimal(2, 1), SqlTypes.decimal(2, 2)), SqlTypes.decimal(5, 3))
             .put(TestCase.of(SqlTypes.decimal(2, 2), SqlTypes.decimal(2, 1)), SqlTypes.decimal(5, 3))
             .put(TestCase.of(SqlTypes.decimal(3, 2), SqlTypes.decimal(2, 1)), SqlTypes.decimal(6, 3))
+            .put(TestCase.of(SqlTypes.decimal(3, 1).required(), SqlTypes.decimal(2, 1).required()), SqlTypes.decimal(6, 2))
+            .put(TestCase.of(SqlTypes.decimal(3, 3).required(), SqlTypes.decimal(2, 1)), SqlTypes.decimal(6, 4))
             .build();
 
     inputToExpected.forEach((in, expected) -> {
@@ -142,6 +158,8 @@ public class SqlDecimalTest {
             .put(TestCase.of(SqlTypes.decimal(2, 2), SqlTypes.decimal(2, 1)), SqlTypes.decimal(7, 6))
             .put(TestCase.of(SqlTypes.decimal(3, 3), SqlTypes.decimal(3, 3)), SqlTypes.decimal(10, 7))
             .put(TestCase.of(SqlTypes.decimal(3, 3), SqlTypes.decimal(3, 2)), SqlTypes.decimal(9, 7))
+            .put(TestCase.of(SqlTypes.decimal(3, 1).required(), SqlTypes.decimal(3, 2).required()), SqlTypes.decimal(10, 6))
+            .put(TestCase.of(SqlTypes.decimal(1, 1).required(), SqlTypes.decimal(3, 2)), SqlTypes.decimal(8, 6))
             .build();
 
     inputToExpected.forEach((in, expected) -> {
@@ -161,6 +179,8 @@ public class SqlDecimalTest {
             .put(TestCase.of(SqlTypes.decimal(2, 2), SqlTypes.decimal(2, 1)), SqlTypes.decimal(2, 2))
             .put(TestCase.of(SqlTypes.decimal(2, 1), SqlTypes.decimal(2, 2)), SqlTypes.decimal(2, 2))
             .put(TestCase.of(SqlTypes.decimal(3, 1), SqlTypes.decimal(2, 2)), SqlTypes.decimal(2, 2))
+            .put(TestCase.of(SqlTypes.decimal(1, 1).required(), SqlTypes.decimal(2, 2).required()), SqlTypes.decimal(2, 2))
+            .put(TestCase.of(SqlTypes.decimal(3, 2).required(), SqlTypes.decimal(2, 2)), SqlTypes.decimal(2, 2))
             .build();
 
     inputToExpected.forEach((in, expected) -> {

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlMapTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlMapTest.java
@@ -34,26 +34,46 @@ public class SqlMapTest {
         .addEqualityGroup(SqlMap.of(OTHER_TYPE, SOME_TYPE))
         .addEqualityGroup(SqlMap.of(SOME_TYPE, OTHER_TYPE))
         .addEqualityGroup(SOME_TYPE)
+        .addEqualityGroup(SqlMap.of(SOME_TYPE.required(), SOME_TYPE.required()).required(),
+                SqlMap.of(SOME_TYPE.required(), SOME_TYPE.required()).required())
+        .addEqualityGroup(SqlMap.of(OTHER_TYPE.required(), SOME_TYPE.required()).required())
+        .addEqualityGroup(SqlMap.of(SOME_TYPE.required(), OTHER_TYPE.required()).required())
+        .addEqualityGroup(SOME_TYPE.required())
         .testEquals();
   }
 
   @Test
   public void shouldReturnBaseType() {
     assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).baseType(), is(SqlBaseType.MAP));
+    assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).isOptional(), is(true));
+    assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).required().baseType(), is(SqlBaseType.MAP));
+    assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).required().isOptional(), is(false));
   }
 
   @Test
   public void shouldReturnKeyType() {
     assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).getKeyType(), is(SOME_TYPE));
+    assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).getKeyType().isOptional(), is(true));
+    assertThat(SqlMap.of(SOME_TYPE.required(), OTHER_TYPE).getKeyType(), is(SOME_TYPE.required()));
+    assertThat(SqlMap.of(SOME_TYPE.required(), OTHER_TYPE).getKeyType().isOptional(), is(false));
   }
 
   @Test
   public void shouldReturnValueType() {
     assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).getValueType(), is(OTHER_TYPE));
+    assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE.required()).getValueType(), is(OTHER_TYPE.required()));
   }
 
   @Test
   public void shouldImplementToString() {
     assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).toString(), is("MAP<DOUBLE, INTEGER>"));
+    assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE.required()).toString(), is("MAP<DOUBLE, INTEGER NOT NULL>"));
+    assertThat(SqlMap.of(SOME_TYPE.required(), OTHER_TYPE).toString(), is("MAP<DOUBLE NOT NULL, INTEGER>"));
+    assertThat(SqlMap.of(SOME_TYPE.required(), OTHER_TYPE.required()).toString(), is("MAP<DOUBLE NOT NULL, INTEGER NOT NULL>"));
+    assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE).required().toString(), is("MAP<DOUBLE, INTEGER> NOT NULL"));
+    assertThat(SqlMap.of(SOME_TYPE, OTHER_TYPE.required()).required().toString(), is("MAP<DOUBLE, INTEGER NOT NULL> NOT NULL"));
+    assertThat(SqlMap.of(SOME_TYPE.required(), OTHER_TYPE).required().toString(), is("MAP<DOUBLE NOT NULL, INTEGER> NOT NULL"));
+    assertThat(SqlMap.of(SOME_TYPE.required(), OTHER_TYPE.required()).required().toString(), is("MAP<DOUBLE NOT NULL, INTEGER NOT NULL> NOT NULL"));
+
   }
 }

--- a/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveTypeTest.java
+++ b/ksqldb-udf/src/test/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveTypeTest.java
@@ -57,6 +57,9 @@ public class SqlPrimitiveTypeTest {
   @Test
   public void shouldReturnSqlType() {
     assertThat(SqlPrimitiveType.of(SqlBaseType.INTEGER).baseType(), is(SqlBaseType.INTEGER));
+    assertThat(SqlPrimitiveType.of(SqlBaseType.INTEGER).isOptional(), is(true));
+    assertThat(SqlPrimitiveType.of(SqlBaseType.INTEGER).required().baseType(), is(SqlBaseType.INTEGER));
+    assertThat(SqlPrimitiveType.of(SqlBaseType.INTEGER).required().isOptional(), is(false));
   }
 
   @Test
@@ -119,9 +122,13 @@ public class SqlPrimitiveTypeTest {
         .put("tImeStamP", SqlBaseType.TIMESTAMP)
         .build();
 
-    primitives.forEach((string, expected) ->
+    primitives.forEach((string, expected) -> {
         // Then:
-        assertThat(SqlPrimitiveType.of(string).baseType(), is(expected))
+        assertThat(SqlPrimitiveType.of(string).baseType(), is(expected));
+        assertThat(SqlPrimitiveType.of(string).isOptional(), is(true));
+        assertThat(SqlPrimitiveType.of(string).required().baseType(), is(expected));
+        assertThat(SqlPrimitiveType.of(string).required().isOptional(), is(false));
+      }
     );
   }
 
@@ -133,9 +140,13 @@ public class SqlPrimitiveTypeTest {
         "VarchaR", SqlBaseType.STRING
     );
 
-    primitives.forEach((string, expected) ->
+    primitives.forEach((string, expected) -> {
         // Then:
-        assertThat(SqlPrimitiveType.of(string).baseType(), is(expected))
+        assertThat(SqlPrimitiveType.of(string).baseType(), is(expected));
+        assertThat(SqlPrimitiveType.of(string).isOptional(), is(true));
+        assertThat(SqlPrimitiveType.of(string).required().baseType(), is(expected));
+        assertThat(SqlPrimitiveType.of(string).required().isOptional(), is(false));
+      }
     );
   }
 
@@ -183,6 +194,8 @@ public class SqlPrimitiveTypeTest {
     ).forEach(type -> {
       // Then:
       assertThat(SqlPrimitiveType.of(type).toString(), is(type.toString()));
+      assertThat(SqlPrimitiveType.of(type).required().toString(), is(type.toString() + " NOT NULL"));
+
     });
   }
 }


### PR DESCRIPTION
### Description 
Ticket [4436](https://github.com/confluentinc/ksql/issues/4436)

It supports `not null` for all ksql data types, including complex ones like `Struct` ,` Maps`, `Arrays`. It also supports defining `not null` in nested fields.

**Keywords:**

- `not null` for required field/s
- `null` or blank (as current ksql version) for optinal field/s. 

###Testing done:
I’ve included unit test and functional tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

