### PR TITLE
docs: Update Maven repo name in Java Client config

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -70,7 +70,7 @@ Start by creating a `pom.xml` for your Java application:
             <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
         </repository>
         <repository>
-            <id>confluent</id>
+            <id>confluent-packages</id>
             <name>Confluent</name>
             <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/{{ site.kstreamsbetabuild }}/maven/</url>
         </repository>
@@ -82,7 +82,7 @@ Start by creating a `pom.xml` for your Java application:
             <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
         </pluginRepository>
         <pluginRepository>
-            <id>confluent</id>
+            <id>confluent-packages</id>
             <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/{{ site.kstreamsbetabuild }}/maven/</url>
         </pluginRepository>
     </pluginRepositories>


### PR DESCRIPTION
### Description 
Based on user feedback, this small change to the example application config reduces the chance the `id` corresponding to the Confluent Packaging Maven repo conflicts with other Maven configurations that also use the current value, `confluent`.
