### PR TITLE
fix: AdminResponseHandler should treat empty string as Optional.empty()

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -335,7 +335,9 @@ final class AdminResponseHandlers {
           source.getString("valueFormat"),
           formatQueries(source.getJsonArray("readQueries")),
           formatQueries(source.getJsonArray("writeQueries")),
-          Optional.ofNullable(source.getString("timestamp")),
+          source.getString("timestamp").isEmpty()
+              ? Optional.empty()
+              : Optional.of(source.getString("timestamp")),
           Optional.ofNullable(source.getString("windowType")),
           source.getString("statement"),
           source.getJsonArray("sourceConstraints").stream()


### PR DESCRIPTION
follow up to https://github.com/confluentinc/ksql/pull/7455#discussion_r625322594

Running `ClientTest` locally it actually failed without this fix. It's unclear to me, why it did not fail on #7455 (or did we miss it, and merge after failing Jenkins??)