### PR TITLE
fix: change the isError to not use the state

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -43,8 +43,6 @@ public interface QueryMetadata {
 
   KafkaStreams.State getState();
 
-  boolean isError();
-
   String getExecutionPlan();
 
   String getQueryApplicationId();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -228,7 +228,7 @@ public class QueryMetadataImpl implements QueryMetadata {
   }
 
   public boolean isError() {
-    return getState() == State.ERROR;
+    return !queryErrors.toImmutableList().isEmpty();
   }
 
   public String getExecutionPlan() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -227,10 +227,6 @@ public class QueryMetadataImpl implements QueryMetadata {
     return kafkaStreams.state();
   }
 
-  public boolean isError() {
-    return !queryErrors.toImmutableList().isEmpty();
-  }
-
   public String getExecutionPlan() {
     return executionPlan;
   }


### PR DESCRIPTION
since the state ERROR changed definitions the current isError is no longer really relevant. However it actually seems that isError is not used so I will just remove it._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

