### PR TITLE
docs: Fix typo in documentation

### DIFF
--- a/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
@@ -42,7 +42,7 @@ ksqlDB will internally repartition the data.
     messages. The use case will determine if these ordering guarantees are
     acceptable.
 
-Joins to tables must use the table's PRIMARY KEY as the join criteria: none primary key joins are 
+Joins to tables must use the table's PRIMARY KEY as the join criteria: non-key joins are 
 [not yet supported](https://github.com/confluentinc/ksql/issues/4424).
 For more information, see [Join Event Streams with ksqlDB](../joins/join-streams-and-tables.md).
 

--- a/docs/developer-guide/ksqldb-reference/create-table-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-table-as-select.md
@@ -44,7 +44,7 @@ ksqlDB will internally repartition the data.
     messages. The use case will determine if these ordering guarantees are
     acceptable.
 
-Joins to tables must use the table's PRIMARY KEY as the join criteria: none primary key joins are 
+Joins to tables must use the table's PRIMARY KEY as the join criteria: non-key joins are 
 [not yet supported](https://github.com/confluentinc/ksql/issues/4424).
 For more information, see [Join Event Streams with ksqlDB](../joins/join-streams-and-tables.md).
 


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

I think "none primary key" joins was a typo. Rephrasing it as "non-primary key" joins is a bit ambiguous, and "non-key" joins is quite clear.


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

N/A

### Reviewer checklist
- [ x ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ x ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

