### PR TITLE
chore: bypass pre-join repartition for foreign key joins

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -131,6 +131,8 @@ public class KsqlConfig extends AbstractConfig {
       + "'CREATE STREAM S AS ...' will create a topic 'thing-S', where as the statement "
       + "'CREATE STREAM S WITH(KAFKA_TOPIC = 'foo') AS ...' will create a topic 'foo'.";
 
+  public static final String KSQL_FOREIGN_KEY_JOINS_ENABLED = "ksql.joins.foreign.key.enable";
+
   public static final String KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG =
       "ksql.query.persistent.active.limit";
   private static final int KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DEFAULT = Integer.MAX_VALUE;
@@ -782,6 +784,12 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DEFAULT,
             Importance.MEDIUM,
             KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DOC
+        ).define(
+            KSQL_FOREIGN_KEY_JOINS_ENABLED,
+            Type.BOOLEAN,
+            false,
+            Importance.MEDIUM,
+            "Feature flag for foreign key joins, currently under development."
         ).define(
             KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG,
             Type.LONG,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -630,9 +630,11 @@ public class LogicalPlanner {
   /**
    * @return whether this is a foreign key join or not
    */
-  private boolean verifyJoin(final JoinInfo joinInfo,
-                          final PlanNode leftNode,
-                          final PlanNode rightNode) {
+  private boolean verifyJoin(
+      final JoinInfo joinInfo,
+      final PlanNode leftNode,
+      final PlanNode rightNode
+  ) {
     final JoinType joinType = joinInfo.getType();
     final Expression leftExpression = joinInfo.getLeftJoinExpression();
     final Expression rightExpression = joinInfo.getRightJoinExpression();

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestUtils.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.test.model.KsqlVersion;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.TestCaseBuilder;
 import io.confluent.ksql.test.tools.TopologyAndConfigs;
+import io.confluent.ksql.util.KsqlConfig;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +32,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public final class PlannedTestUtils {
@@ -47,7 +49,8 @@ public final class PlannedTestUtils {
 
   public static boolean isNotExcluded(final TestCase testCase) {
     // Place temporary logic here to exclude test cases based on feature flags, etc.
-    return true;
+    final Map<String, Object> props = testCase.properties();
+    return !(boolean) props.getOrDefault(KsqlConfig.KSQL_FOREIGN_KEY_JOINS_ENABLED, false);
   }
 
   public static boolean isSamePlan(


### PR DESCRIPTION
### Description 

This PR refactors the logic in the logical planner for building join source nodes to first build a raw source node (either a JoinNode or a DataSourceNode) and then to add potential PreJoinRepartition or PreJoinProject nodes only after the join has been validated, since part of the validation is detecting whether the join is a foreign key join or not, and we do not want to add pre-join repartition nodes in the case of foreign key joins. This PR also adds a feature flag for foreign key joins while the feature is still under development.

### Testing done 

This PR is mostly a refactor; I'll ensure that existing unit and QTT tests pass prior to merging. Test coverage for the new functionality (involving foreign key joins themselves) will be added once more of the relevant functionality is wired in.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

