### PR TITLE
chore: Updates to Vert.x 3.9.7 and Netty 4.1.60.Final

### DIFF
--- a/ksqldb-version-metrics-client/pom.xml
+++ b/ksqldb-version-metrics-client/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>3.10.4</version>
+            <version>5.11.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <version>3.10.4</version>
+            <version>5.11.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
+++ b/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.version.metrics;
 
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.Matchers.is;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
@@ -27,13 +28,13 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.mockserver.integration.ClientAndProxy;
+import org.mockserver.integration.ClientAndServer;
 import org.mockserver.socket.PortFactory;
 
 public class VersionCheckerIntegrationTest {
 
   private static int proxyPort;
-  private static ClientAndProxy clientAndProxy;
+  private static ClientAndServer mockServer;
 
   @Rule
   public final Timeout timeout = Timeout.builder()
@@ -44,7 +45,7 @@ public class VersionCheckerIntegrationTest {
   @BeforeClass
   public static void startProxy() {
     proxyPort = PortFactory.findFreePort();
-    clientAndProxy = ClientAndProxy.startClientAndProxy(proxyPort);
+    mockServer = startClientAndServer(proxyPort);
   }
 
   @Test
@@ -64,7 +65,7 @@ public class VersionCheckerIntegrationTest {
 
     assertThatEventually("Version not submitted", () -> {
           try {
-            clientAndProxy.verify(request().withPath("/ksql/anon").withMethod("POST"));
+            mockServer.verify(request().withPath("/ksql/anon").withMethod("POST"));
             return true;
           } catch (final AssertionError e) {
             return false;

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.1</vertx.version>
+        <vertx.version>3.9.7</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -139,11 +139,11 @@
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
         <kafka.version>7.0.0-52-ccs</kafka.version>
-        <netty-tcnative-version>2.0.29.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against 4.1.49.Final -->
-        <netty.version>4.1.49.Final</netty.version>
+        <netty.version>4.1.60.Final</netty.version>
         <!-- This matches the version in common -->
-        <netty-codec-http2-version>4.1.49.Final</netty-codec-http2-version>
+        <netty-codec-http2-version>4.1.60.Final</netty-codec-http2-version>
         <!-- Brought in by both schema registry and connect, we need to pick a version -->
         <jersey-common>2.31</jersey-common>
     </properties>


### PR DESCRIPTION
### Description 
Updates to Vert.x 3.9.7 and Netty 4.1.60.Final.

This is to mitigate https://github.com/advisories/GHSA-wm47-8v5p-wjpj

### Testing done 
Running CI tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

