### PR TITLE
chore: pin dependency-check version to 6.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <io.confluent.ksql.version>7.0.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
+        <dependency.check.version>6.1.6</dependency.check.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
Same issue as in: confluentinc/common#332

But the ongoing release depends on a version of Confluent that doesn't have this fix yet.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

