### PR TITLE
chore: fix NPE in QueryAnonymizingRewritePolicy.<init>

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/logging/query/QueryAnonymizingRewritePolicy.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/logging/query/QueryAnonymizingRewritePolicy.java
@@ -31,7 +31,7 @@ public final class QueryAnonymizingRewritePolicy implements RewritePolicy {
     final String clusterNamespace =
         config.getString(KsqlConfig.KSQL_QUERYANONYMIZER_CLUSTER_NAMESPACE);
     this.namespace =
-        clusterNamespace.isEmpty()
+        clusterNamespace == null || clusterNamespace.isEmpty()
             ? config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
             : clusterNamespace;
     this.anonymizeQueries = config.getBoolean(KsqlConfig.KSQL_QUERYANONYMIZER_ENABLED);


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
I got an NPE when I started a KSQL server and didn't add the policy config.
```
 (io.confluent.ksql.util.KsqlConfig:372)
[2021-05-11 15:41:58,342] ERROR Failed to start KSQL (io.confluent.ksql.rest.server.KsqlServerMain:69)
java.lang.NullPointerException
	at io.confluent.ksql.logging.query.QueryAnonymizingRewritePolicy.<init>(QueryAnonymizingRewritePolicy.java:34)
	at io.confluent.ksql.logging.query.QueryLogger.configure(QueryLogger.java:58)
	at io.confluent.ksql.rest.server.KsqlServerMain.main(KsqlServerMain.java:59)
(base) sergio@pop-os:~/Development/ksql$ ./bin/ksql-server-start config/ksql-server.properties
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

