### PR TITLE
chore: update joins to allow lack of pre-join repartition (MINOR)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PreJoinProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PreJoinProjectNode.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.planner.plan;
 
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.plan.SelectExpression;
@@ -44,7 +45,7 @@ public class PreJoinProjectNode extends ProjectNode implements JoiningNode {
   private final ImmutableList<SelectExpression> selectExpressions;
   private final ImmutableBiMap<ColumnName, ColumnName> aliases;
   private final LogicalSchema schema;
-  private final JoiningNode joiningSource;
+  private final Optional<JoiningNode> joiningSource;
 
   public PreJoinProjectNode(
       final PlanNodeId id,
@@ -59,7 +60,16 @@ public class PreJoinProjectNode extends ProjectNode implements JoiningNode {
     ));
     this.aliases = buildAliasMapping(selectExpressions);
     this.schema = buildSchema(alias, source.getSchema());
-    this.joiningSource = (JoiningNode) source;
+    if (source instanceof JoiningNode) {
+      this.joiningSource = Optional.of((JoiningNode) source);
+    } else {
+      if (!(source instanceof DataSourceNode)) {
+        throw new IllegalStateException(
+            "PreJoinProjectNode preceded by non-DataSourceNode non-JoiningNode: "
+                + source.getClass());
+      }
+      this.joiningSource = Optional.empty();
+    }
   }
 
   @Override
@@ -73,12 +83,16 @@ public class PreJoinProjectNode extends ProjectNode implements JoiningNode {
 
   @Override
   public Optional<KeyFormat> getPreferredKeyFormat() {
-    return joiningSource.getPreferredKeyFormat();
+    if (joiningSource.isPresent()) {
+      return joiningSource.get().getPreferredKeyFormat();
+    }
+
+    return Optional.of(getSourceKeyFormat());
   }
 
   @Override
   public void setKeyFormat(final KeyFormat format) {
-    joiningSource.setKeyFormat(format);
+    joiningSource.ifPresent(source -> source.setKeyFormat(format));
   }
 
   @Override
@@ -107,6 +121,12 @@ public class PreJoinProjectNode extends ProjectNode implements JoiningNode {
     });
 
     return super.validateColumns(builder.build());
+  }
+
+  // Only safe to call this if joiningSource is empty.
+  private KeyFormat getSourceKeyFormat() {
+    return Iterators.getOnlyElement(getSourceNodes().iterator())
+        .getDataSource().getKsqlTopic().getKeyFormat();
   }
 
   private static ImmutableBiMap<ColumnName, ColumnName> buildAliasMapping(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PreJoinProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PreJoinProjectNode.java
@@ -87,7 +87,11 @@ public class PreJoinProjectNode extends ProjectNode implements JoiningNode {
       return joiningSource.get().getPreferredKeyFormat();
     }
 
-    return Optional.of(getSourceKeyFormat());
+    final KeyFormat sourceKeyFormat =
+        Iterators.getOnlyElement(getSourceNodes().iterator())
+            .getDataSource().getKsqlTopic().getKeyFormat();
+
+    return Optional.of(sourceKeyFormat);
   }
 
   @Override
@@ -121,12 +125,6 @@ public class PreJoinProjectNode extends ProjectNode implements JoiningNode {
     });
 
     return super.validateColumns(builder.build());
-  }
-
-  // Only safe to call this if joiningSource is empty.
-  private KeyFormat getSourceKeyFormat() {
-    return Iterators.getOnlyElement(getSourceNodes().iterator())
-        .getDataSource().getKsqlTopic().getKeyFormat();
   }
 
   private static ImmutableBiMap<ColumnName, ColumnName> buildAliasMapping(


### PR DESCRIPTION
### Description 

Minor follow-up to https://github.com/confluentinc/ksql/pull/7491. This PR only affects foreign key joins (still under development, hidden behind a feature flag). Because https://github.com/confluentinc/ksql/pull/7491 removed the PreJoinRepartition node for foreign key joins, it's now possible that a PreJoinProject node is immediately preceded by a DataSourceNode rather than another JoiningNode. This PR updates PreJoinProject to accommodate this rather than the current behavior which is to throw an error.

### Testing done 

Local QTT with feature flag enabled. (QTT for foreign key join still does not pass since the feature isn't complete yet, but the previous error that was thrown in PreJoinProject is no longer thrown.)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

