### PR TITLE
chore: disallow FK joins in n-way joins (MINOR)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -693,11 +693,21 @@ public class LogicalPlanner {
       if (joinOnNonKeyAttribute(leftExpression, leftNode)) {
         // foreign key join detected
 
-        // after we lift the n-way join restriction, we should be able to support FK-joins
-        // at any level in the join tree, even after we add right-deep/bushy join tree support,
-        // because a FK-join output table has the same PK as its left input table
-
         if (ksqlConfig.getBoolean(KsqlConfig.KSQL_FOREIGN_KEY_JOINS_ENABLED)) {
+
+          // after we lift this n-way join restriction, we should be able to support FK-joins
+          // at any level in the join tree, even after we add right-deep/bushy join tree support,
+          // because a FK-join output table has the same PK as its left input table
+          if (!(leftNode instanceof DataSourceNode)
+              || !(rightNode instanceof DataSourceNode)) {
+            throw new KsqlException(String.format(
+                "Invalid join condition: foreign-key table-table joins are not "
+                    + "supported as part of n-way joins. Got %s = %s.",
+                leftExpression,
+                rightExpression
+            ));
+          }
+
           return true;
         } else {
           throw new KsqlException(String.format(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -630,11 +630,13 @@ public class LogicalPlanner {
   /**
    * @return whether this is a foreign key join or not
    */
+  // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   private boolean verifyJoin(
       final JoinInfo joinInfo,
       final PlanNode leftNode,
       final PlanNode rightNode
   ) {
+    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     final JoinType joinType = joinInfo.getType();
     final Expression leftExpression = joinInfo.getLeftJoinExpression();
     final Expression rightExpression = joinInfo.getRightJoinExpression();

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
@@ -101,7 +101,9 @@
       "comments": [
         "After we add support for binary FK-joins, this test should still fail, but with a different error:",
         "The new error should point out that FK-joins cannot be used in n-way joins yet.",
-        "Note: this case should be supported after we lift the general restriction to not support FK-joins in n-way joins."
+        "Note: this case should be supported after we lift the general restriction to not support FK-joins in n-way joins.",
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test below (with the feature flag enabled)"
       ],
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
@@ -119,17 +121,152 @@
       "comments": [
         "After we add support for binary FK-joins, this test should still fail, but with a different error:",
         "The new error should point out that FK-joins cannot be used in n-way joins yet.",
+        "Note: this case should be supported after we lift the general restriction to not support FK-joins in n-way joins.",
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test below (with the feature flag enabled)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='middle_topic', format='JSON');",
+        "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, id3, f1, f2, f3 FROM left_table JOIN middle_table ON id1 = id2 JOIN right_table ON f1 = id3;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID3."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON id1 = f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for left-join - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON id1 = f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for outer-join - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON id1 = f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join with qualifiers - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON left_table.id1 = right_table.f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join with alias - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON lt.id1 = rt.f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LT.ID1 = RT.F2."
+      }
+    },
+    {
+      "name": "Should fail on n-way join (fk outer) - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
         "Note: this case should be supported after we lift the general restriction to not support FK-joins in n-way joins."
       ],
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='middle_topic', format='JSON');",
         "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, id3, f1, f2, f3 FROM left_table JOIN middle_table ON f1 = id2 JOIN right_table ON id2 = id3;"
+        "CREATE TABLE output AS SELECT id1, id2, id3, f1, f2, f3 FROM left_table JOIN middle_table ON id1 = id2 JOIN right_table ON f1 = id3;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = MIDDLE_TABLE.ID2."
+        "message": "Invalid join condition: foreign-key table-table joins are not supported as part of n-way joins. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID3."
+      }
+    },
+    {
+      "name": "Should fail on n-way join (fk inner) - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "Note: this case should be supported after we lift the general restriction to not support FK-joins in n-way joins."
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='middle_topic', format='JSON');",
+        "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, id3, f1, f2, f3 FROM left_table JOIN middle_table ON id1 = id2 JOIN right_table ON f1 = id3;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: foreign-key table-table joins are not supported as part of n-way joins. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID3."
       }
     }
   ]


### PR DESCRIPTION
### Description 

Three minor changes in this PR:
- disallows foreign key joins in n-way joins, for this first iteration of FK joins. Note that it's fine if a chain of n-way joins starts with an FK join (as processed from left to right), but not if an FK join is encountered later on in the chain.
- adds versions of the existing FK joins tests (all negative test cases, as the functionality is not yet complete) with the feature flag enabled
- updates the existing negative test case for FK joins as part of an n-way join to have the FK join as the second join in the chain, rather than the first, in light of the note above

### Testing done 

Tests pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

