### PR TITLE
docs: make getting started button clearer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@ keywords: ksqldb
 [ksqlDB](https://ksqldb.io/) is a database purpose-built
 for stream processing applications on top of {{ site.aktm }}.
 
+[Get Started](https://ksqldb.io/quickstart.html){ .md-button .md-button--top-level }
+
 ## Try it
 
 <div class="cards">

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -155,3 +155,15 @@ ul.card-items li {
 .card.reference {
     border-top: 3.5px solid #66CC69;
 }
+
+.md-button--top-level {
+    background-color: #ef5762;
+    border-color: #ef5762 !important;
+    color: #ffffff !important;
+}
+
+.md-typeset .md-button:focus, .md-typeset .md-button:hover {
+    opacity: 0.85 !important;
+    background-color: #ef5762 !important;
+    border-color: #ef5762 !important;
+}


### PR DESCRIPTION
### Description 

Can't hurt to make it easier to start. :)

<img width="1389" alt="Screen Shot 2021-05-12 at 2 11 53 PM" src="https://user-images.githubusercontent.com/918857/118044876-0e03e000-b32c-11eb-90e7-643451f435d0.png">

