### PR TITLE
chore: ksqlDB java client can extend Closeable

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.api.client;
 
 import io.confluent.ksql.api.client.impl.ClientImpl;
 import io.vertx.core.Vertx;
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -25,7 +26,7 @@ import org.reactivestreams.Publisher;
 /**
  * A client that connects to a specific ksqlDB server.
  */
-public interface Client {
+public interface Client extends Closeable {
 
   /**
    * Executes a query (push or pull) and returns the results one row at a time.


### PR DESCRIPTION
Signed-off-by: Arjun Satish <arjun@confluent.io>

### Description 
ksqldb java client can extend the java.io.closeable interface. 

### Testing done 
clean run of unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

