### PR TITLE
test: don't allow FK-outer joins and add QTT cases for FK-join with flipped join condition

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -400,6 +400,7 @@ public class Analysis implements ImmutableAnalysis {
     private final Optional<WithinExpression> withinExpression;
     private final AliasedDataSource leftSource;
     private final AliasedDataSource rightSource;
+    private final boolean flippedJoinCondition;
 
     JoinInfo(
         final AliasedDataSource leftSource,
@@ -407,6 +408,7 @@ public class Analysis implements ImmutableAnalysis {
         final AliasedDataSource rightSource,
         final Expression rightJoinExpression,
         final JoinType type,
+        final boolean flippedJoinCondition,
         final Optional<WithinExpression> withinExpression
 
     ) {
@@ -415,6 +417,7 @@ public class Analysis implements ImmutableAnalysis {
       this.leftJoinExpression = requireNonNull(leftJoinExpression, "leftJoinExpression");
       this.rightJoinExpression = requireNonNull(rightJoinExpression, "rightJoinExpression");
       this.type = requireNonNull(type, "type");
+      this.flippedJoinCondition = flippedJoinCondition;
       this.withinExpression = requireNonNull(withinExpression, "withinExpression");
     }
 
@@ -438,6 +441,10 @@ public class Analysis implements ImmutableAnalysis {
       return type;
     }
 
+    public boolean hasFlippedJoinCondition() {
+      return flippedJoinCondition;
+    }
+
     public Optional<WithinExpression> getWithinExpression() {
       return withinExpression;
     }
@@ -449,6 +456,7 @@ public class Analysis implements ImmutableAnalysis {
           leftSource,
           leftJoinExpression,
           type,
+          true,
           withinExpression
       );
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -382,6 +382,7 @@ class Analyzer {
           right,
           comparisonExpression.getRight(),
           joinType,
+          flipped,
           node.getWithinExpression()
       );
       analysis.addJoin(flipped ? joinInfo.flip() : joinInfo);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -699,8 +699,8 @@ public class LogicalPlanner {
 
           if (joinInfo.getType().equals(JoinType.OUTER)) {
             throw new KsqlException(String.format(
-                "Invalid join type: "
-                    + "full-outer join not supported for foreign-key table-table join."
+                "Invalid join type:"
+                    + " full-outer join not supported for foreign-key table-table join."
                     + " Got %s %s %s.",
                 joinInfo.getLeftSource().getDataSource().getName().text(),
                 joinType,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -661,8 +661,8 @@ public class LogicalPlanner {
                   "Invalid join condition:"
                       + " stream-table joins require to join on the table's primary key."
                       + " Got %s = %s.",
-                  leftExpression,
-                  rightExpression
+                  joinInfo.hasFlippedJoinCondition() ? rightExpression : leftExpression,
+                  joinInfo.hasFlippedJoinCondition() ? leftExpression : rightExpression
               ));
         }
       }
@@ -687,8 +687,8 @@ public class LogicalPlanner {
                 "Invalid join condition:"
                     + " table-table joins require to join on the primary key of the right input"
                     + " table. Got %s = %s.",
-                leftExpression,
-                rightExpression
+                joinInfo.hasFlippedJoinCondition() ? rightExpression : leftExpression,
+                joinInfo.hasFlippedJoinCondition() ? leftExpression : rightExpression
            ));
       }
 
@@ -696,6 +696,17 @@ public class LogicalPlanner {
         // foreign key join detected
 
         if (ksqlConfig.getBoolean(KsqlConfig.KSQL_FOREIGN_KEY_JOINS_ENABLED)) {
+
+          if (joinInfo.getType().equals(JoinType.OUTER)) {
+            throw new KsqlException(String.format(
+                "Invalid join type: "
+                    + "full-outer join not supported for foreign-key table-table join."
+                    + " Got %s %s %s.",
+                joinInfo.getLeftSource().getDataSource().getName().text(),
+                joinType,
+                joinInfo.getRightSource().getDataSource().getName().text()
+            ));
+          }
 
           // after we lift this n-way join restriction, we should be able to support FK-joins
           // at any level in the join tree, even after we add right-deep/bushy join tree support,
@@ -705,8 +716,8 @@ public class LogicalPlanner {
             throw new KsqlException(String.format(
                 "Invalid join condition: foreign-key table-table joins are not "
                     + "supported as part of n-way joins. Got %s = %s.",
-                leftExpression,
-                rightExpression
+                joinInfo.hasFlippedJoinCondition() ? rightExpression : leftExpression,
+                joinInfo.hasFlippedJoinCondition() ? leftExpression : rightExpression
             ));
           }
 
@@ -715,8 +726,8 @@ public class LogicalPlanner {
           throw new KsqlException(String.format(
               "Invalid join condition:"
                   + " foreign-key table-table joins are not supported. Got %s = %s.",
-              leftExpression,
-              rightExpression
+              joinInfo.hasFlippedJoinCondition() ? rightExpression : leftExpression,
+              joinInfo.hasFlippedJoinCondition() ? leftExpression : rightExpression
           ));
         }
       }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
@@ -13,11 +13,35 @@
       }
     },
     {
+      "name": "Should fail on right non-key attribute for inner-join -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON f2 = id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
       "name": "Should fail on right non-key attribute for left-join",
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
         "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON id1 = f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for left-join -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON f2 = id1;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
@@ -37,11 +61,35 @@
       }
     },
     {
+      "name": "Should fail on right non-key attribute for outer-join -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON f2 = id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
       "name": "Should fail on left non-key attribute for inner-join",
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
         "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON f1 = id2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID2."
+      }
+    },
+    {
+      "name": "Should fail on left non-key attribute for inner-join -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON id2 = f1;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
@@ -61,11 +109,35 @@
       }
     },
     {
+      "name": "Should fail on left non-key attribute for left-join -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON id2 = f1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID2."
+      }
+    },
+    {
       "name": "Should fail on left non-key attribute for outer-join",
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
         "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON f1 = id2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID2."
+      }
+    },
+    {
+      "name": "Should fail on left non-key attribute for outer-joinc",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON id2 = f1;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
@@ -85,11 +157,35 @@
       }
     },
     {
+      "name": "Should fail on right non-key attribute for inner-join with qualifiers -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON right_table.f2 = left_table.id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
       "name": "Should fail on right non-key attribute for inner-join with alias",
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
         "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON lt.id1 = rt.f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LT.ID1 = RT.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join with alias -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON rt.f2 = lt.id1;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
@@ -156,6 +252,25 @@
       }
     },
     {
+      "name": "Should fail on right non-key attribute for inner-join (reverse join condition order) - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON f2 = id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
       "name": "Should fail on right non-key attribute for left-join - feature flag enabled",
       "properties": {
         "ksql.joins.foreign.key.enable": true
@@ -168,6 +283,25 @@
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
         "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON id1 = f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for left-join (reverse join condition order) - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON f2 = id1;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
@@ -194,6 +328,25 @@
       }
     },
     {
+      "name": "Should fail on right non-key attribute for outer-join (reverse join condition order) - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON f2 = id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
       "name": "Should fail on right non-key attribute for inner-join with qualifiers - feature flag enabled",
       "properties": {
         "ksql.joins.foreign.key.enable": true
@@ -213,6 +366,25 @@
       }
     },
     {
+      "name": "Should fail on right non-key attribute for inner-join with qualifiers (reverse join condition order) - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON right_table.f2 = left_table.id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
       "name": "Should fail on right non-key attribute for inner-join with alias - feature flag enabled",
       "properties": {
         "ksql.joins.foreign.key.enable": true
@@ -225,6 +397,25 @@
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
         "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON lt.id1 = rt.f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LT.ID1 = RT.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join with alias (reverse join condition order - feature flag enabled",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "comments": [
+        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
+        "as it duplicates another test above (without the feature flag)"
+      ],
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON rt.f2 = lt.id1;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
@@ -1,78 +1,6 @@
 {
   "tests": [
     {
-      "name": "Should fail on right non-key attribute for inner-join",
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON id1 = f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join -- revers join condition order",
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON f2 = id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for left-join",
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON id1 = f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for left-join -- revers join condition order",
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON f2 = id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for outer-join",
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON id1 = f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for outer-join -- revers join condition order",
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON f2 = id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
       "name": "Should fail on left non-key attribute for inner-join",
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
@@ -93,7 +21,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID2."
+        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got RIGHT_TABLE.ID2 = LEFT_TABLE.F1."
       }
     },
     {
@@ -117,7 +45,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID2."
+        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got RIGHT_TABLE.ID2 = LEFT_TABLE.F1."
       }
     },
     {
@@ -133,7 +61,7 @@
       }
     },
     {
-      "name": "Should fail on left non-key attribute for outer-joinc",
+      "name": "Should fail on left non-key attribute for outer-join -- revers join condition order",
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
@@ -141,55 +69,37 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID2."
+        "message": "Invalid join condition: foreign-key table-table joins are not supported. Got RIGHT_TABLE.ID2 = LEFT_TABLE.F1."
       }
     },
     {
-      "name": "Should fail on right non-key attribute for inner-join with qualifiers",
+      "name": "Should fail on outer-join",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON left_table.id1 = right_table.f2;"
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON f1 = id2;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+        "message": "Invalid join type: full-outer join not supported for foreign-key table-table join. Got LEFT_TABLE [FULL] OUTER JOIN RIGHT_TABLE."
       }
     },
     {
-      "name": "Should fail on right non-key attribute for inner-join with qualifiers -- revers join condition order",
+      "name": "Should fail on outer-join -- reverse join condition",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
       "statements": [
         "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
         "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON right_table.f2 = left_table.id1;"
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON id2 = f1;"
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join with alias",
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON lt.id1 = rt.f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LT.ID1 = RT.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join with alias -- revers join condition order",
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON rt.f2 = lt.id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LT.ID1 = RT.F2."
+        "message": "Invalid join type: full-outer join not supported for foreign-key table-table join. Got LEFT_TABLE [FULL] OUTER JOIN RIGHT_TABLE."
       }
     },
     {
@@ -230,196 +140,6 @@
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Invalid join condition: foreign-key table-table joins are not supported. Got LEFT_TABLE.F1 = RIGHT_TABLE.ID3."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON id1 = f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join (reverse join condition order) - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON f2 = id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for left-join - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON id1 = f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for left-join (reverse join condition order) - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON f2 = id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for outer-join - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON id1 = f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for outer-join (reverse join condition order) - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON f2 = id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join with qualifiers - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON left_table.id1 = right_table.f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join with qualifiers (reverse join condition order) - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON right_table.f2 = left_table.id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join with alias - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON lt.id1 = rt.f2;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LT.ID1 = RT.F2."
-      }
-    },
-    {
-      "name": "Should fail on right non-key attribute for inner-join with alias (reverse join condition order - feature flag enabled",
-      "properties": {
-        "ksql.joins.foreign.key.enable": true
-      },
-      "comments": [
-        "TODO: this test should be deleted once the feature is ungated and the feature flag is removed",
-        "as it duplicates another test above (without the feature flag)"
-      ],
-      "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON rt.f2 = lt.id1;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LT.ID1 = RT.F2."
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/table-table-join.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/table-table-join.json
@@ -1,0 +1,124 @@
+{
+  "tests": [
+    {
+      "name": "Should fail on right non-key attribute for inner-join",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON id1 = f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON f2 = id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got RIGHT_TABLE.F2 = LEFT_TABLE.ID1."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for left-join",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON id1 = f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for left-join -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table LEFT JOIN right_table ON f2 = id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got RIGHT_TABLE.F2 = LEFT_TABLE.ID1."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for outer-join",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON id1 = f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for outer-join -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table FULL OUTER JOIN right_table ON f2 = id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got RIGHT_TABLE.F2 = LEFT_TABLE.ID1."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join with qualifiers",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON left_table.id1 = right_table.f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LEFT_TABLE.ID1 = RIGHT_TABLE.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join with qualifiers -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table JOIN right_table ON right_table.f2 = left_table.id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got RIGHT_TABLE.F2 = LEFT_TABLE.ID1."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join with alias",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON lt.id1 = rt.f2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got LT.ID1 = RT.F2."
+      }
+    },
+    {
+      "name": "Should fail on right non-key attribute for inner-join with alias -- revers join condition order",
+      "statements": [
+        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE right_table (id2 BIGINT PRIMARY KEY, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT id1, id2, f1, f2 FROM left_table AS lt JOIN right_table AS rt ON rt.f2 = lt.id1;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join condition: table-table joins require to join on the primary key of the right input table. Got RT.F2 = LT.ID1."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
Add a check to disallow OUTER join for FK-joins.

Add new tests for FK-joins with "flipped" join condition. Luckily `JoinTree.build()` take care of the order by calling `join.flip()` if necessary, and thus we don't need to write additional code for FK-joins for this case. However, we should have the corresponding tests.

### Testing done 
Only added tests for binary joins. Not sure if we should add tests for n-way joins at this point, as don't plan to support n-way joins yet.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

