### PR TITLE
Use Java's Base64 instead of Jersey's.

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
@@ -31,8 +31,10 @@ import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.rest.RestConfig;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -48,7 +50,6 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.glassfish.jersey.internal.util.Base64;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -185,7 +186,8 @@ public class BasicAuthFunctionalTest {
   }
 
   private static String buildBasicAuthHeader(final String userName, final String password) {
-    return Base64.encodeAsString(userName + ":" + password);
+    final String creds = userName + ":" + password;
+    return Base64.getEncoder().encodeToString(creds.getBytes(Charset.defaultCharset()));
   }
 
   private static String createJaasConfigContent() {


### PR DESCRIPTION
### Description 

This is a partial backport of @niteshmor's https://github.com/confluentinc/ksql/pull/6702/ back to `5.2.x`. It's only partial because only 1 of the 4 main changes actually apply here.
- In `5.2.x`, the 2 changed POMs don't have the dependency from which Jetty is excluded, and the integration test doesn't exist.

Just like [its sibling change in the blueway repo](https://github.com/confluentinc/blueway/pull/2258), this change is needed because of the CVE fixes in confluentinc/rest-utils#252 and confluentinc/rest-utils#253 - the `rest-utils` changes will be breaking without this.

The change is also missing from 5.3.x, but it's probably best to merge it with `-s ours` from here up and to post a separate PR with a full cherry-pick of the #6702 changes into `5.3.x` (which again should be merged up with `-s ours`, as the original PR landed in `5.4.x` and above).

### Testing done 

- `mvn clean package -DskipTests` for the build
- `mvn -f ksql-cli/pom.xml -Dit.test=BasicAuthFunctionalTest test-compile failsafe:integration-test` for the test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

