### PR TITLE
Backport "fix: use Java's Base64 instead of jersey's (#6702)"

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
@@ -32,8 +32,10 @@ import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.rest.RestConfig;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -50,7 +52,6 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.glassfish.jersey.internal.util.Base64;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -190,7 +191,8 @@ public class BasicAuthFunctionalTest {
   }
 
   private static String buildBasicAuthHeader(final String userName, final String password) {
-    return Base64.encodeAsString(userName + ":" + password);
+    final String creds = userName + ":" + password;
+    return Base64.getEncoder().encodeToString(creds.getBytes(Charset.defaultCharset()));
   }
 
   private static String createJaasConfigContent() {

--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -144,6 +144,16 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Transitive dependency of wiremock-jre8 that's excluded in ksql-parent pom.xml
+             because it brings an older version of jetty than we'd like -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <!-- jetty.version definition comes from rest-utils -->
+            <version>${jetty.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -29,6 +29,8 @@ import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.test.util.secure.Credentials;
 import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +42,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.glassfish.jersey.internal.util.Base64;
 
 final class RestIntegrationTestUtil {
 
@@ -149,7 +150,8 @@ final class RestIntegrationTestUtil {
   }
 
   private static String buildBasicAuthHeader(final Credentials credentials) {
-    return Base64.encodeAsString(credentials.username + ":" + credentials.password);
+    final String creds = credentials.username + ":" + credentials.password;
+    return Base64.getEncoder().encodeToString(creds.getBytes(Charset.defaultCharset()));
   }
 
   private static String buildStreamingRequest(final String sql) {


### PR DESCRIPTION
### Description 

This is a cherry-pick of @niteshmor's https://github.com/confluentinc/ksql/pull/6702 back to `5.3.x`. Unlike the similar change in `5.2.x` (see #7534), this is almost identical to Nitesh's original change.

Just like its sibling changes for `5.2.x` and [in the blueway repo](https://github.com/confluentinc/blueway/pull/2258), this change is needed because of the CVE fixes in confluentinc/rest-utils#252 and confluentinc/rest-utils#253 - the rest-utils changes will be breaking without this.

### Testing done 

- `mvn clean package -DskipTests` for the build
- `mvn -f ksql-rest-app/pom.xml -Dit.test=ClusterTerminationTest,KsqlResourceFunctionalTest,RestApiTest test-compile failsafe:integration-test` for the test utility

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

