### PR TITLE
docs: document query API deprecation

### DIFF
--- a/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
@@ -15,8 +15,8 @@ the response is streamed until the client closes the connection.
 !!! note
       This endpoint was proposed to be deprecated as part of 
       [KLIP-15](https://github.com/confluentinc/ksql/blob/master/design-proposals/klip-15-new-api-and-client.md)
-      in favor of the new `HTTP/2` [`/query-stream`](developer-guide/ksqldb-rest-api/streaming-endpoint).
-      The deprecation itself is not yet scheduled, but if you are able to use HTTP/2,
+      in favor of the new `HTTP/2` [`/query-stream`](/developer-guide/ksqldb-rest-api/streaming-endpoint).
+      The deprecation itself is not yet scheduled, but if you are able to use `HTTP/2`,
       you are recommended to favor `/query-stream`.
 
 ## POST /query

--- a/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
@@ -12,6 +12,13 @@ until the `LIMIT` specified in the statement is reached, or the client
 closes the connection. If no `LIMIT` is specified in the statement, then
 the response is streamed until the client closes the connection.
 
+!!! note
+      This endpoint was proposed to be deprecated as part of 
+      [KLIP-15](https://github.com/confluentinc/ksql/blob/master/design-proposals/klip-15-new-api-and-client.md)
+      in favor of the new `HTTP/2` [`/query-stream`](developer-guide/ksqldb-rest-api/streaming-endpoint).
+      The deprecation itself is not yet scheduled, but if you are able to use HTTP/2,
+      you are recommended to favor `/query-stream`.
+
 ## POST /query
 
 :   Run a ``SELECT`` statement and stream back the results.


### PR DESCRIPTION
### Description 
KLIP-15 proposed to deprecate the `/query` endpoint, which is commonly understood
by some, but never documented nor widely discussed. This adds a callout to the docs
so that new users can be more informed.

### Testing done 
I built the docs locally and verified the appearance and the links.
![docs_000](https://user-images.githubusercontent.com/832787/118544771-63206700-b71b-11eb-845c-e37319a3cf8d.png)


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

