### PR TITLE
docs: specify HTTP1.1 for curl

### DIFF
--- a/docs/developer-guide/ksqldb-rest-api/info-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/info-endpoint.md
@@ -11,7 +11,7 @@ Server, which can be useful for health checks and troubleshooting. You
 can use the `curl` command to query the `/info` endpoint:
 
 ```bash
-curl -sX GET "http://localhost:8088/info" | jq '.'
+curl --http1.1 -sX GET "http://localhost:8088/info" | jq '.'
 ```
 
 Your output should resemble:
@@ -30,7 +30,7 @@ You can also check the health of your ksqlDB server by using the
 ``/healthcheck`` resource:
 
 ```bash
-curl -sX GET "http://localhost:8088/healthcheck" | jq '.'
+curl --http1.1 -sX GET "http://localhost:8088/healthcheck" | jq '.'
 ```
 
 Your output should resemble:

--- a/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
@@ -192,7 +192,8 @@ The ``/ksql`` endpoint may return the following error codes in the ``error_code`
 ### Example curl command
 
 ```bash
-curl -X "POST" "http://<ksqldb-host-name>:8088/ksql" \
+curl --http1.1
+     -X "POST" "http://<ksqldb-host-name>:8088/ksql" \
      -H "Accept: application/vnd.ksql.v1+json" \
      -d $'{
   "ksql": "LIST STREAMS;",

--- a/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
@@ -52,7 +52,8 @@ Response JSON Object:
 ### Example curl command
 
 ```bash
-curl -X "POST" "http://<ksqldb-host-name>:8088/query" \
+curl --http1.1
+     -X "POST" "http://<ksqldb-host-name>:8088/query" \
      -H "Accept: application/vnd.ksql.v1+json" \
      -d $'{
   "ksql": "SELECT * FROM USERS EMIT CHANGES;",


### PR DESCRIPTION
### Description 
Some versions of `curl` defaults to HTTP2, which not all our APIs support.
To avoid confusion, we can just specify HTTP1.1 in the docs.

### Testing done 
I spun up a local ksql cluster using the quickstart and issued all the curl commands in this changeset.
I also generated the docs and verified the formatting.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

