### PR TITLE
docs: document UDF configs

### DIFF
--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -74,7 +74,7 @@ an external `ksql.connect.url`.
 ## `ksql.extension.dir`
 
 The directory in which ksqlDB looks for UDFs. The default value
-is the `ext` directory relative to the ksqlDB's current working directory.
+is the `ext` directory relative to ksqlDB's current working directory.
 
 ## `ksql.fail.on.deserialization.error`
 

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -73,7 +73,7 @@ an external `ksql.connect.url`.
 
 ## `ksql.extension.dir`
 
-The directory in which ksqlDB will look for UDFs. The default value
+The directory in which ksqlDB looks for UDFs. The default value
 is the `ext` directory relative to the ksqlDB's current working directory.
 
 ## `ksql.fail.on.deserialization.error`

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -117,7 +117,7 @@ Makes custom configuration values available to the UDF specified by name.
 For example, if a UDF is named "formula", then you can pass a config
 to that UDF by specifying the property `ksql.functions.formula.base.value`.
 Access the property in the UDF's `configure` method
-by the full name, `ksql.funcitons.formula.base.value`. This example
+by using its full name, `ksql.functions.formula.base.value`. This example
 is explored in detail [here](/how-to-guides/create-a-user-defined-function/).
 
 ## `ksql.functions.collect_list.limit`

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -115,7 +115,7 @@ ksql.fail.on.production.error=false
 
 Makes custom configuration values available to the UDF specified by name.
 For example, if a UDF is named "formula", then you can pass a config
-to that UDF by specifying the property `ksql.functions.formula.base.value`.
+to that UDF by specifying the `ksql.functions.formula.base.value` property.
 Access the property in the UDF's `configure` method
 by using its full name, `ksql.functions.formula.base.value`. This example
 is explored in detail [here](/how-to-guides/create-a-user-defined-function/).

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -114,7 +114,7 @@ ksql.fail.on.production.error=false
 ## `ksql.functions.<UDF Name>.<UDF Config>`
 
 Makes custom configuration values available to the UDF specified by name.
-For example, if a UDF is named "formula", then you can pass a config
+For example, if a UDF is named "formula", you can pass a config
 to that UDF by specifying the `ksql.functions.formula.base.value` property.
 Access the property in the UDF's `configure` method
 by using its full name, `ksql.functions.formula.base.value`. This example

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -71,6 +71,11 @@ The connect worker configuration file, if spinning up {{ site.kconnect }}
 alongside the ksqlDB server. Don't set this property if you're using
 an external `ksql.connect.url`.
 
+## `ksql.extension.dir`
+
+The directory in which ksqlDB will look for UDFs. The default value
+is the `ext` directory relative to the ksqlDB's current working directory.
+
 ## `ksql.fail.on.deserialization.error`
 
 **Per query:** yes
@@ -105,6 +110,15 @@ to your ksqlDB Server properties file:
 ```properties
 ksql.fail.on.production.error=false
 ```
+
+## `ksql.functions.<UDF Name>.<UDF Config>`
+
+Makes custom configuration values available to the UDF specified by name.
+For example, if a UDF is named "formula", then you can pass a config
+to that UDF by specifying the property `ksql.functions.formula.base.value`.
+Within the UDF's `configure` method, it will have access to the propery
+by the full name, `ksql.funcitons.formula.base.value`. This example
+is explored in detail [here](/how-to-guides/create-a-user-defined-function/).
 
 ## `ksql.functions.collect_list.limit`
 

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -116,7 +116,7 @@ ksql.fail.on.production.error=false
 Makes custom configuration values available to the UDF specified by name.
 For example, if a UDF is named "formula", then you can pass a config
 to that UDF by specifying the property `ksql.functions.formula.base.value`.
-Within the UDF's `configure` method, it will have access to the propery
+Access the property in the UDF's `configure` method
 by the full name, `ksql.funcitons.formula.base.value`. This example
 is explored in detail [here](/how-to-guides/create-a-user-defined-function/).
 


### PR DESCRIPTION
### Description 
The documentation for key UDF configs was missing:
1. the directory where UDFs must be uploaded
2. the pattern for passing configs to UDFs

### Testing done 
I built the docs and verified the formatting as well as the hyperlink.
![ext](https://user-images.githubusercontent.com/832787/118558647-91f30900-b72c-11eb-854a-ea210b280aea.png)
![fn](https://user-images.githubusercontent.com/832787/118558662-95869000-b72c-11eb-8372-909ededbbe55.png)


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

