### PR TITLE
chore: KREST-1030 suppress deprecated usage of SslContextFactory

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -47,7 +47,6 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpStatus.Code;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.util.ssl.SslContextFactory.Server;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
@@ -95,10 +94,11 @@ public class SslFunctionalTest {
     new TopicProducer(CLUSTER).produceInputData(dataProvider);
   }
 
+  @SuppressWarnings("deprecation")
   @Before
   public void setUp() {
     clientProps = Collections.emptyMap();
-    sslContextFactory = new Server();
+    sslContextFactory = new SslContextFactory();
   }
 
   @Test

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -47,6 +47,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpStatus.Code;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory.Server;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
@@ -97,7 +98,7 @@ public class SslFunctionalTest {
   @Before
   public void setUp() {
     clientProps = Collections.emptyMap();
-    sslContextFactory = new SslContextFactory();
+    sslContextFactory = new Server();
   }
 
   @Test


### PR DESCRIPTION
### Description 
~Replaced a usage of the default `SslContextFactory` ctor in order to avoid a warning that breaks the build once Jetty is bumped so that the ctor is deprecated.~
I have replaced the fix with a warning suppression, so that this change can be merged proactively. The previous fix is better in theory, but it can be merged only after the `rest-utils` changes have been merged (so it also breaks CI right now).
- This is not a problem on `5.3.x` and above, so this change needs to land solely here. We should merge it up with `pint merge -s ours ksql`. **I actually don't have the permissions to do that, so I'll have to ask the reviewers to help me with this**.
- I didn't cherry-pick the changes fixing this in `5.3.x` as they are slightly messy (there are 2 commits for this, and there's a redundant suppression of deprecation there - see https://github.com/confluentinc/ksql/blob/b860520484e4677602d94a39e78e044db2a89184/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java).

### Testing done 
With the parent pom.xml edited to have explicit Jetty and Jersey dependencies with the versions bumped in https://github.com/confluentinc/rest-utils/pull/252, ensured that a local build passes successfully (it failed without this change with the error seen in https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/5502/console).
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

