### PR TITLE
fix: reject mismatched decimals from avro topics

### DIFF
--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -120,8 +120,7 @@ public class AvroDataTranslator implements DataTranslator {
       case STRUCT:
         return convertStruct((Struct) object, schema);
       case BYTES:
-        return DecimalUtil.ensureFit(
-            (BigDecimal) object, DecimalUtil.precision(schema), DecimalUtil.scale(schema));
+        return DecimalUtil.ensureFit((BigDecimal) object, schema);
       default:
         return object;
     }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.serde.avro;
 
 import io.confluent.ksql.serde.connect.ConnectDataTranslator;
 import io.confluent.ksql.serde.connect.DataTranslator;
+import io.confluent.ksql.util.DecimalUtil;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -117,7 +119,9 @@ public class AvroDataTranslator implements DataTranslator {
 
       case STRUCT:
         return convertStruct((Struct) object, schema);
-
+      case BYTES:
+        return DecimalUtil.ensureFit(
+            (BigDecimal) object, DecimalUtil.precision(schema), DecimalUtil.scale(schema));
       default:
         return object;
     }


### PR DESCRIPTION
### Description 
Fixes #7170 

If you run the following statements
```
CREATE STREAM A (dec DECIMAL(4,2)) WITH (topic='topic', value_format='AVRO');
CREATE STREAM B (dec DECIMAL(6,3)) WITH (topic='topic', value_format='AVRO');
CREATE STREAM C AS SELECT * FROM A;
INSERT INTO B VALUES (123.456);
```

You would end up with a `org.apache.kafka.common.errors.SerializationException` in the logs, instead of rejecting the value to begin with.  

And querying A would return the mismatched decimal
```
SELECT * FROM A EMIT CHANGES;
+---------+
|DEC      |
+---------+
|123.456  |

```

This PR changes the behaviour so that if there is a mismatching decimal, it first tries to convert the topic decimal to the ksql schema, and if that is impossible, then it skips that value and the logs a `org.apache.kafka.common.errors.SerializationException` in the streams log.


### Testing done 
Manually tested, added unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

