### PR TITLE
test: fix QTT tests after upstream change (#7306)

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_to_table_wrapped_single_field_value_schema_on_inputs/5.5.0_1581572097364/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_to_table_wrapped_single_field_value_schema_on_inputs/5.5.0_1581572097364/spec.json
@@ -82,6 +82,14 @@
     }, {
       "topic" : "OUTPUT",
       "key" : "0",
+      "value" : {
+        "ID1" : null,
+        "ID2" : null
+      },
+      "timestamp" : 40
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "0",
       "value" : null,
       "timestamp" : 50
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_to_table_wrapped_single_field_value_schema_on_inputs/6.0.0_1588893930352/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_to_table_wrapped_single_field_value_schema_on_inputs/6.0.0_1588893930352/spec.json
@@ -82,6 +82,14 @@
     }, {
       "topic" : "OUTPUT",
       "key" : 0,
+      "value" : {
+        "NAME1" : null,
+        "NAME2" : null
+      },
+      "timestamp" : 40
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
       "value" : null,
       "timestamp" : 50
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_to_table_wrapped_single_field_value_schema_on_inputs/6.0.0_1589910877721/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_table_to_table_wrapped_single_field_value_schema_on_inputs/6.0.0_1589910877721/spec.json
@@ -82,6 +82,14 @@
     }, {
       "topic" : "OUTPUT",
       "key" : 0,
+      "value" : {
+        "NAME1" : null,
+        "NAME2" : null
+      },
+      "timestamp" : 40
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
       "value" : null,
       "timestamp" : 50
     } ],


### PR DESCRIPTION
Cherrypick of fix in 6.1.x: [#7306](https://github.com/confluentinc/ksql/pull/7306) as these three tests have been failing on 6.0.x (presumably since the emit-on-change logic was originally reverted in Streams, so almost two months)

Cf. https://issues.apache.org/jira/browse/KAFKA-12508

