### PR TITLE
fix: better error message on illegal arithmetic with NULL values

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
@@ -31,7 +31,7 @@ public enum Operator {
     public SqlType resultType(final SqlType left, final SqlType right) {
       if (left == null || right == null) {
         throw new KsqlException(
-                String.format("Arithmetic on types %s and %s are not supported.", left, right));
+                String.format("Arithmetic on types %s and %s are not supported", left, right));
       }
       if (left.baseType() == SqlBaseType.STRING && right.baseType() == SqlBaseType.STRING) {
         return SqlTypes.STRING;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
@@ -30,7 +30,8 @@ public enum Operator {
     @Override
     public SqlType resultType(final SqlType left, final SqlType right) {
       if (left == null || right == null) {
-        throw new KsqlException("Arithmetic on types " + left + " and " + right + " are not supported.");
+        throw new KsqlException(
+                String.format("Arithmetic on types %s and %s are not supported.", left, right));
       }
       if (left.baseType() == SqlBaseType.STRING && right.baseType() == SqlBaseType.STRING) {
         return SqlTypes.STRING;
@@ -65,7 +66,8 @@ public enum Operator {
    */
   public SqlType resultType(final SqlType left, final SqlType right) {
     if (left == null || right == null) {
-      throw new KsqlException("Arithmetic on types " + left + " and " + right + " are not supported.");
+      throw new KsqlException(
+              String.format("Arithmetic on types %s and %s are not supported.", left, right));
     }
     if (left.baseType().isNumber() && right.baseType().isNumber()) {
       if (left.baseType().canImplicitlyCast(right.baseType())) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
@@ -28,7 +28,7 @@ import java.util.function.BinaryOperator;
 public enum Operator {
   ADD("+", SqlDecimal::add) {
     @Override
-    public SqlType resultType(final SqlType left, final SqlType right) {
+    public SqlType resultType(final SqlType left, final SqlType right) throws KsqlException {
       checkForNullTypes(left, right);
 
       if (left.baseType() == SqlBaseType.STRING && right.baseType() == SqlBaseType.STRING) {
@@ -62,7 +62,7 @@ public enum Operator {
    * @param right the right side of the operation.
    * @return the result schema.
    */
-  public SqlType resultType(final SqlType left, final SqlType right) {
+  public SqlType resultType(final SqlType left, final SqlType right) throws KsqlException {
     checkForNullTypes(left, right);
 
     if (left.baseType().isNumber() && right.baseType().isNumber()) {
@@ -87,7 +87,8 @@ public enum Operator {
         "Unsupported arithmetic types. " + left.baseType() + " " + right.baseType());
   }
 
-  private static void checkForNullTypes (final SqlType left, final SqlType right) throws KsqlException {
+  private static void checkForNullTypes(final SqlType left, final SqlType right)
+          throws KsqlException {
     if (left == null || right == null) {
       throw new KsqlException(
               String.format("Arithmetic on types %s and %s are not supported.", left, right));

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
@@ -29,6 +29,9 @@ public enum Operator {
   ADD("+", SqlDecimal::add) {
     @Override
     public SqlType resultType(final SqlType left, final SqlType right) {
+      if (left == null || right == null) {
+        throw new KsqlException("Arithmetic on types " + left + " and " + right + " are not supported.");
+      }
       if (left.baseType() == SqlBaseType.STRING && right.baseType() == SqlBaseType.STRING) {
         return SqlTypes.STRING;
       }
@@ -61,6 +64,9 @@ public enum Operator {
    * @return the result schema.
    */
   public SqlType resultType(final SqlType left, final SqlType right) {
+    if (left == null || right == null) {
+      throw new KsqlException("Arithmetic on types " + left + " and " + right + " are not supported.");
+    }
     if (left.baseType().isNumber() && right.baseType().isNumber()) {
       if (left.baseType().canImplicitlyCast(right.baseType())) {
         if (right.baseType() != SqlBaseType.DECIMAL) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
@@ -29,10 +29,8 @@ public enum Operator {
   ADD("+", SqlDecimal::add) {
     @Override
     public SqlType resultType(final SqlType left, final SqlType right) {
-      if (left == null || right == null) {
-        throw new KsqlException(
-                String.format("Arithmetic on types %s and %s are not supported.", left, right));
-      }
+      checkForNullTypes(left, right);
+
       if (left.baseType() == SqlBaseType.STRING && right.baseType() == SqlBaseType.STRING) {
         return SqlTypes.STRING;
       }
@@ -65,10 +63,8 @@ public enum Operator {
    * @return the result schema.
    */
   public SqlType resultType(final SqlType left, final SqlType right) {
-    if (left == null || right == null) {
-      throw new KsqlException(
-              String.format("Arithmetic on types %s and %s are not supported.", left, right));
-    }
+    checkForNullTypes(left, right);
+
     if (left.baseType().isNumber() && right.baseType().isNumber()) {
       if (left.baseType().canImplicitlyCast(right.baseType())) {
         if (right.baseType() != SqlBaseType.DECIMAL) {
@@ -89,5 +85,13 @@ public enum Operator {
 
     throw new KsqlException(
         "Unsupported arithmetic types. " + left.baseType() + " " + right.baseType());
+  }
+
+  private static void checkForNullTypes (final SqlType left, final SqlType right) throws KsqlException {
+    if (left == null || right == null) {
+      throw new KsqlException(
+              String.format("Arithmetic on types %s and %s are not supported.", left, right));
+    }
+    return;
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/Operator.java
@@ -31,7 +31,7 @@ public enum Operator {
     public SqlType resultType(final SqlType left, final SqlType right) {
       if (left == null || right == null) {
         throw new KsqlException(
-                String.format("Arithmetic on types %s and %s are not supported", left, right));
+                String.format("Arithmetic on types %s and %s are not supported.", left, right));
       }
       if (left.baseType() == SqlBaseType.STRING && right.baseType() == SqlBaseType.STRING) {
         return SqlTypes.STRING;

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/OperatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/OperatorTest.java
@@ -29,6 +29,8 @@ import static io.confluent.ksql.schema.ksql.types.SqlTypes.TIMESTAMP;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
@@ -90,6 +92,33 @@ public class OperatorTest {
   @Test
   public void shouldResolveModulusReturnType() {
     assertConversionRule(MODULUS, SqlDecimal::modulus);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenNullType() {
+    allOperations().forEach(op -> {
+      for (final SqlBaseType leftBaseType : SqlBaseType.values()) {
+        // When:
+        final Throwable exception = assertThrows(KsqlException.class,
+                () -> op.resultType(getType(leftBaseType), null));
+
+        // Then:
+        assertEquals(String.format("Arithmetic on types %s and null are not supported.",
+                getType(leftBaseType)), exception.getMessage());
+      }
+    });
+
+    allOperations().forEach(op -> {
+      for (final SqlBaseType rightBaseType : SqlBaseType.values()) {
+        // When:
+        final Throwable exception = assertThrows(KsqlException.class,
+                () -> op.resultType(null, getType(rightBaseType)));
+
+        // Then:
+        assertEquals(String.format("Arithmetic on types null and %s are not supported.",
+                getType(rightBaseType)), exception.getMessage());
+      }
+    });
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -178,6 +178,20 @@ public class ExpressionEvaluatorParityTest {
         compileTime("Arithmetic on types INTEGER and null are not supported."));
     assertOrdersError("'a' + null",  compileTime("Error processing expression: ('a' + null)."),
         compileTime("Arithmetic on types STRING and null are not supported."));
+    assertOrdersError("MAP(1 := 'cat') + null",  compileTime("Error processing expression: (MAP(1:='cat') + null)."),
+            compileTime("Arithmetic on types MAP<INTEGER, STRING> and null are not supported."));
+    assertOrdersError("Array[1,2,3] + null",  compileTime("Error processing expression: (ARRAY[1, 2, 3] + null)."),
+            compileTime("Arithmetic on types ARRAY<INTEGER> and null are not supported."));
+    assertOrdersError("1 - null",  compileTime("Error processing expression: (1 - null)."),
+            compileTime("Arithmetic on types INTEGER and null are not supported."));
+    assertOrdersError("1 * null",  compileTime("Error processing expression: (1 * null)."),
+            compileTime("Arithmetic on types INTEGER and null are not supported."));
+    assertOrdersError("1 / null",  compileTime("Error processing expression: (1 / null)."),
+            compileTime("Arithmetic on types INTEGER and null are not supported."));
+    assertOrdersError("null + null",  compileTime("Error processing expression: (null + null)."),
+            compileTime("Arithmetic on types null and null are not supported."));
+    assertOrdersError("null / 0",  compileTime("Error processing expression: (null / 0)."),
+            compileTime("Arithmetic on types null and INTEGER are not supported."));
     assertOrdersError("1 + ORDERID",  evalLogger(null));
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -174,10 +174,10 @@ public class ExpressionEvaluatorParityTest {
   @Test
   public void shouldDoArithmetic_nulls() throws Exception {
     ordersRow = GenericRow.genericRow(null, null, null, null, null, null, null, null, null);
-    assertOrdersError("1 + null",  compileTime("Unexpected error generating code for Test"),
-        compileTime("Unexpected error generating code for expression: (1 + null)"));
-    assertOrdersError("'a' + null",  compileTime("Unexpected error generating code for Test"),
-        compileTime("Unexpected error generating code for expression: ('a' + null)"));
+    assertOrdersError("1 + null",  compileTime("Error processing expression: (1 + null)."),
+        compileTime("Arithmetic on types INTEGER and null are not supported."));
+    assertOrdersError("'a' + null",  compileTime("Error processing expression: ('a' + null)."),
+        compileTime("Arithmetic on types STRING and null are not supported."));
     assertOrdersError("1 + ORDERID",  evalLogger(null));
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -174,24 +174,35 @@ public class ExpressionEvaluatorParityTest {
   @Test
   public void shouldDoArithmetic_nulls() throws Exception {
     ordersRow = GenericRow.genericRow(null, null, null, null, null, null, null, null, null);
-    assertOrdersError("1 + null",  compileTime("Error processing expression: (1 + null)."),
-        compileTime("Arithmetic on types INTEGER and null are not supported."));
-    assertOrdersError("'a' + null",  compileTime("Error processing expression: ('a' + null)."),
-        compileTime("Arithmetic on types STRING and null are not supported."));
-    assertOrdersError("MAP(1 := 'cat') + null",  compileTime("Error processing expression: (MAP(1:='cat') + null)."),
-            compileTime("Arithmetic on types MAP<INTEGER, STRING> and null are not supported."));
-    assertOrdersError("Array[1,2,3] + null",  compileTime("Error processing expression: (ARRAY[1, 2, 3] + null)."),
-            compileTime("Arithmetic on types ARRAY<INTEGER> and null are not supported."));
-    assertOrdersError("1 - null",  compileTime("Error processing expression: (1 - null)."),
-            compileTime("Arithmetic on types INTEGER and null are not supported."));
-    assertOrdersError("1 * null",  compileTime("Error processing expression: (1 * null)."),
-            compileTime("Arithmetic on types INTEGER and null are not supported."));
-    assertOrdersError("1 / null",  compileTime("Error processing expression: (1 / null)."),
-            compileTime("Arithmetic on types INTEGER and null are not supported."));
-    assertOrdersError("null + null",  compileTime("Error processing expression: (null + null)."),
-            compileTime("Arithmetic on types null and null are not supported."));
-    assertOrdersError("null / 0",  compileTime("Error processing expression: (null / 0)."),
-            compileTime("Arithmetic on types null and INTEGER are not supported."));
+
+    //The error message coming from the compiler and the interpreter should be the same
+    assertOrdersError("1 + null",  compileTime("Error processing expression: (1 + null). Arithmetic on types INTEGER and null are not supported."),
+        compileTime("Error processing expression: (1 + null). Arithmetic on types INTEGER and null are not supported."));
+
+    assertOrdersError("'a' + null",  compileTime("Error processing expression: ('a' + null). Arithmetic on types STRING and null are not supported."),
+        compileTime("Error processing expression: ('a' + null). Arithmetic on types STRING and null are not supported."));
+
+    assertOrdersError("MAP(1 := 'cat') + null",  compileTime("Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported."),
+            compileTime("Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported."));
+
+    assertOrdersError("Array[1,2,3] + null",  compileTime("Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported."),
+            compileTime("Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported."));
+
+    assertOrdersError("1 - null",  compileTime("Error processing expression: (1 - null). Arithmetic on types INTEGER and null are not supported."),
+            compileTime("Error processing expression: (1 - null). Arithmetic on types INTEGER and null are not supported."));
+
+    assertOrdersError("1 * null",  compileTime("Error processing expression: (1 * null). Arithmetic on types INTEGER and null are not supported."),
+            compileTime("Error processing expression: (1 * null). Arithmetic on types INTEGER and null are not supported."));
+
+    assertOrdersError("1 / null",  compileTime("Error processing expression: (1 / null). Arithmetic on types INTEGER and null are not supported."),
+            compileTime("Error processing expression: (1 / null). Arithmetic on types INTEGER and null are not supported."));
+
+    assertOrdersError("null + null",  compileTime("Error processing expression: (null + null). Arithmetic on types null and null are not supported."),
+            compileTime("Error processing expression: (null + null). Arithmetic on types null and null are not supported."));
+
+    assertOrdersError("null / 0",  compileTime("Error processing expression: (null / 0). Arithmetic on types null and INTEGER are not supported."),
+            compileTime("Error processing expression: (null / 0). Arithmetic on types null and INTEGER are not supported."));
+
     assertOrdersError("1 + ORDERID",  evalLogger(null));
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -153,14 +153,19 @@ public class ExpressionTypeManager {
     public Void visitArithmeticBinary(
         final ArithmeticBinaryExpression node,
         final Context context
-    ) {
+    ) throws KsqlException {
       process(node.getLeft(), context);
       final SqlType leftType = context.getSqlType();
 
       process(node.getRight(), context);
       final SqlType rightType = context.getSqlType();
 
-      final SqlType resultType = node.getOperator().resultType(leftType, rightType);
+      final SqlType resultType;
+      try {
+         resultType = node.getOperator().resultType(leftType, rightType);
+      } catch (KsqlException e) {
+        throw new KsqlException("Error processing expression " + node.toString() + ". " + e.getMessage());
+      }
 
       context.setSqlType(resultType);
       return null;

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -165,7 +165,7 @@ public class ExpressionTypeManager {
         resultType = node.getOperator().resultType(leftType, rightType);
       } catch (KsqlException e) {
         throw new KsqlException(String.format(
-                "Error processing expression %s. %s", node.toString(), e.getMessage()));
+                "Error processing expression: %s. %s", node.toString(), e.getMessage()));
       }
 
       context.setSqlType(resultType);

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -162,9 +162,10 @@ public class ExpressionTypeManager {
 
       final SqlType resultType;
       try {
-         resultType = node.getOperator().resultType(leftType, rightType);
+        resultType = node.getOperator().resultType(leftType, rightType);
       } catch (KsqlException e) {
-        throw new KsqlException("Error processing expression " + node.toString() + ". " + e.getMessage());
+        throw new KsqlException(String.format(
+                "Error processing expression %s. %s", node.toString(), e.getMessage()));
       }
 
       context.setSqlType(resultType);

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -165,7 +165,7 @@ public class ExpressionTypeManager {
         resultType = node.getOperator().resultType(leftType, rightType);
       } catch (KsqlException e) {
         throw new KsqlException(String.format(
-                "Error processing expression: %s. %s", node.toString(), e.getMessage()));
+                "Error processing expression: %s. %s", node.toString(), e.getMessage()), e);
       }
 
       context.setSqlType(resultType);

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/comparison-expression.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/comparison-expression.json
@@ -67,7 +67,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Error in WHERE expression: Unsupported arithmetic types. BOOLEAN DECIMAL"
+        "message": "Error in WHERE expression: Error processing expression: (true + 1.5). Unsupported arithmetic types. BOOLEAN DECIMAL"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
@@ -263,10 +263,9 @@
         "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT 1 + NULL FROM INPUT EMIT CHANGES;"
       ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (1 + null). Arithmetic on types INTEGER and null are not supported.",
-        "status": 400
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Error processing expression: (1 + null). Arithmetic on types INTEGER and null are not supported."
       }
     },
     {
@@ -275,10 +274,9 @@
         "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT MAP(1 := 'cat') + NULL FROM INPUT EMIT CHANGES;"
       ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported.",
-        "status": 400
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported."
       }
     },
     {
@@ -287,10 +285,9 @@
         "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT Array[1,2,3] + NULL FROM INPUT EMIT CHANGES;"
       ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported.",
-        "status": 400
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported."
       }
     },
     {
@@ -299,10 +296,9 @@
         "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT 5.0 / NULL FROM INPUT EMIT CHANGES;"
       ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (5.0 / null). Arithmetic on types DECIMAL(2, 1) and null are not supported.",
-        "status": 400
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Error processing expression: (5.0 / null). Arithmetic on types DECIMAL(2, 1) and null are not supported."
       }
     },
     {
@@ -311,10 +307,9 @@
         "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT NULL * NULL FROM INPUT EMIT CHANGES;"
       ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (null * null). Arithmetic on types null and null are not supported.",
-        "status": 400
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Error processing expression: (null * null). Arithmetic on types null and null are not supported."
       }
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
@@ -256,61 +256,6 @@
           }
         ]
       }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - INTEGER addition",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT 1 + NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Error processing expression: (1 + null). Arithmetic on types INTEGER and null are not supported."
-      }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - MAP addition",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT MAP(1 := 'cat') + NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported."
-      }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - ARRAY addition",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT Array[1,2,3] + NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported."
-      }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - DECIMAL division",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT 5.0 / NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Error processing expression: (5.0 / null). Arithmetic on types DECIMAL(2, 1) and null are not supported."
-      }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - NULL NULL multiplication",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT NULL * NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Error processing expression: (null * null). Arithmetic on types null and null are not supported."
-      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/math.json
@@ -256,6 +256,66 @@
           }
         ]
       }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - INTEGER addition",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT 1 + NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (1 + null). Arithmetic on types INTEGER and null are not supported.",
+        "status": 400
+      }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - MAP addition",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT MAP(1 := 'cat') + NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported.",
+        "status": 400
+      }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - ARRAY addition",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT Array[1,2,3] + NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported.",
+        "status": 400
+      }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - DECIMAL division",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT 5.0 / NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (5.0 / null). Arithmetic on types DECIMAL(2, 1) and null are not supported.",
+        "status": 400
+      }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - NULL NULL multiplication",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT NULL * NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (null * null). Arithmetic on types null and null are not supported.",
+        "status": 400
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -927,66 +927,6 @@
           {"finalMessage":"Limit Reached"}
         ]}
       ]
-    },
-    {
-      "name": "NULL Arithmetic Behavior - INTEGER addition",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT 1 + NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (1 + null). Arithmetic on types INTEGER and null are not supported.",
-        "status": 400
-      }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - MAP addition",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT MAP(1 := 'cat') + NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported.",
-        "status": 400
-      }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - ARRAY addition",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT Array[1,2,3] + NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported.",
-        "status": 400
-      }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - DECIMAL division",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT 5.0 / NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (5.0 / null). Arithmetic on types DECIMAL(2, 1) and null are not supported.",
-        "status": 400
-      }
-    },
-    {
-      "name": "NULL Arithmetic Behavior - NULL NULL multiplication",
-      "statements": [
-        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT NULL * NULL FROM INPUT EMIT CHANGES;"
-      ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
-        "message": "Error processing expression: (null * null). Arithmetic on types null and null are not supported.",
-        "status": 400
-      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -927,6 +927,66 @@
           {"finalMessage":"Limit Reached"}
         ]}
       ]
+    },
+    {
+      "name": "NULL Arithmetic Behavior - INTEGER addition",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT 1 + NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (1 + null). Arithmetic on types INTEGER and null are not supported.",
+        "status": 400
+      }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - MAP addition",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT MAP(1 := 'cat') + NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported.",
+        "status": 400
+      }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - ARRAY addition",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT Array[1,2,3] + NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported.",
+        "status": 400
+      }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - DECIMAL division",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT 5.0 / NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (5.0 / null). Arithmetic on types DECIMAL(2, 1) and null are not supported.",
+        "status": 400
+      }
+    },
+    {
+      "name": "NULL Arithmetic Behavior - NULL NULL multiplication",
+      "statements": [
+        "CREATE STREAM INPUT (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT NULL * NULL FROM INPUT EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Error processing expression: (null * null). Arithmetic on types null and null are not supported.",
+        "status": 400
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 
This PR makes the error handling better when we try to do arithmetic with `NULL`. 
```
ksql> SELECT NULL + 1 FROM s1 EMIT CHANGES;
Error processing expression (null + 1). Arithmetic on types null and INTEGER are not supported.

ksql> SELECT MAP(1 := 'cat') + NULL FROM s1 EMIT CHANGES;
Error processing expression: (MAP(1:='cat') + null). Arithmetic on types MAP<INTEGER, STRING> and null are not supported.

ksql> SELECT Array[1,2,3] + NULL FROM s1 EMIT CHANGES;
Error processing expression: (ARRAY[1, 2, 3] + null). Arithmetic on types ARRAY<INTEGER> and null are not supported.

ksql> SELECT 5.0 / NULL FROM s1 EMIT CHANGES;
Error processing expression: (5.0 / null). Arithmetic on types DECIMAL(2, 1) and null are not supported.

ksql> SELECT NULL * NULL FROM s1 EMIT CHANGES;
Error processing expression: (null * null). Arithmetic on types null and null are not supported.
```

### Testing done 
- manual testing
- Unit testing
- RQTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

