### PR TITLE
feat: add idle timeout

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -298,6 +298,21 @@ public class KsqlRestConfig extends AbstractConfig {
           + "many instances as there are cores you want to use, as each instance is single "
           + "threaded.";
 
+  public static final String IDLE_CONNECTION_TIMEOUT_SECONDS =
+          KSQL_CONFIG_PREFIX + "idle.connection.timeout.seconds";
+  public static final int DEFAULT_IDLE_CONNECTION_TIMEOUT_SECONDS = 60 * 60 * 24; // one day
+  public static final String IDLE_CONNECTION_TIMEOUT_SECONDS_DOC =
+      "The timeout for idle connections. A connection is idle if there is no data in either "
+          + "direction on that connection for the duration of the timeout. This includes "
+          + "connections where the client only makes occasional requests as well as connections "
+          + "where the server takes a long time to send back any data. An example of the latter "
+          + "case is when there is a long period with no new results to send back in response to "
+          + "a streaming query. You can decrease this timeout to close connections more "
+          + "aggressively and save server resources, or make it longer to be more tolerant of "
+          + "low data volume use cases. Note: even though the server's idle connection timeout "
+          + "is set to a high value, you may have firewalls or proxies that enforce their own "
+          + "idle connection timeouts.";
+
   public static final String WORKER_POOL_SIZE = KSQL_CONFIG_PREFIX + "worker.pool.size";
   public static final String WORKER_POOL_DOC =
       "Max number of worker threads for executing blocking code";
@@ -631,6 +646,13 @@ public class KsqlRestConfig extends AbstractConfig {
             oneOrMore(),
             Importance.MEDIUM,
             VERTICLE_INSTANCES_DOC
+        ).define(
+            IDLE_CONNECTION_TIMEOUT_SECONDS,
+            Type.INT,
+            DEFAULT_IDLE_CONNECTION_TIMEOUT_SECONDS,
+            oneOrMore(),
+            Importance.LOW,
+            IDLE_CONNECTION_TIMEOUT_SECONDS_DOC
         ).define(
             WORKER_POOL_SIZE,
             Type.INT,


### PR DESCRIPTION
### Description 
Expose a config to set the server's idle timeout to work around https://github.com/confluentinc/ksql/issues/6970

### Testing done 
Set the configuration to 5 seconds, ran the server locally, and verified that when I create a transient query on the HTTP2 API, the connection gets closed after 5 seconds of inactivity. I also verified that if I cancel my query (`Ctrl-C` on my `curl` command), the transient query gets shut down on the server.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

