### PR TITLE
chore: un-pin kafka dependency version

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/5.5.0_1581572097758/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/5.5.0_1581572097758/spec.json
@@ -82,7 +82,7 @@
         "S_ROWTIME" : 300,
         "S_SF" : 10,
         "T_ROWKEY" : 12589,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_TF" : 12
       },
       "timestamp" : 300

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1585912769122/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1585912769122/spec.json
@@ -82,7 +82,7 @@
         "S_ROWTIME" : 300,
         "S_SF" : 10,
         "T_ROWKEY" : 12589,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_TF" : 12
       },
       "timestamp" : 300

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1587575897830/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_key/6.0.0_1587575897830/spec.json
@@ -82,7 +82,7 @@
         "S_ROWTIME" : 300,
         "S_SF" : 10,
         "T_ROWKEY" : 12589,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_TF" : 12
       },
       "timestamp" : 300

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/5.5.0_1581572097800/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/5.5.0_1581572097800/spec.json
@@ -84,7 +84,7 @@
         "S_ROWTIME" : 300,
         "S_SF" : 12589,
         "T_ROWKEY" : 12589,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_ID" : 12589,
         "T_TF" : 12
       },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1585912769161/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1585912769161/spec.json
@@ -84,7 +84,7 @@
         "S_ROWTIME" : 300,
         "S_SF" : 12589,
         "T_ROWKEY" : 12589,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_ID" : 12589,
         "T_TF" : 12
       },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1587575897905/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1587575897905/spec.json
@@ -84,7 +84,7 @@
         "S_ROWTIME" : 300,
         "S_SF" : 12589,
         "T_ROWKEY" : 12589,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_ID" : 12589,
         "T_TF" : 12
       },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1588893931453/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1588893931453/spec.json
@@ -80,7 +80,7 @@
       "value" : {
         "S_K" : "b",
         "S_ROWTIME" : 300,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_ID" : 12589,
         "T_TF" : 12
       },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1589910878677/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1589910878677/spec.json
@@ -80,7 +80,7 @@
       "value" : {
         "S_K" : "b",
         "S_ROWTIME" : 300,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_ID" : 12589,
         "T_TF" : 12
       },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1594233293706/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.0.0_1594233293706/spec.json
@@ -80,7 +80,7 @@
       "value" : {
         "S_K" : "b",
         "S_ROWTIME" : 300,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_ID" : 12589,
         "T_TF" : 12
       },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.1.0_1594164289267/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/6.1.0_1594164289267/spec.json
@@ -80,7 +80,7 @@
       "value" : {
         "S_K" : "b",
         "S_ROWTIME" : 300,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_ID" : 12589,
         "T_TF" : 12
       },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/7.0.0_1618294660070/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_on_non-STRING_value_column/7.0.0_1618294660070/spec.json
@@ -80,7 +80,7 @@
       "value" : {
         "S_K" : "b",
         "S_ROWTIME" : 300,
-        "T_ROWTIME" : 300,
+        "T_ROWTIME" : 200,
         "T_ID" : 12589,
         "T_TF" : 12
       },

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/6.0.0_1588893939120/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/6.0.0_1588893939120/spec.json
@@ -98,8 +98,8 @@
         "T3_ID" : 0,
         "T3_V0" : 3,
         "S1_ROWTIME" : 12,
-        "T2_ROWTIME" : 12,
-        "T3_ROWTIME" : 12
+        "T2_ROWTIME" : 11,
+        "T3_ROWTIME" : 10
       },
       "timestamp" : 12
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/6.0.0_1589910884946/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/6.0.0_1589910884946/spec.json
@@ -98,8 +98,8 @@
         "T3_ID" : 0,
         "T3_V0" : 3,
         "S1_ROWTIME" : 12,
-        "T2_ROWTIME" : 12,
-        "T3_ROWTIME" : 12
+        "T2_ROWTIME" : 11,
+        "T3_ROWTIME" : 10
       },
       "timestamp" : 12
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/6.0.0_1594233301977/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/6.0.0_1594233301977/spec.json
@@ -98,8 +98,8 @@
         "T3_ID" : 0,
         "T3_V0" : 3,
         "S1_ROWTIME" : 12,
-        "T2_ROWTIME" : 12,
-        "T3_ROWTIME" : 12
+        "T2_ROWTIME" : 11,
+        "T3_ROWTIME" : 10
       },
       "timestamp" : 12
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/6.1.0_1594164298243/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/6.1.0_1594164298243/spec.json
@@ -98,8 +98,8 @@
         "T3_ID" : 0,
         "T3_V0" : 3,
         "S1_ROWTIME" : 12,
-        "T2_ROWTIME" : 12,
-        "T3_ROWTIME" : 12
+        "T2_ROWTIME" : 11,
+        "T3_ROWTIME" : 10
       },
       "timestamp" : 12
     } ],

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/7.0.0_1618294677621/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_explicit_ROWTIME/7.0.0_1618294677621/spec.json
@@ -98,8 +98,8 @@
         "T3_ID" : 0,
         "T3_V0" : 3,
         "S1_ROWTIME" : 12,
-        "T2_ROWTIME" : 12,
-        "T3_ROWTIME" : 12
+        "T2_ROWTIME" : 11,
+        "T3_ROWTIME" : 10
       },
       "timestamp" : 12
     } ],

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1746,7 +1746,7 @@
         {"topic": "stream_topic", "key": "b", "value": {"SF": 12589}, "timestamp": 300}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 12589, "value": {"S_K": "b", "S_ROWTIME": 300, "T_ROWTIME": 300, "T_ID": 12589, "T_TF": 12}, "timestamp": 300}
+        {"topic": "OUTPUT", "key": 12589, "value": {"S_K": "b", "S_ROWTIME": 300, "T_ROWTIME": 200, "T_ID": 12589, "T_TF": 12}, "timestamp": 300}
       ],
       "post": {
         "sources": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -371,7 +371,7 @@
         {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 12}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_ID": 0, "T2_V0": 2, "T3_ID": 0, "T3_V0": 3, "S1_ROWTIME": 12, "T2_ROWTIME": 12, "T3_ROWTIME": 12}, "timestamp": 12}
+        {"topic": "OUTPUT", "key": 0, "value": {"S1_V0": 1, "T2_ID": 0, "T2_V0": 2, "T3_ID": 0, "T3_V0": 3, "S1_ROWTIME": 12, "T2_ROWTIME": 11, "T3_ROWTIME": 10}, "timestamp": 12}
       ],
       "post": {
         "topics": {"blacklist": ".*-repartition"},

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.rest.entity;
 
-import static org.glassfish.jersey.internal.util.collection.ImmutableCollectors.toImmutableList;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.Streams;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -35,6 +35,8 @@ public final class DiscoverRemoteHostsUtil {
       final KsqlHostInfo localHost
   ) {
     return currentQueries.stream()
+        // required filter else QueryMetadata.getAllMetadata() throws
+        .filter(q -> q.getState().isRunningOrRebalancing())
         .map(QueryMetadata::getAllMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteHostExecutorTest.java
@@ -1,5 +1,19 @@
-package io.confluent.ksql.rest.server.execution;
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
+package io.confluent.ksql.rest.server.execution;
 
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.parser.tree.DescribeStreams;
@@ -38,7 +52,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoteHostExecutorTest {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtilTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.util.KsqlHostInfo;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.state.StreamsMetadata;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiscoverRemoteHostsUtilTest {
+
+  private static KsqlHostInfo THIS_HOST_INFO = new KsqlHostInfo("this_host", 8088);
+  private static HostInfo OTHER_HOST_INFO = new HostInfo("other_host", 8088);
+
+  @Mock
+  private PersistentQueryMetadata runningQuery;
+  @Mock
+  private PersistentQueryMetadata notRunningQuery;
+  @Mock
+  private StreamsMetadata streamsMetadata;
+
+  @Before
+  public void setUp() {
+    when(runningQuery.getState()).thenReturn(State.RUNNING);
+    when(runningQuery.getAllMetadata()).thenReturn(Collections.singleton(streamsMetadata));
+    when(notRunningQuery.getState()).thenReturn(State.CREATED);
+    when(streamsMetadata.hostInfo()).thenReturn(OTHER_HOST_INFO);
+  }
+
+  @Test
+  public void shouldFilterQueryMetadataByState() {
+    // When:
+    final Set<HostInfo> info = DiscoverRemoteHostsUtil.getRemoteHosts(
+        ImmutableList.of(runningQuery, notRunningQuery),
+        THIS_HOST_INFO
+    );
+
+    // Then:
+    assertThat(info, contains(OTHER_HOST_INFO));
+
+    verify(notRunningQuery, never()).getAllMetadata();
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <!-- This matches the version in common -->
         <netty-codec-http2-version>4.1.60.Final</netty-codec-http2-version>
         <!-- Brought in by both schema registry and connect, we need to pick a version -->
-        <jersey-common>2.31</jersey-common>
+        <jersey-common>2.34</jersey-common>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,6 @@
         <io.confluent.ksql.version>7.0.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <mockito.version>3.8.0</mockito.version>
-        <kafka.version>7.0.0-52-ccs</kafka.version>
         <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against 4.1.49.Final -->
         <netty.version>4.1.60.Final</netty.version>


### PR DESCRIPTION
### Description 

As the title says. This PR contains a number of required fixes for doing so:
- Updates some stream-table join expected results, due to picking up https://github.com/apache/kafka/commit/476eccb968322879b1843dfa837b63ce386d192c
- Bumps jersey dependency version to accommodate https://github.com/apache/kafka/commit/b73d639adc9e4b5f1940d364f5ece481604b802a#diff-02b139e755ab0e27e0b0a6f9845843ef189116955cc340c49a4022587dbb2b52
- Updates DiscoverRemoteHostsUtil in order to fix a failing unit test in KsqlResourceTest
- Disables the enhancements to left and outer stream-stream joins (with regards to when nulls are emitted), since we're not ready to enable this feature in ksqlDB until the grace period is configurable.

### Testing done 

Build passes.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

