### PR TITLE
fix: allow for KSQL_GC_LOG_OPTS env variable to be passed through without …

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -113,7 +113,9 @@ while [ $# -gt 0 ]; do
       shift 2
       ;;
     -loggc)
-      GC_LOG_ENABLED="true"
+      if [ -z "$KSQL_GC_LOG_OPTS" ]; then
+        GC_LOG_ENABLED="true"
+      fi
       shift
       ;;
     -daemon)
@@ -134,7 +136,6 @@ done
 # GC options
 GC_FILE_SUFFIX='-gc.log'
 GC_LOG_FILE_NAME=''
-KSQL_GC_LOG_OPTS=""
 if [ "x$GC_LOG_ENABLED" = "xtrue" ]; then
   GC_LOG_FILE_NAME=$DAEMON_NAME$GC_FILE_SUFFIX
   # The first segment of the version number, which is '1' for releases before Java 9


### PR DESCRIPTION
…changes if present

### Description 
Allow the KSQL_GC_LOG_OPTS environment variable to be passed through if present.

### Testing done 
Tested the behavior of both providing the KSQL_GC_LOG_OPTS variable, in which case the supplied configuration was used, and omitting it, which reverts to the original behavior.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

