### PR TITLE
chore: fix bugs in FK n-way joins

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -521,13 +521,8 @@ public class JoinNode extends PlanNode implements JoiningNode {
 
       final JoinKey joinKey = joinNode.joinKey;
 
-      final FormatInfo leftValueFormatInfo = joinNode
-          .getLeft()
-          .getLeftmostSourceNode()
-          .getDataSource()
-          .getKsqlTopic()
-          .getValueFormat()
-          .getFormatInfo();
+      final FormatInfo valueFormatInfo = JoiningNode
+          .getValueFormatForSource(joinNode.getLeft()).getFormatInfo();
 
       switch (joinNode.joinType) {
         case LEFT:
@@ -536,7 +531,7 @@ public class JoinNode extends PlanNode implements JoiningNode {
                 rightTable,
                 ((ForeignJoinKey) joinKey).getForeignKeyColumn(),
                 contextStacker,
-                leftValueFormatInfo
+                valueFormatInfo
             );
           } else {
             return leftTable.leftJoin(
@@ -551,7 +546,7 @@ public class JoinNode extends PlanNode implements JoiningNode {
                 rightTable,
                 ((ForeignJoinKey) joinKey).getForeignKeyColumn(),
                 contextStacker,
-                leftValueFormatInfo
+                valueFormatInfo
             );
           } else {
             return leftTable.innerJoin(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -521,13 +521,22 @@ public class JoinNode extends PlanNode implements JoiningNode {
 
       final JoinKey joinKey = joinNode.joinKey;
 
+      final FormatInfo leftValueFormatInfo = joinNode
+          .getLeft()
+          .getLeftmostSourceNode()
+          .getDataSource()
+          .getKsqlTopic()
+          .getValueFormat()
+          .getFormatInfo();
+
       switch (joinNode.joinType) {
         case LEFT:
           if (joinKey.isForeignKey()) {
             return leftTable.foreignKeyLeftJoin(
                 rightTable,
                 ((ForeignJoinKey) joinKey).getForeignKeyColumn(),
-                contextStacker
+                contextStacker,
+                leftValueFormatInfo
             );
           } else {
             return leftTable.leftJoin(
@@ -541,7 +550,8 @@ public class JoinNode extends PlanNode implements JoiningNode {
             return leftTable.foreignKeyInnerJoin(
                 rightTable,
                 ((ForeignJoinKey) joinKey).getForeignKeyColumn(),
-                contextStacker
+                contextStacker,
+                leftValueFormatInfo
             );
           } else {
             return leftTable.innerJoin(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -323,14 +323,14 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
       final SchemaKTable<KRightT> schemaKTable,
       final ColumnName leftJoinColumnName,
       final Stacker contextStacker,
-      final FormatInfo leftValueFormatInfo
+      final FormatInfo valueFormatInfo
   ) {
     final ForeignKeyTableTableJoin<K, KRightT> step =
         ExecutionStepFactory.foreignKeyTableTableJoin(
             contextStacker,
             JoinType.INNER,
             leftJoinColumnName,
-            InternalFormats.of(keyFormat, leftValueFormatInfo),
+            InternalFormats.of(keyFormat, valueFormatInfo),
             sourceTableStep,
             schemaKTable.getSourceTableStep()
         );
@@ -348,14 +348,14 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
       final SchemaKTable<KRightT> schemaKTable,
       final ColumnName leftJoinColumnName,
       final Stacker contextStacker,
-      final FormatInfo leftFormatInfo
+      final FormatInfo valueFormatInfo
   ) {
     final ForeignKeyTableTableJoin<K, KRightT> step =
         ExecutionStepFactory.foreignKeyTableTableJoin(
             contextStacker,
             JoinType.LEFT,
             leftJoinColumnName,
-            InternalFormats.of(keyFormat, leftFormatInfo),
+            InternalFormats.of(keyFormat, valueFormatInfo),
             sourceTableStep,
             schemaKTable.getSourceTableStep()
         );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -322,13 +322,15 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   public <KRightT> SchemaKTable<K> foreignKeyInnerJoin(
       final SchemaKTable<KRightT> schemaKTable,
       final ColumnName leftJoinColumnName,
-      final Stacker contextStacker
+      final Stacker contextStacker,
+      final FormatInfo leftValueFormatInfo
   ) {
     final ForeignKeyTableTableJoin<K, KRightT> step =
         ExecutionStepFactory.foreignKeyTableTableJoin(
             contextStacker,
             JoinType.INNER,
             leftJoinColumnName,
+            InternalFormats.of(keyFormat, leftValueFormatInfo),
             sourceTableStep,
             schemaKTable.getSourceTableStep()
         );
@@ -345,13 +347,15 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   public <KRightT> SchemaKTable<K> foreignKeyLeftJoin(
       final SchemaKTable<KRightT> schemaKTable,
       final ColumnName leftJoinColumnName,
-      final Stacker contextStacker
+      final Stacker contextStacker,
+      final FormatInfo leftFormatInfo
   ) {
     final ForeignKeyTableTableJoin<K, KRightT> step =
         ExecutionStepFactory.foreignKeyTableTableJoin(
             contextStacker,
             JoinType.LEFT,
             leftJoinColumnName,
+            InternalFormats.of(keyFormat, leftFormatInfo),
             sourceTableStep,
             schemaKTable.getSourceTableStep()
         );

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoin.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoin.java
@@ -32,7 +32,7 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
   private final ExecutionStepPropertiesV1 properties;
   private final JoinType joinType;
   private final ColumnName leftJoinColumnName;
-  private final Formats leftFormats;
+  private final Formats formats;
   private final ExecutionStep<KTableHolder<KLeftT>> leftSource;
   private final ExecutionStep<KTableHolder<KRightT>> rightSource;
 
@@ -44,8 +44,8 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
       final JoinType joinType,
       @JsonProperty(value = "leftJoinColumnName", required = true)
       final ColumnName leftJoinColumnName,
-      @JsonProperty(value = "leftFormats", required = true)
-      final Formats leftFormats,
+      @JsonProperty(value = "formats", required = true)
+      final Formats formats,
       @JsonProperty(value = "leftSource", required = true)
       final ExecutionStep<KTableHolder<KLeftT>> leftSource,
       @JsonProperty(value = "rightSource", required = true)
@@ -57,7 +57,7 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
       throw new IllegalArgumentException("OUTER join not supported.");
     }
     this.leftJoinColumnName = requireNonNull(leftJoinColumnName, "leftJoinColumnName");
-    this.leftFormats = requireNonNull(leftFormats, "leftFormats");
+    this.formats = requireNonNull(formats, "formats");
     this.leftSource = requireNonNull(leftSource, "leftSource");
     this.rightSource = requireNonNull(rightSource, "rightSource");
   }
@@ -89,8 +89,8 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
     return leftJoinColumnName;
   }
 
-  public Formats getLeftFormats() {
-    return leftFormats;
+  public Formats getFormats() {
+    return formats;
   }
 
   @Override
@@ -115,12 +115,13 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
     return Objects.equals(properties, that.properties)
         && joinType == that.joinType
         && Objects.equals(leftJoinColumnName, that.leftJoinColumnName)
+        && Objects.equals(formats, that.formats)
         && Objects.equals(leftSource, that.leftSource)
         && Objects.equals(rightSource, that.rightSource);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(properties, joinType, leftJoinColumnName, leftSource, rightSource);
+    return Objects.hash(properties, joinType, leftJoinColumnName, formats, leftSource, rightSource);
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoin.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoin.java
@@ -32,6 +32,7 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
   private final ExecutionStepPropertiesV1 properties;
   private final JoinType joinType;
   private final ColumnName leftJoinColumnName;
+  private final Formats leftFormats;
   private final ExecutionStep<KTableHolder<KLeftT>> leftSource;
   private final ExecutionStep<KTableHolder<KRightT>> rightSource;
 
@@ -43,6 +44,8 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
       final JoinType joinType,
       @JsonProperty(value = "leftJoinColumnName", required = true)
       final ColumnName leftJoinColumnName,
+      @JsonProperty(value = "leftFormats", required = true)
+      final Formats leftFormats,
       @JsonProperty(value = "leftSource", required = true)
       final ExecutionStep<KTableHolder<KLeftT>> leftSource,
       @JsonProperty(value = "rightSource", required = true)
@@ -54,6 +57,7 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
       throw new IllegalArgumentException("OUTER join not supported.");
     }
     this.leftJoinColumnName = requireNonNull(leftJoinColumnName, "leftJoinColumnName");
+    this.leftFormats = requireNonNull(leftFormats, "leftFormats");
     this.leftSource = requireNonNull(leftSource, "leftSource");
     this.rightSource = requireNonNull(rightSource, "rightSource");
   }
@@ -83,6 +87,10 @@ public class ForeignKeyTableTableJoin<KLeftT, KRightT>
 
   public ColumnName getLeftJoinColumnName() {
     return leftJoinColumnName;
+  }
+
+  public Formats getLeftFormats() {
+    return leftFormats;
   }
 
   @Override

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoinTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoinTest.java
@@ -67,7 +67,7 @@ public class ForeignKeyTableTableJoinTest {
             new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME_2, formats1, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats2, left2, right1)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats2, left1, right1)
         )
         .addEqualityGroup(
             new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats1, left2, right1)

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoinTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoinTest.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.execution.plan.JoinType.LEFT;
 
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.serde.FormatInfo;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,29 +44,31 @@ public class ForeignKeyTableTableJoinTest {
   private ExecutionStep<KTableHolder<Struct>> left2;
   @Mock
   private ExecutionStep<KTableHolder<Struct>> right2;
+  @Mock
+  private Formats formats;
 
   @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, left1, right1),
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, left1, right1)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats, left1, right1),
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props2, INNER, JOIN_COLUMN_NAME, left1, right1)
+            new ForeignKeyTableTableJoin<>(props2, INNER, JOIN_COLUMN_NAME, formats, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, LEFT, JOIN_COLUMN_NAME, left1, right1)
+            new ForeignKeyTableTableJoin<>(props1, LEFT, JOIN_COLUMN_NAME, formats, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME_2, left1, right1)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME_2, formats, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, left2, right1)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats, left2, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, left1, right2)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats, left1, right2)
         ).testEquals();
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoinTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/ForeignKeyTableTableJoinTest.java
@@ -45,30 +45,35 @@ public class ForeignKeyTableTableJoinTest {
   @Mock
   private ExecutionStep<KTableHolder<Struct>> right2;
   @Mock
-  private Formats formats;
+  private Formats formats1;
+  @Mock
+  private Formats formats2;
 
   @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats, left1, right1),
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats, left1, right1)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats1, left1, right1),
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats1, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props2, INNER, JOIN_COLUMN_NAME, formats, left1, right1)
+            new ForeignKeyTableTableJoin<>(props2, INNER, JOIN_COLUMN_NAME, formats1, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, LEFT, JOIN_COLUMN_NAME, formats, left1, right1)
+            new ForeignKeyTableTableJoin<>(props1, LEFT, JOIN_COLUMN_NAME, formats1, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME_2, formats, left1, right1)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME_2, formats1, left1, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats, left2, right1)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats2, left2, right1)
         )
         .addEqualityGroup(
-            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats, left1, right2)
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats1, left2, right1)
+        )
+        .addEqualityGroup(
+            new ForeignKeyTableTableJoin<>(props1, INNER, JOIN_COLUMN_NAME, formats1, left1, right2)
         ).testEquals();
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-n-way-join.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-n-way-join.json
@@ -66,28 +66,28 @@
         "ksql.joins.foreign.key.enable": true
       },
       "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
-        "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2, f1, f2, f3 FROM left_table JOIN middle_table ON f1 = id2 LEFT JOIN right_table ON id1 = id3;"
+        "CREATE TABLE left_table (l_id BIGINT PRIMARY KEY, foreign_key BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE middle_table (m_id BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
+        "CREATE TABLE right_table (r_id BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT l_id, m_id, foreign_key, f2, f3 FROM left_table JOIN middle_table ON foreign_key = m_id LEFT JOIN right_table ON l_id = r_id;"
       ],
       "inputs": [
         {"topic": "middle_topic", "key": 0, "value": {"F2": 100, "OTHER": "unused"}, "timestamp": 0},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 0}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 0}, "timestamp": 10000},
         {"topic": "right_topic", "key": 1, "value": {"F3": 4}, "timestamp": 11000},
         {"topic": "middle_topic", "key": 8, "value": {"F2": 10, "OTHER": "unused"}, "timestamp": 13000},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 8}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 8}, "timestamp": 16000},
         {"topic": "left_topic", "key": 1, "value": null, "timestamp": 18000}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2": 0, "F1": 0, "F2": 100, "F3": null}, "timestamp": 10000},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2": 0, "F1": 0, "F2": 100, "F3": 4}, "timestamp": 11000},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2": 0, "F1": 8, "F2": 10, "F3": 4}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID": 0, "FOREIGN_KEY": 0, "F2": 100, "F3": null}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID": 0, "FOREIGN_KEY": 0, "F2": 100, "F3": 4}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID": 8, "FOREIGN_KEY": 8, "F2": 10, "F3": 4}, "timestamp": 16000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "ID1 BIGINT KEY, ID2 BIGINT, F1 BIGINT, F2 BIGINT, F3 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "L_ID BIGINT KEY, M_ID BIGINT, FOREIGN_KEY BIGINT, F2 BIGINT, F3 BIGINT"}
         ]
       }
     },
@@ -117,28 +117,28 @@
         "ksql.joins.foreign.key.enable": true
       },
       "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
-        "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, f2, f3 FROM left_table JOIN middle_table ON f1 = id2 LEFT JOIN right_table ON id1 = id3;"
+        "CREATE TABLE left_table (l_id BIGINT PRIMARY KEY, foreign_key BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE middle_table (m_id BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
+        "CREATE TABLE right_table (r_id BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT l_id, f2, f3 FROM left_table JOIN middle_table ON foreign_key = m_id LEFT JOIN right_table ON l_id = r_id;"
       ],
       "inputs": [
         {"topic": "middle_topic", "key": 0, "value": {"F2": 100, "OTHER": "unused"}, "timestamp": 0},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 0}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 0}, "timestamp": 10000},
         {"topic": "right_topic", "key": 1, "value": {"F3": 4}, "timestamp": 11000},
         {"topic": "middle_topic", "key": 8, "value": {"F2": 10, "OTHER": "unused"}, "timestamp": 13000},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 8}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 8}, "timestamp": 16000},
         {"topic": "left_topic", "key": 1, "value": null, "timestamp": 18000}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": 1, "value": {"F2": 100, "F3": null}, "timestamp": 10000},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2": 0, "F1": 0, "F2": 100, "F3": 4}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 1, "value": {"F2": 100, "F3": 4}, "timestamp": 11000},
         {"topic": "OUTPUT", "key": 1, "value": {"F2": 10, "F3": 4}, "timestamp": 16000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "ID1 BIGINT KEY, F2 BIGINT, F3 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "L_ID BIGINT KEY, F2 BIGINT, F3 BIGINT"}
         ]
       }
     },
@@ -165,28 +165,28 @@
         "ksql.joins.foreign.key.enable": true
       },
       "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
-        "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id3, id2, f1, f2, f3 FROM left_table JOIN middle_table ON f1 = id2 LEFT JOIN right_table ON id1 = id3;"
+        "CREATE TABLE left_table (l_id BIGINT PRIMARY KEY, foreign_key BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE middle_table (m_id BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
+        "CREATE TABLE right_table (r_id BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT r_id, m_id, foreign_key, f2, f3 FROM left_table JOIN middle_table ON foreign_key = m_id LEFT JOIN right_table ON l_id = r_id;"
       ],
       "inputs": [
         {"topic": "middle_topic", "key": 0, "value": {"F2": 100, "OTHER": "unused"}, "timestamp": 0},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 0}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 0}, "timestamp": 10000},
         {"topic": "right_topic", "key": 1, "value": {"F3": 4}, "timestamp": 11000},
         {"topic": "middle_topic", "key": 8, "value": {"F2": 10, "OTHER": "unused"}, "timestamp": 13000},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 8}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 8}, "timestamp": 16000},
         {"topic": "left_topic", "key": 1, "value": null, "timestamp": 18000}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2": 0, "F1": 0, "F2": 100, "F3": null}, "timestamp": 10000},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2": 0, "F1": 0, "F2": 100, "F3": 4}, "timestamp": 11000},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2": 0, "F1": 8, "F2": 10, "F3": 4}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID": 0, "FOREIGN_KEY": 0, "F2": 100, "F3": null}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID": 0, "FOREIGN_KEY": 0, "F2": 100, "F3": 4}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID": 8, "FOREIGN_KEY": 8, "F2": 10, "F3": 4}, "timestamp": 16000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "ID3 BIGINT KEY, ID2 BIGINT, F1 BIGINT, F2 BIGINT, F3 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "R_ID BIGINT KEY, M_ID BIGINT, FOREIGN_KEY BIGINT, F2 BIGINT, F3 BIGINT"}
         ]
       }
     },
@@ -197,28 +197,28 @@
         "ksql.joins.foreign.key.enable": true
       },
       "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
-        "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT * FROM left_table JOIN middle_table ON f1 = id2 LEFT JOIN right_table ON id1 = id3;"
+        "CREATE TABLE left_table (l_id BIGINT PRIMARY KEY, foreign_key BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE middle_table (m_id BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
+        "CREATE TABLE right_table (r_id BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT * FROM left_table JOIN middle_table ON foreign_key = m_id LEFT JOIN right_table ON l_id = r_id;"
       ],
       "inputs": [
         {"topic": "middle_topic", "key": 0, "value": {"F2": 100, "OTHER": "unused"}, "timestamp": 0},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 0}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 0}, "timestamp": 10000},
         {"topic": "right_topic", "key": 1, "value": {"F3": 4}, "timestamp": 11000},
         {"topic": "middle_topic", "key": 8, "value": {"F2": 10, "OTHER": "unused"}, "timestamp": 13000},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 8}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 8}, "timestamp": 16000},
         {"topic": "left_topic", "key": 1, "value": null, "timestamp": 18000}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"LEFT_TABLE_F1": 0, "MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 100, "RIGHT_TABLE_ID3": null, "RIGHT_TABLE_F3": null}, "timestamp": 10000},
-        {"topic": "OUTPUT", "key": 1, "value": {"LEFT_TABLE_F1": 0, "MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 100, "RIGHT_TABLE_ID3": 1, "RIGHT_TABLE_F3": 4}, "timestamp": 11000},
-        {"topic": "OUTPUT", "key": 1, "value": {"LEFT_TABLE_F1": 8, "MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 10, "RIGHT_TABLE_ID3": 1, "RIGHT_TABLE_F3": 4}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 1, "value": {"LEFT_TABLE_FOREIGN_KEY": 0, "MIDDLE_TABLE_M_ID": 0, "MIDDLE_TABLE_F2": 100, "MIDDLE_TABLE_OTHER": "unused", "RIGHT_TABLE_R_ID": null, "RIGHT_TABLE_F3": null}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 1, "value": {"LEFT_TABLE_FOREIGN_KEY": 0, "MIDDLE_TABLE_M_ID": 0, "MIDDLE_TABLE_F2": 100, "MIDDLE_TABLE_OTHER": "unused", "RIGHT_TABLE_R_ID": 1, "RIGHT_TABLE_F3": 4}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 1, "value": {"LEFT_TABLE_FOREIGN_KEY": 8, "MIDDLE_TABLE_M_ID": 8, "MIDDLE_TABLE_F2": 10, "MIDDLE_TABLE_OTHER": "unused", "RIGHT_TABLE_R_ID": 1, "RIGHT_TABLE_F3": 4}, "timestamp": 16000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "LEFT_TABLE_ID1 BIGINT KEY, LEFT_TABLE_F1 BIGINT, MIDDLE_TABLE_ID2 BIGINT, MIDDLE_TABLE_F2 BIGINT, RIGHT_TABLE_ID3 BIGINT, RIGHT_TABLE_F3 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "LEFT_TABLE_L_ID BIGINT KEY, LEFT_TABLE_FOREIGN_KEY BIGINT, MIDDLE_TABLE_M_ID BIGINT, MIDDLE_TABLE_F2 BIGINT, MIDDLE_TABLE_OTHER VARCHAR, RIGHT_TABLE_R_ID BIGINT, RIGHT_TABLE_F3 BIGINT"}
         ]
       }
     },
@@ -261,28 +261,28 @@
         "ksql.joins.foreign.key.enable": true
       },
       "statements": [
-        "CREATE TABLE left_table (id1 BIGINT PRIMARY KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
-        "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
-        "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
-        "CREATE TABLE output AS SELECT id1, id2 AS id2_alias, f1, mt.f2 AS mt_f2_alias, rt.f3 FROM left_table AS lt JOIN middle_table AS mt ON f1 = mt.id2 LEFT JOIN right_table AS rt ON lt.id1 = id3;"
+        "CREATE TABLE left_table (l_id BIGINT PRIMARY KEY, foreign_key BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE middle_table (m_id BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
+        "CREATE TABLE right_table (r_id BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT l_id, m_id AS m_id_alias, foreign_key, mt.f2 AS mt_f2_alias, rt.f3 FROM left_table AS lt JOIN middle_table AS mt ON foreign_key = mt.m_id LEFT JOIN right_table AS rt ON lt.l_id = r_id;"
       ],
       "inputs": [
         {"topic": "middle_topic", "key": 0, "value": {"F2": 100, "OTHER": "unused"}, "timestamp": 0},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 0}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 0}, "timestamp": 10000},
         {"topic": "right_topic", "key": 1, "value": {"F3": 4}, "timestamp": 11000},
         {"topic": "middle_topic", "key": 8, "value": {"F2": 10, "OTHER": "unused"}, "timestamp": 13000},
-        {"topic": "left_topic", "key": 1, "value": {"F1": 8}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 1, "value": {"FOREIGN_KEY": 8}, "timestamp": 16000},
         {"topic": "left_topic", "key": 1, "value": null, "timestamp": 18000}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2_ALIAS": 0, "F1": 0, "MT_F2_ALIAS": 100, "F3": null}, "timestamp": 10000},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2_ALIAS": 0, "F1": 0, "MT_F2_ALIAS": 100, "F3": 4}, "timestamp": 11000},
-        {"topic": "OUTPUT", "key": 1, "value": {"ID2_ALIAS": 0, "F1": 8, "MT_F2_ALIAS": 10, "F3": 4}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID_ALIAS": 0, "FOREIGN_KEY": 0, "MT_F2_ALIAS": 100, "F3": null}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID_ALIAS": 0, "FOREIGN_KEY": 0, "MT_F2_ALIAS": 100, "F3": 4}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 1, "value": {"M_ID_ALIAS": 8, "FOREIGN_KEY": 8, "MT_F2_ALIAS": 10, "F3": 4}, "timestamp": 16000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "ID1 BIGINT KEY, ID2_ALIAS BIGINT, F1 BIGINT, MT_F2_ALIAS BIGINT, F3 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "L_ID BIGINT KEY, M_ID_ALIAS BIGINT, FOREIGN_KEY BIGINT, MT_F2_ALIAS BIGINT, F3 BIGINT"}
         ]
       }
     }

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -1063,6 +1063,9 @@
         "leftJoinColumnName" : {
           "type" : "string"
         },
+        "formats" : {
+          "$ref" : "#/definitions/Formats"
+        },
         "leftSource" : {
           "$ref" : "#/definitions/ExecutionStep"
         },
@@ -1071,7 +1074,7 @@
         }
       },
       "title" : "fkTableTableJoinV1",
-      "required" : [ "@type", "properties", "joinType", "leftJoinColumnName", "leftSource", "rightSource" ]
+      "required" : [ "@type", "properties", "joinType", "leftJoinColumnName", "formats", "leftSource", "rightSource" ]
     },
     "RefinementInfo" : {
       "type" : "object",

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -326,6 +326,7 @@ public final class ExecutionStepFactory {
           final QueryContext.Stacker stacker,
           final JoinType joinType,
           final ColumnName leftJoinColumnName,
+          final Formats leftFormats,
           final ExecutionStep<KTableHolder<KLeftT>> left,
           final ExecutionStep<KTableHolder<KRightT>> right
   ) {
@@ -334,6 +335,7 @@ public final class ExecutionStepFactory {
         new ExecutionStepPropertiesV1(queryContext),
         joinType,
         leftJoinColumnName,
+        leftFormats,
         left,
         right
     );

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -326,7 +326,7 @@ public final class ExecutionStepFactory {
           final QueryContext.Stacker stacker,
           final JoinType joinType,
           final ColumnName leftJoinColumnName,
-          final Formats leftFormats,
+          final Formats formats,
           final ExecutionStep<KTableHolder<KLeftT>> left,
           final ExecutionStep<KTableHolder<KRightT>> right
   ) {
@@ -335,7 +335,7 @@ public final class ExecutionStepFactory {
         new ExecutionStepPropertiesV1(queryContext),
         joinType,
         leftJoinColumnName,
-        leftFormats,
+        formats,
         left,
         right
     );

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ForeignKeyTableTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ForeignKeyTableTableJoinBuilder.java
@@ -43,16 +43,16 @@ public final class ForeignKeyTableTableJoinBuilder {
     final ForeignKeyJoinParams<KRightT> joinParams = ForeignKeyJoinParamsFactory
         .create(join.getLeftJoinColumnName(), leftSchema, rightSchema);
 
-    final Formats leftFormats = join.getLeftFormats();
+    final Formats formats = join.getFormats();
 
     final PhysicalSchema physicalSchema = PhysicalSchema.from(
         joinParams.getSchema(),
-        leftFormats.getKeyFeatures(),
-        leftFormats.getValueFeatures()
+        formats.getKeyFeatures(),
+        formats.getValueFeatures()
     );
 
     final Serde<GenericRow> valSerde = buildContext.buildValueSerde(
-        leftFormats.getValueFormat(),
+        formats.getValueFormat(),
         physicalSchema,
         join.getProperties().getQueryContext()
     );

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ForeignKeyTableTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ForeignKeyTableTableJoinBuilder.java
@@ -17,9 +17,14 @@ package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.plan.ForeignKeyTableTableJoin;
+import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KTableHolder;
+import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
 
 public final class ForeignKeyTableTableJoinBuilder {
 
@@ -29,7 +34,8 @@ public final class ForeignKeyTableTableJoinBuilder {
   public static <KLeftT, KRightT> KTableHolder<KLeftT> build(
       final KTableHolder<KLeftT> left,
       final KTableHolder<KRightT> right,
-      final ForeignKeyTableTableJoin<KLeftT, KRightT> join
+      final ForeignKeyTableTableJoin<KLeftT, KRightT> join,
+      final RuntimeBuildContext buildContext
   ) {
     final LogicalSchema leftSchema = left.getSchema();
     final LogicalSchema rightSchema = right.getSchema();
@@ -37,20 +43,36 @@ public final class ForeignKeyTableTableJoinBuilder {
     final ForeignKeyJoinParams<KRightT> joinParams = ForeignKeyJoinParamsFactory
         .create(join.getLeftJoinColumnName(), leftSchema, rightSchema);
 
+    final Formats leftFormats = join.getLeftFormats();
+
+    final PhysicalSchema physicalSchema = PhysicalSchema.from(
+        joinParams.getSchema(),
+        leftFormats.getKeyFeatures(),
+        leftFormats.getValueFeatures()
+    );
+
+    final Serde<GenericRow> valSerde = buildContext.buildValueSerde(
+        leftFormats.getValueFormat(),
+        physicalSchema,
+        join.getProperties().getQueryContext()
+    );
+
     final KTable<KLeftT, GenericRow> result;
     switch (join.getJoinType()) {
-      case LEFT:
-        result = left.getTable().leftJoin(
-            right.getTable(),
-            joinParams.getKeyExtractor(),
-            joinParams.getJoiner()
-        );
-        break;
       case INNER:
         result = left.getTable().join(
             right.getTable(),
             joinParams.getKeyExtractor(),
-            joinParams.getJoiner()
+            joinParams.getJoiner(),
+            Materialized.with(null, valSerde)
+        );
+        break;
+      case LEFT:
+        result = left.getTable().leftJoin(
+            right.getTable(),
+            joinParams.getKeyExtractor(),
+            joinParams.getJoiner(),
+            Materialized.with(null, valSerde)
         );
         break;
       default:

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
@@ -410,6 +410,11 @@ public final class KSPlanBuilder implements PlanBuilder {
         foreignKeyTableTableJoin.getLeftSource().build(this, planInfo);
     final KTableHolder<KRightT> right =
         foreignKeyTableTableJoin.getRightSource().build(this, planInfo);
-    return ForeignKeyTableTableJoinBuilder.build(left, right, foreignKeyTableTableJoin);
+    return ForeignKeyTableTableJoinBuilder.build(
+        left,
+        right,
+        foreignKeyTableTableJoin,
+        buildContext
+    );
   }
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
@@ -39,11 +39,11 @@ public final class TableTableJoinBuilder {
 
     final KTable<K, GenericRow> result;
     switch (join.getJoinType()) {
-      case LEFT:
-        result = left.getTable().leftJoin(right.getTable(), joinParams.getJoiner());
-        break;
       case INNER:
         result = left.getTable().join(right.getTable(), joinParams.getJoiner());
+        break;
+      case LEFT:
+        result = left.getTable().leftJoin(right.getTable(), joinParams.getJoiner());
         break;
       case OUTER:
         result = left.getTable().outerJoin(right.getTable(), joinParams.getJoiner());


### PR DESCRIPTION
### Description 
FK-joins need to set their output-format to make n-way join works. Without this fix, we fail with a `ClassCastException` because downstream operators fall back to default ByteArraySerde as no `valueSerde` is set.

All but two n-way join QQT test pass now, but as long as QTT is not fixed, we cannot enable them yet. One test fails with missing result columns (we need to fix forward in a follow up PR). The other fails with an error resolving an alias (this is fixed via #7547)

### Testing done 
Tested locally using `fk-n-way-joins.json`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

