### PR TITLE
chore: relax copartitioning requirements for FK joins + disallow on windowed tables

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -778,6 +778,12 @@ public class LogicalPlanner {
           joinInfo.hasFlippedJoinCondition()
       );
 
+      if (((DataSourceNode) rightNode).isWindowed()) {
+        throw new KsqlException(
+           "Foreign-key table-table joins are not supported on windowed tables."
+        );
+      }
+
       return Optional.of(fkColumnReference);
     } else {
       throw new KsqlException(String.format(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -176,7 +176,9 @@ public class JoinNode extends PlanNode implements JoiningNode {
   @Override
   public SchemaKStream<?> buildStream(final PlanBuildContext buildContext) {
 
-    ensureMatchingPartitionCounts(buildContext.getServiceContext().getTopicClient());
+    if (!joinKey.isForeignKey()) {
+      ensureMatchingPartitionCounts(buildContext.getServiceContext().getTopicClient());
+    }
 
     final JoinerFactory joinerFactory = new JoinerFactory(
         buildContext,

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -429,6 +429,22 @@
       ]
     },
     {
+      "name": "Should not allow foreign key join on windowed tables",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "statements": [
+        "CREATE TABLE left_table (k STRING PRIMARY KEY, f1 STRING) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='1 SECOND');",
+        "CREATE TABLE right_table (k STRING PRIMARY KEY, id INT) WITH (kafka_topic='right_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='1 SECOND');",
+        "SELECT * FROM left_table JOIN right_table ON left_table.f1 = right_table.k EMIT CHANGES;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlErrorMessage",
+        "message": "Foreign-key table-table joins are not supported on windowed tables.",
+        "status": 400
+      }
+    },
+    {
       "name": "windowed group by - window bounds in SELECT",
       "statements": [
         "CREATE STREAM TEST (K INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",


### PR DESCRIPTION
### Description 

Two minor fixes in this PR:
- Do not require copartitioning for foreign key joins. The existing QTTs for this (currently disabled) are now passing except for the requisite changes to the QTT framework (see https://github.com/confluentinc/ksql/pull/7576 for more).
- Disallow foreign key joins on windowed tables, since it doesn't make sense to extract a column/expression from the left source to match a windowed key from the right source. ksqlDB does not support persistent queries on windowed tables so this is only relevant for push queries, so I've added a corresponding RQTT.

### Testing done 

Added tests. (Copartitioning tests will be enabled in a future PR.)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

