### PR TITLE
chore: ignore FK internal topics from QTT tests

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -67,7 +67,7 @@ import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
  */
 public class TopicInfoCache {
 
-  private static final String TOPIC_PATTERN_PREFIX = "_confluent.*query_(?<queryId>.*_\\d+)-";
+  public static final String TOPIC_PATTERN_PREFIX = "_confluent.*query_(?<queryId>.*_\\d+)-";
 
   private static final List<InternalTopicPattern> INTERNAL_TOPIC_PATTERNS = ImmutableList.of(
       // GROUP BY change-logs and repartition topics:

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -22,6 +22,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
@@ -67,7 +68,7 @@ import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
  */
 public class TopicInfoCache {
 
-  public static final String TOPIC_PATTERN_PREFIX = "_confluent.*query_(?<queryId>.*_\\d+)-";
+  private static final String TOPIC_PATTERN_PREFIX = "_confluent.*query_(?<queryId>.*_\\d+)-";
 
   private static final List<InternalTopicPattern> INTERNAL_TOPIC_PATTERNS = ImmutableList.of(
       // GROUP BY change-logs and repartition topics:
@@ -87,6 +88,17 @@ public class TopicInfoCache {
       )
   );
 
+  // Internal topic names that are ignored by the TopicInfoCache::get() method.
+  // This is a temporary fix to allow foreign key QT tests to pass without complaining about
+  // internal FK topics not unknown or with not clear schema information. A long-term fix
+  // to support multiple schema information in FK internal topics can be found here -
+  // https://github.com/confluentinc/ksql/issues/7586
+  private static final Set<Pattern> IGNORE_INTERNAL_TOPIC_NAMES_PATTERNS = ImmutableSet.of(
+      Pattern.compile(TOPIC_PATTERN_PREFIX + ".*-FK-JOIN-SUBSCRIPTION-REGISTRATION-\\d+-topic"),
+      Pattern.compile(TOPIC_PATTERN_PREFIX + ".*-FK-JOIN-SUBSCRIPTION-RESPONSE-\\d+-topic"),
+      Pattern.compile(TOPIC_PATTERN_PREFIX + ".*-FK-JOIN-SUBSCRIPTION-STATE-STORE-\\d+-changelog")
+  );
+
   private final KsqlExecutionContext ksqlEngine;
   private final SchemaRegistryClient srClient;
   private final LoadingCache<String, TopicInfo> cache;
@@ -101,8 +113,12 @@ public class TopicInfoCache {
         .build(CacheLoader.from(this::load));
   }
 
-  public TopicInfo get(final String topicName) {
-    return cache.getUnchecked(topicName);
+  public Optional<TopicInfo> get(final String topicName) {
+    if (ignoreInternalTopic(topicName)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(cache.getUnchecked(topicName));
   }
 
   public List<TopicInfo> all() {
@@ -111,6 +127,16 @@ public class TopicInfoCache {
 
   public void clear() {
     cache.invalidateAll();
+  }
+
+  private boolean ignoreInternalTopic(final String topicName) {
+    for (final Pattern p : IGNORE_INTERNAL_TOPIC_NAMES_PATTERNS) {
+      if (p.matcher(topicName).matches()) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private TopicInfo load(final String topicName) {

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -49,6 +49,7 @@ import io.confluent.ksql.test.tools.TopicInfoCache.TopicInfo;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.RetryUtil;
 import java.io.Closeable;
@@ -210,7 +211,8 @@ public class RestTestExecutor implements Closeable {
   private void produceInputs(final Map<String, List<Record>> inputs) {
     inputs.forEach((topicName, records) -> {
 
-      final TopicInfo topicInfo = topicInfoCache.get(topicName);
+      final TopicInfo topicInfo = topicInfoCache.get(topicName)
+          .orElseThrow(() -> new KsqlException("No information found for topic: " + topicName));
 
       try (KafkaProducer<Object, Object> producer = new KafkaProducer<>(
           kafkaCluster.producerConfig(),
@@ -320,7 +322,8 @@ public class RestTestExecutor implements Closeable {
   private void verifyOutput(final RestTestCase testCase) {
     testCase.getOutputsByTopic().forEach((topicName, records) -> {
 
-      final TopicInfo topicInfo = topicInfoCache.get(topicName);
+      final TopicInfo topicInfo = topicInfoCache.get(topicName)
+          .orElseThrow(() -> new KsqlException("No information found for topic: " + topicName));
 
       final List<? extends ConsumerRecord<?, ?>> received = kafkaCluster
           .verifyAvailableRecords(


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
The loop in `TestExecutor` that calls the `topicInfoCache.get()` does not do anything with the resulted topic info. Seesm it only checks the get() call works. This `get()` call is causing the errors with QTT when determining the key formats. This PR filters out those internal FK topics to allow QTT for FK joins to pass.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

