### PR TITLE
fix: silently ignores KEY qualifier if enclosed in parentheses (#5852)

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_VARCHAR(STRING)_as_key_and_value/7.1.0_1627023646891/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_VARCHAR(STRING)_as_key_and_value/7.1.0_1627023646891/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, V1 STRING) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `V1` STRING",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `V1` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `V1` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "V1 AS V1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_VARCHAR(STRING)_as_key_and_value/7.1.0_1627023646891/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_VARCHAR(STRING)_as_key_and_value/7.1.0_1627023646891/spec.json
@@ -1,0 +1,96 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1627023646891,
+  "path" : "query-validation-tests/key-schemas.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `V1` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `V1` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "VARCHAR(STRING) as key and value",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : "bob",
+      "value" : {
+        "v1" : "foo"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "bob",
+      "value" : {
+        "V1" : "foo"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (k VARCHAR(STRING) KEY, v1 VARCHAR(STRING)) WITH (kafka_topic='input',value_format='JSON');", "CREATE STREAM OUTPUT as SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `V1` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `V1` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_VARCHAR(STRING)_as_key_and_value/7.1.0_1627023646891/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/key-schemas_-_VARCHAR(STRING)_as_key_and_value/7.1.0_1627023646891/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
@@ -458,6 +458,100 @@
         {"topic": "OUTPUT", "key": 0.0, "value": {"ID": 2}},
         {"topic": "OUTPUT", "key": 0.1, "value": {"ID": 3}}
       ]
+    },
+    {
+      "name": "fail on STRING with parameter",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K STRING (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      }
+    },
+    {
+      "name": "fail on INTEGER with parameter",
+      "statements": [
+        "CREATE STREAM INPUT (K INTEGER (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K INTEGER (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      }
+    },
+    {
+      "name": "fail on DOUBLE with parameter",
+      "statements": [
+        "CREATE STREAM INPUT (K DOUBLE (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K DOUBLE (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      }
+    },
+    {
+      "name": "fail on VARCHAR with parameter",
+      "statements": [
+        "CREATE STREAM INPUT (K VARCHAR (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K VARCHAR (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      }
+    },
+    {
+      "name": "fail on INT with parameter",
+      "statements": [
+        "CREATE STREAM INPUT (K INT (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "line 1:29: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K INT (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      }
+    },
+    {
+      "name": "fail on BOOLEAN with parameter",
+      "statements": [
+        "CREATE STREAM INPUT (K BOOLEAN (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "line 1:33: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K BOOLEAN (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      }
+    },
+    {
+      "name": "fail on BIGINT with parameter",
+      "statements": [
+        "CREATE STREAM INPUT (K BIGINT (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "line 1:32: mismatched input 'KEY' expecting {'STRING', INTEGER_VALUE}\nStatement: CREATE STREAM INPUT (K BIGINT (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      }
+    },
+    {
+      "name": "fail on VARCHAR(STRING) with parameter",
+      "statements": [
+        "CREATE STREAM INPUT (K VARCHAR(STRING) (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.parser.exception.ParseFailedException",
+        "message": "line 1:40: mismatched input '(' expecting {',', ')'}\nStatement: CREATE STREAM INPUT (K VARCHAR(STRING) (KEY)) WITH (kafka_topic='input',value_format='JSON');"
+      }
+    },
+    {
+      "name": "VARCHAR(STRING) as key and value",
+      "statements": [
+        "CREATE STREAM INPUT (k VARCHAR(STRING) KEY, v1 VARCHAR(STRING)) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": "bob", "value": {"v1": "foo"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "bob", "value": {"V1": "foo"}}
+
+      ]
     }
   ]
 }

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -333,7 +333,7 @@ type
     ;
 
 typeParameter
-    : INTEGER_VALUE | type
+    : INTEGER_VALUE | 'STRING'
     ;
 
 baseType
@@ -387,7 +387,7 @@ literal
 nonReserved
     : SHOW | TABLES | COLUMNS | COLUMN | PARTITIONS | FUNCTIONS | FUNCTION | SESSION
     | STRUCT | MAP | ARRAY | PARTITION
-    | INTEGER | DATE | TIME | TIMESTAMP | INTERVAL | ZONE
+    | INTEGER | DATE | TIME | TIMESTAMP | INTERVAL | ZONE | 'STRING'
     | YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
     | EXPLAIN | ANALYZE | TYPE | TYPES
     | SET | RESET

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -757,4 +757,60 @@ public class AstBuilderTest {
   ) {
     return new QualifiedColumnReferenceExp(source, ColumnName.of(fieldName));
   }
+
+  @Test
+  public void shouldFailOnStringWithParameter() {
+     assertThrows(
+            ParseFailedException.class,
+            () -> givenQuery("CREATE STREAM INPUT (K STRING (KEY)) WITH (kafka_topic='input',value_format='JSON');")
+    );
+  }
+
+  @Test
+  public void shouldFailOnIntegerWithParameter() {
+    assertThrows(
+            ParseFailedException.class,
+            () -> givenQuery("CREATE STREAM INPUT (K INTEGER (KEY)) WITH (kafka_topic='input',value_format='JSON');")
+    );
+  }
+
+  @Test
+  public void shouldFailOnVarcharWithParameter() {
+    assertThrows(
+            ParseFailedException.class,
+            () -> givenQuery("CREATE STREAM INPUT (K VARCHAR (KEY)) WITH (kafka_topic='input',value_format='JSON');")
+    );
+  }
+
+  @Test
+  public void shouldFailOnIntWithParameter() {
+    assertThrows(
+            ParseFailedException.class,
+            () -> givenQuery("CREATE STREAM INPUT (K INT (KEY)) WITH (kafka_topic='input',value_format='JSON');")
+    );
+  }
+
+  @Test
+  public void shouldFailOnDoubleWithParameter() {
+    assertThrows(
+            ParseFailedException.class,
+            () -> givenQuery("CREATE STREAM INPUT (K DOUBLE (KEY)) WITH (kafka_topic='input',value_format='JSON');")
+    );
+  }
+
+  @Test
+  public void shouldFailOnBooleanWithParameter() {
+    assertThrows(
+            ParseFailedException.class,
+            () -> givenQuery("CREATE STREAM INPUT (K BOOLEAN (KEY)) WITH (kafka_topic='input',value_format='JSON');")
+    );
+  }
+
+  @Test
+  public void shouldFailOnBigIntWithParameter() {
+    assertThrows(
+            ParseFailedException.class,
+            () -> givenQuery("CREATE STREAM INPUT (K BIGINT (KEY)) WITH (kafka_topic='input',value_format='JSON');")
+    );
+  }
 }


### PR DESCRIPTION
### Description 
There’s an ambiguity in the grammar declared in `SqlBase.g4`. This is happening at **tableElement** only for primitive types.
Ex.  `BOB STRING (KEY)`, evaluates **STRING(KEY)** as a type parameter. 
<img width="333" alt="Screenshot 2021-05-25 at 07 34 41" src="https://user-images.githubusercontent.com/10224618/119452160-efd7b000-bd2d-11eb-986a-597f0b9c7f13.png">

One possible solution is support `(KEY)` by adding at **KEY** token another option as `'(KEY)'`, but this causes another ambiguity, since fields named as **KEY** are supported, causing ambiguity when using a function.
ex. `AS_VALUE(KEY)`.

My proposed solution validates the schema in code at the parsing, throwing an exception if any primitive type has been evaluated as type parameter.

### Testing done 
ksqldb-parser - AstBuilderTest
ksqldb-functional-test - key-schema.json

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

