### PR TITLE
fix: qualified select * now works in n-way joins with repartitions and multiple layers of nesting

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -871,6 +871,7 @@ public class JoinNodeTest {
   ) {
     when(dataSourceNode.getDataSource()).thenReturn(dataSource);
     when(node.getLeftmostSourceNode()).thenReturn(dataSourceNode);
+    when(node.getSources()).thenReturn(ImmutableList.of(dataSourceNode));
 
     final KsqlTopic ksqlTopic = mock(KsqlTopic.class);
     when(ksqlTopic.getValueFormat()).thenReturn(valueFormat);

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_qualified_select__/7.0.0_1621950302884/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_qualified_select__/7.0.0_1621950302884/plan.json
@@ -1,0 +1,314 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM LEFT_STREAM (ID1 BIGINT KEY, F1 BIGINT) WITH (FORMAT='JSON', KAFKA_TOPIC='left_topic');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "LEFT_STREAM",
+      "schema" : "`ID1` BIGINT KEY, `F1` BIGINT",
+      "topicName" : "left_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE MIDDLE_TABLE (ID2 BIGINT PRIMARY KEY, F2 BIGINT, OTHER STRING) WITH (FORMAT='JSON', KAFKA_TOPIC='middle_topic');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "MIDDLE_TABLE",
+      "schema" : "`ID2` BIGINT KEY, `F2` BIGINT, `OTHER` STRING",
+      "topicName" : "middle_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE RIGHT_TABLE (ID3 BIGINT PRIMARY KEY, F3 BIGINT) WITH (FORMAT='JSON', KAFKA_TOPIC='right_topic');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "RIGHT_TABLE",
+      "schema" : "`ID3` BIGINT KEY, `F3` BIGINT",
+      "topicName" : "right_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  LEFT_STREAM.ID1 ID1,\n  LEFT_STREAM.F1 F1,\n  MIDDLE_TABLE.*,\n  RIGHT_TABLE.*\nFROM LEFT_STREAM LEFT_STREAM\nINNER JOIN MIDDLE_TABLE MIDDLE_TABLE ON ((LEFT_STREAM.ID1 = MIDDLE_TABLE.ID2))\nLEFT OUTER JOIN RIGHT_TABLE RIGHT_TABLE ON ((LEFT_STREAM.F1 = RIGHT_TABLE.ID3))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`F1` BIGINT KEY, `ID1` BIGINT, `MIDDLE_TABLE_ID2` BIGINT, `MIDDLE_TABLE_F2` BIGINT, `MIDDLE_TABLE_OTHER` STRING, `RIGHT_TABLE_ID3` BIGINT, `RIGHT_TABLE_F3` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        },
+        "keyFeatures" : [ "UNWRAP_SINGLES" ]
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "LEFT_STREAM", "MIDDLE_TABLE", "RIGHT_TABLE" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "LEFT",
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "JSON"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              },
+              "keyFeatures" : [ "UNWRAP_SINGLES" ]
+            },
+            "leftSource" : {
+              "@type" : "streamSelectKeyV2",
+              "properties" : {
+                "queryContext" : "LeftSourceKeyed"
+              },
+              "source" : {
+                "@type" : "streamTableJoinV1",
+                "properties" : {
+                  "queryContext" : "L_Join"
+                },
+                "joinType" : "INNER",
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "JSON"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  },
+                  "keyFeatures" : [ "UNWRAP_SINGLES" ]
+                },
+                "leftSource" : {
+                  "@type" : "streamSelectV1",
+                  "properties" : {
+                    "queryContext" : "PrependAliasL_Left"
+                  },
+                  "source" : {
+                    "@type" : "streamSourceV1",
+                    "properties" : {
+                      "queryContext" : "KafkaTopic_L_Left/Source"
+                    },
+                    "topicName" : "left_topic",
+                    "formats" : {
+                      "keyFormat" : {
+                        "format" : "JSON"
+                      },
+                      "valueFormat" : {
+                        "format" : "JSON"
+                      },
+                      "keyFeatures" : [ "UNWRAP_SINGLES" ]
+                    },
+                    "sourceSchema" : "`ID1` BIGINT KEY, `F1` BIGINT"
+                  },
+                  "keyColumnNames" : [ "LEFT_STREAM_ID1" ],
+                  "selectExpressions" : [ "F1 AS LEFT_STREAM_F1", "ROWTIME AS LEFT_STREAM_ROWTIME", "ID1 AS LEFT_STREAM_ID1" ]
+                },
+                "rightSource" : {
+                  "@type" : "tableSelectV1",
+                  "properties" : {
+                    "queryContext" : "PrependAliasL_Right"
+                  },
+                  "source" : {
+                    "@type" : "tableSourceV1",
+                    "properties" : {
+                      "queryContext" : "KafkaTopic_L_Right/Source"
+                    },
+                    "topicName" : "middle_topic",
+                    "formats" : {
+                      "keyFormat" : {
+                        "format" : "JSON"
+                      },
+                      "valueFormat" : {
+                        "format" : "JSON"
+                      },
+                      "keyFeatures" : [ "UNWRAP_SINGLES" ]
+                    },
+                    "sourceSchema" : "`ID2` BIGINT KEY, `F2` BIGINT, `OTHER` STRING",
+                    "forceChangelog" : true
+                  },
+                  "keyColumnNames" : [ "MIDDLE_TABLE_ID2" ],
+                  "selectExpressions" : [ "F2 AS MIDDLE_TABLE_F2", "OTHER AS MIDDLE_TABLE_OTHER", "ROWTIME AS MIDDLE_TABLE_ROWTIME", "ID2 AS MIDDLE_TABLE_ID2" ],
+                  "internalFormats" : {
+                    "keyFormat" : {
+                      "format" : "JSON"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    },
+                    "keyFeatures" : [ "UNWRAP_SINGLES" ]
+                  }
+                },
+                "keyColName" : "LEFT_STREAM_ID1"
+              },
+              "keyExpression" : [ "LEFT_STREAM_F1" ]
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right_topic",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "JSON"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  },
+                  "keyFeatures" : [ "UNWRAP_SINGLES" ]
+                },
+                "sourceSchema" : "`ID3` BIGINT KEY, `F3` BIGINT",
+                "forceChangelog" : true
+              },
+              "keyColumnNames" : [ "RIGHT_TABLE_ID3" ],
+              "selectExpressions" : [ "F3 AS RIGHT_TABLE_F3", "ROWTIME AS RIGHT_TABLE_ROWTIME", "ID3 AS RIGHT_TABLE_ID3" ],
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "JSON"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                },
+                "keyFeatures" : [ "UNWRAP_SINGLES" ]
+              }
+            },
+            "keyColName" : "LEFT_STREAM_F1"
+          },
+          "keyColumnNames" : [ "F1" ],
+          "selectExpressions" : [ "LEFT_STREAM_ID1 AS ID1", "MIDDLE_TABLE_ID2 AS MIDDLE_TABLE_ID2", "MIDDLE_TABLE_F2 AS MIDDLE_TABLE_F2", "MIDDLE_TABLE_OTHER AS MIDDLE_TABLE_OTHER", "RIGHT_TABLE_ID3 AS RIGHT_TABLE_ID3", "RIGHT_TABLE_F3 AS RIGHT_TABLE_F3" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "JSON"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "keyFeatures" : [ "UNWRAP_SINGLES" ]
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.joins.foreign.key.enable" : "false",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_qualified_select__/7.0.0_1621950302884/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_qualified_select__/7.0.0_1621950302884/spec.json
@@ -1,0 +1,295 @@
+{
+  "version" : "7.0.0",
+  "timestamp" : 1621950302884,
+  "path" : "query-validation-tests/multi-joins.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.L_Join.Left" : {
+      "schema" : "`LEFT_STREAM_ID1` BIGINT KEY, `LEFT_STREAM_F1` BIGINT, `LEFT_STREAM_ROWTIME` BIGINT, `LEFT_STREAM_ID1` BIGINT",
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.KafkaTopic_Right.Source" : {
+      "schema" : "`ID3` BIGINT KEY, `F3` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.KafkaTopic_L_Right.Source" : {
+      "schema" : "`ID2` BIGINT KEY, `F2` BIGINT, `OTHER` STRING",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.Join.Left" : {
+      "schema" : "`LEFT_STREAM_F1` BIGINT KEY, `LEFT_STREAM_F1` BIGINT, `LEFT_STREAM_ROWTIME` BIGINT, `LEFT_STREAM_ID1` BIGINT, `MIDDLE_TABLE_F2` BIGINT, `MIDDLE_TABLE_OTHER` STRING, `MIDDLE_TABLE_ROWTIME` BIGINT, `MIDDLE_TABLE_ID2` BIGINT",
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.L_Join" : {
+      "schema" : "`LEFT_STREAM_ID1` BIGINT KEY, `LEFT_STREAM_F1` BIGINT, `LEFT_STREAM_ROWTIME` BIGINT, `LEFT_STREAM_ID1` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`F1` BIGINT KEY, `ID1` BIGINT, `MIDDLE_TABLE_ID2` BIGINT, `MIDDLE_TABLE_F2` BIGINT, `MIDDLE_TABLE_OTHER` STRING, `RIGHT_TABLE_ID3` BIGINT, `RIGHT_TABLE_F3` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.PrependAliasL_Right" : {
+      "schema" : "`MIDDLE_TABLE_ID2` BIGINT KEY, `MIDDLE_TABLE_F2` BIGINT, `MIDDLE_TABLE_OTHER` STRING, `MIDDLE_TABLE_ROWTIME` BIGINT, `MIDDLE_TABLE_ID2` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.Join" : {
+      "schema" : "`LEFT_STREAM_F1` BIGINT KEY, `LEFT_STREAM_F1` BIGINT, `LEFT_STREAM_ROWTIME` BIGINT, `LEFT_STREAM_ID1` BIGINT, `MIDDLE_TABLE_F2` BIGINT, `MIDDLE_TABLE_OTHER` STRING, `MIDDLE_TABLE_ROWTIME` BIGINT, `MIDDLE_TABLE_ID2` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      }
+    },
+    "CSAS_OUTPUT_0.KafkaTopic_L_Left.Source" : {
+      "schema" : "`ID1` BIGINT KEY, `F1` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.PrependAliasRight" : {
+      "schema" : "`RIGHT_TABLE_ID3` BIGINT KEY, `RIGHT_TABLE_F3` BIGINT, `RIGHT_TABLE_ROWTIME` BIGINT, `RIGHT_TABLE_ID3` BIGINT",
+      "keyFormat" : {
+        "format" : "JSON",
+        "features" : [ "UNWRAP_SINGLES" ]
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "stream-table-table - qualified select *",
+    "inputs" : [ {
+      "topic" : "middle_topic",
+      "key" : 0,
+      "value" : {
+        "F2" : 100,
+        "OTHER" : "unused"
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "left_topic",
+      "key" : 0,
+      "value" : {
+        "F1" : 0
+      },
+      "timestamp" : 10000
+    }, {
+      "topic" : "right_topic",
+      "key" : 0,
+      "value" : {
+        "F3" : 4
+      },
+      "timestamp" : 11000
+    }, {
+      "topic" : "middle_topic",
+      "key" : 8,
+      "value" : {
+        "F2" : 10,
+        "OTHER" : "unused"
+      },
+      "timestamp" : 13000
+    }, {
+      "topic" : "left_topic",
+      "key" : 8,
+      "value" : {
+        "F1" : 8
+      },
+      "timestamp" : 16000
+    }, {
+      "topic" : "left_topic",
+      "key" : 0,
+      "value" : null,
+      "timestamp" : 18000
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "ID1" : 0,
+        "MIDDLE_TABLE_ID2" : 0,
+        "MIDDLE_TABLE_F2" : 100,
+        "MIDDLE_TABLE_OTHER" : "unused",
+        "RIGHT_TABLE_ID3" : null,
+        "RIGHT_TABLE_F3" : null
+      },
+      "timestamp" : 10000
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 8,
+      "value" : {
+        "ID1" : 8,
+        "MIDDLE_TABLE_ID2" : 8,
+        "MIDDLE_TABLE_F2" : 10,
+        "MIDDLE_TABLE_OTHER" : "unused",
+        "RIGHT_TABLE_ID3" : null,
+        "RIGHT_TABLE_F3" : null
+      },
+      "timestamp" : 16000
+    } ],
+    "topics" : [ {
+      "name" : "right_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "middle_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "left_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM left_stream (id1 BIGINT KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');", "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');", "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');", "CREATE STREAM output AS SELECT id1, f1, middle_table.*, right_table.* FROM left_stream JOIN middle_table ON id1 = id2 LEFT JOIN right_table ON f1 = id3;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "LEFT_STREAM",
+        "type" : "STREAM",
+        "schema" : "`ID1` BIGINT KEY, `F1` BIGINT",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "MIDDLE_TABLE",
+        "type" : "TABLE",
+        "schema" : "`ID2` BIGINT KEY, `F2` BIGINT, `OTHER` STRING",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`F1` BIGINT KEY, `ID1` BIGINT, `MIDDLE_TABLE_ID2` BIGINT, `MIDDLE_TABLE_F2` BIGINT, `MIDDLE_TABLE_OTHER` STRING, `RIGHT_TABLE_ID3` BIGINT, `RIGHT_TABLE_F3` BIGINT",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "RIGHT_TABLE",
+        "type" : "TABLE",
+        "schema" : "`ID3` BIGINT KEY, `F3` BIGINT",
+        "keyFormat" : {
+          "format" : "JSON"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ "UNWRAP_SINGLES" ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KafkaTopic_Right-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-KafkaTopic_L_Right-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "middle_topic",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "left_topic",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CSAS_OUTPUT_0-Join-repartition",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "right_topic",
+          "keyFormat" : {
+            "format" : "JSON",
+            "features" : [ "UNWRAP_SINGLES" ]
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_qualified_select__/7.0.0_1621950302884/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_stream-table-table_-_qualified_select__/7.0.0_1621950302884/topology
@@ -1,0 +1,62 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [right_topic])
+      --> KTABLE-SOURCE-0000000002
+    Source: Join-repartition-source (topics: [Join-repartition])
+      --> Join
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: Join (stores: [KafkaTopic_Right-Reduce])
+      --> Project
+      <-- Join-repartition-source
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000022
+      <-- Join
+    Sink: KSTREAM-SINK-0000000022 (topic: OUTPUT)
+      <-- Project
+    Processor: PrependAliasRight (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000012 (topics: [left_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000013
+    Processor: KSTREAM-TRANSFORMVALUES-0000000013 (stores: [])
+      --> PrependAliasL_Left
+      <-- KSTREAM-SOURCE-0000000012
+    Source: KSTREAM-SOURCE-0000000007 (topics: [middle_topic])
+      --> KTABLE-SOURCE-0000000008
+    Processor: PrependAliasL_Left (stores: [])
+      --> L_Join
+      <-- KSTREAM-TRANSFORMVALUES-0000000013
+    Processor: KTABLE-SOURCE-0000000008 (stores: [])
+      --> KTABLE-MAPVALUES-0000000009
+      <-- KSTREAM-SOURCE-0000000007
+    Processor: L_Join (stores: [KafkaTopic_L_Right-Reduce])
+      --> LeftSourceKeyed-SelectKey
+      <-- PrependAliasL_Left
+    Processor: KTABLE-MAPVALUES-0000000009 (stores: [KafkaTopic_L_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000010
+      <-- KTABLE-SOURCE-0000000008
+    Processor: LeftSourceKeyed-SelectKey (stores: [])
+      --> Join-repartition-filter
+      <-- L_Join
+    Processor: Join-repartition-filter (stores: [])
+      --> Join-repartition-sink
+      <-- LeftSourceKeyed-SelectKey
+    Processor: KTABLE-TRANSFORMVALUES-0000000010 (stores: [])
+      --> PrependAliasL_Right
+      <-- KTABLE-MAPVALUES-0000000009
+    Sink: Join-repartition-sink (topic: Join-repartition)
+      <-- Join-repartition-filter
+    Processor: PrependAliasL_Right (stores: [])
+      --> none
+      <-- KTABLE-TRANSFORMVALUES-0000000010
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_table-table-table-table_-_qualified_select__/7.0.0_1621951715025/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_table-table-table-table_-_qualified_select__/7.0.0_1621951715025/plan.json
@@ -1,0 +1,355 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T1 (ID INTEGER PRIMARY KEY, V0 BIGINT) WITH (KAFKA_TOPIC='left', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T1",
+      "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+      "topicName" : "left",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T2 (ID INTEGER PRIMARY KEY, V0 BIGINT) WITH (KAFKA_TOPIC='right', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T2",
+      "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+      "topicName" : "right",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T3 (ID INTEGER PRIMARY KEY, V0 BIGINT) WITH (KAFKA_TOPIC='right2', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T3",
+      "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+      "topicName" : "right2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE T4 (ID INTEGER PRIMARY KEY, V0 BIGINT) WITH (KAFKA_TOPIC='right3', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "T4",
+      "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+      "topicName" : "right3",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  T1.ID T1_ID,\n  T2.*,\n  T3.V0 T3_V0,\n  T4.*\nFROM T1 T1\nINNER JOIN T2 T2 ON ((T1.ID = T2.ID))\nINNER JOIN T3 T3 ON ((T1.ID = T3.ID))\nINNER JOIN T4 T4 ON ((T1.ID = T4.ID))\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`T1_ID` INTEGER KEY, `T2_ID` INTEGER, `T2_V0` BIGINT, `T3_V0` BIGINT, `T4_ID` INTEGER, `T4_V0` BIGINT",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "T1", "T2", "T3", "T4" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableTableJoinV1",
+            "properties" : {
+              "queryContext" : "Join"
+            },
+            "joinType" : "INNER",
+            "leftSource" : {
+              "@type" : "tableTableJoinV1",
+              "properties" : {
+                "queryContext" : "L_Join"
+              },
+              "joinType" : "INNER",
+              "leftSource" : {
+                "@type" : "tableTableJoinV1",
+                "properties" : {
+                  "queryContext" : "L_L_Join"
+                },
+                "joinType" : "INNER",
+                "leftSource" : {
+                  "@type" : "tableSelectV1",
+                  "properties" : {
+                    "queryContext" : "PrependAliasL_L_Left"
+                  },
+                  "source" : {
+                    "@type" : "tableSourceV1",
+                    "properties" : {
+                      "queryContext" : "KafkaTopic_L_L_Left/Source"
+                    },
+                    "topicName" : "left",
+                    "formats" : {
+                      "keyFormat" : {
+                        "format" : "KAFKA"
+                      },
+                      "valueFormat" : {
+                        "format" : "JSON"
+                      }
+                    },
+                    "sourceSchema" : "`ID` INTEGER KEY, `V0` BIGINT",
+                    "forceChangelog" : true
+                  },
+                  "keyColumnNames" : [ "T1_ID" ],
+                  "selectExpressions" : [ "V0 AS T1_V0", "ROWTIME AS T1_ROWTIME", "ID AS T1_ID" ],
+                  "internalFormats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  }
+                },
+                "rightSource" : {
+                  "@type" : "tableSelectV1",
+                  "properties" : {
+                    "queryContext" : "PrependAliasL_L_Right"
+                  },
+                  "source" : {
+                    "@type" : "tableSourceV1",
+                    "properties" : {
+                      "queryContext" : "KafkaTopic_L_L_Right/Source"
+                    },
+                    "topicName" : "right",
+                    "formats" : {
+                      "keyFormat" : {
+                        "format" : "KAFKA"
+                      },
+                      "valueFormat" : {
+                        "format" : "JSON"
+                      }
+                    },
+                    "sourceSchema" : "`ID` INTEGER KEY, `V0` BIGINT",
+                    "forceChangelog" : true
+                  },
+                  "keyColumnNames" : [ "T2_ID" ],
+                  "selectExpressions" : [ "V0 AS T2_V0", "ROWTIME AS T2_ROWTIME", "ID AS T2_ID" ],
+                  "internalFormats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  }
+                },
+                "keyColName" : "T1_ID"
+              },
+              "rightSource" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "PrependAliasL_Right"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KafkaTopic_L_Right/Source"
+                  },
+                  "topicName" : "right2",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` INTEGER KEY, `V0` BIGINT",
+                  "forceChangelog" : true
+                },
+                "keyColumnNames" : [ "T3_ID" ],
+                "selectExpressions" : [ "V0 AS T3_V0", "ROWTIME AS T3_ROWTIME", "ID AS T3_ID" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                }
+              },
+              "keyColName" : "T1_ID"
+            },
+            "rightSource" : {
+              "@type" : "tableSelectV1",
+              "properties" : {
+                "queryContext" : "PrependAliasRight"
+              },
+              "source" : {
+                "@type" : "tableSourceV1",
+                "properties" : {
+                  "queryContext" : "KafkaTopic_Right/Source"
+                },
+                "topicName" : "right3",
+                "formats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                },
+                "sourceSchema" : "`ID` INTEGER KEY, `V0` BIGINT",
+                "forceChangelog" : true
+              },
+              "keyColumnNames" : [ "T4_ID" ],
+              "selectExpressions" : [ "V0 AS T4_V0", "ROWTIME AS T4_ROWTIME", "ID AS T4_ID" ],
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "keyColName" : "T1_ID"
+          },
+          "keyColumnNames" : [ "T1_ID" ],
+          "selectExpressions" : [ "T2_ID AS T2_ID", "T2_V0 AS T2_V0", "T3_V0 AS T3_V0", "T4_ID AS T4_ID", "T4_V0 AS T4_V0" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.joins.foreign.key.enable" : "false",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_table-table-table-table_-_qualified_select__/7.0.0_1621951715025/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_table-table-table-table_-_qualified_select__/7.0.0_1621951715025/spec.json
@@ -1,0 +1,305 @@
+{
+  "version" : "7.0.0",
+  "timestamp" : 1621951715025,
+  "path" : "query-validation-tests/multi-joins.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.PrependAliasL_Right" : {
+      "schema" : "`T3_ID` INTEGER KEY, `T3_V0` BIGINT, `T3_ROWTIME` BIGINT, `T3_ID` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KafkaTopic_L_Right.Source" : {
+      "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Project" : {
+      "schema" : "`T1_ID` INTEGER KEY, `T2_ID` INTEGER, `T2_V0` BIGINT, `T3_V0` BIGINT, `T4_ID` INTEGER, `T4_V0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KafkaTopic_Right.Source" : {
+      "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KafkaTopic_L_L_Right.Source" : {
+      "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`T1_ID` INTEGER KEY, `T2_ID` INTEGER, `T2_V0` BIGINT, `T3_V0` BIGINT, `T4_ID` INTEGER, `T4_V0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.PrependAliasRight" : {
+      "schema" : "`T4_ID` INTEGER KEY, `T4_V0` BIGINT, `T4_ROWTIME` BIGINT, `T4_ID` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.PrependAliasL_L_Right" : {
+      "schema" : "`T2_ID` INTEGER KEY, `T2_V0` BIGINT, `T2_ROWTIME` BIGINT, `T2_ID` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.PrependAliasL_L_Left" : {
+      "schema" : "`T1_ID` INTEGER KEY, `T1_V0` BIGINT, `T1_ROWTIME` BIGINT, `T1_ID` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KafkaTopic_L_L_Left.Source" : {
+      "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "table-table-table-table - qualified select *",
+    "inputs" : [ {
+      "topic" : "left",
+      "key" : 0,
+      "value" : {
+        "V0" : 1
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "right",
+      "key" : 0,
+      "value" : {
+        "V0" : 2
+      },
+      "timestamp" : 1
+    }, {
+      "topic" : "right2",
+      "key" : 0,
+      "value" : {
+        "V0" : 3
+      },
+      "timestamp" : 2
+    }, {
+      "topic" : "right3",
+      "key" : 0,
+      "value" : {
+        "V0" : 4
+      },
+      "timestamp" : 3
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "T2_ID" : 0,
+        "T2_V0" : 2,
+        "T3_V0" : 3,
+        "T4_ID" : 0,
+        "T4_V0" : 4
+      },
+      "timestamp" : 3
+    } ],
+    "topics" : [ {
+      "name" : "left",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "right2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "right3",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "right",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE T1 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');", "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');", "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');", "CREATE TABLE T4 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right3', value_format='JSON');", "CREATE TABLE OUTPUT as SELECT T1.ID, T2.*, T3.V0, T4.* FROM T1 JOIN T2 ON T1.ID = T2.ID JOIN T3 ON T1.ID = T3.ID JOIN T4 ON T1.ID = T4.ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`T1_ID` INTEGER KEY, `T2_ID` INTEGER, `T2_V0` BIGINT, `T3_V0` BIGINT, `T4_ID` INTEGER, `T4_V0` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "T1",
+        "type" : "TABLE",
+        "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "T2",
+        "type" : "TABLE",
+        "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "T3",
+        "type" : "TABLE",
+        "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "T4",
+        "type" : "TABLE",
+        "schema" : "`ID` INTEGER KEY, `V0` BIGINT",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-KafkaTopic_L_L_Left-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Project-Last-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-KafkaTopic_L_Right-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "left",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-KafkaTopic_Right-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "right3",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "right2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "right",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-KafkaTopic_L_L_Right-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        } ],
+        "blackList" : ".*-repartition"
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_table-table-table-table_-_qualified_select__/7.0.0_1621951715025/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/multi-joins_-_table-table-table-table_-_qualified_select__/7.0.0_1621951715025/topology
@@ -1,0 +1,94 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [left])
+      --> KTABLE-SOURCE-0000000002
+    Source: KSTREAM-SOURCE-0000000007 (topics: [right])
+      --> KTABLE-SOURCE-0000000008
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-SOURCE-0000000008 (stores: [])
+      --> KTABLE-MAPVALUES-0000000009
+      <-- KSTREAM-SOURCE-0000000007
+    Source: KSTREAM-SOURCE-0000000016 (topics: [right2])
+      --> KTABLE-SOURCE-0000000017
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KafkaTopic_L_L_Left-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-MAPVALUES-0000000009 (stores: [KafkaTopic_L_L_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000010
+      <-- KTABLE-SOURCE-0000000008
+    Processor: KTABLE-SOURCE-0000000017 (stores: [])
+      --> KTABLE-MAPVALUES-0000000018
+      <-- KSTREAM-SOURCE-0000000016
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> PrependAliasL_L_Left
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: KTABLE-TRANSFORMVALUES-0000000010 (stores: [])
+      --> PrependAliasL_L_Right
+      <-- KTABLE-MAPVALUES-0000000009
+    Source: KSTREAM-SOURCE-0000000025 (topics: [right3])
+      --> KTABLE-SOURCE-0000000026
+    Processor: KTABLE-MAPVALUES-0000000018 (stores: [KafkaTopic_L_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000019
+      <-- KTABLE-SOURCE-0000000017
+    Processor: PrependAliasL_L_Left (stores: [])
+      --> KTABLE-JOINTHIS-0000000013
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: PrependAliasL_L_Right (stores: [])
+      --> KTABLE-JOINOTHER-0000000014
+      <-- KTABLE-TRANSFORMVALUES-0000000010
+    Processor: KTABLE-JOINOTHER-0000000014 (stores: [KafkaTopic_L_L_Left-Reduce])
+      --> KTABLE-MERGE-0000000012
+      <-- PrependAliasL_L_Right
+    Processor: KTABLE-JOINTHIS-0000000013 (stores: [KafkaTopic_L_L_Right-Reduce])
+      --> KTABLE-MERGE-0000000012
+      <-- PrependAliasL_L_Left
+    Processor: KTABLE-SOURCE-0000000026 (stores: [])
+      --> KTABLE-MAPVALUES-0000000027
+      <-- KSTREAM-SOURCE-0000000025
+    Processor: KTABLE-TRANSFORMVALUES-0000000019 (stores: [])
+      --> PrependAliasL_Right
+      <-- KTABLE-MAPVALUES-0000000018
+    Processor: KTABLE-MAPVALUES-0000000027 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000028
+      <-- KTABLE-SOURCE-0000000026
+    Processor: KTABLE-MERGE-0000000012 (stores: [])
+      --> KTABLE-JOINTHIS-0000000022
+      <-- KTABLE-JOINTHIS-0000000013, KTABLE-JOINOTHER-0000000014
+    Processor: PrependAliasL_Right (stores: [])
+      --> KTABLE-JOINOTHER-0000000023
+      <-- KTABLE-TRANSFORMVALUES-0000000019
+    Processor: KTABLE-JOINOTHER-0000000023 (stores: [KafkaTopic_L_L_Left-Reduce, KafkaTopic_L_L_Right-Reduce])
+      --> KTABLE-MERGE-0000000021
+      <-- PrependAliasL_Right
+    Processor: KTABLE-JOINTHIS-0000000022 (stores: [KafkaTopic_L_Right-Reduce])
+      --> KTABLE-MERGE-0000000021
+      <-- KTABLE-MERGE-0000000012
+    Processor: KTABLE-TRANSFORMVALUES-0000000028 (stores: [])
+      --> PrependAliasRight
+      <-- KTABLE-MAPVALUES-0000000027
+    Processor: KTABLE-MERGE-0000000021 (stores: [])
+      --> KTABLE-JOINTHIS-0000000031
+      <-- KTABLE-JOINTHIS-0000000022, KTABLE-JOINOTHER-0000000023
+    Processor: PrependAliasRight (stores: [])
+      --> KTABLE-JOINOTHER-0000000032
+      <-- KTABLE-TRANSFORMVALUES-0000000028
+    Processor: KTABLE-JOINOTHER-0000000032 (stores: [KafkaTopic_L_L_Left-Reduce, KafkaTopic_L_Right-Reduce, KafkaTopic_L_L_Right-Reduce])
+      --> KTABLE-MERGE-0000000030
+      <-- PrependAliasRight
+    Processor: KTABLE-JOINTHIS-0000000031 (stores: [KafkaTopic_Right-Reduce])
+      --> KTABLE-MERGE-0000000030
+      <-- KTABLE-MERGE-0000000021
+    Processor: KTABLE-MERGE-0000000030 (stores: [])
+      --> KTABLE-TRANSFORMVALUES-0000000033
+      <-- KTABLE-JOINTHIS-0000000031, KTABLE-JOINOTHER-0000000032
+    Processor: KTABLE-TRANSFORMVALUES-0000000033 (stores: [Project-Last])
+      --> KTABLE-TOSTREAM-0000000034
+      <-- KTABLE-MERGE-0000000030
+    Processor: KTABLE-TOSTREAM-0000000034 (stores: [])
+      --> KSTREAM-SINK-0000000035
+      <-- KTABLE-TRANSFORMVALUES-0000000033
+    Sink: KSTREAM-SINK-0000000035 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000034
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-n-way-join.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-n-way-join.json
@@ -235,22 +235,22 @@
         "CREATE TABLE output AS SELECT id1, middle_table.*, right_table.* FROM left_table JOIN middle_table ON f1 = id2 LEFT JOIN right_table ON id1 = id3;"
       ],
       "inputs": [
-        {"topic": "middle_topic", "key": 0, "value": {"F2": 100, "OTHER": "unused"}, "timestamp": 0},
+        {"topic": "middle_topic", "key": 0, "value": {"F2": 100, "OTHER": "foo"}, "timestamp": 0},
         {"topic": "left_topic", "key": 1, "value": {"F1": 0}, "timestamp": 10000},
         {"topic": "right_topic", "key": 1, "value": {"F3": 4}, "timestamp": 11000},
-        {"topic": "middle_topic", "key": 8, "value": {"F2": 10, "OTHER": "unused"}, "timestamp": 13000},
+        {"topic": "middle_topic", "key": 8, "value": {"F2": 10, "OTHER": "bar"}, "timestamp": 13000},
         {"topic": "left_topic", "key": 1, "value": {"F1": 8}, "timestamp": 16000},
         {"topic": "left_topic", "key": 1, "value": null, "timestamp": 18000}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 100, "RIGHT_TABLE_ID3": null, "RIGHT_TABLE_F3": null}, "timestamp": 10000},
-        {"topic": "OUTPUT", "key": 1, "value": {"MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 100, "RIGHT_TABLE_ID3": 1, "RIGHT_TABLE_F3": 4}, "timestamp": 11000},
-        {"topic": "OUTPUT", "key": 1, "value": {"MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 10, "RIGHT_TABLE_ID3": 1, "RIGHT_TABLE_F3": 4}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 1, "value": {"MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 100, "MIDDLE_TABLE_OTHER": "foo", "RIGHT_TABLE_ID3": null, "RIGHT_TABLE_F3": null}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 1, "value": {"MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 100, "MIDDLE_TABLE_OTHER": "foo", "RIGHT_TABLE_ID3": 1, "RIGHT_TABLE_F3": 4}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 1, "value": {"MIDDLE_TABLE_ID2": 8, "MIDDLE_TABLE_F2": 10, "MIDDLE_TABLE_OTHER": "bar", "RIGHT_TABLE_ID3": 1, "RIGHT_TABLE_F3": 4}, "timestamp": 16000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "LEFT_TABLE_ID1 BIGINT KEY, MIDDLE_TABLE_ID2 BIGINT, MIDDLE_TABLE_F2 BIGINT, RIGHT_TABLE_ID3 BIGINT, RIGHT_TABLE_F3 BIGINT"}
+          {"name": "OUTPUT", "type": "table", "schema": "ID1 BIGINT KEY, MIDDLE_TABLE_ID2 BIGINT, MIDDLE_TABLE_F2 BIGINT, MIDDLE_TABLE_OTHER STRING, RIGHT_TABLE_ID3 BIGINT, RIGHT_TABLE_F3 BIGINT"}
         ]
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -1321,6 +1321,32 @@
           ]
         }
       }
+    },
+    {
+      "name": "stream-table-table - qualified select *",
+      "statements": [
+        "CREATE STREAM left_stream (id1 BIGINT KEY, f1 BIGINT) WITH (kafka_topic='left_topic', format='JSON');",
+        "CREATE TABLE middle_table (id2 BIGINT PRIMARY KEY, f2 BIGINT, other STRING) WITH (kafka_topic='middle_topic', format='JSON');",
+        "CREATE TABLE right_table (id3 BIGINT PRIMARY KEY, f3 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE STREAM output AS SELECT id1, f1, middle_table.*, right_table.* FROM left_stream JOIN middle_table ON id1 = id2 LEFT JOIN right_table ON f1 = id3;"
+      ],
+      "inputs": [
+        {"topic": "middle_topic", "key": 0, "value": {"F2": 100, "OTHER": "unused"}, "timestamp": 0},
+        {"topic": "left_topic", "key": 0, "value": {"F1": 0}, "timestamp": 10000},
+        {"topic": "right_topic", "key": 0, "value": {"F3": 4}, "timestamp": 11000},
+        {"topic": "middle_topic", "key": 8, "value": {"F2": 10, "OTHER": "unused"}, "timestamp": 13000},
+        {"topic": "left_topic", "key": 8, "value": {"F1": 8}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 0, "value": null, "timestamp": 18000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"ID1": 0, "MIDDLE_TABLE_ID2": 0, "MIDDLE_TABLE_F2": 100, "MIDDLE_TABLE_OTHER": "unused", "RIGHT_TABLE_ID3": null, "RIGHT_TABLE_F3": null}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 8, "value": {"ID1": 8, "MIDDLE_TABLE_ID2": 8, "MIDDLE_TABLE_F2": 10, "MIDDLE_TABLE_OTHER": "unused", "RIGHT_TABLE_ID3": null, "RIGHT_TABLE_F3": null}, "timestamp": 16000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "F1 BIGINT KEY, ID1 BIGINT, MIDDLE_TABLE_ID2 BIGINT, MIDDLE_TABLE_F2 BIGINT, MIDDLE_TABLE_OTHER STRING, RIGHT_TABLE_ID3 BIGINT, RIGHT_TABLE_F3 BIGINT"}
+        ]
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/multi-joins.json
@@ -1347,6 +1347,31 @@
           {"name": "OUTPUT", "type": "stream", "schema": "F1 BIGINT KEY, ID1 BIGINT, MIDDLE_TABLE_ID2 BIGINT, MIDDLE_TABLE_F2 BIGINT, MIDDLE_TABLE_OTHER STRING, RIGHT_TABLE_ID3 BIGINT, RIGHT_TABLE_F3 BIGINT"}
         ]
       }
+    },
+    {
+      "name": "table-table-table-table - qualified select *",
+      "statements": [
+        "CREATE TABLE T1 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='left', value_format='JSON');",
+        "CREATE TABLE T2 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right', value_format='JSON');",
+        "CREATE TABLE T3 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right2', value_format='JSON');",
+        "CREATE TABLE T4 (ID INT PRIMARY KEY, V0 bigint) WITH (kafka_topic='right3', value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT T1.ID, T2.*, T3.V0, T4.* FROM T1 JOIN T2 ON T1.ID = T2.ID JOIN T3 ON T1.ID = T3.ID JOIN T4 ON T1.ID = T4.ID;"
+      ],
+      "inputs": [
+        {"topic": "left", "key": 0, "value": {"V0": 1}, "timestamp": 0},
+        {"topic": "right", "key": 0, "value": {"V0": 2}, "timestamp": 1},
+        {"topic": "right2", "key": 0, "value": {"V0": 3}, "timestamp": 2},
+        {"topic": "right3", "key": 0, "value": {"V0": 4}, "timestamp": 3}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": {"T2_ID": 0, "T2_V0": 2, "T3_V0": 3, "T4_ID": 0, "T4_V0": 4}, "timestamp": 3}
+      ],
+      "post": {
+        "topics": {"blacklist": ".*-repartition"},
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "schema": "T1_ID INT PRIMARY KEY, T2_ID INTEGER, T2_V0 BIGINT, T3_V0 BIGINT, T4_ID INTEGER, T4_V0 BIGINT"}
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/7583.
Fixes https://github.com/confluentinc/ksql/issues/7584.

The reason for both bugs is because the current logic in `JoinNode#resolveSelectStar()` for finding data source names says "if the current node is a JoinNode, inspect its children, else use the current node". This is incorrect because

1. The current node might be neither a JoinNode nor a node corresponding to a single data source -- it might be a PreJoinRepartitionNode attached to a JoinNode. In this case, the current logic says to use the current node but the current node is not associated with any data source. As a result, some data sources are missing from the set of data source names considered when resolving the qualified select `*`.
2. Even if the current node is a JoinNode, its children might not correspond to specific data sources. This is the case if one or more children are themselves JoinNodes, i.e., the n-way join involves 3 or more joins. In this case, the current logic says to inspect the children of the JoinNode but not all children are associated with specific data sources, and again some data sources are missing from the set of data source names considered when resolving the qualified select `*`.

This PR fixes this class of bugs by updating the logic to properly find all source nodes for the n-way join.

This PR also includes minor fixes to one of the new foreign key join tests (currently disabled), the one that exposed this class of long-standing bugs.

### Testing done 

Added two QTTs that fail before the bug fix in this PR but pass with the fix.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

