### PR TITLE
feat: Adds Scalable Push Query Routing

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -280,12 +280,6 @@ public class KsqlConfig extends AbstractConfig {
           + "functions, aggregations, or joins, but may include projections and filters.";
   public static final boolean KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT = false;
 
-  public static final String KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_CONFIG
-      = "ksql.query.push.scalable.thread.pool.size";
-  public static final Integer KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_DEFAULT = 100;
-  public static final String KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_DOC =
-      "Size of thread pool used for making scalable push query connections.";
-
   public static final String KSQL_STRING_CASE_CONFIG_TOGGLE = "ksql.cast.strings.preserve.nulls";
   public static final String KSQL_STRING_CASE_CONFIG_TOGGLE_DOC =
       "When casting a SQLType to string, if false, use String.valueof(), else if true use"
@@ -901,13 +895,6 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PUSH_SCALABLE_ENABLED_DOC
-        )
-        .define(
-            KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_CONFIG,
-            Type.BOOLEAN,
-            KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_DEFAULT,
-            Importance.LOW,
-            KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_DOC
         )
         .define(
             KSQL_ERROR_CLASSIFIER_REGEX_PREFIX,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -280,6 +280,12 @@ public class KsqlConfig extends AbstractConfig {
           + "functions, aggregations, or joins, but may include projections and filters.";
   public static final boolean KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT = false;
 
+  public static final String KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_CONFIG
+      = "ksql.query.push.scalable.thread.pool.size";
+  public static final Integer KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_DEFAULT = 100;
+  public static final String KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_DOC =
+      "Size of thread pool used for making scalable push query connections.";
+
   public static final String KSQL_STRING_CASE_CONFIG_TOGGLE = "ksql.cast.strings.preserve.nulls";
   public static final String KSQL_STRING_CASE_CONFIG_TOGGLE_DOC =
       "When casting a SQLType to string, if false, use String.valueof(), else if true use"
@@ -895,6 +901,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PUSH_SCALABLE_ENABLED_DOC
+        )
+        .define(
+            KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_CONFIG,
+            Type.BOOLEAN,
+            KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_DOC
         )
         .define(
             KSQL_ERROR_CLASSIFIER_REGEX_PREFIX,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRouting.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.physical.scalablepush;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.physical.pull.HARouting;
+import io.confluent.ksql.physical.scalablepush.locator.PushLocator.KsqlNode;
+import io.confluent.ksql.query.TransientQueryQueue;
+import io.confluent.ksql.reactive.BaseSubscriber;
+import io.confluent.ksql.reactive.BufferedPublisher;
+import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlRequestConfig;
+import io.vertx.core.Context;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PushRouting implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HARouting.class);
+  private static final long TIMEOUT_CONNECT_MS = 3000;
+
+  private final ExecutorService executorService;
+
+  public PushRouting(
+      final KsqlConfig ksqlConfig
+  ) {
+    // This thread pool is used to make connections to other servers, but not while sending rows
+    // (which is async).
+    this.executorService = Executors.newFixedThreadPool(
+        ksqlConfig.getInt(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_THREAD_POOL_SIZE_CONFIG),
+        new ThreadFactoryBuilder().setNameFormat("scalable-push-query-executor-%d").build());
+  }
+
+  @Override
+  public void close() {
+    executorService.shutdown();
+  }
+
+  public CompletableFuture<PushConnectionsHandle> handlePushQuery(
+      final ServiceContext serviceContext,
+      final PushPhysicalPlan pushPhysicalPlan,
+      final ConfiguredStatement<Query> statement,
+      final PushRoutingOptions pushRoutingOptions,
+      final LogicalSchema outputSchema,
+      final TransientQueryQueue transientQueryQueue
+  ) {
+    final List<KsqlNode> hosts = pushPhysicalPlan.getScalablePushRegistry()
+        .getLocator()
+        .locate()
+        .stream()
+        .filter(node -> !pushRoutingOptions.getIsSkipForwardRequest() || node.isLocal())
+        .distinct()
+        .collect(Collectors.toList());
+
+    if (hosts.isEmpty()) {
+      LOG.debug("Unable to execute push query: {}. No nodes executing persistent queries",
+          statement.getStatementText());
+      throw new KsqlException(String.format(
+          "Unable to execute push query. No nodes executing persistent queries %s",
+          statement.getStatementText()));
+    }
+
+    // At the moment, this isn't async, but we return a future anyway.
+    final CompletableFuture<PushConnectionsHandle> completableFuture = new CompletableFuture<>();
+    try {
+      PushConnectionsHandle pushConnectionsHandle =
+          connectToHosts(serviceContext, pushPhysicalPlan, statement, hosts, outputSchema,
+              transientQueryQueue);
+      completableFuture.complete(pushConnectionsHandle);
+    } catch (Throwable t) {
+      completableFuture.completeExceptionally(t);
+    }
+
+    return completableFuture;
+  }
+
+  private PushConnectionsHandle connectToHosts(
+      final ServiceContext serviceContext,
+      final PushPhysicalPlan pushPhysicalPlan,
+      final ConfiguredStatement<Query> statement,
+      final List<KsqlNode> hosts,
+      final LogicalSchema outputSchema,
+      final TransientQueryQueue transientQueryQueue
+  ) throws InterruptedException {
+    final List<Callable<RoutingResult>> callables = new ArrayList<>();
+    final CompletableFuture<Void> errorCallback = new CompletableFuture<>();
+    for (final KsqlNode node : hosts) {
+      callables.add(() -> executeOrRouteQuery(
+          node, statement, serviceContext, pushPhysicalPlan, outputSchema,
+          transientQueryQueue, errorCallback::completeExceptionally));
+    }
+    List<Future<RoutingResult>> futureList = executorService.invokeAll(callables,
+        TIMEOUT_CONNECT_MS, TimeUnit.MILLISECONDS);
+
+    int i = 0;
+    final PushConnectionsHandle pushConnectionsHandle = new PushConnectionsHandle(errorCallback);
+    KsqlException exception = null;
+    for (final KsqlNode node : hosts) {
+      final Future<RoutingResult> future = futureList.get(i++);
+      RoutingResult routingResult = null;
+      try {
+        routingResult = future.get();
+        pushConnectionsHandle.add(node, routingResult);
+      } catch (ExecutionException | CancellationException e) {
+        LOG.warn("Error routing query {} to host {} at timestamp {} with exception {}",
+            statement.getStatementText(), node, System.currentTimeMillis(), e.getCause());
+        exception = new KsqlException(String.format(
+            "Unable to execute push query \"%s\". %s",
+            statement.getStatementText(), e.getCause().getMessage()));
+      }
+    }
+    if (exception != null) {
+      pushConnectionsHandle.close();
+      pushConnectionsHandle.completeExceptionally(exception);
+    }
+    return pushConnectionsHandle;
+  }
+
+  @VisibleForTesting
+  static RoutingResult executeOrRouteQuery(
+      final KsqlNode node,
+      final ConfiguredStatement<Query> statement,
+      final ServiceContext serviceContext,
+      final PushPhysicalPlan pushPhysicalPlan,
+      final LogicalSchema outputSchema,
+      final TransientQueryQueue transientQueryQueue,
+      final Consumer<Throwable> errorCallback
+  ) {
+    if (node.isLocal()) {
+      BufferedPublisher<List<?>> publisher = null;
+      try {
+        LOG.debug("Query {} executed locally at host {} at timestamp {}.",
+            statement.getStatementText(), node.location(), System.currentTimeMillis());
+        publisher = pushPhysicalPlan.execute();
+        publisher.subscribe(new LocalQueryStreamSubscriber(publisher.getContext(),
+            transientQueryQueue, errorCallback));
+        return new RoutingResult(RoutingResultStatus.SUCCESS, pushPhysicalPlan::close);
+      } catch (Exception e) {
+        if (publisher != null) {
+          publisher.close();
+        }
+        pushPhysicalPlan.close();
+        LOG.error("Error executing query {} locally at node {}",
+            statement.getStatementText(), node.location(), e.getCause());
+        throw new KsqlException(
+            String.format("Error executing query locally at node %s: %s", node.location(),
+                e.getMessage()),
+            e
+        );
+      }
+    } else {
+      BufferedPublisher<StreamedRow> publisher = null;
+      try {
+        LOG.debug("Query {} routed to host {} at timestamp {}.",
+            statement.getStatementText(), node.location(), System.currentTimeMillis());
+        publisher = forwardTo(node, statement, serviceContext, outputSchema);
+        publisher.subscribe(new QueryStreamSubscriber(publisher.getContext(), transientQueryQueue,
+            errorCallback));
+        return new RoutingResult(RoutingResultStatus.SUCCESS, publisher::close);
+      } catch (Exception e) {
+        if (publisher != null) {
+          publisher.close();
+        }
+        LOG.error("Error forwarding query {} to node {}",
+            statement.getStatementText(), node, e.getCause());
+        throw new KsqlException(
+            String.format("Error forwarding query to node %s: %s", node.location(),
+                e.getMessage()),
+            e
+        );
+      }
+    }
+  }
+
+  private static BufferedPublisher<StreamedRow> forwardTo(
+      final KsqlNode owner,
+      final ConfiguredStatement<Query> statement,
+      final ServiceContext serviceContext,
+      final LogicalSchema outputSchema
+  ) {
+    // Add skip forward flag to properties
+    final Map<String, Object> requestProperties = ImmutableMap.of(
+        KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_SKIP_FORWARDING, true,
+        KsqlRequestConfig.KSQL_REQUEST_INTERNAL_REQUEST, true);
+
+    final RestResponse<BufferedPublisher<StreamedRow>> response  = serviceContext
+          .getKsqlClient()
+          .makeQueryRequestStreamed(
+              owner.location(),
+              statement.getStatementText(),
+              statement.getSessionConfig().getOverrides(),
+              requestProperties
+          );
+
+    if (response.isErroneous()) {
+      throw new KsqlException(String.format(
+          "Forwarding pull query request [%s, %s] failed with error %s ",
+          statement.getSessionConfig().getOverrides(), requestProperties,
+          response.getErrorMessage()));
+    }
+
+    return response.getResponse();
+  }
+
+  public enum RoutingResultStatus {
+    SUCCESS
+  }
+
+  public static class RoutingResult {
+    private final RoutingResultStatus status;
+    private final AutoCloseable closeable;
+
+    public RoutingResult(final RoutingResultStatus status, final AutoCloseable closeable) {
+      this.status = status;
+      this.closeable = closeable;
+    }
+
+    public void close() {
+      try {
+        closeable.close();
+      } catch (Exception e) {
+        LOG.error("Error closing routing result: " + e.getMessage(), e);
+      }
+    }
+
+    public RoutingResultStatus getStatus() {
+      return status;
+    }
+  }
+
+  private static class QueryStreamSubscriber extends BaseSubscriber<StreamedRow> {
+
+    private final TransientQueryQueue transientQueryQueue;
+    private final Consumer<Throwable> errorCallback;
+    private boolean closed;
+
+    QueryStreamSubscriber(final Context context,
+        final TransientQueryQueue transientQueryQueue,
+        final Consumer<Throwable> errorCallback) {
+      super(context);
+      this.transientQueryQueue = transientQueryQueue;
+      this.errorCallback = errorCallback;
+    }
+
+    @Override
+    protected void afterSubscribe(final Subscription subscription) {
+      makeRequest(1);
+    }
+
+    @Override
+    protected synchronized void handleValue(final StreamedRow row) {
+      if (closed) {
+        return;
+      }
+      if (row.isTerminal()) {
+        close();
+        return;
+      }
+      if (row.getRow().isPresent()) {
+          if (!transientQueryQueue.acceptRowNonBlocking(null,
+              GenericRow.fromList(row.getRow().get().getColumns()))) {
+            errorCallback.accept(new KsqlException("Hit limit of request queue"));
+            close();
+            return;
+          };
+      }
+      makeRequest(1);
+    }
+
+    @Override
+    protected void handleComplete() {
+    }
+
+    @Override
+    protected void handleError(final Throwable t) {
+      errorCallback.accept(t);
+    }
+
+    synchronized void close() {
+      closed = true;
+      context.runOnContext(v -> cancel());
+    }
+  }
+
+  private static class LocalQueryStreamSubscriber extends BaseSubscriber<List<?>> {
+
+    private final TransientQueryQueue transientQueryQueue;
+    private final Consumer<Throwable> errorCallback;
+    private boolean closed;
+
+    LocalQueryStreamSubscriber(
+        final Context context,
+        final TransientQueryQueue transientQueryQueue,
+        final Consumer<Throwable> errorCallback
+    ) {
+      super(context);
+      this.transientQueryQueue = transientQueryQueue;
+      this.errorCallback = errorCallback;
+    }
+
+    @Override
+    protected void afterSubscribe(final Subscription subscription) {
+      makeRequest(1);
+    }
+
+    @Override
+    protected synchronized void handleValue(final List<?> row) {
+      if (closed) {
+        return;
+      }
+      if (!transientQueryQueue.acceptRowNonBlocking(null, GenericRow.fromList(row))) {
+        errorCallback.accept(new KsqlException("Hit limit of request queue"));
+        close();
+        return;
+      }
+
+      makeRequest(1);
+    }
+
+    @Override
+    protected void handleComplete() {
+    }
+
+    @Override
+    protected void handleError(final Throwable t) {
+      errorCallback.accept(t);
+    }
+
+    synchronized void close() {
+      closed = true;
+      context.runOnContext(v -> cancel());
+    }
+  }
+
+  public static class PushConnectionsHandle {
+    private final Map<KsqlNode, RoutingResult> results = new LinkedHashMap<>();
+    private final CompletableFuture<Void> errorCallback;
+
+    public PushConnectionsHandle(final CompletableFuture<Void> errorCallback) {
+      this.errorCallback = errorCallback;
+    }
+
+    public void add(final KsqlNode ksqlNode, RoutingResult result) {
+      results.put(ksqlNode, result);
+    }
+
+    public void remove(final KsqlNode ksqlNode) {
+      results.remove(ksqlNode);
+    }
+
+    public void close() {
+      for (RoutingResult result : results.values()) {
+        result.close();
+      }
+    }
+
+    public void onException(final Consumer<Throwable> consumer) {
+      errorCallback.exceptionally(t -> {
+        consumer.accept(t);
+        return null;
+      });
+    }
+
+    public void completeExceptionally(final Throwable throwable) {
+      if (!errorCallback.isDone()) {
+        errorCallback.completeExceptionally(throwable);
+      }
+    }
+
+    public Throwable getError() throws InterruptedException {
+      try {
+        errorCallback.get();
+      } catch (ExecutionException e) {
+        return e.getCause();
+      }
+      return null;
+    }
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
@@ -1,0 +1,6 @@
+package io.confluent.ksql.physical.scalablepush;
+
+public interface PushRoutingOptions {
+
+  boolean getIsSkipForwardRequest();
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
@@ -1,6 +1,25 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.physical.scalablepush;
 
+/**
+ * Routing options given to scalable push queries.
+ */
 public interface PushRoutingOptions {
 
+  // If we should avoid skipping forwarding the request because it's already been forwarded.
   boolean getIsSkipForwardRequest();
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
@@ -135,7 +135,7 @@ public class PushRoutingTest {
     CompletableFuture<PushConnectionsHandle> future =
         routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
             outputSchema, transientQueryQueue);
-    PushConnectionsHandle handle = future.get();
+    future.get();
     context.runOnContext(v -> {
       localPublisher.accept(LOCAL_ROW1);
       localPublisher.accept(LOCAL_ROW2);
@@ -171,7 +171,7 @@ public class PushRoutingTest {
     CompletableFuture<PushConnectionsHandle> future =
         routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
             outputSchema, transientQueryQueue);
-    PushConnectionsHandle handle = future.get();
+    future.get();
     context.runOnContext(v -> {
       localPublisher.accept(LOCAL_ROW1);
       localPublisher.accept(LOCAL_ROW2);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
@@ -1,0 +1,309 @@
+package io.confluent.ksql.physical.scalablepush;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.physical.scalablepush.PushRouting.PushConnectionsHandle;
+import io.confluent.ksql.physical.scalablepush.locator.PushLocator;
+import io.confluent.ksql.physical.scalablepush.locator.PushLocator.KsqlNode;
+import io.confluent.ksql.query.TransientQueryQueue;
+import io.confluent.ksql.reactive.BufferedPublisher;
+import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.services.SimpleKsqlClient;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KeyValue;
+import io.confluent.ksql.util.KsqlConfig;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PushRoutingTest {
+
+  private static final List<?> LOCAL_ROW1 = ImmutableList.of(1, "a");
+  private static final List<?> LOCAL_ROW2 = ImmutableList.of(2, "b");
+
+  private static final StreamedRow REMOTE_ROW1
+      = StreamedRow.pushRow(GenericRow.fromList(ImmutableList.of(3, "c")));
+  private static final StreamedRow REMOTE_ROW2
+      = StreamedRow.pushRow(GenericRow.fromList(ImmutableList.of(4, "d")));
+
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private SimpleKsqlClient simpleKsqlClient;
+  @Mock
+  private PushPhysicalPlan pushPhysicalPlan;
+  @Mock
+  private ConfiguredStatement<Query> statement;
+  @Mock
+  private SessionConfig sessionConfig;
+  @Mock
+  private PushRoutingOptions pushRoutingOptions;
+  @Mock
+  private LogicalSchema outputSchema;
+  @Mock
+  private ScalablePushRegistry scalablePushRegistry;
+  @Mock
+  private PushLocator locator;
+  @Mock
+  private KsqlNode ksqlNodeLocal;
+  @Mock
+  private KsqlNode ksqlNodeRemote;
+  @Mock
+  private TransientQueryQueue transientQueryQueueMock;
+
+  private Vertx vertx;
+  private Context context;
+  private TransientQueryQueue transientQueryQueue;
+
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+    context = vertx.getOrCreateContext();
+    when(statement.getStatementText()).thenReturn("SELECT * FROM STREAM EMIT CHANGES");
+    when(statement.getSessionConfig()).thenReturn(sessionConfig);
+    when(sessionConfig.getOverrides()).thenReturn(ImmutableMap.of());
+    when(serviceContext.getKsqlClient()).thenReturn(simpleKsqlClient);
+    when(pushPhysicalPlan.getScalablePushRegistry()).thenReturn(scalablePushRegistry);
+    when(scalablePushRegistry.getLocator()).thenReturn(locator);
+    when(locator.locate()).thenReturn(ImmutableList.of(ksqlNodeLocal, ksqlNodeRemote));
+    when(ksqlNodeLocal.location()).thenReturn(URI.create("http://localhost:8088"));
+    when(ksqlNodeLocal.isLocal()).thenReturn(true);
+    when(ksqlNodeRemote.location()).thenReturn(URI.create("http://remote:8088"));
+    when(ksqlNodeRemote.isLocal()).thenReturn(false);
+    when(pushRoutingOptions.getIsSkipForwardRequest()).thenReturn(false);
+
+    transientQueryQueue = new TransientQueryQueue(OptionalInt.empty());
+  }
+
+  @After
+  public void tearDown() {
+    vertx.close();
+  }
+
+  @Test
+  public void shouldSucceed_forward() throws ExecutionException, InterruptedException {
+    // Given:
+    KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+    final PushRouting routing = new PushRouting(ksqlConfig);
+    BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
+    BufferedPublisher<StreamedRow> remotePublisher = new BufferedPublisher<>(context);
+    when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
+    when(simpleKsqlClient.makeQueryRequestStreamed(any(), any(), any(), any()))
+        .thenReturn(RestResponse.successful(200, remotePublisher));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    PushConnectionsHandle handle = future.get();
+    context.runOnContext(v -> {
+      localPublisher.accept(LOCAL_ROW1);
+      localPublisher.accept(LOCAL_ROW2);
+      remotePublisher.accept(REMOTE_ROW1);
+      remotePublisher.accept(REMOTE_ROW2);
+    });
+
+    // Then:
+    Set<List<?>> rows = new HashSet<>();
+    while (rows.size() < 4) {
+      final KeyValue<List<?>, GenericRow> kv = transientQueryQueue.poll();
+      if (kv == null) {
+        Thread.sleep(100);
+        continue;
+      }
+      rows.add(kv.value().values());
+    }
+    assertThat(rows.contains(LOCAL_ROW1), is(true));
+    assertThat(rows.contains(LOCAL_ROW2), is(true));
+    assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
+    assertThat(rows.contains(REMOTE_ROW2.getRow().get().getColumns()), is(true));
+  }
+
+  @Test
+  public void shouldSucceed_justForwarded() throws ExecutionException, InterruptedException {
+    // Given:
+    when(pushRoutingOptions.getIsSkipForwardRequest()).thenReturn(true);
+    KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+    final PushRouting routing = new PushRouting(ksqlConfig);
+    BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
+    when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    PushConnectionsHandle handle = future.get();
+    context.runOnContext(v -> {
+      localPublisher.accept(LOCAL_ROW1);
+      localPublisher.accept(LOCAL_ROW2);
+    });
+
+    // Then:
+    verify(simpleKsqlClient, never()).makeQueryRequestStreamed(any(), any(), any(), any());
+    Set<List<?>> rows = new HashSet<>();
+    while (rows.size() < 2) {
+      final KeyValue<List<?>, GenericRow> kv = transientQueryQueue.poll();
+      if (kv == null) {
+        Thread.sleep(100);
+        continue;
+      }
+      rows.add(kv.value().values());
+    }
+    assertThat(rows.contains(LOCAL_ROW1), is(true));
+    assertThat(rows.contains(LOCAL_ROW2), is(true));
+  }
+
+  @Test
+  public void shouldFail_duringPlanExecute() throws ExecutionException, InterruptedException {
+    // Given:
+    when(pushRoutingOptions.getIsSkipForwardRequest()).thenReturn(true);
+    KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+    final PushRouting routing = new PushRouting(ksqlConfig);
+    when(pushPhysicalPlan.execute()).thenThrow(new RuntimeException("Error!"));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    PushConnectionsHandle handle = future.get();
+
+    // Then:
+    assertThat(handle.getError().getMessage(), containsString("Error!"));
+  }
+
+  @Test
+  public void shouldFail_non200RemoteCall() throws ExecutionException, InterruptedException {
+    // Given:
+    when(locator.locate()).thenReturn(ImmutableList.of(ksqlNodeRemote));
+    KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+    final PushRouting routing = new PushRouting(ksqlConfig);
+    when(simpleKsqlClient.makeQueryRequestStreamed(any(), any(), any(), any()))
+        .thenReturn(RestResponse.erroneous(500, "Error response!"));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    PushConnectionsHandle handle = future.get();
+
+    // Then:
+    assertThat(handle.getError().getMessage(), containsString("Error response!"));
+  }
+
+  @Test
+  public void shouldFail_errorRemoteCall() throws ExecutionException, InterruptedException {
+    // Given:
+    when(locator.locate()).thenReturn(ImmutableList.of(ksqlNodeRemote));
+    KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+    final PushRouting routing = new PushRouting(ksqlConfig);
+    when(simpleKsqlClient.makeQueryRequestStreamed(any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("Error remote!"));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    PushConnectionsHandle handle = future.get();
+
+    // Then:
+    assertThat(handle.getError().getMessage(), containsString("Error remote!"));
+  }
+
+  @Test
+  public void shouldFail_hitRequestLimitLocal() throws ExecutionException, InterruptedException {
+    // Given:
+    transientQueryQueue = new TransientQueryQueue(OptionalInt.empty(), 1, 100);
+    when(pushRoutingOptions.getIsSkipForwardRequest()).thenReturn(true);
+    KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+    final PushRouting routing = new PushRouting(ksqlConfig);
+    BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
+    when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    PushConnectionsHandle handle = future.get();
+    context.runOnContext(v -> {
+      localPublisher.accept(LOCAL_ROW1);
+      localPublisher.accept(LOCAL_ROW2);
+    });
+
+    // Then:
+    List<List<?>> rows = new ArrayList<>();
+    while (rows.size() < 1) {
+      final KeyValue<List<?>, GenericRow> kv = transientQueryQueue.poll();
+      if (kv == null) {
+        Thread.sleep(100);
+        continue;
+      }
+      rows.add(kv.value().values());
+    }
+    assertThat(rows.get(0), is(LOCAL_ROW1));
+    assertThat(handle.getError().getMessage(), containsString("Hit limit of request queue"));
+  }
+
+  @Test
+  public void shouldFail_hitRequestLimitRemote() throws ExecutionException, InterruptedException {
+    // Given:
+    when(locator.locate()).thenReturn(ImmutableList.of(ksqlNodeRemote));
+    transientQueryQueue = new TransientQueryQueue(OptionalInt.empty(), 1, 100);
+    KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+    final PushRouting routing = new PushRouting(ksqlConfig);
+    BufferedPublisher<StreamedRow> remotePublisher = new BufferedPublisher<>(context);
+    when(simpleKsqlClient.makeQueryRequestStreamed(any(), any(), any(), any()))
+        .thenReturn(RestResponse.successful(200, remotePublisher));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    PushConnectionsHandle handle = future.get();
+    context.runOnContext(v -> {
+      remotePublisher.accept(REMOTE_ROW1);
+      remotePublisher.accept(REMOTE_ROW2);
+    });
+
+    // Then:
+    List<List<?>> rows = new ArrayList<>();
+    while (rows.size() < 1) {
+      final KeyValue<List<?>, GenericRow> kv = transientQueryQueue.poll();
+      if (kv == null) {
+        Thread.sleep(100);
+        continue;
+      }
+      rows.add(kv.value().values());
+    }
+    assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
+    assertThat(handle.getError().getMessage(), containsString("Hit limit of request queue"));
+  }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.services;
 
+import io.confluent.ksql.reactive.BufferedPublisher;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
@@ -64,6 +65,13 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
       final Map<String, ?> requestProperties,
       final Consumer<List<StreamedRow>> rowConsumer
   ) {
+    throw new UnsupportedOperationException("KSQL client is disabled");
+  }
+
+  @Override
+  public RestResponse<BufferedPublisher<StreamedRow>> makeQueryRequestStreamed(
+      URI serverEndPoint, String sql, Map<String, ?> configOverrides,
+      Map<String, ?> requestProperties) {
     throw new UnsupportedOperationException("KSQL client is disabled");
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.util.KsqlHostInfo;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
@@ -69,7 +70,7 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
   }
 
   @Override
-  public RestResponse<BufferedPublisher<StreamedRow>> makeQueryRequestStreamed(
+  public CompletableFuture<RestResponse<BufferedPublisher<StreamedRow>>> makeQueryRequestStreamed(
       URI serverEndPoint, String sql, Map<String, ?> configOverrides,
       Map<String, ?> requestProperties) {
     throw new UnsupportedOperationException("KSQL client is disabled");

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -71,8 +71,11 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
 
   @Override
   public CompletableFuture<RestResponse<BufferedPublisher<StreamedRow>>> makeQueryRequestStreamed(
-      URI serverEndPoint, String sql, Map<String, ?> configOverrides,
-      Map<String, ?> requestProperties) {
+      final URI serverEndPoint,
+      final String sql,
+      final Map<String, ?> configOverrides,
+      final Map<String, ?> requestProperties
+  ) {
     throw new UnsupportedOperationException("KSQL client is disabled");
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.services;
 
+import io.confluent.ksql.reactive.BufferedPublisher;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.ThreadSafe;
+import org.reactivestreams.Publisher;
 
 @ThreadSafe
 public interface SimpleKsqlClient {
@@ -74,6 +76,13 @@ public interface SimpleKsqlClient {
       Map<String, ?> configOverrides,
       Map<String, ?> requestProperties,
       Consumer<List<StreamedRow>> rowConsumer
+  );
+
+  RestResponse<BufferedPublisher<StreamedRow>> makeQueryRequestStreamed(
+      final URI serverEndPoint,
+      final String sql,
+      final Map<String, ?> configOverrides,
+      final Map<String, ?> requestProperties
   );
 
   /**

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.util.KsqlHostInfo;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.ThreadSafe;
 import org.reactivestreams.Publisher;
@@ -78,7 +79,7 @@ public interface SimpleKsqlClient {
       Consumer<List<StreamedRow>> rowConsumer
   );
 
-  RestResponse<BufferedPublisher<StreamedRow>> makeQueryRequestStreamed(
+  CompletableFuture<RestResponse<BufferedPublisher<StreamedRow>>> makeQueryRequestStreamed(
       final URI serverEndPoint,
       final String sql,
       final Map<String, ?> configOverrides,

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import javax.annotation.concurrent.ThreadSafe;
-import org.reactivestreams.Publisher;
 
 @ThreadSafe
 public interface SimpleKsqlClient {
@@ -63,7 +62,8 @@ public interface SimpleKsqlClient {
 
   /**
    * Send pull query request to remote Ksql server.  This version of makeQueryRequest allows
-   * consuming the rows as they stream in rather than aggregating them all in one list.
+   * consuming the rows as they stream in rather than aggregating them all in one list. The method
+   * itself blocks until the query is complete.
    * @param serverEndPoint the remote destination
    * @param sql the pull query statement
    * @param configOverrides the config overrides provided by the client
@@ -79,11 +79,22 @@ public interface SimpleKsqlClient {
       Consumer<List<StreamedRow>> rowConsumer
   );
 
+  /**
+   * Send query request to remote Ksql server.  This method is similar to
+   * {@link #makeQueryRequest(URI, String, Map, Map, Consumer)}, but gives a different API.
+   * First, this is run asynchronously and second, when a response is received, a publisher is
+   * returned which publishes results asynchronously as they become available.
+   * @param serverEndPoint the remote destination
+   * @param sql the pull query statement
+   * @param configOverrides the config overrides provided by the client
+   * @param requestProperties the request metadata provided by the server
+   * @return the future containing a publisher of {@link StreamedRow}s.
+   */
   CompletableFuture<RestResponse<BufferedPublisher<StreamedRow>>> makeQueryRequestStreamed(
-      final URI serverEndPoint,
-      final String sql,
-      final Map<String, ?> configOverrides,
-      final Map<String, ?> requestProperties
+      URI serverEndPoint,
+      String sql,
+      Map<String, ?> configOverrides,
+      Map<String, ?> requestProperties
   );
 
   /**

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -100,8 +100,8 @@ public class QueryEndpoint {
 
   public QueryPublisher createQueryPublisher(
       final String sql,
-      final JsonObject properties,
-      final JsonObject sessionVariables,
+      final Map<String, Object> properties,
+      final Map<String, Object> sessionVariables,
       final Context context,
       final WorkerExecutor workerExecutor,
       final ServiceContext serviceContext,
@@ -110,7 +110,7 @@ public class QueryEndpoint {
     VertxUtils.checkIsWorker();
 
     final ConfiguredStatement<Query> statement = createStatement(
-        sql, properties.getMap(), sessionVariables.getMap());
+        sql, properties, sessionVariables);
 
     if (statement.getStatement().isPullQuery()) {
       return createPullQueryPublisher(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -54,7 +54,6 @@ import io.confluent.ksql.util.TransientQueryMetadata;
 import io.confluent.ksql.util.VertxUtils;
 import io.vertx.core.Context;
 import io.vertx.core.WorkerExecutor;
-import io.vertx.core.json.JsonObject;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/Endpoints.java
@@ -30,6 +30,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Subscriber;
@@ -51,8 +52,8 @@ public interface Endpoints {
    * @param workerExecutor The worker executor to use for blocking operations
    * @return A CompletableFuture representing the future result of the operation
    */
-  CompletableFuture<QueryPublisher> createQueryPublisher(String sql, JsonObject properties,
-      JsonObject sessionVariables, Context context, WorkerExecutor workerExecutor,
+  CompletableFuture<QueryPublisher> createQueryPublisher(String sql, Map<String, Object> properties,
+      Map<String, Object> sessionVariables, Context context, WorkerExecutor workerExecutor,
       ApiSecurityContext apiSecurityContext, MetricsCallbackHolder metricsCallbackHolder);
 
   /**

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerEndpoints.java
@@ -57,6 +57,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -140,8 +141,8 @@ public class KsqlServerEndpoints implements Endpoints {
 
   @Override
   public CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
-      final JsonObject properties,
-      final JsonObject sessionVariables,
+      final Map<String, Object> properties,
+      final Map<String, Object> sessionVariables,
       final Context context,
       final WorkerExecutor workerExecutor,
       final ApiSecurityContext apiSecurityContext,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
@@ -23,12 +23,14 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.VertxSslOptionsFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.SocketAddress;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public final class InternalKsqlClientFactory {
 
@@ -46,16 +48,18 @@ public final class InternalKsqlClientFactory {
     return new KsqlClient(
         Optional.empty(),
         new LocalProperties(ImmutableMap.of()),
-        httpOptionsFactory(clientProps, verifyHost),
+        httpOptionsFactory(clientProps, verifyHost, InternalKsqlClientFactory::createClientOptions),
+        httpOptionsFactory(clientProps, verifyHost, InternalKsqlClientFactory::createClientOptions2),
         socketAddressFactory,
         vertx
     );
   }
 
   private static Function<Boolean, HttpClientOptions> httpOptionsFactory(
-      final Map<String, String> clientProps, final boolean verifyHost) {
+      final Map<String, String> clientProps, final boolean verifyHost,
+      final Supplier<HttpClientOptions> optionsSupplier) {
     return (tls) -> {
-      final HttpClientOptions httpClientOptions = createClientOptions();
+      final HttpClientOptions httpClientOptions = optionsSupplier.get();
       if (!tls) {
         return httpClientOptions;
       }
@@ -84,5 +88,9 @@ public final class InternalKsqlClientFactory {
 
   private static HttpClientOptions createClientOptions() {
     return new HttpClientOptions().setMaxPoolSize(100);
+  }
+
+  private static HttpClientOptions createClientOptions2() {
+    return new HttpClientOptions().setHttp2MaxPoolSize(100).setProtocolVersion(HttpVersion.HTTP_2);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
@@ -49,7 +49,8 @@ public final class InternalKsqlClientFactory {
         Optional.empty(),
         new LocalProperties(ImmutableMap.of()),
         httpOptionsFactory(clientProps, verifyHost, InternalKsqlClientFactory::createClientOptions),
-        httpOptionsFactory(clientProps, verifyHost, InternalKsqlClientFactory::createClientOptions2),
+        httpOptionsFactory(clientProps, verifyHost,
+            InternalKsqlClientFactory::createClientOptionsHttp2),
         socketAddressFactory,
         vertx
     );
@@ -90,7 +91,7 @@ public final class InternalKsqlClientFactory {
     return new HttpClientOptions().setMaxPoolSize(100);
   }
 
-  private static HttpClientOptions createClientOptions2() {
+  private static HttpClientOptions createClientOptionsHttp2() {
     return new HttpClientOptions().setHttp2MaxPoolSize(100).setProtocolVersion(HttpVersion.HTTP_2);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.services;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.util.Objects.requireNonNull;
 
+import io.confluent.ksql.reactive.BufferedPublisher;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.ClusterStatusResponse;
@@ -91,6 +92,13 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
       final Map<String, ?> requestProperties,
       final Consumer<List<StreamedRow>> rowConsumer
   ) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public RestResponse<BufferedPublisher<StreamedRow>> makeQueryRequestStreamed(
+      URI serverEndPoint, String sql, Map<String, ?> configOverrides,
+      Map<String, ?> requestProperties) {
     throw new UnsupportedOperationException();
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
@@ -35,6 +35,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
@@ -96,7 +97,7 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
   }
 
   @Override
-  public RestResponse<BufferedPublisher<StreamedRow>> makeQueryRequestStreamed(
+  public CompletableFuture<RestResponse<BufferedPublisher<StreamedRow>>> makeQueryRequestStreamed(
       URI serverEndPoint, String sql, Map<String, ?> configOverrides,
       Map<String, ?> requestProperties) {
     throw new UnsupportedOperationException();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
@@ -98,8 +98,11 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
 
   @Override
   public CompletableFuture<RestResponse<BufferedPublisher<StreamedRow>>> makeQueryRequestStreamed(
-      URI serverEndPoint, String sql, Map<String, ?> configOverrides,
-      Map<String, ?> requestProperties) {
+      final URI serverEndPoint,
+      final String sql,
+      final Map<String, ?> configOverrides,
+      final Map<String, ?> requestProperties
+  ) {
     throw new UnsupportedOperationException();
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -41,6 +41,7 @@ import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -65,8 +66,12 @@ public class TestEndpoints implements Endpoints {
   private ApiSecurityContext lastApiSecurityContext;
 
   @Override
-  public synchronized CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
-      final JsonObject properties, JsonObject sessionVariables, final Context context, final WorkerExecutor workerExecutor,
+  public synchronized CompletableFuture<QueryPublisher> createQueryPublisher(
+      final String sql,
+      final Map<String, Object> properties,
+      final Map<String, Object> sessionVariables,
+      final Context context,
+      final WorkerExecutor workerExecutor,
       final ApiSecurityContext apiSecurityContext,
       final MetricsCallbackHolder metricsCallbackHolder) {
     CompletableFuture<QueryPublisher> completableFuture = new CompletableFuture<>();
@@ -75,8 +80,8 @@ public class TestEndpoints implements Endpoints {
       completableFuture.completeExceptionally(createQueryPublisherException);
     } else {
       this.lastSql = sql;
-      this.lastProperties = properties;
-      this.lastSessionVariables = sessionVariables;
+      this.lastProperties = new JsonObject(properties);
+      this.lastSessionVariables = new JsonObject(sessionVariables);
       this.lastApiSecurityContext = apiSecurityContext;
       final boolean push = sql.toLowerCase().contains("emit changes");
       final int limit = extractLimit(sql);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/InsertsStreamRunner.java
@@ -41,6 +41,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.ext.web.codec.BodyCodec;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.reactivestreams.Subscriber;
@@ -160,8 +161,8 @@ public class InsertsStreamRunner extends BasePerfRunner {
 
     @Override
     public CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
-        final JsonObject properties,
-        final JsonObject sessionVariables,
+        final Map<String, Object> properties,
+        final Map<String, Object> sessionVariables,
         final Context context,
         final WorkerExecutor workerExecutor,
         final ApiSecurityContext apiSecurityContext,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -47,6 +47,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -118,8 +119,8 @@ public class PullQueryRunner extends BasePerfRunner {
 
     @Override
     public synchronized CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
-        final JsonObject properties,
-        final JsonObject sessionVariables,
+        final Map<String, Object> properties,
+        final Map<String, Object> sessionVariables,
         final Context context,
         final WorkerExecutor workerExecutor,
         final ApiSecurityContext apiSecurityContext,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -45,6 +45,7 @@ import io.vertx.core.parsetools.RecordParser;
 import io.vertx.ext.web.codec.BodyCodec;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -97,8 +98,8 @@ public class QueryStreamRunner extends BasePerfRunner {
 
     @Override
     public synchronized CompletableFuture<QueryPublisher> createQueryPublisher(final String sql,
-        final JsonObject properties,
-        final JsonObject sessionVariables,
+        final Map<String, Object> properties,
+        final Map<String, Object> sessionVariables,
         final Context context,
         final WorkerExecutor workerExecutor,
         final ApiSecurityContext apiSecurityContext,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -626,7 +626,7 @@ public class RestApiTest {
   public void shouldExecutePullQueryOverHttp2QueryStream() {
       QueryStreamArgs queryStreamArgs = new QueryStreamArgs(
           "SELECT COUNT, USERID from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';",
-          Collections.emptyMap(), Collections.emptyMap());
+          Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
 
       QueryResponse[] queryResponse = new QueryResponse[1];
       assertThatEventually(() -> {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/FaultyKsqlClient.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/FaultyKsqlClient.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server;
 
+import io.confluent.ksql.reactive.BufferedPublisher;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
@@ -80,6 +81,14 @@ public class FaultyKsqlClient implements SimpleKsqlClient {
       final Consumer<List<StreamedRow>> rowConsumer) {
     return getClient().makeQueryRequest(serverEndPoint, sql, configOverrides, requestProperties,
         rowConsumer);
+  }
+
+  @Override
+  public RestResponse<BufferedPublisher<StreamedRow>> makeQueryRequestStreamed(
+      URI serverEndPoint, String sql, Map<String, ?> configOverrides,
+      Map<String, ?> requestProperties) {
+    return getClient().makeQueryRequestStreamed(serverEndPoint, sql, configOverrides,
+        requestProperties);
   }
 
   @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/FaultyKsqlClient.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/FaultyKsqlClient.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.util.KsqlHostInfo;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -84,7 +85,7 @@ public class FaultyKsqlClient implements SimpleKsqlClient {
   }
 
   @Override
-  public RestResponse<BufferedPublisher<StreamedRow>> makeQueryRequestStreamed(
+  public CompletableFuture<RestResponse<BufferedPublisher<StreamedRow>>> makeQueryRequestStreamed(
       URI serverEndPoint, String sql, Map<String, ?> configOverrides,
       Map<String, ?> requestProperties) {
     return getClient().makeQueryRequestStreamed(serverEndPoint, sql, configOverrides,

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClient.java
@@ -48,6 +48,8 @@ public final class KsqlClient implements AutoCloseable {
   private final Vertx vertx;
   private final HttpClient httpNonTlsClient;
   private final HttpClient httpTlsClient;
+  private final Optional<HttpClient> httpNonTlsClientHttp2;
+  private final Optional<HttpClient> httpTlsClientHttp2;
   private final LocalProperties localProperties;
   private final Optional<String> basicAuthHeader;
   private final BiFunction<Integer, String, SocketAddress> socketAddressFactory;
@@ -64,7 +66,8 @@ public final class KsqlClient implements AutoCloseable {
       final Map<String, String> clientProps,
       final Optional<BasicCredentials> credentials,
       final LocalProperties localProperties,
-      final HttpClientOptions httpClientOptions
+      final HttpClientOptions httpClientOptions,
+      final Optional<HttpClientOptions> httpClientOptionsHttp2
   ) {
     this.vertx = Vertx.vertx();
     this.basicAuthHeader = createBasicAuthHeader(
@@ -73,6 +76,10 @@ public final class KsqlClient implements AutoCloseable {
     this.socketAddressFactory = SocketAddress::inetSocketAddress;
     this.httpNonTlsClient = createHttpClient(vertx, clientProps, httpClientOptions, false);
     this.httpTlsClient = createHttpClient(vertx, clientProps, httpClientOptions, true);
+    this.httpNonTlsClientHttp2 = httpClientOptionsHttp2.map(
+        options -> createHttpClient(vertx, clientProps, options, false));
+    this.httpTlsClientHttp2 = httpClientOptionsHttp2.map(
+        options -> createHttpClient(vertx, clientProps, options, true));
     this.ownedVertx = true;
   }
 
@@ -90,6 +97,7 @@ public final class KsqlClient implements AutoCloseable {
       final Optional<BasicCredentials> credentials,
       final LocalProperties localProperties,
       final Function<Boolean, HttpClientOptions> httpClientOptionsFactory,
+      final Function<Boolean, HttpClientOptions> httpClientOptionsFactory2,
       final BiFunction<Integer, String, SocketAddress> socketAddressFactory,
       final Vertx vertx
   ) {
@@ -101,12 +109,24 @@ public final class KsqlClient implements AutoCloseable {
         socketAddressFactory, "socketAddressFactory");
     this.httpNonTlsClient = createHttpClient(vertx, httpClientOptionsFactory, false);
     this.httpTlsClient = createHttpClient(vertx, httpClientOptionsFactory, true);
+    this.httpNonTlsClientHttp2 = Optional.of(
+        createHttpClient(vertx, httpClientOptionsFactory2, false));
+    this.httpTlsClientHttp2 = Optional.of(createHttpClient(vertx, httpClientOptionsFactory2, true));
     this.ownedVertx = false;
   }
 
   public KsqlTarget target(final URI server) {
     final boolean isUriTls = server.getScheme().equalsIgnoreCase("https");
     final HttpClient client = isUriTls ? httpTlsClient : httpNonTlsClient;
+    return new KsqlTarget(client,
+        socketAddressFactory.apply(server.getPort(), server.getHost()), localProperties,
+        basicAuthHeader, server.getHost());
+  }
+
+  public KsqlTarget targetHttp2(final URI server) {
+    final boolean isUriTls = server.getScheme().equalsIgnoreCase("https");
+    final HttpClient client = (isUriTls ? httpTlsClientHttp2 : httpNonTlsClientHttp2).orElseThrow(
+        () -> new IllegalStateException("Must provide http2 options to use targetHttp2"));
     return new KsqlTarget(client,
         socketAddressFactory.apply(server.getPort(), server.getHost()), localProperties,
         basicAuthHeader, server.getHost());

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClientUtil.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClientUtil.java
@@ -20,6 +20,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.Errors;
@@ -117,6 +118,15 @@ public final class KsqlClientUtil {
         Errors.ERROR_CODE_FORBIDDEN,
         new AuthenticationException("You are forbidden from using this cluster.")
     );
+  }
+
+  static JsonNode deserialize(final Buffer buffer) {
+    final ObjectMapper objectMapper = ApiJsonMapper.INSTANCE.get();
+    try {
+      return objectMapper.readTree(buffer.getBytes());
+    } catch (Exception e) {
+      throw new KsqlRestClientException("Failed to deserialise object", e);
+    }
   }
 
 }

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClientUtil.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlClientUtil.java
@@ -20,7 +20,6 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.Errors;
@@ -118,15 +117,6 @@ public final class KsqlClientUtil {
         Errors.ERROR_CODE_FORBIDDEN,
         new AuthenticationException("You are forbidden from using this cluster.")
     );
-  }
-
-  static JsonNode deserialize(final Buffer buffer) {
-    final ObjectMapper objectMapper = ApiJsonMapper.INSTANCE.get();
-    try {
-      return objectMapper.readTree(buffer.getBytes());
-    } catch (Exception e) {
-      throw new KsqlRestClientException("Failed to deserialise object", e);
-    }
   }
 
 }

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -34,7 +34,6 @@ import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.ServerMetadata;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpVersion;
 import java.io.Closeable;
 import java.net.URI;
 import java.net.URL;

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.ServerMetadata;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpVersion;
 import java.io.Closeable;
 import java.net.URI;
 import java.net.URL;
@@ -70,7 +71,7 @@ public final class KsqlRestClient implements Closeable {
         clientProps,
         creds,
         (cprops, credz, lprops) -> new KsqlClient(cprops, credz, lprops,
-            new HttpClientOptions())
+            new HttpClientOptions(), Optional.empty())
     );
   }
 

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTarget.java
@@ -19,14 +19,7 @@ import static io.confluent.ksql.rest.client.KsqlClientUtil.deserialize;
 import static io.confluent.ksql.rest.client.KsqlClientUtil.serialize;
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Strings;
-import com.google.common.collect.Streams;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.metastore.TypeRegistry;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.LocalProperties;
-import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
@@ -34,24 +27,15 @@ import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.HeartbeatResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
-import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
 import io.confluent.ksql.rest.entity.LagReportingResponse;
-import io.confluent.ksql.rest.entity.QueryResponseMetadata;
 import io.confluent.ksql.rest.entity.QueryStreamArgs;
 import io.confluent.ksql.rest.entity.ServerClusterId;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.ServerMetadata;
-import io.confluent.ksql.rest.entity.SourceInfo.Stream;
 import io.confluent.ksql.rest.entity.StreamedRow;
-import io.confluent.ksql.rest.entity.StreamedRow.DataRow;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.SimpleColumn;
-import io.confluent.ksql.schema.ksql.SqlTypeParser;
-import io.confluent.ksql.schema.ksql.types.SqlType;
-import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -59,7 +43,6 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -238,7 +221,7 @@ public final class KsqlTarget {
   }
 
   public CompletableFuture<RestResponse<StreamPublisher<StreamedRow>>>
-  postQueryRequestStreamedAsync(
+      postQueryRequestStreamedAsync(
       final String sql,
       final Map<String, ?> requestProperties
   ) {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.rest.client;
 
 import static io.confluent.ksql.rest.client.KsqlClientUtil.deserialize;
@@ -20,7 +35,9 @@ import io.vertx.core.buffer.Buffer;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class KsqlTargetUtil {
+public final class KsqlTargetUtil {
+
+  private KsqlTargetUtil() { }
 
   public static StreamedRow toRowFromDelimited(final Buffer buff) {
     try {
@@ -28,16 +45,19 @@ public class KsqlTargetUtil {
       return StreamedRow.header(new QueryId(Strings.nullToEmpty(metadata.queryId)),
           createSchema(metadata));
     } catch (KsqlRestClientException e) {
+      // Not a {@link QueryResponseMetadata}
     }
     try {
       final KsqlErrorMessage error = deserialize(buff, KsqlErrorMessage.class);
       return StreamedRow.error(new RuntimeException(error.getMessage()), error.getErrorCode());
     } catch (KsqlRestClientException e) {
+      // Not a {@link KsqlErrorMessage}
     }
     try {
       final List<?> row = deserialize(buff, List.class);
       return StreamedRow.pushRow(GenericRow.fromList(row));
     } catch (KsqlRestClientException e) {
+      // Not a {@link List}
     }
     throw new IllegalStateException("Couldn't parse message: " + buff.toString());
   }

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
@@ -1,0 +1,66 @@
+package io.confluent.ksql.rest.client;
+
+import static io.confluent.ksql.rest.client.KsqlClientUtil.deserialize;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Streams;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.metastore.TypeRegistry;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.QueryResponseMetadata;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SimpleColumn;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.Pair;
+import io.vertx.core.buffer.Buffer;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class KsqlTargetUtil {
+
+  public static StreamedRow toRowFromDelimited(final Buffer buff) {
+    try {
+      final QueryResponseMetadata metadata = deserialize(buff, QueryResponseMetadata.class);
+      return StreamedRow.header(new QueryId(Strings.nullToEmpty(metadata.queryId)),
+          createSchema(metadata));
+    } catch (KsqlRestClientException e) {
+    }
+    try {
+      final KsqlErrorMessage error = deserialize(buff, KsqlErrorMessage.class);
+      return StreamedRow.error(new RuntimeException(error.getMessage()), error.getErrorCode());
+    } catch (KsqlRestClientException e) {
+    }
+    try {
+      final List<?> row = deserialize(buff, List.class);
+      return StreamedRow.pushRow(GenericRow.fromList(row));
+    } catch (KsqlRestClientException e) {
+    }
+    throw new IllegalStateException("Couldn't parse message: " + buff.toString());
+  }
+
+  private static LogicalSchema createSchema(final QueryResponseMetadata metadata) {
+    final SqlTypeParser parser = SqlTypeParser.create(TypeRegistry.EMPTY);
+    return LogicalSchema.builder().valueColumns(
+        Streams.zip(metadata.columnNames.stream(), metadata.columnTypes.stream(), Pair::of)
+            .map(pair -> {
+              final SqlType sqlType = parser.parse(pair.getRight()).getSqlType();
+              final ColumnName name = ColumnName.of(pair.getLeft());
+              return new SimpleColumn() {
+                @Override
+                public ColumnName name() {
+                  return name;
+                }
+
+                @Override
+                public SqlType type() {
+                  return sqlType;
+                }
+              };
+            }).collect(Collectors.toList()))
+        .build();
+  }
+}

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -776,13 +776,15 @@ public class KsqlClientTest {
   private void createClient(Optional<BasicCredentials> credentials) {
     ksqlClient = new KsqlClient(new HashMap<>(), credentials,
         new LocalProperties(properties),
-        new HttpClientOptions().setVerifyHost(false));
+        new HttpClientOptions().setVerifyHost(false),
+        Optional.empty());
   }
 
   private void createClient(Map<String, String> clientProps) {
     ksqlClient = new KsqlClient(clientProps, Optional.empty(),
         new LocalProperties(properties),
-        new HttpClientOptions().setVerifyHost(false));
+        new HttpClientOptions().setVerifyHost(false),
+        Optional.empty());
   }
 
   private String toAuthHeader(BasicCredentials credentials) {

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlClientTest.java
@@ -39,6 +39,7 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.QueryStreamArgs;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.TopicDescription;
@@ -52,6 +53,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.JksOptions;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -78,7 +80,7 @@ public class KsqlClientTest {
   private FakeApiServer server;
   private KsqlClient ksqlClient;
   private String deploymentId;
-  private Map<String, ?> properties;
+  private Map<String, Object> properties;
   private URI serverUri;
 
   @Before
@@ -407,6 +409,54 @@ public class KsqlClientTest {
   }
 
   @Test
+  public void shouldPostQueryRequestStreamedHttp2() throws Exception {
+
+    // Given:
+
+    int numRows = 10;
+    List<List<?>> expectedResponse = setQueryStreamDelimitedResponse(numRows);
+    String sql = "whateva";
+
+    // When:
+    KsqlTarget target = ksqlClient.targetHttp2(serverUri);
+    CompletableFuture<RestResponse<StreamPublisher<StreamedRow>>> future = target
+        .postQueryRequestStreamedAsync(sql, ImmutableMap.of());
+    RestResponse<StreamPublisher<StreamedRow>> response = future.get();
+
+    // Then:
+    assertThat(server.getHttpMethod(), is(HttpMethod.POST));
+
+    assertThat(server.getPath(), is("/query-stream"));
+    assertThat(server.getHeaders().get("Accept"), is("application/vnd.ksqlapi.delimited.v1"));
+    assertThat(getQueryStreamArgs(), is(new QueryStreamArgs(sql, properties,
+        Collections.emptyMap(), Collections.emptyMap())));
+
+    List<StreamedRow> rows = getElementsFromPublisher(numRows + 1, response.getResponse());
+    int i = 0;
+    for (StreamedRow row : rows) {
+      assertThat(row.getRow().isPresent(), is(true));
+      assertThat(row.getRow().get().getColumns(), is(expectedResponse.get(i++)));
+    }
+  }
+
+  @Test
+  public void shouldFailWithNonHttp2Options() {
+    // When:
+    final IllegalArgumentException e = assertThrows(
+        IllegalArgumentException.class,
+        () -> new KsqlClient(new HashMap<>(), Optional.empty(),
+            new LocalProperties(properties),
+            new HttpClientOptions().setVerifyHost(false),
+            Optional.of(new HttpClientOptions()))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Expecting http2 protocol version"
+    ));
+  }
+
+  @Test
   public void shouldExecutePrintTopic() throws Exception {
 
     // Given:
@@ -699,6 +749,16 @@ public class KsqlClientTest {
     return expectedResponse;
   }
 
+  private List<List<?>> setQueryStreamDelimitedResponse(int numRows) {
+    List<List<?>> expectedResponse = new ArrayList<>();
+    for (int i = 0; i < numRows; i++) {
+      GenericRow row = GenericRow.genericRow("foo", 123, true);
+      expectedResponse.add(row.values());
+    }
+    server.setResponseBuffer(createDelimitedResponseBuffer(expectedResponse));
+    return expectedResponse;
+  }
+
   private List<String> setupPrintTopicResponse(int numRows) {
     List<String> expectedResponse = new ArrayList<>();
     Buffer responseBuffer = Buffer.buffer();
@@ -777,14 +837,14 @@ public class KsqlClientTest {
     ksqlClient = new KsqlClient(new HashMap<>(), credentials,
         new LocalProperties(properties),
         new HttpClientOptions().setVerifyHost(false),
-        Optional.empty());
+        Optional.of(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2)));
   }
 
   private void createClient(Map<String, String> clientProps) {
     ksqlClient = new KsqlClient(clientProps, Optional.empty(),
         new LocalProperties(properties),
         new HttpClientOptions().setVerifyHost(false),
-        Optional.empty());
+        Optional.of(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2)));
   }
 
   private String toAuthHeader(BasicCredentials credentials) {
@@ -795,6 +855,10 @@ public class KsqlClientTest {
 
   private KsqlRequest getKsqlRequest() {
     return KsqlClientUtil.deserialize(server.getBody(), KsqlRequest.class);
+  }
+
+  private QueryStreamArgs getQueryStreamArgs() {
+    return KsqlClientUtil.deserialize(server.getBody(), QueryStreamArgs.class);
   }
 
   private static Buffer createResponseBuffer(List<StreamedRow> rows) {
@@ -813,6 +877,23 @@ public class KsqlClientTest {
       }
     }
     buffer.appendString("]");
+    return buffer;
+  }
+
+  private static Buffer createDelimitedResponseBuffer(List<List<?>> rows) {
+    // The old API returns rows in a strange format - it looks like a JSON array but it isn't.
+    // There are newlines separating the elements which are illegal in JSON
+    // And there can be an extra comma after the last element
+    // There can also be random newlines in the response
+    Buffer buffer = Buffer.buffer();
+    for (int i = 0; i < rows.size(); i++) {
+      buffer.appendBuffer(KsqlClientUtil.serialize(rows.get(i)));
+      buffer.appendString(",\n");
+      if (i == rows.size() / 2) {
+        // insert a random newline for good measure - the server can actually do this
+        buffer.appendString("\n");
+      }
+    }
     return buffer;
   }
 

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetUtilTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlTargetUtilTest.java
@@ -1,0 +1,88 @@
+package io.confluent.ksql.rest.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.Column.Namespace;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.vertx.core.buffer.Buffer;
+import java.math.BigDecimal;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlTargetUtilTest {
+
+  @Mock
+  private KsqlEntityList entities;
+
+  @Before
+  public void setUp() {
+  }
+
+  @Test
+  public void shouldParseHeader() {
+    // When:
+    final StreamedRow row = KsqlTargetUtil.toRowFromDelimited(Buffer.buffer(
+        "{\"queryId\": \"query_id_10\", "
+            + "\"columnNames\":[\"col1\",\"col2\"], "
+            + "\"columnTypes\":[\"BIGINT\",\"DOUBLE\"]}"));
+
+    // Then:
+    assertThat(row.getHeader().isPresent(), is(true));
+    assertThat(row.getHeader().get().getQueryId().toString(), is("query_id_10"));
+    assertThat(row.getHeader().get().getSchema().key(), is(Collections.emptyList()));
+    assertThat(row.getHeader().get().getSchema().value().size(), is(2));
+    assertThat(row.getHeader().get().getSchema().value().get(0),
+        is (Column.of(ColumnName.of("col1"), SqlTypes.BIGINT, Namespace.VALUE, 0)));
+    assertThat(row.getHeader().get().getSchema().value().get(1),
+        is (Column.of(ColumnName.of("col2"), SqlTypes.DOUBLE, Namespace.VALUE, 1)));
+  }
+
+  @Test
+  public void shouldParseError() {
+    // When:
+    final StreamedRow row = KsqlTargetUtil.toRowFromDelimited(Buffer.buffer(
+        "{\"@type\":\"generic_error\",\"error_code\": 500,\"message\":\"Really bad problem\"}"));
+
+    // Then:
+    assertThat(row.getErrorMessage().isPresent(), is(true));
+    assertThat(row.getErrorMessage().get().getErrorCode(), is(500));
+    assertThat(row.getErrorMessage().get().getMessage(), is("Really bad problem"));
+  }
+
+  @Test
+  public void shouldParseRow() {
+    // When:
+    final StreamedRow row = KsqlTargetUtil.toRowFromDelimited(Buffer.buffer(
+        "[3467362496,5.5]"));
+
+    // Then:
+    assertThat(row.getRow().isPresent(), is(true));
+    assertThat(row.getRow().get().getColumns().size(), is(2));
+    assertThat(row.getRow().get().getColumns().get(0), is(3467362496L));
+    assertThat(row.getRow().get().getColumns().get(1), is(BigDecimal.valueOf(5.5d)));
+  }
+
+  @Test
+  public void shouldError_badJSON() {
+    // When:
+    final Exception e = assertThrows(
+        IllegalStateException.class,
+        () -> KsqlTargetUtil.toRowFromDelimited(Buffer.buffer("[34"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Couldn't parse message: [34"));
+  }
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStreamArgs.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStreamArgs.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonObject;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -30,17 +31,23 @@ public class QueryStreamArgs {
   public final String sql;
   public final JsonObject properties;
   public final JsonObject sessionVariables;
+  public final Map<String, Object> requestProperties;
 
   public QueryStreamArgs(final @JsonProperty(value = "sql", required = true) String sql,
       final @JsonProperty(value = "properties")
           Map<String, Object> properties,
       final @JsonProperty(value = "sessionVariables")
-          Map<String, Object> sessionVariables) {
+          Map<String, Object> sessionVariables,
+      final @JsonProperty(value = "requestProperties")
+          Map<String, Object> requestProperties) {
     this.sql = Objects.requireNonNull(sql);
     this.properties = properties == null ? new JsonObject() : new JsonObject(properties);
     this.sessionVariables = sessionVariables == null
         ? new JsonObject()
         : new JsonObject(sessionVariables);
+    this.requestProperties = requestProperties == null
+        ? Collections.emptyMap()
+        : requestProperties;
   }
 
   @Override
@@ -49,6 +56,7 @@ public class QueryStreamArgs {
         + "sql='" + sql + '\''
         + ", properties=" + properties
         + ", sessionVariables=" + sessionVariables
+        + ", requestProperties=" + requestProperties
         + '}';
   }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStreamArgs.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryStreamArgs.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.vertx.core.json.JsonObject;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -29,8 +28,8 @@ import java.util.Objects;
 public class QueryStreamArgs {
 
   public final String sql;
-  public final JsonObject properties;
-  public final JsonObject sessionVariables;
+  public final Map<String, Object> properties;
+  public final Map<String, Object> sessionVariables;
   public final Map<String, Object> requestProperties;
 
   public QueryStreamArgs(final @JsonProperty(value = "sql", required = true) String sql,
@@ -41,13 +40,36 @@ public class QueryStreamArgs {
       final @JsonProperty(value = "requestProperties")
           Map<String, Object> requestProperties) {
     this.sql = Objects.requireNonNull(sql);
-    this.properties = properties == null ? new JsonObject() : new JsonObject(properties);
+    this.properties = properties == null ? Collections.emptyMap() : properties;
     this.sessionVariables = sessionVariables == null
-        ? new JsonObject()
-        : new JsonObject(sessionVariables);
+        ? Collections.emptyMap()
+        : sessionVariables;
     this.requestProperties = requestProperties == null
         ? Collections.emptyMap()
         : requestProperties;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof QueryStreamArgs)) {
+      return false;
+    }
+
+    final QueryStreamArgs that = (QueryStreamArgs) o;
+    return Objects.equals(sql, that.sql)
+        && Objects.equals(properties, that.properties)
+        && Objects.equals(requestProperties, that.requestProperties)
+        && Objects.equals(sessionVariables, that.sessionVariables);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sql, properties, requestProperties,
+        sessionVariables);
   }
 
   @Override


### PR DESCRIPTION
### Description 
The next step of scalable push queries, this adds the routing logic in `PushRouting`.

At the moment, it attempts to determine the set of hosts at start time to connect to and just sticks with them. A followup change will fail the query if there's a rebalance.

`PushRouting` does everything async, meaning that it uses the Vertx Context and CompletableFutures to handle everything, so it doesn't require a thread pool.

This also introduces a http2 client to `KsqlClient` since this is required to issue http2 requests, which this now does for the `/query-stream` requests between cluster instances.

### Testing done 
Ran unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

