### PR TITLE
test: add test for FK-join with format mismatch

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
@@ -684,6 +684,60 @@
       ],
       "post": {
         "topics": {
+          "topics": [
+            {
+              "name": "OUTPUT",
+              "keyFormat": { "format": "KAFKA" },
+              "valueFormat": { "format": "JSON" },
+              "partitions": 4
+            }
+          ],
+          "blacklist": ".*-repartition"
+        }
+      }
+    },
+    {
+      "enabled": false,
+      "name": "Should allow format mismatch without repartitioning",
+      "properties": {
+        "ksql.joins.foreign.key.enable": true
+      },
+      "statements": [
+        "CREATE TABLE left_table (l_id BIGINT PRIMARY KEY, name VARCHAR, foreign_key BIGINT) WITH (kafka_topic='left_topic', format='AVRO');",
+        "CREATE TABLE right_table (r_id BIGINT PRIMARY KEY, f1 VARCHAR, f2 BIGINT) WITH (kafka_topic='right_topic', format='JSON');",
+        "CREATE TABLE output AS SELECT l_id, r_id, name, f1 FROM left_table JOIN right_table ON foreign_key = r_id;"
+      ],
+      "inputs": [
+        {"topic": "right_topic", "key": 0, "value": {"F1": "blah", "F2": 4}, "timestamp": 0},
+        {"topic": "left_topic", "key": 1, "value": {"NAME": "zero", "FOREIGN_KEY": 0}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 0, "value": {"NAME": "foo", "FOREIGN_KEY": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "left_topic", "key": 10, "value": {"NAME": "bar", "FOREIGN_KEY": 0}, "timestamp": 16000},
+        {"topic": "right_topic", "key": 0, "value": null, "timestamp": 17000},
+        {"topic": "left_topic", "key": 1, "value": null, "timestamp": 18000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"R_ID": 0, "NAME": "zero", "F1": "blah"}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 1, "value": {"R_ID": 0, "NAME": "zero", "F1": "a"}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 10, "value": {"R_ID": 0, "NAME": "bar", "F1": "a"}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 10, "value": null, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000}
+      ],
+      "post": {
+        "topics": {
+          "topics": [
+            {
+              "name": "OUTPUT",
+              "keyFormat": {
+                "format": "AVRO",
+                "properties": { "fullSchemaName": "io.confluent.ksql.avro_schemas.OutputKey" },
+                "features": ["UNWRAP_SINGLES"]
+              },
+              "valueFormat": { "format": "AVRO" },
+              "partitions": 4
+            }
+          ],
           "blacklist": ".*-repartition"
         }
       }


### PR DESCRIPTION
### Description 
We should add a test that verifies that a format mismatch of left and right input does not trigger a repartitioning for FK-joins.

### Testing done 
Added QTT test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

