### PR TITLE
chore: fix alias resolution in n-way join logic

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -217,9 +217,9 @@ public class JoinNode extends PlanNode implements JoiningNode {
   void validateKeyPresent(final SourceName sinkName, final Projection projection) {
 
     if (joinKey.isForeignKey()) {
-      final DataSource leftInputTable = getLeftmostSourceNode().getDataSource();
-      final SourceName leftInputTableName = leftInputTable.getName();
-      final List<Column> leftInputTableKeys = leftInputTable.getSchema().key();
+      final DataSourceNode leftInputTable = getLeftmostSourceNode();
+      final SourceName leftInputTableName = leftInputTable.getAlias();
+      final List<Column> leftInputTableKeys = leftInputTable.getDataSource().getSchema().key();
       final List<Column> missingKeys =
           leftInputTableKeys.stream().filter(
               k -> !projection.containsExpression(

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/fk-join.json
@@ -355,7 +355,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "LT_ID BIGINT KEY, RT_ID_ALIAS STRING, NAME_ALIAS STRING, F1 STRING"}
+          {"name": "OUTPUT", "type": "table", "schema": "LT_ID BIGINT KEY, RT_ID_ALIAS BIGINT, NAME_ALIAS STRING, F1 STRING"}
         ]
       }
     },
@@ -388,14 +388,14 @@
         {"topic": "OUTPUT", "key": 0, "value": {"RT_ID": null, "NAME": "foo", "F1": null}, "timestamp": 13000},
         {"topic": "OUTPUT", "key": 1, "value": {"RT_ID": 0, "NAME": "zero", "F1": "a"}, "timestamp": 15000},
         {"topic": "OUTPUT", "key": 10, "value": {"RT_ID": 0, "NAME": "bar", "F1": "a"}, "timestamp": 16000},
-        {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 17000},
-        {"topic": "OUTPUT", "key": 10, "value": null, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 1, "value": {"RT_ID": null, "NAME": "zero", "F1": null}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 10, "value": {"RT_ID": null, "NAME": "bar", "F1": null}, "timestamp": 17000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000},
         {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 19000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "LT_ID BIGINT KEY, RT_ID STRING, NAME STRING, F1 STRING"}
+          {"name": "OUTPUT", "type": "table", "schema": "LT_ID BIGINT KEY, RT_ID BIGINT, NAME STRING, F1 STRING"}
         ]
       }
     },
@@ -462,14 +462,14 @@
         {"topic": "OUTPUT", "key": 0, "value": {"RT_ID_ALIAS": null, "NAME_ALIAS": "foo", "F1": null}, "timestamp": 13000},
         {"topic": "OUTPUT", "key": 1, "value": {"RT_ID_ALIAS": 0, "NAME_ALIAS": "zero", "F1": "a"}, "timestamp": 15000},
         {"topic": "OUTPUT", "key": 10, "value": {"RT_ID_ALIAS": 0, "NAME_ALIAS": "bar", "F1": "a"}, "timestamp": 16000},
-        {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 17000},
-        {"topic": "OUTPUT", "key": 10, "value": null, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 1, "value": {"RT_ID_ALIAS": null, "NAME_ALIAS": "zero", "F1": null}, "timestamp": 17000},
+        {"topic": "OUTPUT", "key": 10, "value": {"RT_ID_ALIAS": null, "NAME_ALIAS": "bar", "F1": null}, "timestamp": 17000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000},
         {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 19000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "LT_ID BIGINT KEY, RT_ID_ALIAS STRING, NAME_ALIAS STRING, F1 STRING"}
+          {"name": "OUTPUT", "type": "table", "schema": "LT_ID BIGINT KEY, RT_ID_ALIAS BIGINT, NAME_ALIAS STRING, F1 STRING"}
         ]
       }
     },
@@ -606,14 +606,14 @@
         {"topic": "left_topic", "key": 1, "value": null, "timestamp": 18000}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 1, "value": {"LT_NAME": "zero", "LT_VALUE": 0, "RT_R_ID": null, "RT_F1": null, "RT_F2": 4, "NAME_ALIAS": "zero"}, ",timestamp": 0},
-        {"topic": "OUTPUT", "key": 1, "value": {"LT_NAME": "zero", "LT_VALUE": 0, "RT_R_ID": 0, "RT_F1": "blah", "RT_F2": 4, "NAME_ALIAS": "zero"}, "timestamp": 10000},
-        {"topic": "OUTPUT", "key": 1, "value": {"LT_NAME": "zero", "LT_VALUE": 0, "RT_R_ID": 0, "RT_F1": "blah", "RT_F2": 4, "NAME_ALIAS": "zero"}, "timestamp": 11000},
+        {"topic": "OUTPUT", "key": 1, "value": {"LT_NAME": "zero", "LT_FOREIGN_KEY": 0, "RT_R_ID": null, "RT_F1": null, "RT_F2": null, "NAME_ALIAS": "zero"}, ",timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"LT_NAME": "zero", "LT_FOREIGN_KEY": 0, "RT_R_ID": 0, "RT_F1": "blah", "RT_F2": 4, "NAME_ALIAS": "zero"}, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 1, "value": {"LT_NAME": "zero", "LT_FOREIGN_KEY": 0, "RT_R_ID": 0, "RT_F1": "blah", "RT_F2": 4, "NAME_ALIAS": "zero"}, "timestamp": 11000},
         {"topic": "OUTPUT", "key": 1, "value": null, "timestamp": 18000}
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "schema": "LT_L_ID BIGINT KEY, LT_NAME STRING, LT_VALUE BIGINT, RT_R_ID BIGINT, RT_F1 STRING, RT_F2 BIGINT, NAME_ALIAS STRING"}
+          {"name": "OUTPUT", "type": "table", "schema": "LT_L_ID BIGINT KEY, LT_NAME STRING, LT_FOREIGN_KEY BIGINT, RT_R_ID BIGINT, RT_F1 STRING, RT_F2 BIGINT, NAME_ALIAS STRING"}
         ]
       }
     },


### PR DESCRIPTION
### Description 
We need to use the alias name (instead of the table name) if an alias exist to verify if the key column is present in the projection.

### Testing done 
Updated existing QTT tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

