### PR TITLE
fix: DROP stream for persistent query doesn't always drop underlying query

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -52,6 +52,10 @@ public final class KsqlConstants {
     PUSH
   }
 
+  public enum PersistentQueryType {
+    CREATE_AS, INSERT
+  }
+
   public enum KsqlQueryStatus {
     RUNNING,
     ERROR,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.PersistentQueryMetadataImpl;
@@ -215,6 +216,7 @@ final class QueryExecutor {
   }
 
   PersistentQueryMetadata buildPersistentQuery(
+      final KsqlConstants.PersistentQueryType persistentQueryType,
       final String statementText,
       final QueryId queryId,
       final DataSource sinkDataSource,
@@ -262,6 +264,7 @@ final class QueryExecutor {
         .orElse(userErrorClassifiers);
 
     return new PersistentQueryMetadataImpl(
+        persistentQueryType,
         statementText,
         querySchema,
         sources,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
@@ -165,6 +166,9 @@ public class QueryRegistryImpl implements QueryRegistry {
     final QueryExecutor executor =
         executorFactory.create(config, processingLogContext, serviceContext, metaStore);
     final PersistentQueryMetadata query = executor.buildPersistentQuery(
+        createAsQuery
+            ? KsqlConstants.PersistentQueryType.CREATE_AS
+            : KsqlConstants.PersistentQueryType.INSERT,
         statementText,
         queryId,
         sinkDataSource,
@@ -290,16 +294,21 @@ public class QueryRegistryImpl implements QueryRegistry {
       final QueryId queryId = persistentQuery.getQueryId();
       persistentQueries.remove(queryId);
 
-      // If query is a INSERT query, then this line should not cause any effect
-      createAsQueries.remove(persistentQuery.getSinkName());
-
-      // If query is a C*AS query, then these lines should not cause any effect
-      sinkAndSources(persistentQuery).forEach(sourceName ->
-          insertQueries.computeIfPresent(sourceName, (s, queries) -> {
-            queries.remove(queryId);
-            return (queries.isEmpty()) ? null : queries;
-          })
-      );
+      switch (persistentQuery.getPersistentQueryType()) {
+        case CREATE_AS:
+          createAsQueries.remove(persistentQuery.getSinkName());
+          break;
+        case INSERT:
+          sinkAndSources(persistentQuery).forEach(sourceName ->
+              insertQueries.computeIfPresent(sourceName, (s, queries) -> {
+                queries.remove(queryId);
+                return (queries.isEmpty()) ? null : queries;
+              })
+          );
+          break;
+        default:
+          // nothing to do with unknown query types
+      }
     }
 
     allLiveQueries.remove(query);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -46,6 +46,8 @@ public interface PersistentQueryMetadata extends QueryMetadata {
 
   DataSource getSink();
 
+  KsqlConstants.PersistentQueryType getPersistentQueryType();
+
   ProcessingLogger getProcessingLogger();
 
   Optional<Materialization> getMaterialization(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -46,7 +46,7 @@ import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
  */
 public class PersistentQueryMetadataImpl
     extends QueryMetadataImpl implements PersistentQueryMetadata {
-
+  private final KsqlConstants.PersistentQueryType persistentQueryType;
   private final DataSource sinkDataSource;
   private final QuerySchemas schemas;
   private final PhysicalSchema resultSchema;
@@ -60,6 +60,7 @@ public class PersistentQueryMetadataImpl
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public PersistentQueryMetadataImpl(
+      final KsqlConstants.PersistentQueryType persistentQueryType,
       final String statementString,
       final PhysicalSchema schema,
       final Set<SourceName> sourceNames,
@@ -111,6 +112,7 @@ public class PersistentQueryMetadataImpl
         requireNonNull(materializationProviderBuilder, "materializationProviderBuilder");
     this.processingLogger = requireNonNull(processingLogger, "processingLogger");
     this.scalablePushRegistry = requireNonNull(scalablePushRegistry, "scalablePushRegistry");
+    this.persistentQueryType = requireNonNull(persistentQueryType, "persistentQueryType");
   }
 
   // for creating sandbox instances
@@ -127,6 +129,7 @@ public class PersistentQueryMetadataImpl
     this.materializationProviderBuilder = original.materializationProviderBuilder;
     this.processingLogger = original.processingLogger;
     this.scalablePushRegistry = original.scalablePushRegistry;
+    this.persistentQueryType = original.getPersistentQueryType();
   }
 
   @Override
@@ -177,6 +180,10 @@ public class PersistentQueryMetadataImpl
 
   public DataSource getSink() {
     return sinkDataSource;
+  }
+
+  public KsqlConstants.PersistentQueryType getPersistentQueryType() {
+    return persistentQueryType;
   }
 
   @VisibleForTesting

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -262,7 +262,7 @@ public class QueryExecutorTest {
   }
 
   @Test
-  public void shouldBuildPersistentQueryCorrectly() {
+  public void shouldBuildCreateAsPersistentQueryCorrectly() {
     // Given:
     final ProcessingLogger uncaughtProcessingLogger = mock(ProcessingLogger.class);
     when(processingLoggerFactory.getLogger(
@@ -299,6 +299,46 @@ public class QueryExecutorTest {
     assertThat(queryMetadata.getProcessingLogger(), equalTo(uncaughtProcessingLogger));
     assertThat(queryMetadata.getPersistentQueryType(),
         equalTo(KsqlConstants.PersistentQueryType.CREATE_AS));
+  }
+
+  @Test
+  public void shouldBuildInsertPersistentQueryCorrectly() {
+    // Given:
+    final ProcessingLogger uncaughtProcessingLogger = mock(ProcessingLogger.class);
+    when(processingLoggerFactory.getLogger(
+        QueryLoggerUtil.queryLoggerName(QUERY_ID, new QueryContext.Stacker()
+            .push("ksql.logger.thread.exception.uncaught").getQueryContext())
+    )).thenReturn(uncaughtProcessingLogger);
+
+    // When:
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.INSERT,
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        SOURCES,
+        physicalPlan,
+        SUMMARY,
+        queryListener,
+        Collections::emptyList
+    );
+    queryMetadata.initialize();
+
+    // Then:
+    assertThat(queryMetadata.getStatementString(), equalTo(STATEMENT_TEXT));
+    assertThat(queryMetadata.getQueryId(), equalTo(QUERY_ID));
+    assertThat(queryMetadata.getSinkName(), equalTo(SINK_NAME));
+    assertThat(queryMetadata.getPhysicalSchema(), equalTo(SINK_PHYSICAL_SCHEMA));
+    assertThat(queryMetadata.getResultTopic(), is(ksqlTopic));
+    assertThat(queryMetadata.getSourceNames(), equalTo(SOURCES));
+    assertThat(queryMetadata.getDataSourceType(), equalTo(DataSourceType.KSTREAM));
+    assertThat(queryMetadata.getExecutionPlan(), equalTo(SUMMARY));
+    assertThat(queryMetadata.getTopology(), is(topology));
+    assertThat(queryMetadata.getOverriddenProperties(), equalTo(OVERRIDES));
+    assertThat(queryMetadata.getStreamsProperties(), equalTo(capturedStreamsProperties()));
+    assertThat(queryMetadata.getProcessingLogger(), equalTo(uncaughtProcessingLogger));
+    assertThat(queryMetadata.getPersistentQueryType(),
+        equalTo(KsqlConstants.PersistentQueryType.INSERT));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.QueryMetadataImpl;
@@ -271,6 +272,7 @@ public class QueryExecutorTest {
 
     // When:
     final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -295,12 +297,15 @@ public class QueryExecutorTest {
     assertThat(queryMetadata.getOverriddenProperties(), equalTo(OVERRIDES));
     assertThat(queryMetadata.getStreamsProperties(), equalTo(capturedStreamsProperties()));
     assertThat(queryMetadata.getProcessingLogger(), equalTo(uncaughtProcessingLogger));
+    assertThat(queryMetadata.getPersistentQueryType(),
+        equalTo(KsqlConstants.PersistentQueryType.CREATE_AS));
   }
 
   @Test
   public void shouldBuildPersistentQueryWithCorrectStreamsApp() {
     // When:
     final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -321,6 +326,7 @@ public class QueryExecutorTest {
   public void shouldStartPersistentQueryWithCorrectMaterializationProvider() {
     // Given:
     final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -344,6 +350,7 @@ public class QueryExecutorTest {
   public void shouldCreateKSMaterializationCorrectly() {
     // When:
     queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -373,6 +380,7 @@ public class QueryExecutorTest {
   public void shouldMaterializeCorrectlyOnStart() {
     // Given:
     final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -403,6 +411,7 @@ public class QueryExecutorTest {
     when(tableHolder.getMaterializationBuilder()).thenReturn(Optional.empty());
 
     final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -425,6 +434,7 @@ public class QueryExecutorTest {
   public void shouldCreateExpectedServiceId() {
     // When:
     queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -447,6 +457,7 @@ public class QueryExecutorTest {
   public void shouldAddMetricsInterceptorsToStreamsConfig() {
     // When:
     queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -478,6 +489,7 @@ public class QueryExecutorTest {
 
     // When:
     final PersistentQueryMetadata queryMetadata = queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -540,6 +552,7 @@ public class QueryExecutorTest {
 
     // When:
     queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -566,6 +579,7 @@ public class QueryExecutorTest {
 
     // When:
     queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -593,6 +607,7 @@ public class QueryExecutorTest {
 
     // When:
     queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,
@@ -624,6 +639,7 @@ public class QueryExecutorTest {
 
     // When:
     queryBuilder.buildPersistentQuery(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         STATEMENT_TEXT,
         QUERY_ID,
         sink,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.query.QueryError.Type;
 import io.confluent.ksql.query.QueryRegistryImpl.QueryExecutorFactory;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
@@ -319,7 +320,7 @@ public class QueryRegistryImplTest {
   ) {
     givenCreate(registry, id, "source", "sink1", true);
     verify(executor).buildPersistentQuery(
-        any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any());
+        any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any());
     return queryListenerCaptor.getValue();
   }
 
@@ -338,8 +339,11 @@ public class QueryRegistryImplTest {
     when(query.getSinkName()).thenReturn(SourceName.of(sink));
     when(query.getSink()).thenReturn(sinkSource);
     when(query.getSourceNames()).thenReturn(ImmutableSet.of(SourceName.of(source)));
+    when(query.getPersistentQueryType()).thenReturn(createAs
+        ? KsqlConstants.PersistentQueryType.CREATE_AS
+        : KsqlConstants.PersistentQueryType.INSERT);
     when(executor.buildPersistentQuery(
-        any(), any(), any(), any(), any(), any(), any(), any())
+        any(), any(), any(), any(), any(), any(), any(), any(), any())
     ).thenReturn(query);
     registry.createOrReplacePersistentQuery(
         config,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -106,6 +106,7 @@ public class PersistentQueryMetadataTest {
     when(kafkaStreams.state()).thenReturn(State.NOT_RUNNING);
 
     query = new PersistentQueryMetadataImpl(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         SQL,
         physicalSchema,
         Collections.emptySet(),
@@ -131,6 +132,72 @@ public class PersistentQueryMetadataTest {
     );
 
     query.initialize();
+  }
+
+  @Test
+  public void shouldReturnInsertQueryType() {
+    // Given
+    final PersistentQueryMetadata query = new PersistentQueryMetadataImpl(
+        KsqlConstants.PersistentQueryType.INSERT,
+        SQL,
+        physicalSchema,
+        Collections.emptySet(),
+        sinkDataSource,
+        EXECUTION_PLAN,
+        QUERY_ID,
+        Optional.of(materializationProviderBuilder),
+        APPLICATION_ID,
+        topology,
+        kafkaStreamsBuilder,
+        schemas,
+        props,
+        overrides,
+        CLOSE_TIMEOUT,
+        queryErrorClassifier,
+        physicalPlan,
+        10,
+        processingLogger,
+        0L,
+        0L,
+        listener,
+        Optional.empty()
+    );
+
+    // When/Then
+    assertThat(query.getPersistentQueryType(), is(KsqlConstants.PersistentQueryType.INSERT));
+  }
+
+  @Test
+  public void shouldReturnCreateAsQueryType() {
+    // Given
+    final PersistentQueryMetadata query = new PersistentQueryMetadataImpl(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
+        SQL,
+        physicalSchema,
+        Collections.emptySet(),
+        sinkDataSource,
+        EXECUTION_PLAN,
+        QUERY_ID,
+        Optional.of(materializationProviderBuilder),
+        APPLICATION_ID,
+        topology,
+        kafkaStreamsBuilder,
+        schemas,
+        props,
+        overrides,
+        CLOSE_TIMEOUT,
+        queryErrorClassifier,
+        physicalPlan,
+        10,
+        processingLogger,
+        0L,
+        0L,
+        listener,
+        Optional.empty()
+    );
+
+    // When/Then
+    assertThat(query.getPersistentQueryType(), is(KsqlConstants.PersistentQueryType.CREATE_AS));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImplTest.java
@@ -97,6 +97,7 @@ public class SandboxedPersistentQueryMetadataImplTest {
         .thenReturn(Optional.of(materializationProvider));
 
     final PersistentQueryMetadataImpl query = new PersistentQueryMetadataImpl(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         SQL,
         physicalSchema,
         Collections.emptySet(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -150,6 +151,7 @@ public class QueryDescriptionFactoryTest {
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery, Collections.emptyMap());
 
     persistentQuery = new PersistentQueryMetadataImpl(
+        KsqlConstants.PersistentQueryType.CREATE_AS,
         SQL_TEXT,
         PhysicalSchema.from(PERSISTENT_SCHEMA, SerdeFeatures.of(), SerdeFeatures.of()),
         SOURCE_NAMES,


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
This PR fixes an issue when terminating an INSERT query that caused the underlying CREATE_AS query to not be terminated when dropping the stream.

i.e.
```
ksql> create stream p1 as select * from s1;
ksql> insert into p1 select * from s2;
ksql> show queries;
Query ID       | Query Type | Status    | Sink Name | Sink Kafka Topic | Query String                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 INSERTQUERY_43 | PERSISTENT | RUNNING:1 | P1        | P1               | insert into p1 select * from s2;                                                                        
 CSAS_P1_41     | PERSISTENT | RUNNING:1 | P1        | P1               | CREATE STREAM P1 WITH (KAFKA_TOPIC='P1', PARTITIONS=1, REPLICAS=1) AS SELECT * FROM S1 S1 EMIT CHANGES; 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ksql> terminate INSERTQUERY_43;
ksql> drop stream p1;
ksql> show queries;
Query ID       | Query Type | Status    | Sink Name | Sink Kafka Topic | Query String                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
CSAS_P1_41     | PERSISTENT | RUNNING:1 | P1        | P1               | CREATE STREAM P1 WITH (KAFKA_TOPIC='P1', PARTITIONS=1, REPLICAS=1) AS SELECT * FROM S1 S1 EMIT CHANGES; 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

The `CSAS_P1_41` should have been terminated automatically with DROP stream.

The problem was in `QueryRegistryImpl` that was removing query references from both `insertQueries` and `createAsQueries` mapping variables. This PR now removes the references from the right map variable.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

