### PR TITLE
test: fix shouldNotBeAbleToUseWssIfClientDoesNotTrustServerCert test

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/SslFunctionalTest.java
@@ -99,6 +99,7 @@ public class SslFunctionalTest {
   public void setUp() {
     clientProps = Collections.emptyMap();
     sslContextFactory = new SslContextFactory();
+    sslContextFactory.setEndpointIdentificationAlgorithm("");
   }
 
   @Test
@@ -162,7 +163,6 @@ public class SslFunctionalTest {
     // WS:
     sslContextFactory.setTrustStorePath(ClientTrustStore.trustStorePath());
     sslContextFactory.setTrustStorePassword(ClientTrustStore.trustStorePassword());
-    sslContextFactory.setEndpointIdentificationAlgorithm("");
   }
 
   private Code canMakeCliRequest() {


### PR DESCRIPTION
### Description 
From https://kafka.apache.org/21/documentation.html#upgrade_200_notable: 

The default value for ssl.endpoint.identification.algorithm was changed to https, which performs hostname verification (man-in-the-middle attacks are possible otherwise). Set ssl.endpoint.identification.algorithm to an empty string to restore the previous behaviour.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

