### PR TITLE
fix: Add redhat repository for jackson-mapper-asl.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,10 @@
             <id>confluent-snapshots</id>
             <url>https://s3-us-west-2.amazonaws.com/confluent-snapshots/</url>
         </repository>
+        <repository>
+            <id>redhat-repo</id>
+            <url>https://maven.repository.redhat.com/ga/</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
### Description 
org.codehaus.jackson:jackson-mapper-asl:jar:1.9.14.jdk17-redhat-00001 is added to override the 1.9.13 version brought by avro.
This is provided by Redhat and thus we need to add their repo.

### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

