### PR TITLE
fix: Update Maven wrapper and document its use to fix version resolution

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 # custmized maven that help avoid download only highest poms from version range
 # https://issues.apache.org/jira/browse/MRESOLVER-164
-distributionUrl=https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/apache-maven-3.6.3.1-bin.zip
+distributionUrl=https://confluent-packaging-tools.s3-us-west-2.amazonaws.com/apache-maven-3.8.1.2-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,47 @@ If you have any questions about how to contribute, either [create a GH issue](ht
 
 ## Developing KSQL
 
+### About the Apache Maven wrapper
+
+Development versions of KSQL use version ranges for dependencies
+on other Confluent projects, and due to
+[a bug in Apache Maven](https://issues.apache.org/jira/browse/MRESOLVER-164),
+you may find that both Maven and your IDE download hundreds or thousands
+of pom files while resolving dependencies. They get cached, so it will
+be most apparent on fresh forks or switching to branches that you haven't
+used in a while.
+
+Until we are able to get a fix in and released officially, we need to work
+around the bug. We have added a Maven wrapper script and configured
+it to download a patched version of Maven. You can use this wrapper simply by
+substituting `./mvnw` instead of `mvn` for every Maven invocation.
+The patch is experimental, so if it causes you some trouble, you can switch
+back to the official release just by using `mvn` again. Please let us know
+if you do have any trouble with the wrapper.
+
+You can also configure IntelliJ IDEA to use the patched version of Maven.
+First, get the path to the patched Maven home:
+
+```shell
+$ ./mvnw -v
+...
+Maven home: /home/john/.m2/wrapper/dists/apache-maven-3.8.1.2-bin/1npbma9t0n1k5b22fpopvupbmn/apache-maven-3.8.1.2
+...
+```
+
+Then, update your IDEA Maven home in **Settings > Build, Execution, Deployment > Build Tools > Maven**
+and set the value of **Maven home path** to the same directory listed as the "Maven home" above.
+In the above example, it is `/home/john/.m2/wrapper/dists/apache-maven-3.8.1.2-bin/1npbma9t0n1k5b22fpopvupbmn/apache-maven-3.8.1.2`,
+but it may be different on your machine.
+
+There is likely a similar option available for other IDEs.
+
 ### Building and running KSQL locally
 
 To build and run KSQL locally, run the following commands:
 
 ```shell
-$ ./mvnw clean package -DskipTests -DversionFilter
+$ ./mvnw clean package -DskipTests
 $ ./bin/ksql-server-start -daemon config/ksql-server.properties
 $ ./bin/ksql
 ```
@@ -24,6 +59,16 @@ including any errors.
 If you would rather have the KSQL server logs spool to the console, then
 drop the `-daemon` switch, and start the CLI in a second console.
 
+#### Running in an IDE
+
+You can create a run configuration in your IDE for the main class:
+`io.confluent.ksql.rest.server.KsqlServerMain`, using the classpath
+of the `ksqldb-rest-app` module, and specifying the path to a config
+file as the program argument. There is a basic config available in
+`config/ksql-server.properties`.
+
+You may wish to be sure you have already configured your IDE to use
+the Maven wrapper (see "About the Apache Maven wrapper", above).
 
 ### Testing changes locally
 


### PR DESCRIPTION
### Description 

Update the wrapper to include https://github.com/confluentinc/maven/pull/1
Document what the wrapper does, and how to use it on the CLI and in IDEs

### Testing done 

I verified the wrapper works as expected by doing:

```
mvn clean
rm -r ~/.m2/repository
./mvnw clean compile
```

This build completes in about 12 minutes with the wrapper, and takes a few hours without it. I can also visually verify that I'm not downloading extra pom files.

I also followed the documentation included in this PR to update IDEA and verified that it also doesn't resolve the extra dependencies (and that it also takes about 12 minutes to complete, instead of hours).

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

