### PR TITLE
docs: document parallel build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,12 @@ the Maven wrapper (see "About the Apache Maven wrapper", above).
 To build and test changes locally, run the following commands:
 
 ```shell
-$ ./mvnw verify
+$ ./mvnw verify -T 1.5C
 ```
+
+This example showcases [the new parallel build feature of Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3).
+If it causes problems for you, you can change the parallelism argument, or
+drop the `-T ...` option altogether.
 
 ### Testing docker image
 


### PR DESCRIPTION
### Description 

Document how to use parallel build in Maven to speed up tests.

### Testing done 

Ran it locally. Also @agavra has been doing this for a while.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

