### PR TITLE
fix: Fixes race condition exposing uninitialized query

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -270,7 +270,7 @@ public class QueryRegistryImpl implements QueryRegistry {
       }
 
       // Initialize the query before it's exposed to other threads via the map/sets.
-      query.initialize();
+      persistentQuery.initialize();
       persistentQueries.put(queryId, persistentQuery);
       if (createAsQuery) {
         createAsQueries.put(persistentQuery.getSinkName(), queryId);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -251,6 +251,9 @@ public class QueryRegistryImpl implements QueryRegistry {
       final QueryMetadata query,
       final boolean createAsQuery
   ) {
+    // First initialize the query.  Once it's added to these maps/sets, it's exposed to other
+    // threads and it's important that it's initialized.
+    query.initialize();
     if (query instanceof PersistentQueryMetadata) {
       final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) query;
       final QueryId queryId = persistentQuery.getQueryId();
@@ -281,7 +284,6 @@ public class QueryRegistryImpl implements QueryRegistry {
     }
     allLiveQueries.add(query);
     notifyCreate(serviceContext, metaStore, query);
-    query.initialize();
   }
 
   private void unregisterQuery(final QueryMetadata query) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -53,8 +53,6 @@ public interface PersistentQueryMetadata extends QueryMetadata {
       QueryContext.Stacker contextStacker
   );
 
-  void restart();
-
   void stop();
 
   StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -37,7 +37,6 @@ import io.confluent.ksql.schema.query.QuerySchemas;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
@@ -54,9 +53,9 @@ public class PersistentQueryMetadataImpl
   private final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
       materializationProviderBuilder;
   private final Optional<ScalablePushRegistry> scalablePushRegistry;
+  private final ProcessingLogger processingLogger;
 
   private Optional<MaterializationProvider> materializationProvider;
-  private ProcessingLogger processingLogger;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public PersistentQueryMetadataImpl(
@@ -194,23 +193,6 @@ public class PersistentQueryMetadataImpl
       final QueryContext.Stacker contextStacker
   ) {
     return materializationProvider.map(builder -> builder.build(queryId, contextStacker));
-  }
-
-  public synchronized void restart() {
-    if (isClosed()) {
-      throw new IllegalStateException(String.format(
-          "Query with application id %s is already closed, cannot restart.",
-          getQueryApplicationId()));
-    }
-
-    closeKafkaStreams();
-
-    final KafkaStreams newKafkaStreams = buildKafkaStreams();
-    materializationProvider = materializationProviderBuilder.flatMap(
-        builder -> builder.apply(newKafkaStreams, getTopology()));
-
-    resetKafkaStreams(newKafkaStreams);
-    start();
   }
 
   /**

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -16,9 +16,7 @@
 package io.confluent.ksql.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -48,7 +46,6 @@ import java.util.Optional;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -171,42 +168,6 @@ public class PersistentQueryMetadataTest {
 
     // Then:
     verify(kafkaStreams, never()).cleanUp();
-  }
-
-  @Test
-  public void shouldRestartKafkaStreams() {
-    final KafkaStreams newKafkaStreams = mock(KafkaStreams.class);
-    final MaterializationProvider newMaterializationProvider = mock(MaterializationProvider.class);
-
-    // Given:
-    when(kafkaStreamsBuilder.build(any(), any())).thenReturn(newKafkaStreams);
-    when(materializationProviderBuilder.apply(newKafkaStreams, topology))
-        .thenReturn(Optional.of(newMaterializationProvider));
-
-    // When:
-    query.restart();
-
-    // Then:
-    final InOrder inOrder = inOrder(kafkaStreams, newKafkaStreams);
-    inOrder.verify(kafkaStreams).close(any());
-    inOrder.verify(newKafkaStreams).setUncaughtExceptionHandler(
-        any(StreamsUncaughtExceptionHandler.class));
-    inOrder.verify(newKafkaStreams).start();
-
-    assertThat(query.getKafkaStreams(), is(newKafkaStreams));
-    assertThat(query.getMaterializationProvider(), is(Optional.of(newMaterializationProvider)));
-  }
-
-  @Test
-  public void shouldNotRestartIfQueryIsClosed() {
-    // Given:
-    query.close();
-
-    // When:
-    final Exception e = assertThrows(Exception.class, () -> query.restart());
-
-    // Then:
-    assertThat(e.getMessage(), containsString("is already closed, cannot restart."));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Fixes a race that was caused by exposing a query via the map `persistentQueries` or set `allLiveQueries` without having initialized it.  This is done in particular in `HeartbeatAgent` and `RemoteHostExecutor`.  For example, when calling:

```
final List<PersistentQueryMetadata> currentQueries = engine.getPersistentQueries();
final Set<HostInfo> uniqueHosts =
            DiscoverRemoteHostsUtil.getRemoteHosts(currentQueries, localHost);
```

The list of persistent queries isn't guaranteed to be initialized and the calls to the query in `DiscoverRemoteHostsUtil` such as `getState()` and `getAllMetadata()` will fail with NPEs.


### Testing done 
Unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

