### PR TITLE
docs: Update KLIP-36 to add GRACE syntax on joins with before/after windows

### DIFF
--- a/design-proposals/klip-36-grace-stream-stream-joins.md
+++ b/design-proposals/klip-36-grace-stream-stream-joins.md
@@ -41,8 +41,14 @@ JOIN <stream> WITHIN <time unit> ON <condition>
 This will be expanded to support a more complex `withinExpression` that leverages the same
 syntax as aggregation windows:
 
+Joins with simple windows:
 ```
 JOIN <stream> WITHIN (SIZE <time unit>, GRACE PERIOD <time unit>) ON <condition>
+```
+
+Joins with before/after windows:
+```
+JOIN <stream> WITHIN (BEFORE <time unit>, AFTER <time unit>, GRACE PERIOD <time unit>) ON <condition>
 ```
 
 The old syntax will still be supported for backwards compatibility.


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

Updates the KLIP-36 to add GRACE PERIOD on joins with before/after windows.
i.e.
```
JOIN <stream> WITHIN (BEFORE <time unit>, AFTER <time unit>, GRACE PERIOD <time unit>) ON <condition>
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

