### PR TITLE
fix: make current java clients compatible with pre-0.15 servers

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.api.client.TableInfo;
 import io.confluent.ksql.api.client.TopicInfo;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -338,7 +339,7 @@ final class AdminResponseHandlers {
           Optional.ofNullable(emptyToNull(source.getString("timestamp"))),
           Optional.ofNullable(emptyToNull(source.getString("windowType"))),
           source.getString("statement"),
-          source.getJsonArray("sourceConstraints").stream()
+          source.getJsonArray("sourceConstraints", new JsonArray()).stream()
               .map(o -> (String)o)
               .collect(Collectors.toList())
       ));

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.api.client.TableInfo;
 import io.confluent.ksql.api.client.TopicInfo;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -1991,7 +1991,7 @@ public class ClientTest extends BaseApiTest {
     }
   }
 
-  private static class LegacySourceDescriptionEntity {
+  private static class LegacySourceDescriptionEntity extends KsqlEntity{
 
     @JsonProperty("statementText") final String statementText;
     @JsonProperty("sourceDescription") final LegacySourceDescription sourceDescription;
@@ -2002,6 +2002,7 @@ public class ClientTest extends BaseApiTest {
         final LegacySourceDescription sourceDescription,
         final List<KsqlWarning> warnings
     ) {
+      super(statementText);
       this.statementText = statementText;
       this.sourceDescription = sourceDescription;
       this.warnings = warnings;

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -66,11 +66,13 @@ import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.entity.KafkaTopicInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
 import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.PushQueryId;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryDescription;
 import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
+import io.confluent.ksql.rest.entity.QueryOffsetSummary;
 import io.confluent.ksql.rest.entity.QueryStatusCount;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SchemaInfo;
@@ -1419,6 +1421,68 @@ public class ClientTest extends BaseApiTest {
   }
 
   @Test
+  public void shouldDescribeSourceWithoutSourceConstraints() throws Exception {
+    // Given
+    final LegacySourceDescription sd =
+        new LegacySourceDescription(
+            "name",
+            Optional.of(WindowType.TUMBLING),
+            Collections.singletonList(new RunningQuery(
+                "query_sql",
+                ImmutableSet.of("sink"),
+                ImmutableSet.of("sink_topic"),
+                new QueryId("a_persistent_query"),
+                new QueryStatusCount(ImmutableMap.of(KsqlQueryStatus.RUNNING, 1)),
+                KsqlQueryType.PERSISTENT)),
+            Collections.emptyList(),
+            ImmutableList.of(
+                new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null), Optional.of(FieldType.KEY)),
+                new FieldInfo("f2", new SchemaInfo(SqlBaseType.INTEGER, null, null), Optional.empty())),
+            "TABLE",
+            "",
+            false,
+            "KAFKA",
+            "JSON",
+            "topic",
+            4,
+            1,
+            "sql",
+            Collections.emptyList()
+        );
+    final LegacySourceDescriptionEntity entity = new LegacySourceDescriptionEntity(
+        "describe source;", sd, Collections.emptyList());
+    testEndpoints.setKsqlEndpointResponse(Collections.singletonList(entity));
+
+    // When
+    final SourceDescription description = javaClient.describeSource("source").get();
+
+    // Then
+    assertThat(description.name(), is("name"));
+    assertThat(description.type(), is("TABLE"));
+    assertThat(description.fields(), hasSize(2));
+    assertThat(description.fields().get(0).name(), is("f1"));
+    assertThat(description.fields().get(0).type().getType(), is(ColumnType.Type.STRING));
+    assertThat(description.fields().get(0).isKey(), is(true));
+    assertThat(description.fields().get(1).name(), is("f2"));
+    assertThat(description.fields().get(1).type().getType(), is(ColumnType.Type.INTEGER));
+    assertThat(description.fields().get(1).isKey(), is(false));
+    assertThat(description.topic(), is("topic"));
+    assertThat(description.keyFormat(), is("KAFKA"));
+    assertThat(description.valueFormat(), is("JSON"));
+    assertThat(description.readQueries(), hasSize(1));
+    assertThat(description.readQueries().get(0).getQueryType(), is(QueryType.PERSISTENT));
+    assertThat(description.readQueries().get(0).getId(), is("a_persistent_query"));
+    assertThat(description.readQueries().get(0).getSql(), is("query_sql"));
+    assertThat(description.readQueries().get(0).getSink(), is(Optional.of("sink")));
+    assertThat(description.readQueries().get(0).getSinkTopic(), is(Optional.of("sink_topic")));
+    assertThat(description.writeQueries(), hasSize(0));
+    assertThat(description.timestampColumn(), is(Optional.empty()));
+    assertThat(description.windowType(), is(Optional.of("TUMBLING")));
+    assertThat(description.sqlStatement(), is("sql"));
+    assertThat(description.getSourceConstraints().size(), is(0));
+  }
+
+  @Test
   public void shouldGetServerInfo() throws Exception {
     final ServerInfo serverInfo = javaClient.serverInfo().get();
     assertThat(serverInfo.getServerVersion(), is(AppInfo.getVersion()));
@@ -1871,6 +1935,76 @@ public class ClientTest extends BaseApiTest {
     public LegacyTablesList(final String sql, final List<LegacyTableInfo> tables) {
       super(sql);
       this.tables = tables;
+    }
+  }
+
+  private static class LegacySourceDescription {
+
+    @JsonProperty("name") private final String name;
+    @JsonProperty("windowType") private final Optional<WindowType> windowType;
+    @JsonProperty("readQueries") private final List<RunningQuery> readQueries;
+    @JsonProperty("writeQueries") final List<RunningQuery> writeQueries;
+    @JsonProperty("fields") final List<FieldInfo> fields;
+    @JsonProperty("type") final String type;
+    @JsonProperty("timestamp") final String timestamp;
+    @JsonProperty("extended") final boolean extended;
+    @JsonProperty("keyFormat") final String keyFormat;
+    @JsonProperty("valueFormat") final String valueFormat;
+    @JsonProperty("topic") final String topic;
+    @JsonProperty("partitions") final int partitions;
+    @JsonProperty("replication") final int replication;
+    @JsonProperty("statement") final String statement;
+    @JsonProperty("queryOffsetSummaries") final List<QueryOffsetSummary> queryOffsetSummaries;
+
+    public LegacySourceDescription(
+        final String name,
+        final Optional<WindowType> windowType,
+        final List<RunningQuery> readQueries,
+        final List<RunningQuery> writeQueries,
+        final List<FieldInfo> fields,
+        final String type,
+        final String timestamp,
+        final boolean extended,
+        final String keyFormat,
+        final String valueFormat,
+        final String topic,
+        final int partitions,
+        final int replication,
+        final String statement,
+        final List<QueryOffsetSummary> queryOffsetSummaries
+    ) {
+      this.name = name;
+      this.windowType = windowType;
+      this.readQueries = readQueries;
+      this.writeQueries = writeQueries;
+      this.fields = fields;
+      this.type = type;
+      this.timestamp = timestamp;
+      this.extended = extended;
+      this.keyFormat = keyFormat;
+      this.valueFormat = valueFormat;
+      this.topic = topic;
+      this.partitions = partitions;
+      this.replication = replication;
+      this.statement = statement;
+      this.queryOffsetSummaries = queryOffsetSummaries;
+    }
+  }
+
+  private static class LegacySourceDescriptionEntity {
+
+    @JsonProperty("statementText") final String statementText;
+    @JsonProperty("sourceDescription") final LegacySourceDescription sourceDescription;
+    @JsonProperty("warnings") final List<KsqlWarning> warnings;
+
+    public LegacySourceDescriptionEntity(
+        final String statementText,
+        final LegacySourceDescription sourceDescription,
+        final List<KsqlWarning> warnings
+    ) {
+      this.statementText = statementText;
+      this.sourceDescription = sourceDescription;
+      this.warnings = warnings;
     }
   }
 }


### PR DESCRIPTION
### Description 
If `sourceConstraints` is not included in the server response, then default to an empty list in the java client.

### Testing done 
Added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

