### PR TITLE
Fixes example code docs typo

### DIFF
--- a/docs/developer-guide/joins/join-streams-and-tables.md
+++ b/docs/developer-guide/joins/join-streams-and-tables.md
@@ -51,7 +51,7 @@ the order was placed, and shipped within 2 hours of the payment being received.
 ```sql
    CREATE STREAM shipped_orders AS
      SELECT 
-        o.id as orderId 
+        o.id as orderId,
         o.itemid as itemId,
         s.id as shipmentId,
         p.id as paymentId


### PR DESCRIPTION
Fixes missing comma in example code.

Let's merge this to the live branch since it's currently broken.

