### PR TITLE
fix: stop users from applying the same migration more than once

### DIFF
--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -266,6 +266,7 @@ public class MigrationsTest {
     assertThat(applyStatus, is(0));
 
     verifyMigrationsApplied();
+    assertThat(MIGRATIONS_CLI.parse("--config-file", configFilePath, "apply", "-v", "2").runCommand(), is(1));
   }
 
   private void shouldDisplayInfo() {


### PR DESCRIPTION
### Description 
Adds a check in the apply command that stops users from applying migrations that have already been applied.

### Testing done 
Unit tests, added to the integration test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

