### PR TITLE
test: set test timeout for BaseApiTest (MINOR)

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -55,6 +55,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,6 +89,9 @@ public class BaseApiTest {
   protected Server server;
   protected TestEndpoints testEndpoints;
   protected ServerState serverState;
+
+  @Rule
+  public final Timeout timeout = Timeout.seconds(90);
 
   @Before
   public void setUp() {


### PR DESCRIPTION
### Description 

We saw a flakey test failure on Jenkins where AuthTest.java somehow got stuck in a loop and caused the build to hit the four-hour timeout. This PR adds a test timeout to all the api tests (including AuthTest.java) to at least prevent bad test runs from timing out the entire build.

### Testing done 

Test-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

