### PR TITLE
fix: block out of order migrations in migrations tool

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -201,14 +201,11 @@ public class ApplyMigrationCommand extends BaseCommand {
       final Clock clock
   ) {
     String previous = MetadataUtil.getLatestMigratedVersion(config, ksqlClient);
-    final int minimumVersion = previous.equals(MetadataUtil.NONE_VERSION)
-        ? 1
-        : Integer.parseInt(previous) + 1;
 
     LOGGER.info("Loading migration files");
     final List<MigrationFile> migrations;
     try {
-      migrations = loadMigrationsToApply(migrationsDir, minimumVersion);
+      migrations = loadMigrationsToApply(migrationsDir, previous);
     } catch (MigrationException e) {
       LOGGER.error(e.getMessage());
       return false;
@@ -232,8 +229,11 @@ public class ApplyMigrationCommand extends BaseCommand {
 
   private List<MigrationFile> loadMigrationsToApply(
       final String migrationsDir,
-      final int minimumVersion
+      final String previousVersion
   ) {
+    final int minimumVersion = previousVersion.equals(MetadataUtil.NONE_VERSION)
+        ? 1
+        : Integer.parseInt(previousVersion) + 1;
     if (version > 0) {
       final Optional<MigrationFile> migration =
           getMigrationForVersion(String.valueOf(version), migrationsDir);
@@ -243,7 +243,7 @@ public class ApplyMigrationCommand extends BaseCommand {
       if (version < minimumVersion) {
         throw new MigrationException(
             "Version must be newer than the last version migrated. Last version migrated was "
-                + (minimumVersion - 1));
+                + previousVersion);
       }
       return Collections.singletonList(migration.get());
     }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -240,6 +240,11 @@ public class ApplyMigrationCommand extends BaseCommand {
       if (!migration.isPresent()) {
         throw new MigrationException("No migration file with version " + version + " exists.");
       }
+      if (version < minimumVersion) {
+        throw new MigrationException(
+            "Version must be newer than the last version migrated. Last version migrated was "
+                + (minimumVersion - 1));
+      }
       return Collections.singletonList(migration.get());
     }
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -266,6 +266,9 @@ public class MigrationsTest {
     assertThat(applyStatus, is(0));
 
     verifyMigrationsApplied();
+
+    // Verify that older versions cannot be applied
+    assertThat(MIGRATIONS_CLI.parse("--config-file", configFilePath, "apply", "-v", "1").runCommand(), is(1));
   }
 
   private void shouldDisplayInfo() {


### PR DESCRIPTION
### Description 
Adds a check to make sure the version specified by `apply -v <number>` is greater than the last applied version.

### Testing done 
Unit and integration tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

