### PR TITLE
chore: fix build for KafkaConfig deprecations (MINOR)

### DIFF
--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
+import kafka.cluster.EndPoint;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import kafka.utils.TestUtils;
@@ -91,8 +92,8 @@ class KafkaEmbedded {
    * @return the broker list
    */
   String brokerList() {
-    final ListenerName listenerName = kafka.config().advertisedListeners().apply(0).listenerName();
-    return kafka.config().hostName() + ":" + kafka.boundPort(listenerName);
+    final EndPoint endPoint = kafka.advertisedListeners().head();
+    return endPoint.host() + ":" + endPoint.port();
   }
 
   /**
@@ -104,7 +105,8 @@ class KafkaEmbedded {
    * @return the broker list
    */
   String brokerList(final SecurityProtocol securityProtocol) {
-    return kafka.config().hostName() + ":"
+    final EndPoint endPoint = kafka.advertisedListeners().head();
+    return endPoint.host() + ":"
            + kafka.boundPort(new ListenerName(securityProtocol.toString()));
   }
 

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -93,7 +93,8 @@ class KafkaEmbedded {
    */
   String brokerList() {
     final EndPoint endPoint = kafka.advertisedListeners().head();
-    return endPoint.host() + ":" + endPoint.port();
+    final String hostname = endPoint.host() == null ? "" : endPoint.host();
+    return hostname + ":" + endPoint.port();
   }
 
   /**
@@ -106,7 +107,8 @@ class KafkaEmbedded {
    */
   String brokerList(final SecurityProtocol securityProtocol) {
     final EndPoint endPoint = kafka.advertisedListeners().head();
-    return endPoint.host() + ":"
+    final String hostname = endPoint.host() == null ? "" : endPoint.host();
+    return hostname + ":"
            + kafka.boundPort(new ListenerName(securityProtocol.toString()));
   }
 


### PR DESCRIPTION
### Description 

The build is currently failing since ksqlDB's KafkaEmbedded class depends on deprecated methods of KafkaConfig that were recently removed in https://github.com/apache/kafka/pull/10872. This PR switches away from the methods to fix the build.

### Testing done 

Will wait for Jenkins to pass before merging.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

