### PR TITLE
docs: adds documentation for high availability

### DIFF
--- a/docs/operate-and-deploy/high-availability.md
+++ b/docs/operate-and-deploy/high-availability.md
@@ -9,6 +9,8 @@ High availability is turned off by default, but you can enable it with the follo
 1. Set [`ksql.heartbeat.enable`](/reference/server-configuration/#ksqlheartbeatenable) to `true`.
 1. Set [`ksql.lag.reporting.enable`](/reference/server-configuration/#ksqllagreportingenable) to `true`.
 
+In addition, make sure that all of your nodes identify as part of the same cluster by setting [`ksql.service.id`](/reference/server-configuration/#ksqlserviceid) to the same value.
+
 ## Controlling consistency
 
 Because ksqlDB replicates data between its servers asynchronously, you may want to bound the potential staleness that your query will tolerate. You can control this per pull query using the [`ksql.query.pull.max.allowed.offset.lag`](/reference/server-configuration/#ksqlquerypullmaxallowedoffsetlag) parameter. For instance, a value of 10,000 means that results of pull queries forwarded to servers whose current offset is more than 10,000 positions behind the end offset of the changelog topic will be rejected.

--- a/docs/operate-and-deploy/high-availability.md
+++ b/docs/operate-and-deploy/high-availability.md
@@ -1,0 +1,14 @@
+# High availability
+
+When you run pull queries, it’s often the case that you need your data to remain available for querying even if the server fails. Because ksqlDB supports clustering, it can remain highly available to support pull queries on replicas of your data, even in the face of partial cluster failure.
+
+High availability is turned off by default, but you can enable it with the following server configuration parameters. These parameters must be turned on for all nodes in your ksqlDB cluster.
+
+1. Set [`ksql.streams.num.standby.replicas`](/reference/server-configuration/#ksqlstreamsnumstandbyreplicas) to a value greater than `1`.
+1. Set [`ksql.query.pull.enable.standby.reads`](/reference/server-configuration/#ksqlquerypullenablestandbyreads) to `true`.
+1. Set [`ksql.heartbeat.enable`](/reference/server-configuration/#ksqlheartbeatenable) to `true`.
+1. Set [`ksql.lag.reporting.enable`](/reference/server-configuration/#ksqllagreportingenable) to `true`.
+
+## Controlling consistency
+
+Because ksqlDB replicates data between its servers asynchronously, you may want to bound the potential staleness that your query will tolerate. You can control this per pull query using the [`ksql.query.pull.max.allowed.offset.lag`](/reference/server-configuration/#ksqlquerypullmaxallowedoffsetlag) parameter. For instance, a value of 10,000 means that results of pull queries forwarded to servers whose current offset is more than 10,000 positions behind the end offset of the changelog topic will be rejected.

--- a/docs/operate-and-deploy/high-availability.md
+++ b/docs/operate-and-deploy/high-availability.md
@@ -4,7 +4,7 @@ When you run pull queries, it’s often the case that you need your data to rema
 
 High availability is turned off by default, but you can enable it with the following server configuration parameters. These parameters must be turned on for all nodes in your ksqlDB cluster.
 
-1. Set [`ksql.streams.num.standby.replicas`](/reference/server-configuration/#ksqlstreamsnumstandbyreplicas) to a value greater than `1`.
+1. Set [`ksql.streams.num.standby.replicas`](/reference/server-configuration/#ksqlstreamsnumstandbyreplicas) to a value greater than `0`.
 1. Set [`ksql.query.pull.enable.standby.reads`](/reference/server-configuration/#ksqlquerypullenablestandbyreads) to `true`.
 1. Set [`ksql.heartbeat.enable`](/reference/server-configuration/#ksqlheartbeatenable) to `true`.
 1. Set [`ksql.lag.reporting.enable`](/reference/server-configuration/#ksqllagreportingenable) to `true`.

--- a/docs/operate-and-deploy/high-availability.md
+++ b/docs/operate-and-deploy/high-availability.md
@@ -1,6 +1,6 @@
 # High availability
 
-When you run pull queries, it’s often the case that you need your data to remain available for querying even if the server fails. Because ksqlDB supports clustering, it can remain highly available to support pull queries on replicas of your data, even in the face of partial cluster failure.
+When you run pull queries, it’s often the case that you need your data to remain available for querying even if one server fails. Because ksqlDB supports clustering, it can remain highly available to support pull queries on replicas of your data, even in the face of partial cluster failures.
 
 High availability is turned off by default, but you can enable it with the following server configuration parameters. These parameters must be turned on for all nodes in your ksqlDB cluster.
 

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -469,7 +469,7 @@ and
 
 ## `ksql.streams.num.standby.replicas`
 
-The number of standby replicas. Standby replicas are shadow copies of tables. ksqlDB, through Kafka Streams, attempts to create the specified number of replicas and keep them up to date as long as there are enough instances running. Standby replicas are used to minimize the latency of failover. A table that was previously hosted on a failed instance is preferred to restart on an instance that has standby replicas so that the local state store restoration process from its changelog can be minimized.
+The number of standby replicas. Standby replicas are shadow copies of tables. ksqlDB, through {{ site.kstreams }}, attempts to create the specified number of replicas and keep them up to date as long as there are enough instances running. Standby replicas are used to minimize the latency of failover. A table that was previously hosted on a failed instance is preferred to restart on an instance that has standby replicas so that the local state store restoration process from its changelog can be minimized.
 
 ## `ksql.streams.num.stream.threads`
 

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -384,8 +384,6 @@ over a secure connection, see
 
 ## `ksql.service.id`
 
-**Per query:** yes
-
 The service ID of the ksqlDB server. This is used to define the ksqlDB
 cluster membership of a ksqlDB Server instance.
 
@@ -468,6 +466,10 @@ For more information, see the
 [Streams parameter reference](https://docs.confluent.io/current/streams/developer-guide/config-streams.html#optional-configuration-parameters)
 and
 [CACHE_MAX_BYTES_BUFFERING_CONFIG](https://docs.confluent.io/{{ site.ksqldbversion }}/streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#CACHE_MAX_BYTES_BUFFERING_CONFIG).
+
+## `ksql.streams.num.standby.replicas`
+
+The number of standby replicas. Standby replicas are shadow copies of tables. ksqlDB, through Kafka Streams, attempts to create the specified number of replicas and keep them up to date as long as there are enough instances running. Standby replicas are used to minimize the latency of failover. A table that was previously hosted on a failed instance is preferred to restart on an instance that has standby replicas so that the local state store restoration process from its changelog can be minimized.
 
 ## `ksql.streams.num.stream.threads`
 

--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -469,7 +469,9 @@ and
 
 ## `ksql.streams.num.standby.replicas`
 
-The number of standby replicas. Standby replicas are shadow copies of tables. ksqlDB, through {{ site.kstreams }}, attempts to create the specified number of replicas and keep them up to date as long as there are enough instances running. Standby replicas are used to minimize the latency of failover. A table that was previously hosted on a failed instance is preferred to restart on an instance that has standby replicas so that the local state store restoration process from its changelog can be minimized.
+Sets the number of hot-standby replicas of internal state to maintain. If a server fails and a standby replica is present, the standby will be able to immediately take over active processing for any of the failed server's tasks. Additionally, if [High Availability](../operate-and-deploy/high-availability) is enabled, and a server is offline, pull queries for its tasks can fail over to the standby replicas.
+
+Therefore, configuring standbys enables you to minimize the recovery time for both stream processing and pull queries in the event of a failure. Note that, regardless of the configuration value, ksqlDB can only provision one replica on each server, so you need at least two servers in the cluster to provision an active replica and a standby replica, for example.
 
 ## `ksql.streams.num.stream.threads`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - Logging: operate-and-deploy/logging.md
       - Monitoring: operate-and-deploy/monitoring.md
       - Exactly once semantics: operate-and-deploy/exactly-once-semantics.md
+      - High availability: operate-and-deploy/high-availability.md
       - Schema Registry integration: operate-and-deploy/schema-registry-integration.md
       - Plan Capacity: operate-and-deploy/capacity-planning.md
       - Performance Guidelines: operate-and-deploy/performance-guidelines.md


### PR DESCRIPTION
Adds a new section for HA, primarily pulling from https://www.confluent.io/blog/ksqldb-pull-queries-high-availability/
