### PR TITLE
feat: define how DATE data is formatted

### DIFF
--- a/ksqldb-engine-common/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksqldb-engine-common/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -299,7 +299,7 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
             .put(key(DOUBLE, DOUBLE), Coercer.PASS_THROUGH)
             // STRING:
             .put(key(STRING, STRING), Coercer.PASS_THROUGH)
-            .put(key(STRING, TIMESTAMP), parser((v, t) -> SqlTimestamps.parseTimestamp(v)))
+            .put(key(STRING, TIMESTAMP), parser((v, t) -> SqlTimeTypes.parseTimestamp(v)))
             // ARRAY:
             .put(key(ARRAY, ARRAY), coercer(
                 DefaultSqlValueCoercer::canCoerceToArray,
@@ -343,7 +343,7 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
             .put(key(STRING, DOUBLE), parser((v, t) -> SqlDoubles.parseDouble(v)))
             // TIMESTAMP:
             .put(key(TIMESTAMP, STRING), coercer((c, v, t)
-                -> Result.of(SqlTimestamps.formatTimestamp((Timestamp) v))))
+                -> Result.of(SqlTimeTypes.formatTimestamp((Timestamp) v))))
             .build();
 
     private static Coercer parser(final BiFunction<String, SqlType, Object> parserFunction) {

--- a/ksqldb-engine-common/src/main/java/io/confluent/ksql/schema/ksql/SqlTimeTypes.java
+++ b/ksqldb-engine-common/src/main/java/io/confluent/ksql/schema/ksql/SqlTimeTypes.java
@@ -17,20 +17,23 @@ package io.confluent.ksql.schema.ksql;
 
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.timestamp.PartialStringToTimestampParser;
+import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Helpers for working with SQL time types.
  */
-public final class SqlTimestamps {
+public final class SqlTimeTypes {
 
   private static PartialStringToTimestampParser PARSER = new PartialStringToTimestampParser();
 
-  private SqlTimestamps() {
+  private SqlTimeTypes() {
   }
 
   /**
@@ -54,5 +57,9 @@ public final class SqlTimestamps {
 
   public static String formatTime(final Time time) {
     return LocalTime.ofSecondOfDay(time.getTime() / 1000).toString();
+  }
+
+  public static String formatDate(final Date date) {
+    return LocalDate.ofEpochDay(TimeUnit.MILLISECONDS.toDays(date.getTime())).toString();
   }
 }

--- a/ksqldb-engine-common/src/test/java/io/confluent/ksql/schema/ksql/SqlTimeTypesTest.java
+++ b/ksqldb-engine-common/src/test/java/io/confluent/ksql/schema/ksql/SqlTimeTypesTest.java
@@ -20,31 +20,38 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 import io.confluent.ksql.util.KsqlException;
+import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import org.junit.Test;
 
-public class SqlTimestampsTest {
+public class SqlTimeTypesTest {
   @Test
   public void shouldParseTimestamp() {
-    assertThat(SqlTimestamps.parseTimestamp("2019-03-17T10:00:00"), is(new Timestamp(1552816800000L)));
-    assertThat(SqlTimestamps.parseTimestamp("2019-03-17T03:00-0700"), is(new Timestamp(1552816800000L)));
+    assertThat(SqlTimeTypes.parseTimestamp("2019-03-17T10:00:00"), is(new Timestamp(1552816800000L)));
+    assertThat(SqlTimeTypes.parseTimestamp("2019-03-17T03:00-0700"), is(new Timestamp(1552816800000L)));
   }
 
   @Test
   public void shouldNotParseTimestamp() {
-    assertThrows(KsqlException.class, () -> SqlTimestamps.parseTimestamp("abc"));
-    assertThrows(KsqlException.class, () -> SqlTimestamps.parseTimestamp("2019-03-17 03:00"));
+    assertThrows(KsqlException.class, () -> SqlTimeTypes.parseTimestamp("abc"));
+    assertThrows(KsqlException.class, () -> SqlTimeTypes.parseTimestamp("2019-03-17 03:00"));
   }
 
   @Test
   public void shouldFormatTimestamp() {
-    assertThat(SqlTimestamps.formatTimestamp(new Timestamp(1552816800000L)), is("2019-03-17T10:00:00.000"));
+    assertThat(SqlTimeTypes.formatTimestamp(new Timestamp(1552816800000L)), is("2019-03-17T10:00:00.000"));
   }
 
   @Test
   public void shouldFormatTime() {
-    assertThat(SqlTimestamps.formatTime(new Time(1000)), is("00:00:01"));
-    assertThat(SqlTimestamps.formatTime(new Time(1005)), is("00:00:01"));
+    assertThat(SqlTimeTypes.formatTime(new Time(1000)), is("00:00:01"));
+    assertThat(SqlTimeTypes.formatTime(new Time(1005)), is("00:00:01"));
+  }
+
+  @Test
+  public void shouldFormatDate() {
+    assertThat(SqlTimeTypes.formatDate(new Date(864000000)), is("1970-01-11"));
+    assertThat(SqlTimeTypes.formatDate(new Date(864000000 - 10)), is("1970-01-10"));
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
 import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -527,6 +528,11 @@ public final class ExpressionTreeRewriter<C> {
 
     @Override
     public Expression visitTimeLiteral(final TimeLiteral node, final C context) {
+      return plugin.apply(node, new Context<>(context, this)).orElse(node);
+    }
+
+    @Override
+    public Expression visitDateLiteral(final DateLiteral node, final C context) {
       return plugin.apply(node, new Context<>(context, this)).orElse(node);
     }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
 import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -76,6 +77,7 @@ import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.util.KsqlParserTestUtil;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.List;
@@ -101,6 +103,7 @@ public class ExpressionTreeRewriterTest {
       new NullLiteral(),
       new DecimalLiteral(BigDecimal.ONE),
       new TimeLiteral(new Time(1000L)),
+      new DateLiteral(new Date(864000000L)),
       new TimestampLiteral(new Timestamp(0))
   );
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
 import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -95,7 +96,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlBooleans;
 import io.confluent.ksql.schema.ksql.SqlDoubles;
-import io.confluent.ksql.schema.ksql.SqlTimestamps;
+import io.confluent.ksql.schema.ksql.SqlTimeTypes;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
@@ -163,7 +164,7 @@ public class SqlToJavaVisitor {
       InListEvaluator.class.getCanonicalName(),
       SqlDoubles.class.getCanonicalName(),
       SqlBooleans.class.getCanonicalName(),
-      SqlTimestamps.class.getCanonicalName()
+      SqlTimeTypes.class.getCanonicalName()
   );
 
   private static final Map<Operator, String> DECIMAL_OPERATOR_NAME = ImmutableMap
@@ -343,6 +344,14 @@ public class SqlToJavaVisitor {
         final Context context
     ) {
       return new Pair<>(node.toString(), SqlTypes.TIME);
+    }
+
+    @Override
+    public Pair<String, SqlType> visitDateLiteral(
+        final DateLiteral node,
+        final Context context
+    ) {
+      return new Pair<>(node.toString(), SqlTypes.DATE);
     }
 
     @Override
@@ -725,7 +734,7 @@ public class SqlToJavaVisitor {
         case TIMESTAMP:
           return "%" + index + "$s";
         case STRING:
-          return "SqlTimestamps.parseTimestamp(%" + index + "$s)";
+          return "SqlTimeTypes.parseTimestamp(%" + index + "$s)";
         default:
           throw new KsqlException("Unexpected comparison to TIMESTAMP: " + schema.baseType());
       }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/CastEvaluator.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/CastEvaluator.java
@@ -89,7 +89,7 @@ public final class CastEvaluator {
       .put(key(STRING, BIGINT), nonNullSafeCode("Long.parseLong(%s.trim())"))
       .put(key(STRING, DECIMAL), CastEvaluator::castToDecimal)
       .put(key(STRING, DOUBLE), nonNullSafeCode("SqlDoubles.parseDouble(%s.trim())"))
-      .put(key(STRING, TIMESTAMP), nonNullSafeCode("SqlTimestamps.parseTimestamp(%s.trim())"))
+      .put(key(STRING, TIMESTAMP), nonNullSafeCode("SqlTimeTypes.parseTimestamp(%s.trim())"))
       // ARRAY:
       .put(key(ARRAY, ARRAY), CastEvaluator::castArrayToArray)
       .put(key(ARRAY, STRING), CastEvaluator::castToString)
@@ -100,7 +100,7 @@ public final class CastEvaluator {
       .put(key(STRUCT, STRUCT), CastEvaluator::castStructToStruct)
       .put(key(STRUCT, STRING), CastEvaluator::castToString)
       // TIMESTAMP:
-      .put(key(TIMESTAMP, STRING), nonNullSafeCode("SqlTimestamps.formatTimestamp(%s)"))
+      .put(key(TIMESTAMP, STRING), nonNullSafeCode("SqlTimeTypes.formatTimestamp(%s)"))
       .build();
 
   private CastEvaluator() {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
 import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -59,7 +60,7 @@ import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
 import io.confluent.ksql.name.Name;
-import io.confluent.ksql.schema.ksql.SqlTimestamps;
+import io.confluent.ksql.schema.ksql.SqlTimeTypes;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.List;
@@ -191,12 +192,17 @@ public final class ExpressionFormatter {
 
     @Override
     public String visitTimeLiteral(final TimeLiteral node, final Context context) {
-      return SqlTimestamps.formatTime(node.getValue());
+      return SqlTimeTypes.formatTime(node.getValue());
+    }
+
+    @Override
+    public String visitDateLiteral(final DateLiteral node, final Context context) {
+      return SqlTimeTypes.formatDate(node.getValue());
     }
 
     @Override
     public String visitTimestampLiteral(final TimestampLiteral node, final Context context) {
-      return SqlTimestamps.formatTimestamp(node.getValue());
+      return SqlTimeTypes.formatTimestamp(node.getValue());
     }
 
     @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DateLiteral.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DateLiteral.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.expression.tree;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.NodeLocation;
+import java.sql.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class DateLiteral extends Literal {
+
+  private final long value;
+
+  public DateLiteral(final Date value) {
+    this(Optional.empty(), value);
+  }
+
+  public DateLiteral(final Optional<NodeLocation> location, final Date value) {
+    super(location);
+    this.value = requireNonNull(value, "value").getTime();
+  }
+
+  @Override
+  public Date getValue() {
+    return new Date(value);
+  }
+
+  @Override
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
+    return visitor.visitDateLiteral(this, context);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final DateLiteral that = (DateLiteral) o;
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(value);
+  }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
@@ -81,6 +81,8 @@ public interface ExpressionVisitor<R, C> {
 
   R visitTimeLiteral(TimeLiteral exp, C context);
 
+  R visitDateLiteral(DateLiteral exp, C context);
+
   R visitTimestampLiteral(TimestampLiteral exp, C context);
 
   R visitType(Type exp, C context);

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
@@ -189,6 +189,11 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
   }
 
   @Override
+  public Void visitDateLiteral(final DateLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
   public Void visitTimestampLiteral(final TimestampLiteral node, final C context) {
     return null;
   }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
@@ -77,6 +77,11 @@ public abstract class VisitParentExpressionVisitor<R, C> implements ExpressionVi
   }
 
   @Override
+  public R visitDateLiteral(final DateLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
   public R visitTimestampLiteral(final TimestampLiteral node, final C context) {
     return visitLiteral(node, context);
   }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/CastInterpreter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/CastInterpreter.java
@@ -22,7 +22,7 @@ import io.confluent.ksql.execution.interpreter.terms.CastTerm.ComparableCastFunc
 import io.confluent.ksql.execution.interpreter.terms.Term;
 import io.confluent.ksql.schema.ksql.SqlBooleans;
 import io.confluent.ksql.schema.ksql.SqlDoubles;
-import io.confluent.ksql.schema.ksql.SqlTimestamps;
+import io.confluent.ksql.schema.ksql.SqlTimeTypes;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
@@ -180,7 +180,7 @@ public final class CastInterpreter {
     if (from.baseType() == SqlBaseType.DECIMAL) {
       return object -> ((BigDecimal) object).toPlainString();
     } else if (from.baseType() == SqlBaseType.TIMESTAMP) {
-      return object -> SqlTimestamps.formatTimestamp(((Timestamp) object));
+      return object -> SqlTimeTypes.formatTimestamp(((Timestamp) object));
     }
     return object -> config.getBoolean(KsqlConfig.KSQL_STRING_CASE_CONFIG_TOGGLE)
         ? Objects.toString(object, null)
@@ -202,7 +202,7 @@ public final class CastInterpreter {
       final SqlType from
   ) {
     if (from.baseType() == SqlBaseType.STRING) {
-      return object -> SqlTimestamps.parseTimestamp(((String) object).trim());
+      return object -> SqlTimeTypes.parseTimestamp(((String) object).trim());
     } else if (from.baseType() == SqlBaseType.TIMESTAMP) {
       return object -> (Timestamp) object;
     }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
 import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -222,6 +223,14 @@ public class TermCompiler implements ExpressionVisitor<Term, Context> {
       final Context context
   ) {
     return visitUnsupported(timeLiteral);
+  }
+
+  @Override
+  public Term visitDateLiteral(
+      final DateLiteral dateLiteral,
+      final Context context
+  ) {
+    return visitUnsupported(dateLiteral);
   }
 
   @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
 import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -574,6 +575,14 @@ public class ExpressionTypeManager {
         final TimeLiteral timeLiteral, final Context context
     ) {
       context.setSqlType(SqlTypes.TIME);
+      return null;
+    }
+
+    @Override
+    public Void visitDateLiteral(
+        final DateLiteral dateLiteral, final Context context
+    ) {
+      context.setSqlType(SqlTypes.DATE);
       return null;
     }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/Literals.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/Literals.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.util;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
@@ -27,6 +28,7 @@ import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.function.Function;
@@ -47,6 +49,7 @@ public final class Literals {
           .put(SqlBaseType.DOUBLE, v -> new DoubleLiteral((Double) v))
           .put(SqlBaseType.STRING, v -> new StringLiteral((String) v))
           .put(SqlBaseType.TIME, v -> new TimeLiteral((Time) v))
+          .put(SqlBaseType.DATE, v -> new DateLiteral((Date) v))
           .put(SqlBaseType.TIMESTAMP, v -> new TimestampLiteral((Timestamp) v))
           .build();
 

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -848,7 +848,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(COL10.compareTo(SqlTimestamps.parseTimestamp(\"2020-01-01T00:00:00\")) == 0)"));
+    assertThat(java, containsString("(COL10.compareTo(SqlTimeTypes.parseTimestamp(\"2020-01-01T00:00:00\")) == 0)"));
   }
 
   @Test
@@ -864,7 +864,7 @@ public class SqlToJavaVisitorTest {
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(SqlTimestamps.parseTimestamp(\"2020-01-01T00:00:00\").compareTo(COL10) >= 0)"));
+    assertThat(java, containsString("(SqlTimeTypes.parseTimestamp(\"2020-01-01T00:00:00\").compareTo(COL10) >= 0)"));
   }
 
   @Test

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
 import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -71,6 +72,7 @@ import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Collections;
@@ -172,6 +174,11 @@ public class ExpressionFormatterTest {
   @Test
   public void shouldFormatTimeLiteral() {
     assertThat(ExpressionFormatter.formatExpression(new TimeLiteral(new Time(10000))), equalTo("00:00:10"));
+  }
+
+  @Test
+  public void shouldFormatDateLiteral() {
+    assertThat(ExpressionFormatter.formatExpression(new DateLiteral(new Date(864000000))), equalTo("1970-01-11"));
   }
 
   @Test

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
 import io.confluent.ksql.execution.expression.tree.CreateMapExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
+import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
@@ -89,6 +90,7 @@ import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
+import java.sql.Date;
 import java.sql.Time;
 import java.util.Optional;
 import org.hamcrest.Matchers;
@@ -1060,6 +1062,11 @@ public class ExpressionTypeManagerTest {
   @Test
   public void shouldProcessTimeLiteral() {
     assertThat(expressionTypeManager.getExpressionSqlType(new TimeLiteral(new Time(1000))), is(SqlTypes.TIME));
+  }
+
+  @Test
+  public void shouldProcessDateLiteral() {
+    assertThat(expressionTypeManager.getExpressionSqlType(new DateLiteral(new Date(86400000))), is(SqlTypes.DATE));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Adds the DateLiteral class and define DATE expressions to be formatted as yyyy-MM-dd. Also renames `SqlTimestamps` to `SqlTimeTypes`

### Testing done 
unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

