### PR TITLE
fix: dont incorrectly log events for each pull query

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -218,9 +218,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
 
     final PreparedStatement<?> statement = parseStatement(request);
 
-    // log validated statements for query anonymization
-    QueryLogger.info("Transient query created", statement.getStatementText());
-
     CommandStoreUtil.httpWaitForCommandSequenceNumber(
         commandQueue, request, commandQueueCatchupTimeout);
 
@@ -282,6 +279,10 @@ public class StreamedQueryResource implements KsqlConfigurable {
               metricsCallbackHolder
           );
         }
+
+        // log validated statements for query anonymization
+        QueryLogger.info("Transient query created", statement.getStatementText());
+
         if (ScalablePushUtil.isScalablePushQuery(statement.getStatement(), ksqlEngine, ksqlConfig,
             configProperties)) {
           return handleScalablePushQuery(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -368,7 +368,26 @@ public class StreamedQueryResourceTest {
   }
 
   @Test
-  public void queryLoggerShouldReceiveStatementsWhenHandleKsqlStatement() {
+  public void queryLoggerShouldReceiveStatementsWhenHandlePushQuery() {
+    when(mockStatementParser.<Query>parseSingleStatement(PUSH_QUERY_STRING))
+        .thenReturn(query);
+    try (MockedStatic<QueryLogger> logger = Mockito.mockStatic(QueryLogger.class)) {
+      testResource.streamQuery(
+          securityContext,
+          new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), Collections.emptyMap(), null),
+          new CompletableFuture<>(),
+          Optional.empty(),
+          KsqlMediaType.LATEST_FORMAT,
+          new MetricsCallbackHolder(),
+          context);
+
+      logger.verify(() -> QueryLogger.info("Transient query created",
+          PUSH_QUERY_STRING), times(1));
+    }
+  }
+
+  @Test
+  public void queryLoggerShouldNotReceiveStatementsWhenHandlePullQuery() {
     try (MockedStatic<QueryLogger> logger = Mockito.mockStatic(QueryLogger.class)) {
       testResource.streamQuery(
           securityContext,
@@ -380,7 +399,7 @@ public class StreamedQueryResourceTest {
           context);
 
       logger.verify(() -> QueryLogger.info("Transient query created",
-          PULL_QUERY_STRING), times(1));
+          PULL_QUERY_STRING), never());
     }
   }
 


### PR DESCRIPTION
### Description 

We were logging `Transient query created` each time a pull query was issued incorrectly. This fixes that issue

### Testing done 

Set a debugger and issued a pull query.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

