### PR TITLE
docs: fix accidental commas and add extre note to GRACE PERIOD syntax

### DIFF
--- a/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
+++ b/docs/developer-guide/ksqldb-reference/create-stream-as-select.md
@@ -19,7 +19,7 @@ CREATE [OR REPLACE] STREAM stream_name
   FROM from_stream
   [[ LEFT | FULL | INNER ]
       JOIN [join_table | join_stream]
-          [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [, GRACE PERIOD <grace_size> <timeunit>]]
+          [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [GRACE PERIOD <grace_size> <timeunit>]]
       ON join_criteria]*
   [ WHERE condition ]
   [PARTITION BY column_name]

--- a/docs/developer-guide/ksqldb-reference/insert-into.md
+++ b/docs/developer-guide/ksqldb-reference/insert-into.md
@@ -18,7 +18,7 @@ INSERT INTO stream_name
   FROM from_stream
   [ LEFT | FULL | INNER ]
       JOIN [join_table | join_stream]
-        [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [, GRACE PERIOD <grace_size> <timeunit>]]
+        [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [GRACE PERIOD <grace_size> <timeunit>]]
       ON join_criteria
   [ WHERE condition ]
   [ PARTITION BY new_key_expr [, ...] ]

--- a/docs/developer-guide/ksqldb-reference/quick-reference.md
+++ b/docs/developer-guide/ksqldb-reference/quick-reference.md
@@ -170,7 +170,7 @@ CREATE STREAM stream_name
   FROM from_stream
   [[ LEFT | FULL | INNER ]
     JOIN [join_table | join_stream]
-      [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [, GRACE PERIOD <grace_size> <timeunit>]]
+      [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [GRACE PERIOD <grace_size> <timeunit>]]
     ON join_criteria]*
   [ WHERE condition ]
   [PARTITION BY new_key_expr [, ...]]
@@ -372,7 +372,7 @@ INSERT INTO stream_name
   FROM from_stream
   [ LEFT | FULL | INNER ]
       JOIN [join_table | join_stream]
-        [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [, GRACE PERIOD <grace_size> <timeunit>]]
+        [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [GRACE PERIOD <grace_size> <timeunit>]]
       ON join_criteria
   [ WHERE condition ]
   [ PARTITION BY new_key_expr [, ...] ]
@@ -490,7 +490,7 @@ SELECT select_expr [, ...]
   FROM from_item
   [[ LEFT | FULL | INNER ]
       JOIN join_item
-        [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [, GRACE PERIOD <grace_size> <timeunit>]]
+        [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [GRACE PERIOD <grace_size> <timeunit>]]
       ON join_criteria]*
   [ WINDOW window_expression ]
   [ WHERE condition ]

--- a/docs/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-push-query.md
@@ -17,7 +17,7 @@ SELECT select_expr [, ...]
   FROM from_item
   [[ LEFT | FULL | INNER ]
     JOIN join_item
-        [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [, GRACE PERIOD <grace_size> <timeunit>]]
+        [WITHIN [<size> <timeunit> | (<before_size> <timeunit>, <after_size> <timeunit>)] [GRACE PERIOD <grace_size> <timeunit>]]
     ON join_criteria]*
   [ WINDOW window_expression ]
   [ WHERE where_condition ]
@@ -218,14 +218,20 @@ the order was placed, and shipped within 2 hours of the payment being received.
         INNER JOIN shipments s WITHIN 2 HOURS ON s.id = o.id;
 ```
 
-The GRACE PERIOD, part of the WITHIN clause, allows the join to process late records for up
+The GRACE PERIOD, part of the WITHIN clause, allows the join to process out-of-order records for up
 to the specified grace period. Events that arrive after the grace period has passed are dropped
-and not joined with older records.
+as _late_ record and not joined.
 
-The default grace period, if not used in the join, is 24 hours. This could cause a huge amount
-of disk usage on high-throughput streams. Setting a specific GRACE PERIOD is recommended to
-
+The default grace period, i.e., if no explicitly specified, is 24 hours. This could cause a huge
+amount of disk usage on high-throughput streams. Setting a specific GRACE PERIOD is recommended to
 reduce high disk usage.
+
+!!! note
+    If you specify a GRACE PERIOD for left/outer joins, the grace period define when left/outer
+    join result will be emitted. If you don't specify a GRACE PERIOD for left/outer joins,
+    left/outer join results are emitted eagerly, what may lead to "spurious" result records. Thus,
+    it's highly recommended to specify a GRACE PERIOD. For this reason, we plan to make
+    GRACE PERIOD a mandatory clause in the future.
 
 ```sql
    CREATE STREAM shipped_orders AS

--- a/docs/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-push-query.md
@@ -222,16 +222,20 @@ The GRACE PERIOD, part of the WITHIN clause, allows the join to process out-of-o
 to the specified grace period. Events that arrive after the grace period has passed are dropped
 as _late_ record and not joined.
 
-The default grace period, i.e., if no explicitly specified, is 24 hours. This could cause a huge
+If you don't specify it explicitly, the default grace period is 24 hours. This could cause a huge
+
 amount of disk usage on high-throughput streams. Setting a specific GRACE PERIOD is recommended to
 reduce high disk usage.
 
 !!! note
-    If you specify a GRACE PERIOD for left/outer joins, the grace period define when left/outer
-    join result will be emitted. If you don't specify a GRACE PERIOD for left/outer joins,
-    left/outer join results are emitted eagerly, what may lead to "spurious" result records. Thus,
-    it's highly recommended to specify a GRACE PERIOD. For this reason, we plan to make
-    GRACE PERIOD a mandatory clause in the future.
+    If you specify a GRACE PERIOD for left/outer joins, the grace period defines when the left/outer
+
+    join result is emitted. If you don't specify a GRACE PERIOD for left/outer joins,
+
+    left/outer join results are emitted eagerly, which may cause "spurious" result records, so
+
+    we recommended that you specify a GRACE PERIOD.
+
 
 ```sql
    CREATE STREAM shipped_orders AS

--- a/docs/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-push-query.md
@@ -220,12 +220,11 @@ the order was placed, and shipped within 2 hours of the payment being received.
 
 The GRACE PERIOD, part of the WITHIN clause, allows the join to process out-of-order records for up
 to the specified grace period. Events that arrive after the grace period has passed are dropped
-as _late_ record and not joined.
+as _late_ records and not joined.
 
-If you don't specify it explicitly, the default grace period is 24 hours. This could cause a huge
-
-amount of disk usage on high-throughput streams. Setting a specific GRACE PERIOD is recommended to
-reduce high disk usage.
+If you don't specify a grace period explicitly, the default grace period is 24 hours. This could
+cause a huge amount of disk usage on high-throughput streams. Setting a specific GRACE PERIOD is
+recommended to reduce high disk usage.
 
 !!! note
     If you specify a GRACE PERIOD for left/outer joins, the grace period defines when the left/outer


### PR DESCRIPTION
### Description 
Fix some accidental commas left from PR https://github.com/confluentinc/ksql/pull/7687. Also add a new note when using GRACE PERIOD syntax for left/outer joins.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

