### PR TITLE
fix: enable time unit functions for interpreter

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlParserTestUtil;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -148,6 +149,7 @@ public class ExpressionEvaluatorParityTest {
   public void shouldDoUdfs() throws Exception {
     assertOrders("CONCAT('abc-', 'def')", "abc-def");
     assertOrders("SPLIT('a-b-c', '-')", ImmutableList.of("a", "b", "c"));
+    assertOrders("TIMESTAMPADD(SECONDS, 1, '2020-01-01')", new Timestamp(1577836801000L));
     assertOrdersError("SPLIT(123, '2')",
         compileTime("Function 'split' does not accept parameters (INTEGER, STRING)"),
         compileTime("Function 'split' does not accept parameters (INTEGER, STRING)"));

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
@@ -303,7 +303,7 @@ public class TermCompiler implements ExpressionVisitor<Term, Context> {
 
   @Override
   public Term visitIntervalUnit(final IntervalUnit exp, final Context context) {
-    return visitUnsupported(exp);
+    return LiteralTerms.of(exp.getUnit());
   }
 
   @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LiteralTerms.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LiteralTerms.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public final class LiteralTerms {
@@ -52,6 +53,10 @@ public final class LiteralTerms {
 
   public static Term of(final Timestamp value) {
     return new TimestampTermImpl(value);
+  }
+
+  public static Term of(final TimeUnit value) {
+    return new IntervalUnitTermImpl(value);
   }
 
   public static NullTerm ofNull() {
@@ -207,6 +212,25 @@ public final class LiteralTerms {
     @Override
     public SqlType getSqlType() {
       return SqlTypes.TIMESTAMP;
+    }
+  }
+
+  public static class IntervalUnitTermImpl implements Term {
+
+    private final TimeUnit value;
+
+    public IntervalUnitTermImpl(final TimeUnit timeUnit) {
+      this.value = timeUnit;
+    }
+
+    @Override
+    public Object getValue(final TermEvaluationContext context) {
+      return value;
+    }
+
+    @Override
+    public SqlType getSqlType() {
+      return null;
     }
   }
 }


### PR DESCRIPTION
### Description 
Fixes #7512. Implements `visitIntervalUnit ` in `TermCompiler`.

### Testing done 
Added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

