### PR TITLE
chore: bump protobuf version to 3.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <csv.version>1.4</csv.version>
         <lang3.version>3.3.1</lang3.version>
         <guava.version>24.1.1-jre</guava.version>
-        <protobuf.version>3.11.1</protobuf.version>
+        <protobuf.version>3.17.0</protobuf.version>
         <retrying.version>2.0.0</retrying.version>
         <inject.version>1</inject.version>
         <janino.version>3.0.7</janino.version>


### PR DESCRIPTION
### Description 
protobuf version was bumped in schema registry, so we're seeing test failures with errors such as

```
java.lang.NoSuchMethodError: com.google.protobuf.DescriptorProtos$FieldDescriptorProto$Builder.setProto3Optional(Z)
```

meaning that there are some functions in 3.17.0 that SR uses that the current version doesnt have. 

see #7710 

### Testing done 
Master build passes locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

