### PR TITLE
fix: Fixes slow streams shut down bug which made tests flaky

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -337,11 +337,11 @@ public class QueryMetadataImpl implements QueryMetadata {
 
   void doClose(final boolean cleanUp) {
     closed = true;
-    boolean closed = closeKafkaStreams();
+    final boolean closedKafkaStreams = closeKafkaStreams();
 
-    if (cleanUp && closed) {
+    if (cleanUp && closedKafkaStreams) {
       kafkaStreams.cleanUp();
-    } else if (!closed) {
+    } else if (!closedKafkaStreams) {
       LOG.warn("Query has not successfully closed, skipping cleanup");
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedPersistentQueryMetadataImpl.java
@@ -46,7 +46,8 @@ public final class SandboxedPersistentQueryMetadataImpl extends PersistentQueryM
   }
 
   @Override
-  protected void closeKafkaStreams() {
+  protected boolean closeKafkaStreams() {
     // no-op
+    return true;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -186,6 +186,20 @@ public class QueryMetadataTest {
   }
 
   @Test
+  public void shouldSkipCleanUpKStreamsAppAfterCloseOnCloseIfRunning() {
+    // Given:
+    when(kafkaStreams.state()).thenReturn(State.RUNNING);
+
+    // When:
+    query.close();
+
+    // Then:
+    final InOrder inOrder = inOrder(kafkaStreams);
+    inOrder.verify(kafkaStreams).close(Duration.ofMillis(closeTimeout));
+    inOrder.verify(kafkaStreams, never()).cleanUp();
+  }
+
+  @Test
   public void shouldReturnSources() {
     assertThat(query.getSourceNames(), is(SOME_SOURCES));
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -466,6 +466,7 @@ public class CommandRunner implements Closeable {
         );
         closeEarly();
       } finally {
+        LOG.info("Closing command store");
         commandStore.close();
       }
     }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -95,7 +95,6 @@ import org.slf4j.LoggerFactory;
  * <p>For tests on general syntax and handled see RestQueryTranslationTest's
  * materialized-aggregate-static-queries.json
  */
-@Ignore
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 @Category({IntegrationTest.class})
 public class PullQueryRoutingFunctionalTest {
@@ -456,7 +455,7 @@ public class PullQueryRoutingFunctionalTest {
     waitForRemoteServerToChangeStatus(clusterFormation.router.getApp(),
         clusterFormation.router.getHost(),
         HighAvailabilityTestUtil.lagsReported(clusterFormation.standBy.getHost(),
-            Optional.empty(), 5),
+            Optional.of(5L), 5),
         USER_CREDS);
 
     // Cut off standby from Kafka to simulate lag
@@ -475,7 +474,7 @@ public class PullQueryRoutingFunctionalTest {
     // Make sure that the lags get reported before we kill active
     waitForRemoteServerToChangeStatus(clusterFormation.router.getApp(),
         clusterFormation.router.getHost(),
-        HighAvailabilityTestUtil.lagsReported(clusterFormation.active.getHost(), Optional.empty(),
+        HighAvailabilityTestUtil.lagsReported(clusterFormation.active.getHost(), Optional.of(10L),
             10),
         USER_CREDS);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -227,7 +227,7 @@ public class PullQueryRoutingFunctionalTest {
 
   @Rule
   public final Timeout timeout = Timeout.builder()
-      .withTimeout(1, TimeUnit.MINUTES)
+      .withTimeout(2, TimeUnit.MINUTES)
       .withLookingForStuckThread(true)
       .build();
 


### PR DESCRIPTION
### Description 
Fixes flaky test `PullQueryRoutingFunctionalTest`.  The symptom of the flakiness was the failure:

```
io.confluent.ksql.rest.integration.PullQueryRoutingFunctionalTest.shouldFilterLaggyServers
Error Message
error msg: Timed out while waiting for a previous command to execute. command sequence number: 14
Stacktrace
java.lang.UnsupportedOperationException: error msg: Timed out while waiting for a previous command to execute. command sequence number: 14
	at io.confluent.ksql.rest.integration.PullQueryRoutingFunctionalTest.cleanUp(PullQueryRoutingFunctionalTest.java:287)
```

After a lot of investigation, I noticed that `SequenceNumberFutureStore.completeFuturesUpToAndIncludingSequenceNumber` was never being called in rare scenarios, causing the future to never complete.  It turns out that the `CommandStore` was being closed, which was due to the line here in `CommandRunner`: https://github.com/confluentinc/ksql/blob/master/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java#L469.

This was ultimately caused by an exception:
```
[2021-06-22 18:08:13,927] WARN query has not terminated even after close. This may happen when streams threads are hung. State: PENDING_SHUTDOWN (io.confluent.ksql.util.QueryMetadataImpl:315)
java.lang.IllegalStateException: Cannot clean up while running.
	at org.apache.kafka.streams.KafkaStreams.cleanUp(KafkaStreams.java:1439)
	at io.confluent.ksql.util.QueryMetadataImpl.doClose(QueryMetadataImpl.java:338)
	at io.confluent.ksql.util.QueryMetadataImpl.close(QueryMetadataImpl.java:329)
```

This PR avoids the cleanup if the `KafkaStreams` doesn't close correctly.

### Testing done 
Ran `PullQueryRoutingFunctionalTest` a zillion times both before the change, reproducing the bug, and after it, not reproducing it.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

