### PR TITLE
fix: fixed nondeterminism in UdfIndex

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -58,8 +58,8 @@ import org.slf4j.LoggerFactory;
  *       arguments.</li>
  *   <li>If two methods exist that match given the above rules, return the
  *       method with fewer generic arguments.</li>
- *   <li>If two methods exist that match given the above rules, an exception
- *       is thrown due to a vague function call</li>
+ *   <li>If two methods exist that match given the above rules, the function
+ *       call is ambiguous and an exception is thrown.</li>
  * </ul>
  */
 public class UdfIndex<T extends FunctionSignature> {
@@ -145,27 +145,27 @@ public class UdfIndex<T extends FunctionSignature> {
   }
 
   T getFunction(final List<SqlArgument> arguments) {
-    final List<Node> candidates = new ArrayList<>();
 
     // first try to get the candidates without any implicit casting
-    Optional<T> candidate = findMatchingCandidate(candidates, arguments, false);
+    Optional<T> candidate = findMatchingCandidate(arguments, false);
     if (candidate.isPresent()) {
       return candidate.get();
     } else if (!supportsImplicitCasts) {
       throw createNoMatchingFunctionException(arguments);
     }
-    candidates.clear();
 
-    //if non were found (candidate isn't present) try again with implicit casting
-    candidate = findMatchingCandidate(candidates, arguments, true);
+    // if none were found (candidate isn't present) try again with implicit casting
+    candidate = findMatchingCandidate(arguments, true);
     if (candidate.isPresent()) {
       return candidate.get();
     }
     throw createNoMatchingFunctionException(arguments);
   }
 
-  private Optional<T> findMatchingCandidate(final List<Node> candidates,
+  private Optional<T> findMatchingCandidate(
       final List<SqlArgument> arguments, final boolean allowCasts) {
+
+    final List<Node> candidates = new ArrayList<>();
 
     getCandidates(arguments, 0, root, candidates, new HashMap<>(), allowCasts);
     candidates.sort(Node::compare);

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -56,8 +56,10 @@ import org.slf4j.LoggerFactory;
  *   <li>If two methods exist that match given the above rules, and both
  *       have variable arguments, return the method with the more non-variable
  *       arguments.</li>
- *   <li>If two methods exist that match only null values, return the one
- *       that was added first.</li>
+ *   <li>If two methods exist that match given the above rules, return the
+ *       method with fewer generic arguments.</li>
+ *   <li>If two methods exist that match given the above rules, an exception
+ *       is thrown due to a vague function call</li>
  * </ul>
  */
 public class UdfIndex<T extends FunctionSignature> {
@@ -112,7 +114,6 @@ public class UdfIndex<T extends FunctionSignature> {
       );
     }
 
-    final int order = allFunctions.size();
 
     Node curr = root;
     Node parent = curr;
@@ -125,14 +126,14 @@ public class UdfIndex<T extends FunctionSignature> {
     if (function.isVariadic()) {
       // first add the function to the parent to address the
       // case of empty varargs
-      parent.update(function, order);
+      parent.update(function);
 
       // then add a new child node with the parameter value type
       // and add this function to that node
       final ParamType varargSchema = Iterables.getLast(parameters);
       final Parameter vararg = new Parameter(varargSchema, true);
       final Node leaf = parent.children.computeIfAbsent(vararg, ignored -> new Node());
-      leaf.update(function, order);
+      leaf.update(function);
 
       // add a self referential loop for varargs so that we can
       // add as many of the same param at the end and still retrieve
@@ -140,33 +141,43 @@ public class UdfIndex<T extends FunctionSignature> {
       leaf.children.putIfAbsent(vararg, leaf);
     }
 
-    curr.update(function, order);
+    curr.update(function);
   }
 
   T getFunction(final List<SqlArgument> arguments) {
     final List<Node> candidates = new ArrayList<>();
 
     // first try to get the candidates without any implicit casting
-    getCandidates(arguments, 0, root, candidates, new HashMap<>(), false);
-    final Optional<T> fun = candidates
-        .stream()
-        .max(Node::compare)
-        .map(node -> node.value);
-
-    if (fun.isPresent()) {
-      return fun.get();
+    Optional<T> candidate = findMatchingCandidate(candidates, arguments, false);
+    if (candidate.isPresent()) {
+      return candidate.get();
     } else if (!supportsImplicitCasts) {
       throw createNoMatchingFunctionException(arguments);
     }
+    candidates.clear();
 
-    // if none were found (candidates is empty) try again with
-    // implicit casting
-    getCandidates(arguments, 0, root, candidates, new HashMap<>(), true);
-    return candidates
-        .stream()
-        .max(Node::compare)
-        .map(node -> node.value)
-        .orElseThrow(() -> createNoMatchingFunctionException(arguments));
+    //if non were found (candidate isn't present) try again with implicit casting
+    candidate = findMatchingCandidate(candidates, arguments, true);
+    if (candidate.isPresent()) {
+      return candidate.get();
+    }
+    throw createNoMatchingFunctionException(arguments);
+  }
+
+  private Optional<T> findMatchingCandidate(final List<Node> candidates,
+      final List<SqlArgument> arguments, final boolean allowCasts) {
+
+    getCandidates(arguments, 0, root, candidates, new HashMap<>(), allowCasts);
+    candidates.sort(Node::compare);
+
+    final int len = candidates.size();
+    if (len == 1) {
+      return Optional.of(candidates.get(0).value);
+    } else if (len > 1 && candidates.get(len - 1).compare(candidates.get(len - 2)) > 0) {
+      return Optional.of(candidates.get(len - 1).value);
+    }
+
+    return Optional.empty();
   }
 
   private void getCandidates(
@@ -273,17 +284,15 @@ public class UdfIndex<T extends FunctionSignature> {
 
     private final Map<Parameter, Node> children;
     private T value;
-    private int order = 0;
 
     private Node() {
       this.children = new HashMap<>();
       this.value = null;
     }
 
-    private void update(final T function, final int order) {
+    private void update(final T function) {
       if (compareFunctions.compare(function, value) > 0) {
         value = function;
-        this.order = order;
       }
     }
 
@@ -307,8 +316,15 @@ public class UdfIndex<T extends FunctionSignature> {
     }
 
     int compare(final Node other) {
-      final int compare = compareFunctions.compare(value, other.value);
-      return compare == 0 ? -(order - other.order) : compare;
+      final int compareVal = compareFunctions.compare(value, other.value);
+      return compareVal == 0 ? countGenerics(other) - countGenerics(this) : compareVal;
+    }
+
+    private int countGenerics(final Node node) {
+      return node.value.parameters().stream()
+          .filter(GenericsUtil::hasGenerics)
+          .mapToInt(p -> 1)
+          .sum();
     }
 
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -177,15 +177,7 @@ public class UdfIndex<T extends FunctionSignature> {
       if (candidates.get(len - 1).compare(candidates.get(len - 2)) > 0) {
         return Optional.of(candidates.get(len - 1).value);
       }
-      throw new KsqlException("Function '" + udfName
-          + "' cannot be resolved due to ambiguous method parameters "
-          + getParamsAsString(arguments) + "."
-          + System.lineSeparator()
-          + "Valid function calls are:"
-          + System.lineSeparator()
-          + getAcceptedTypesAsString()
-          + System.lineSeparator()
-          + "For detailed information on a function run: DESCRIBE FUNCTION <Function-Name>;");
+      throw createVagueImplicitCastException(arguments);
     }
 
     return Optional.empty();
@@ -232,6 +224,21 @@ public class UdfIndex<T extends FunctionSignature> {
     return allFunctions.values().stream()
         .map(UdfIndex::formatAvailableSignatures)
         .collect(Collectors.joining(System.lineSeparator()));
+  }
+
+  private KsqlException createVagueImplicitCastException(final List<SqlArgument> paramTypes) {
+    LOG.debug("Current UdfIndex:\n{}", describe());
+    throw new KsqlException("Function '" + udfName
+        + "' cannot be resolved due to ambiguous method parameters "
+        + getParamsAsString(paramTypes) + "."
+        + System.lineSeparator()
+        + "Use CAST() to explicitly cast your parameters to one of the supported function calls."
+        + System.lineSeparator()
+        + "Valid function calls are:"
+        + System.lineSeparator()
+        + getAcceptedTypesAsString()
+        + System.lineSeparator()
+        + "For detailed information on a function run: DESCRIBE FUNCTION <Function-Name>;");
   }
 
   private KsqlException createNoMatchingFunctionException(final List<SqlArgument> paramTypes) {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -3,6 +3,7 @@ package io.confluent.ksql.function;
 import static io.confluent.ksql.function.KsqlScalarFunction.INTERNAL_PATH;
 import static io.confluent.ksql.function.types.ArrayType.of;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.INTEGER;
+import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
 import static java.lang.System.lineSeparator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -563,35 +564,6 @@ public class UdfIndexTest {
   }
 
   @Test
-  public void shouldChooseFirstAddedWithNullValues() {
-    // Given:
-    givenFunctions(
-        function(EXPECTED, false, STRING),
-        function(OTHER, false, INT)
-    );
-
-    // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Collections.singletonList(null));
-
-    // Then:
-    assertThat(fun.name(), equalTo(EXPECTED));
-  }
-
-  @Test
-  public void shouldFindVarargWithNullValues() {
-    // Given:
-    givenFunctions(
-        function(EXPECTED, true, STRING_VARARGS)
-    );
-
-    // When:
-    final KsqlScalarFunction fun = udfIndex.getFunction(Arrays.asList(new SqlArgument[]{null}));
-
-    // Then:
-    assertThat(fun.name(), equalTo(EXPECTED));
-  }
-
-  @Test
   public void shouldFindVarargWithSomeNullValues() {
     // Given:
     givenFunctions(
@@ -963,6 +935,60 @@ public class UdfIndexTest {
     assertThat(e.getMessage(), containsString("Function 'name' does not accept parameters "
             + "(INTEGER)"));
   }
+
+  @Test
+  public void shouldThrowWhenGivenVagueImplicitCast() {
+    // Given:
+    givenFunctions(
+        function(FIRST_FUNC, false, LONG, LONG),
+        function(SECOND_FUNC, false, DOUBLE, DOUBLE)
+    );
+
+    // When:
+    final Exception e = assertThrows(Exception.class,
+        () -> udfIndex
+            .getFunction(ImmutableList.of(SqlArgument.of(INTEGER), SqlArgument.of(BIGINT))));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Function 'name' does not accept parameters "
+        + "(INTEGER, BIGINT)"));
+  }
+
+  @Test
+  public void shouldFindFewerGenerics() {
+    // Given:
+    givenFunctions(
+        function(EXPECTED, false, INT, GenericType.of("A"), INT),
+        function(OTHER, false, INT, GenericType.of("A"), GenericType.of("B"))
+    );
+
+    // When:
+    final KsqlScalarFunction fun = udfIndex.getFunction(ImmutableList
+        .of(SqlArgument.of(INTEGER), SqlArgument.of(INTEGER), SqlArgument.of(INTEGER)));
+
+    // Then:
+    assertThat(fun.name(), equalTo(EXPECTED));
+  }
+
+  @Test
+  public void shouldThrowOnComparablyEqualFunctionsWithSameGenericCount() {
+    // Given:
+    givenFunctions(
+        function(FIRST_FUNC, false, LONG, GenericType.of("A"), GenericType.of("B")),
+        function(SECOND_FUNC, false, DOUBLE, GenericType.of("A"), GenericType.of("B"))
+    );
+
+    // When:
+    final Exception e = assertThrows(Exception.class,
+        () -> udfIndex
+            .getFunction(ImmutableList
+                .of(SqlArgument.of(INTEGER), SqlArgument.of(INTEGER), SqlArgument.of(INTEGER))));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Function 'name' does not accept parameters "
+        + "(INTEGER, INTEGER, INTEGER)"));
+  }
+
 
   private void givenFunctions(final KsqlScalarFunction... functions) {
     Arrays.stream(functions).forEach(udfIndex::addFunction);

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -950,7 +950,8 @@ public class UdfIndexTest {
             .getFunction(ImmutableList.of(SqlArgument.of(INTEGER), SqlArgument.of(BIGINT))));
 
     // Then:
-    assertThat(e.getMessage(), containsString("Function 'name' does not accept parameters "
+    assertThat(e.getMessage(), containsString("Function 'name' cannot be resolved due " +
+        "to ambiguous method parameters "
         + "(INTEGER, BIGINT)"));
   }
 
@@ -985,10 +986,10 @@ public class UdfIndexTest {
                 .of(SqlArgument.of(INTEGER), SqlArgument.of(INTEGER), SqlArgument.of(INTEGER))));
 
     // Then:
-    assertThat(e.getMessage(), containsString("Function 'name' does not accept parameters "
+    assertThat(e.getMessage(), containsString("Function 'name' cannot be resolved due " +
+        "to ambiguous method parameters "
         + "(INTEGER, INTEGER, INTEGER)"));
   }
-
 
   private void givenFunctions(final KsqlScalarFunction... functions) {
     Arrays.stream(functions).forEach(udfIndex::addFunction);

--- a/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -937,7 +937,7 @@ public class UdfIndexTest {
   }
 
   @Test
-  public void shouldThrowWhenGivenVagueImplicitCast() {
+  public void shouldThrowOnAmbiguousImplicitCastWithoutGenerics() {
     // Given:
     givenFunctions(
         function(FIRST_FUNC, false, LONG, LONG),
@@ -945,7 +945,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final Exception e = assertThrows(Exception.class,
+    final KsqlException e = assertThrows(KsqlException.class,
         () -> udfIndex
             .getFunction(ImmutableList.of(SqlArgument.of(INTEGER), SqlArgument.of(BIGINT))));
 
@@ -971,7 +971,7 @@ public class UdfIndexTest {
   }
 
   @Test
-  public void shouldThrowOnComparablyEqualFunctionsWithSameGenericCount() {
+  public void shouldThrowOnAmbiguousImplicitCastWithGenerics() {
     // Given:
     givenFunctions(
         function(FIRST_FUNC, false, LONG, GenericType.of("A"), GenericType.of("B")),
@@ -979,7 +979,7 @@ public class UdfIndexTest {
     );
 
     // When:
-    final Exception e = assertThrows(Exception.class,
+    final KsqlException e = assertThrows(KsqlException.class,
         () -> udfIndex
             .getFunction(ImmutableList
                 .of(SqlArgument.of(INTEGER), SqlArgument.of(INTEGER), SqlArgument.of(INTEGER))));


### PR DESCRIPTION
### Description 
When working on `LEAST` and `GREATEST` functions, I noticed there was some nondeterminism inside the `UdfIndex` class, specifically with the `order` field, which was intended to give comparably equal functions a final ordering based in the way they were added inside the Udf's class. This wasn't working in practice, and was leading to equally comparable methods that matched a query being selected arbitrarily. For example, when calling `LEAST(INT, LONG)`, several UDFs could be selected: `LEAST(LONG, LONG...)`, `LEAST(DOUBLE, DOUBLE...)`, `LEAST(DECIMAL, DECIMAL)`.

To fix this, `UdfIndex.Node.compare()` was changed to no longer consider `order`. As this change implies we are no longer able to select a matching function if multiple exist, `getFunction` now throws a `KsqlException` if there is more than one equally comparable method that would match the query.

A minor change that was made on top of this is adding to `UdfIndex.Node.compare()` the preference of picking methods with fewer generics as a final comparison.

BREAKING CHANGE: Existing queries that relied on vague implicit casting will not be started after an upgrade, and new queries that rely on vague implicit casting will be rejected.  For example, `foo(INT, INT)` will not be able to resolve against two underlying function signatures of `foo(BIGINT, BIGINT)` and `foo(DOUBLE, DOUBLE)`. Calling a function whose only parameter is variadic with an explicit null will also result in the call being rejected as vague.


### Testing done 
Added to UDFIndexTest negative tests which ensure that queries which would rely on vague implicit casting fail properly.

Some tests that relied on vague implicit casting may need to be removed, this is worth discussion.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")