### PR TITLE
fix: enable KAFKA-10847 bugfix when GRACE PERIOD is used on Joins

### DIFF
--- a/docs/developer-guide/ksqldb-reference/select-push-query.md
+++ b/docs/developer-guide/ksqldb-reference/select-push-query.md
@@ -228,11 +228,8 @@ recommended to reduce high disk usage.
 
 !!! note
     If you specify a GRACE PERIOD for left/outer joins, the grace period defines when the left/outer
-
     join result is emitted. If you don't specify a GRACE PERIOD for left/outer joins,
-
     left/outer join results are emitted eagerly, which may cause "spurious" result records, so
-
     we recommended that you specify a GRACE PERIOD.
 
 

--- a/docs/operate-and-deploy/installation/upgrading.md
+++ b/docs/operate-and-deploy/installation/upgrading.md
@@ -137,6 +137,24 @@ This will stop all processing and delete any internal topics in Kafka.
 
 ## Upgrade notes
 
+### Upgrading from ksqlDB 0.14.0 to 0.20.0
+
+In-place upgrades are supported from ksqlDB 0.14.0 to 0.20.0.
+See the [changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md)
+for potential breaking changes that may affect the behavior or required syntax
+for new queries.
+
+#### Join statements
+
+The GRACE PERIOD clause is now supported in stream-stream joins since 0.20.0. However, when set
+explicitly, the grace period now defines when the left/outer non-joined results are emitted.
+Contrary to the old syntax (without GRACE PERIOD) that emits left/outer non-joined results eagerly,
+which may cause "spurious" result records.
+
+The use of GRACE PERIOD is highly recommended now that it is supported. It helps to reduce high
+disk usage when using small grace period values (default 24 hours if not set) and also provides
+better semantics for left/outer joins.
+
 ### Upgrading from ksqlDB 0.10.0 to 0.14.0
 
 In-place upgrades are supported from ksqlDB 0.10.0 to 0.14.0.

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.util;
 
 import static io.confluent.ksql.configdef.ConfigValidators.zeroOrPositive;
-import static org.apache.kafka.streams.StreamsConfig.InternalConfig.ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -547,12 +546,7 @@ public class KsqlConfig extends AbstractConfig {
           new CompatibilityBreakingStreamsConfig(
               StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG,
               StreamsConfig.OPTIMIZE,
-              StreamsConfig.OPTIMIZE),
-          // Disable KAFKA-10847 for now until grace period is made configurable
-          new CompatibilityBreakingStreamsConfig(
-              ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
-              false,
-              false)
+              StreamsConfig.OPTIMIZE)
   );
 
   private static final class CompatibilityBreakingStreamsConfig {
@@ -563,7 +557,7 @@ public class KsqlConfig extends AbstractConfig {
     CompatibilityBreakingStreamsConfig(final String name, final Object defaultValueLegacy,
         final Object defaultValueCurrent) {
       this.name = Objects.requireNonNull(name);
-      if (!StreamsConfig.configDef().names().contains(name) && !isInternal(name)) {
+      if (!StreamsConfig.configDef().names().contains(name)) {
         throw new IllegalArgumentException(
             String.format("%s is not a valid streams config", name));
       }
@@ -573,10 +567,6 @@ public class KsqlConfig extends AbstractConfig {
 
     String getName() {
       return this.name;
-    }
-
-    private static boolean isInternal(final String name) {
-      return name.equals(ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX);
     }
   }
 

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947957608/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947957608/spec.json
@@ -106,31 +106,11 @@
       "key" : 0,
       "value" : {
         "T_ID" : 0,
-        "TT_ID" : null,
-        "L1" : "A",
-        "L2" : null
-      },
-      "timestamp" : 0
-    }, {
-      "topic" : "OUTER_JOIN",
-      "key" : 0,
-      "value" : {
-        "T_ID" : 0,
         "TT_ID" : 0,
         "L1" : "A",
         "L2" : "a"
       },
       "timestamp" : 60000
-    }, {
-      "topic" : "OUTER_JOIN",
-      "key" : 1,
-      "value" : {
-        "T_ID" : null,
-        "TT_ID" : 1,
-        "L1" : null,
-        "L2" : "b"
-      },
-      "timestamp" : 330000
     }, {
       "topic" : "OUTER_JOIN",
       "key" : 2,

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947957608/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947957608/spec.json
@@ -100,6 +100,13 @@
         "L1" : "D"
       },
       "timestamp" : 60000
+    }, {
+      "topic" : "right_topic",
+      "key" : 4,
+      "value" : {
+        "L2" : "dummy record that emits expired record b"
+      },
+      "timestamp" : 800000
     } ],
     "outputs" : [ {
       "topic" : "OUTER_JOIN",
@@ -151,6 +158,16 @@
         "L2" : null
       },
       "timestamp" : 60000
+    }, {
+      "topic" : "OUTER_JOIN",
+      "key" : 1,
+      "value" : {
+        "T_ID" : null,
+        "TT_ID" : 1,
+        "L1" : null,
+        "L2" : "b"
+      },
+      "timestamp" : 330000
     } ],
     "topics" : [ {
       "name" : "OUTER_JOIN",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947957608/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947957608/topology
@@ -22,10 +22,10 @@ Topologies:
     Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-outer-this-join
       <-- PrependAliasLeft
-    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERSHARED-0000000008-store, KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTERSHARED-0000000008-store, KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957938/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957938/spec.json
@@ -106,31 +106,11 @@
       "key" : 0,
       "value" : {
         "T_ID" : 0,
-        "TT_ID" : null,
-        "L1" : "A",
-        "L2" : null
-      },
-      "timestamp" : 0
-    }, {
-      "topic" : "OUTER_JOIN",
-      "key" : 0,
-      "value" : {
-        "T_ID" : 0,
         "TT_ID" : 0,
         "L1" : "A",
         "L2" : "a"
       },
       "timestamp" : 60000
-    }, {
-      "topic" : "OUTER_JOIN",
-      "key" : 1,
-      "value" : {
-        "T_ID" : null,
-        "TT_ID" : 1,
-        "L1" : null,
-        "L2" : "b"
-      },
-      "timestamp" : 330000
     }, {
       "topic" : "OUTER_JOIN",
       "key" : 2,

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957938/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957938/spec.json
@@ -100,6 +100,13 @@
         "L1" : "D"
       },
       "timestamp" : 60000
+    }, {
+      "topic" : "right_topic",
+      "key" : 4,
+      "value" : {
+        "L2" : "dummy record that emits expired record b"
+      },
+      "timestamp" : 800000
     } ],
     "outputs" : [ {
       "topic" : "OUTER_JOIN",
@@ -151,6 +158,16 @@
         "L2" : null
       },
       "timestamp" : 60000
+    }, {
+      "topic" : "OUTER_JOIN",
+      "key" : 1,
+      "value" : {
+        "T_ID" : null,
+        "TT_ID" : 1,
+        "L1" : null,
+        "L2" : "b"
+      },
+      "timestamp" : 330000
     } ],
     "topics" : [ {
       "name" : "OUTER_JOIN",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957938/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_full_outer_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957938/topology
@@ -22,10 +22,10 @@ Topologies:
     Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-outer-this-join
       <-- PrependAliasLeft
-    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERSHARED-0000000008-store, KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTERSHARED-0000000008-store, KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947956837/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947956837/spec.json
@@ -106,25 +106,9 @@
       "key" : 0,
       "value" : {
         "L1" : "A",
-        "L2" : null
-      },
-      "timestamp" : 0
-    }, {
-      "topic" : "LEFT_JOIN",
-      "key" : 0,
-      "value" : {
-        "L1" : "A",
         "L2" : "a"
       },
       "timestamp" : 60000
-    }, {
-      "topic" : "LEFT_JOIN",
-      "key" : 1,
-      "value" : {
-        "L1" : "B",
-        "L2" : null
-      },
-      "timestamp" : 330000
     }, {
       "topic" : "LEFT_JOIN",
       "key" : 2,

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947956837/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947956837/spec.json
@@ -100,6 +100,13 @@
         "L2" : "d"
       },
       "timestamp" : 60000
+    }, {
+      "topic" : "left_topic",
+      "key" : 4,
+      "value" : {
+        "L1" : "dummy record that emits expired record B"
+      },
+      "timestamp" : 800000
     } ],
     "outputs" : [ {
       "topic" : "LEFT_JOIN",
@@ -133,6 +140,14 @@
         "L2" : null
       },
       "timestamp" : 60000
+    }, {
+      "topic" : "LEFT_JOIN",
+      "key" : 1,
+      "value" : {
+        "L1" : "B",
+        "L2" : null
+      },
+      "timestamp" : 330000
     } ],
     "topics" : [ {
       "name" : "right_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947956837/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_AVRO/7.0.0_1623947956837/topology
@@ -22,10 +22,10 @@ Topologies:
     Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- PrependAliasLeft
-    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store, KSTREAM-OUTERSHARED-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTERSHARED-0000000008-store, KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957230/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957230/spec.json
@@ -106,25 +106,9 @@
       "key" : 0,
       "value" : {
         "L1" : "A",
-        "L2" : null
-      },
-      "timestamp" : 0
-    }, {
-      "topic" : "LEFT_JOIN",
-      "key" : 0,
-      "value" : {
-        "L1" : "A",
         "L2" : "a"
       },
       "timestamp" : 60000
-    }, {
-      "topic" : "LEFT_JOIN",
-      "key" : 1,
-      "value" : {
-        "L1" : "B",
-        "L2" : null
-      },
-      "timestamp" : 330000
     }, {
       "topic" : "LEFT_JOIN",
       "key" : 2,

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957230/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957230/spec.json
@@ -100,6 +100,13 @@
         "L2" : "d"
       },
       "timestamp" : 60000
+    }, {
+      "topic" : "left_topic",
+      "key" : 4,
+      "value" : {
+        "L1" : "dummy record that emits expired record B"
+      },
+      "timestamp" : 800000
     } ],
     "outputs" : [ {
       "topic" : "LEFT_JOIN",
@@ -133,6 +140,14 @@
         "L2" : null
       },
       "timestamp" : 60000
+    }, {
+      "topic" : "LEFT_JOIN",
+      "key" : 1,
+      "value" : {
+        "L1" : "B",
+        "L2" : null
+      },
+      "timestamp" : 330000
     } ],
     "topics" : [ {
       "name" : "right_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957230/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/joins_-_stream_stream_left_join_with_out_of_order_and_custom_grace_period_-_JSON/7.0.0_1623947957230/topology
@@ -22,10 +22,10 @@ Topologies:
     Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- PrependAliasLeft
-    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store, KSTREAM-OUTERSHARED-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTERSHARED-0000000008-store, KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -895,9 +895,7 @@
         {"topic": "right_topic", "key": 3, "value": {"L2": "d"}, "timestamp": 60000}
       ],
       "outputs": [
-        {"topic": "LEFT_JOIN", "key": 0, "value": {"L1": "A", "L2": null}, "timestamp": 0},
         {"topic": "LEFT_JOIN", "key": 0, "value": {"L1": "A", "L2": "a"}, "timestamp": 60000},
-        {"topic": "LEFT_JOIN", "key": 1, "value": {"L1": "B", "L2": null}, "timestamp": 330000},
         {"topic": "LEFT_JOIN", "key": 2, "value": {"L1": "C", "L2": null}, "timestamp": 90000},
         {"topic": "LEFT_JOIN", "key": 2, "value": {"L1": "C", "L2": "c"}, "timestamp": 90000},
         {"topic": "LEFT_JOIN", "key": 3, "value": {"L1": "D", "L2": null}, "timestamp": 60000}
@@ -921,9 +919,7 @@
         {"topic": "left_topic", "key": 3, "value": {"L1": "D"}, "timestamp": 60000}
       ],
       "outputs": [
-        {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "TT_ID": null, "L1": "A", "L2": null}, "timestamp": 0},
         {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "TT_ID": 0, "L1": "A", "L2": "a"}, "timestamp": 60000},
-        {"topic": "OUTER_JOIN", "key": 1, "value": {"T_ID": null, "TT_ID": 1, "L1": null, "L2": "b"}, "timestamp": 330000},
         {"topic": "OUTER_JOIN", "key": 2, "value": {"T_ID": null, "TT_ID": 2, "L1": null, "L2": "c"}, "timestamp": 90000},
         {"topic": "OUTER_JOIN", "key": 2, "value": {"T_ID": 2, "TT_ID": 2, "L1": "C", "L2": "c"}, "timestamp": 90000},
         {"topic": "OUTER_JOIN", "key": 3, "value": {"T_ID": null, "TT_ID": 3, "L1": null, "L2": "d"}, "timestamp": 60000},

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -892,13 +892,15 @@
         {"topic": "left_topic", "key": 2, "value": {"L1": "C"}, "timestamp": 90000},
         {"topic": "right_topic", "key": 2, "value": {"L2": "c"}, "timestamp": 90000},
         {"topic": "left_topic", "key": 3, "value": {"L1": "D"}, "timestamp": 60000},
-        {"topic": "right_topic", "key": 3, "value": {"L2": "d"}, "timestamp": 60000}
+        {"topic": "right_topic", "key": 3, "value": {"L2": "d"}, "timestamp": 60000},
+        {"topic": "left_topic", "key": 4, "value": {"L1": "dummy record that emits expired record B"}, "timestamp": 800000}
       ],
       "outputs": [
         {"topic": "LEFT_JOIN", "key": 0, "value": {"L1": "A", "L2": "a"}, "timestamp": 60000},
         {"topic": "LEFT_JOIN", "key": 2, "value": {"L1": "C", "L2": null}, "timestamp": 90000},
         {"topic": "LEFT_JOIN", "key": 2, "value": {"L1": "C", "L2": "c"}, "timestamp": 90000},
-        {"topic": "LEFT_JOIN", "key": 3, "value": {"L1": "D", "L2": null}, "timestamp": 60000}
+        {"topic": "LEFT_JOIN", "key": 3, "value": {"L1": "D", "L2": null}, "timestamp": 60000},
+        {"topic": "LEFT_JOIN", "key": 1, "value": {"L1": "B", "L2": null}, "timestamp": 330000}
       ]
     },
     {
@@ -916,14 +918,16 @@
         {"topic": "right_topic", "key": 2, "value": {"L2": "c"}, "timestamp": 90000},
         {"topic": "left_topic", "key": 2, "value": {"L1": "C"}, "timestamp": 90000},
         {"topic": "right_topic", "key": 3, "value": {"L2": "d"}, "timestamp": 60000},
-        {"topic": "left_topic", "key": 3, "value": {"L1": "D"}, "timestamp": 60000}
+        {"topic": "left_topic", "key": 3, "value": {"L1": "D"}, "timestamp": 60000},
+        {"topic": "right_topic", "key": 4, "value": {"L2": "dummy record that emits expired record b"}, "timestamp": 800000}
       ],
       "outputs": [
         {"topic": "OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "TT_ID": 0, "L1": "A", "L2": "a"}, "timestamp": 60000},
         {"topic": "OUTER_JOIN", "key": 2, "value": {"T_ID": null, "TT_ID": 2, "L1": null, "L2": "c"}, "timestamp": 90000},
         {"topic": "OUTER_JOIN", "key": 2, "value": {"T_ID": 2, "TT_ID": 2, "L1": "C", "L2": "c"}, "timestamp": 90000},
         {"topic": "OUTER_JOIN", "key": 3, "value": {"T_ID": null, "TT_ID": 3, "L1": null, "L2": "d"}, "timestamp": 60000},
-        {"topic": "OUTER_JOIN", "key": 3, "value": {"T_ID": 3, "TT_ID": null, "L1": "D", "L2": null}, "timestamp": 60000}
+        {"topic": "OUTER_JOIN", "key": 3, "value": {"T_ID": 3, "TT_ID": null, "L1": "D", "L2": null}, "timestamp": 60000},
+        {"topic": "OUTER_JOIN", "key": 1, "value": {"T_ID": null, "TT_ID": 1, "L1": null, "L2": "b"}, "timestamp": 330000}
       ]
     },
     {

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
@@ -85,15 +85,20 @@ public final class StreamStreamJoinBuilder {
     final JoinParams joinParams = JoinParamsFactory
         .create(join.getKeyColName(), leftSchema, rightSchema);
 
-    JoinWindows joinWindows =
-        JoinWindows.of(join.getBeforeMillis()).after(join.getAfterMillis());
+    JoinWindows joinWindows;
 
-    // Grace, as optional, helps to identify if a user use the new GRACE PERIOD syntax in the
-    // join window or not. If used, then we'll call the new KStreams API ofSizeAndGrace() which
-    // enables the bugfix with left/outer joins (see KAFKA-10847).
+    // Grace, as optional, helps to identify if a user specified the GRACE PERIOD syntax in the
+    // join window. If specified, then we'll call the new KStreams API ofTimeDifferenceAndGrace()
+    // which enables the "spurious" results bugfix with left/outer joins (see KAFKA-10847).
     if (join.getGraceMillis().isPresent()) {
-      joinWindows = joinWindows.grace(join.getGraceMillis().get());
+      joinWindows = JoinWindows.ofTimeDifferenceAndGrace(
+            join.getBeforeMillis(),
+            join.getGraceMillis().get());
+    } else {
+      joinWindows = JoinWindows.of(join.getBeforeMillis());
     }
+
+    joinWindows = joinWindows.after(join.getAfterMillis());
 
     final KStream<K, GenericRow> result;
     switch (join.getJoinType()) {


### PR DESCRIPTION
### Description 
Now that https://github.com/confluentinc/ksql/pull/7695 is merged, this PR enables the stream-stream left/outer joins fix implemented in https://issues.apache.org/jira/browse/KAFKA-10847.

To enabled it, I removed the `ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX` compatibility flag (which was set to False) from `KsqlConfig.java` so that all QTT tests and joins commands use the bugfix. The flag is enabled by default, so there is no need to enable it in `KsqlConfig.java`.

I also call the new `JoinWindows.ofTimeDifferenceAndGrace()` API when the `GRACE PERIOD` clause is used in Joins. The new API has the bugfix enabled internally.

BREAKING CHANGE: If the user sets GRACE PERIOD explicitly in stream-stream left/outer joins, the grace period defines when the left/outer non-joined results are emitted. Contrary to the old syntax (without GRACE PERIOD) that emits left/outer non-joined results eagerly, which may cause "spurious" result records. Using the GRACE PERIOD syntax enables the bugfix implemented in KAFKA-10847.

### Testing done 
Updated QTT tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

