### PR TITLE
test: add filter for RQTT

### DIFF
--- a/ksqldb-functional-tests/README.md
+++ b/ksqldb-functional-tests/README.md
@@ -51,6 +51,15 @@ mvn test -pl ksqldb-functional-tests -Dtest=QueryTranslationTest -Dksql.test.fil
 
 The above commands can execute only a single test (sum.json) or multiple tests (sum.json and substring.json).
 
+There is also a version of `QueryTranslationTest` that runs a full KSQL server in order to
+verify REST responses: `RestQueryTranslationTest`. These tests are much slower and should
+be used sparingly. To run a subset of these tests, supply a regex of the test name:
+
+```
+mvn test -pl ksqldb-functional-tests -Dtest=RestQueryTranslationTest -Dksql.rqtt.regex="pull-queries.*join"
+```
+
+
 ## Adding new tests
 
 The following is a template test file:

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -104,8 +104,11 @@ public class RestQueryTranslationTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
+    final String testRegex = System.getProperty("ksql.rqtt.regex");
+
     return JsonTestLoader.of(TEST_DIR, RqttTestFile.class)
         .load()
+        .filter(testCase -> testRegex == null || testCase.getName().matches(testRegex))
         .map(testCase -> new Object[]{testCase.getName(), testCase})
         .collect(Collectors.toCollection(ArrayList::new));
   }


### PR DESCRIPTION
I needed to run just one or two RQTT tests, but it didn't seem to be supported. I didn't add a file-based filter, since the files contain close to 100 test cases. The test name is a much better filter basis.