### PR TITLE
chore: remove flaky pull query functional test

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -292,34 +292,6 @@ public class PullQueryRoutingFunctionalTest {
   }
 
   @Test
-  public void shouldQueryActiveWhenActiveAliveQueryIssuedToStandby() throws Exception {
-    // Given:
-    ClusterFormation clusterFormation = findClusterFormation(TEST_APP_0, TEST_APP_1, TEST_APP_2);
-    waitForClusterToBeDiscovered(clusterFormation.standBy.getApp(), 3, USER_CREDS);
-    waitForRemoteServerToChangeStatus(clusterFormation.router.getApp(),
-        clusterFormation.router.getHost(), HighAvailabilityTestUtil.lagsReported(3), USER_CREDS);
-
-    waitForRemoteServerToChangeStatus(
-        clusterFormation.standBy.getApp(),
-        clusterFormation.active.getHost(),
-        HighAvailabilityTestUtil::remoteServerIsUp,
-        USER_CREDS);
-
-    // When:
-    List<StreamedRow> rows_0 =
-        makePullQueryRequest(clusterFormation.standBy.getApp(), sql, null, USER_CREDS);
-
-    // Then:
-    assertThat(rows_0, hasSize(HEADER + 1));
-    KsqlHostInfoEntity host = rows_0.get(1).getSourceHost().get();
-    assertThat(host.getHost(), is(clusterFormation.active.getHost().getHost()));
-    assertThat(host.getPort(), is(clusterFormation.active.getHost().getPort()));
-    assertThat(rows_0.get(1).getRow(), is(not(Optional.empty())));
-    assertThat(rows_0.get(1).getRow().get().getColumns(), is(ImmutableList.of(KEY, 1)));
-  }
-
-
-  @Test
   public void shouldQueryActiveWhenActiveAliveStandbyDeadQueryIssuedToRouter() {
     // Given:
     ClusterFormation clusterFormation = findClusterFormation(TEST_APP_0, TEST_APP_1, TEST_APP_2);


### PR DESCRIPTION
### Description 
Right now, the port check in `PullQueryRoutingFunctionalTest` errors out inconsistently because in a heavy load system, we'll sometimes use the standby port instead of the active port if the active port isn't in a good state or wasn't able to send health checks due to load. This check is valuable on some systems, but because the CI environment is less reliable, we're not getting consistent results there. Since this is giving us an inconsistent signal, it makes sense to remove this check for now. 

An alternative is to add a retry after the initial check, but that doesn't seem foolproof to me either. We could retry indefinitely but that wouldn't give us any signal for the test.

Recent master failures:
https://jenkins.confluent.io/job/confluentinc/job/ksql/job/master/7968/
https://jenkins.confluent.io/job/confluentinc/job/ksql/job/master/7966/


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

