### PR TITLE
feat: add observability metric skeleton

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/UtilizationMetricsListener.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/UtilizationMetricsListener.java
@@ -1,0 +1,52 @@
+package io.confluent.ksql.internal;
+
+import io.confluent.ksql.engine.QueryEventListener;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.QueryMetadata;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+public class UtilizationMetricsListener implements Runnable, QueryEventListener {
+
+    private final List<KafkaStreams> kafkaStreams;
+    private final Logger logger = LoggerFactory.getLogger(UtilizationMetricsListener.class);
+    private final List<String> metrics;
+    private final Time time;
+    private long lastSampleTime;
+
+    public UtilizationMetricsListener(){
+        this.kafkaStreams = new ArrayList<>();
+        this.metrics = new LinkedList<>();
+        time = Time.SYSTEM;
+        lastSampleTime = time.milliseconds();
+    }
+
+    @Override
+    public void onCreate(
+            final ServiceContext serviceContext,
+            final MetaStore metaStore,
+            final QueryMetadata queryMetadata) {
+        kafkaStreams.add(queryMetadata.getKafkaStreams());
+    }
+
+    @Override
+    public void onDeregister(final QueryMetadata query) {
+        final KafkaStreams streams = query.getKafkaStreams();
+        kafkaStreams.remove(streams);
+    }
+
+    @Override
+    public void run() {
+        logger.info("Reporting Observability Metrics");
+        final Long currentTime = time.milliseconds();
+        // here is where we would report metrics
+        lastSampleTime = currentTime;
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/UtilizationMetricsListener.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/UtilizationMetricsListener.java
@@ -1,52 +1,66 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.internal;
 
 import io.confluent.ksql.engine.QueryEventListener;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.QueryMetadata;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
 public class UtilizationMetricsListener implements Runnable, QueryEventListener {
 
-    private final List<KafkaStreams> kafkaStreams;
-    private final Logger logger = LoggerFactory.getLogger(UtilizationMetricsListener.class);
-    private final List<String> metrics;
-    private final Time time;
-    private long lastSampleTime;
+  private final List<KafkaStreams> kafkaStreams;
+  private final Logger logger = LoggerFactory.getLogger(UtilizationMetricsListener.class);
+  private final List<String> metrics;
+  private final Time time;
+  private long lastSampleTime;
 
-    public UtilizationMetricsListener(){
-        this.kafkaStreams = new ArrayList<>();
-        this.metrics = new LinkedList<>();
-        time = Time.SYSTEM;
-        lastSampleTime = time.milliseconds();
-    }
+  public UtilizationMetricsListener() {
+    this.kafkaStreams = new ArrayList<>();
+    this.metrics = new LinkedList<>();
+    time = Time.SYSTEM;
+    lastSampleTime = time.milliseconds();
+  }
 
-    @Override
-    public void onCreate(
-            final ServiceContext serviceContext,
-            final MetaStore metaStore,
-            final QueryMetadata queryMetadata) {
-        kafkaStreams.add(queryMetadata.getKafkaStreams());
-    }
+  @Override
+  public void onCreate(
+      final ServiceContext serviceContext,
+      final MetaStore metaStore,
+      final QueryMetadata queryMetadata) {
+    kafkaStreams.add(queryMetadata.getKafkaStreams());
+  }
 
-    @Override
-    public void onDeregister(final QueryMetadata query) {
-        final KafkaStreams streams = query.getKafkaStreams();
-        kafkaStreams.remove(streams);
-    }
+  @Override
+  public void onDeregister(final QueryMetadata query) {
+    final KafkaStreams streams = query.getKafkaStreams();
+    kafkaStreams.remove(streams);
+  }
 
-    @Override
-    public void run() {
-        logger.info("Reporting Observability Metrics");
-        final Long currentTime = time.milliseconds();
-        // here is where we would report metrics
-        lastSampleTime = currentTime;
-    }
+  @Override
+  public void run() {
+    logger.info("Reporting Observability Metrics");
+    final Long currentTime = time.milliseconds();
+    // here is where we would report metrics
+    lastSampleTime = currentTime;
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -117,7 +117,11 @@ public class PersistentQueryMetadataImpl
     this.processingLogger = requireNonNull(processingLogger, "processingLogger");
     this.scalablePushRegistry = requireNonNull(scalablePushRegistry, "scalablePushRegistry");
     this.persistentQueryType = requireNonNull(persistentQueryType, "persistentQueryType");
-    this.executorService = Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setNameFormat("ksql-csu-metrics-reporter-%d").build());
+    this.executorService =
+      Executors.newScheduledThreadPool(
+        1,
+        new ThreadFactoryBuilder().setNameFormat("ksql-csu-metrics-reporter-%d").build()
+      );
   }
 
   // for creating sandbox instances

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.plan.ExecutionStep;
@@ -37,6 +38,9 @@ import io.confluent.ksql.schema.query.QuerySchemas;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
@@ -56,6 +60,7 @@ public class PersistentQueryMetadataImpl
   private final ProcessingLogger processingLogger;
 
   private Optional<MaterializationProvider> materializationProvider;
+  private final ScheduledExecutorService executorService;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public PersistentQueryMetadataImpl(
@@ -112,6 +117,7 @@ public class PersistentQueryMetadataImpl
     this.processingLogger = requireNonNull(processingLogger, "processingLogger");
     this.scalablePushRegistry = requireNonNull(scalablePushRegistry, "scalablePushRegistry");
     this.persistentQueryType = requireNonNull(persistentQueryType, "persistentQueryType");
+    this.executorService = Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setNameFormat("ksql-csu-metrics-reporter-%d").build());
   }
 
   // for creating sandbox instances
@@ -129,6 +135,7 @@ public class PersistentQueryMetadataImpl
     this.processingLogger = original.processingLogger;
     this.scalablePushRegistry = original.scalablePushRegistry;
     this.persistentQueryType = original.getPersistentQueryType();
+    this.executorService = original.executorService;
   }
 
   @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -693,7 +693,7 @@ public final class KsqlRestApplication implements Executable {
     final SpecificQueryIdGenerator specificQueryIdGenerator =
         new SpecificQueryIdGenerator();
 
-    ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1,
+    final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1,
         new ThreadFactoryBuilder()
             .setNameFormat("ksql-csu-metrics-reporter-%d")
             .build()


### PR DESCRIPTION
### Description 
Adds a basic metric reporter skeleton for observability metrics. This will be expanded on when we implement storage by node + query and saturation etc.

### Testing done 
Additional testing will be added when metrics are implemented, benchmarking for saturation confirms that this structure works

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

