### PR TITLE
feat: make SchemaRegistry permission validations on KSQL requests

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -14,6 +14,34 @@
 #
 
 #------ Endpoint config -------
+#------ RBAC ------------------
+
+# Enable KSQL authorization and impersonation
+ksql.security.extension.class=io.confluent.ksql.security.KsqlConfluentSecurityExtension
+
+# Metadata URL and access credentials (shared by Security handlers and KSQL security extension)
+# The `ksql:ksql` user:password are pre-configured in the `login.properties` you pasted in the Kafka server.properties
+confluent.metadata.bootstrap.server.urls=http://localhost:8090
+confluent.metadata.http.auth.credentials.provider=BASIC
+confluent.metadata.basic.auth.user.info=ksql:ksql
+
+# Configure the plugin (found in the confluent-security-plugins)
+# You must add the `confluent-security-plugins` to the ksqlDB classpath `KSQL_CLASSPATH`
+ksql.authentication.plugin.class=io.confluent.ksql.security.VertxBearerOrBasicAuthenticationPlugin
+
+# Replace {PUBLIC_KEY} with the location of the `publickey.pem` file of this repository
+# (i.e. /path/to/devel-tools/rbac/config/creds/publickey.pem)
+# This is the same public key shared with the Kafka server. It is used only to validate client tokens.
+public.key.path=/home/sergio/Tools/devel-tools/rbac/config/creds/publickey.pem
+
+# Configure the connection to the Kafka server
+# The `ksql:ksql` user:password is pre-configured in the `login.properties`.
+# Note: You must configure RBAC roles-bindings to allow `ksql` to access Kafka topics later.
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=OAUTHBEARER
+sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
+    metadataServerUrls="http://localhost:8090" username="ksql" password="ksql";
+sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
 
 ### HTTP  ###
 # The URL the KSQL server will listen on:
@@ -78,5 +106,7 @@ compression.type=snappy
 #------ Schema Registry -------
 
 # Uncomment and complete the following to enable KSQL's integration to the Confluent Schema Registry:
-# ksql.schema.registry.url=http://localhost:8081
+ksql.schema.registry.url=http://localhost:8081
+ksql.schema.registry.basic.auth.credentials.source=USER_INFO
+ksql.schema.registry.basic.auth.user.info=ksql:ksql
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/AuthObjectType.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/AuthObjectType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.security;
+
+import static java.util.Objects.requireNonNull;
+
+public enum AuthObjectType {
+  TOPIC("Topic"),
+  SUBJECT("Subject");
+
+  private final String name;
+
+  AuthObjectType(final String name) {
+    this.name = requireNonNull(name, "name");
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAccessValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAccessValidator.java
@@ -22,12 +22,30 @@ import org.apache.kafka.common.acl.AclOperation;
  */
 public interface KsqlAccessValidator {
   /**
-   * Checks if an authenticated user provided by the {@code securityContext} has authorization
-   * to execute the {@code operation} on the kafka {@code topicName}.
+   * Checks if an authenticated user, provided by the {@code securityContext}, has authorization
+   * to execute all specified {@code actions} on the {@code topicName}.
    *
    * @param securityContext The context for the authenticated user.
    * @param topicName The topic name to check access.
    * @param operation The {@code AclOperation} to validate against the {@code topicName}.
    */
-  void checkAccess(KsqlSecurityContext securityContext, String topicName, AclOperation operation);
+  void checkTopicAccess(
+      KsqlSecurityContext securityContext,
+      String topicName,
+      AclOperation operation
+  );
+
+  /**
+   * Checks if an authenticated user, provided by the {@code securityContext}, has authorization
+   * to execute all specified {@code actions} on the {@code subjectName}.
+   *
+   * @param securityContext The context for the authenticated user.
+   * @param subjectName The subject name to check access.
+   * @param operation The {@code AclOperation} to validate against the {@code subjectName}.
+   */
+  void checkSubjectAccess(
+      KsqlSecurityContext securityContext,
+      String subjectName,
+      AclOperation operation
+  );
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationProvider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationProvider.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.security;
 
 import java.security.Principal;
+import java.util.List;
+import org.apache.kafka.common.acl.AclOperation;
 
 /**
  * Interface that provides authorization to KSQL.
@@ -29,4 +31,18 @@ public interface KsqlAuthorizationProvider {
    * @param path The endpoint path to access, i.e. "/ksql", "/ksql/terminate", "/query"*
    */
   void checkEndpointAccess(Principal user, String method, String path);
+
+  /**
+   * Checks if the user (if available) with the {@code userSecurityContext} has the specified
+   * {@code privileges} on the the specified {@code objectType} and {@code objectName}.
+   *
+   * @param userSecurityContext The user security context which privileges will be checked
+   * @param objectType The object type to check for privileges
+   * @param objectName The object name to check for privileges
+   * @param privileges The list of privileges to check in the resource
+   */
+  void checkPrivileges(KsqlSecurityContext userSecurityContext,
+                       AuthObjectType objectType,
+                       String objectName,
+                       List<AclOperation> privileges);
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImpl.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.security;
 
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
@@ -24,8 +25,13 @@ import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.topic.SourceTopicsExtractor;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
+import java.util.Set;
 import org.apache.kafka.common.acl.AclOperation;
 
 /**
@@ -69,10 +75,9 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
       final MetaStore metaStore,
       final Query query
   ) {
-    final SourceTopicsExtractor extractor = new SourceTopicsExtractor(metaStore);
-    extractor.process(query, null);
-    for (String kafkaTopic : extractor.getSourceTopics()) {
-      accessValidator.checkAccess(securityContext, kafkaTopic, AclOperation.READ);
+    for (KsqlTopic ksqlTopic : extractQueryTopics(query, metaStore)) {
+      checkTopicAccess(securityContext, ksqlTopic.getKafkaTopicName(), AclOperation.READ);
+      checkSchemaAccess(securityContext, ksqlTopic, AclOperation.READ);
     }
   }
 
@@ -94,7 +99,7 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
 
     // At this point, the topic should have been created by the TopicCreateInjector
     final String kafkaTopic = getCreateAsSelectSinkTopic(metaStore, createAsSelect);
-    accessValidator.checkAccess(securityContext, kafkaTopic, AclOperation.WRITE);
+    checkTopicAccess(securityContext, kafkaTopic, AclOperation.WRITE);
   }
 
   private void validateInsertInto(
@@ -111,14 +116,17 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
     validateQuery(securityContext, metaStore, insertInto.getQuery());
 
     final String kafkaTopic = getSourceTopicName(metaStore, insertInto.getTarget());
-    accessValidator.checkAccess(securityContext, kafkaTopic, AclOperation.WRITE);
+    checkTopicAccess(securityContext, kafkaTopic, AclOperation.WRITE);
   }
 
   private void validatePrintTopic(
           final KsqlSecurityContext securityContext,
           final PrintTopic printTopic
   ) {
-    accessValidator.checkAccess(securityContext, printTopic.getTopic(), AclOperation.READ);
+    checkTopicAccess(securityContext, printTopic.getTopic(), AclOperation.READ);
+
+    // SchemaRegistry permissions cannot be validated here because the schema is guessed when
+    // printing the topic by obtaining the first row and attempt to find the right schema
   }
 
   private void validateCreateSource(
@@ -126,7 +134,10 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
       final CreateSource createSource
   ) {
     final String sourceTopic = createSource.getProperties().getKafkaTopic();
-    accessValidator.checkAccess(securityContext, sourceTopic, AclOperation.READ);
+    checkTopicAccess(securityContext, sourceTopic, AclOperation.READ);
+
+    // SchemaRegistry permissions are validated when SchemaRegisterInjector is called during CREATE
+    // operations. There's no need to validate the user has READ permissions here.
   }
 
   private String getSourceTopicName(final MetaStore metaStore, final SourceName streamOrTable) {
@@ -145,5 +156,40 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
   ) {
     return createAsSelect.getProperties().getKafkaTopic()
         .orElseGet(() -> getSourceTopicName(metaStore, createAsSelect.getName()));
+  }
+
+  private Set<KsqlTopic> extractQueryTopics(final Query query, final MetaStore metaStore) {
+    final SourceTopicsExtractor extractor = new SourceTopicsExtractor(metaStore);
+    extractor.process(query, null);
+    return extractor.getSourceTopics();
+  }
+
+  private void checkTopicAccess(
+      final KsqlSecurityContext securityContext,
+      final String resourceName,
+      final AclOperation operation
+  ) {
+    accessValidator.checkTopicAccess(securityContext, resourceName, operation);
+  }
+
+  private void checkSchemaAccess(
+      final KsqlSecurityContext securityContext,
+      final KsqlTopic ksqlTopic,
+      final AclOperation operation
+  ) {
+
+    if (formatSupportsSchemaInference(ksqlTopic.getKeyFormat().getFormatInfo())) {
+      accessValidator.checkSubjectAccess(securityContext,
+          KsqlConstants.getSRSubject(ksqlTopic.getKafkaTopicName(), true), operation);
+    }
+
+    if (formatSupportsSchemaInference(ksqlTopic.getValueFormat().getFormatInfo())) {
+      accessValidator.checkSubjectAccess(securityContext,
+          KsqlConstants.getSRSubject(ksqlTopic.getKafkaTopicName(), false), operation);
+    }
+  }
+
+  private static boolean formatSupportsSchemaInference(final FormatInfo format) {
+    return FormatFactory.of(format).supportsFeature(SerdeFeature.SCHEMA_INFERENCE);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlBackendAccessValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlBackendAccessValidator.java
@@ -22,11 +22,11 @@ import org.apache.kafka.common.acl.AclOperation;
 
 /**
  * An implementation of {@link KsqlAccessValidator} that provides authorization checks
- * from the Kafka service.
+ * from the backend services.
  */
 public class KsqlBackendAccessValidator implements KsqlAccessValidator {
   @Override
-  public void checkAccess(
+  public void checkTopicAccess(
       final KsqlSecurityContext securityContext,
       final String topicName,
       final AclOperation operation
@@ -41,5 +41,17 @@ public class KsqlBackendAccessValidator implements KsqlAccessValidator {
       // due to an authorization error. I used this message to keep a consistent message.
       throw new KsqlTopicAuthorizationException(operation, Collections.singleton(topicName));
     }
+  }
+
+  @Override
+  public void checkSubjectAccess(
+      final KsqlSecurityContext securityContext,
+      final String subjectName,
+      final AclOperation operation
+  ) {
+    // Nothing to do. Checking permissions for Schema Registry require an external authorization
+    // provider. Schema Registry does not have an API to list the allowed permissions for
+    // the user in a specified subject.
+    return;
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlCacheAccessValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlCacheAccessValidator.java
@@ -20,6 +20,7 @@ import com.google.common.base.Ticker;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.exception.KsqlSchemaAuthorizationException;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.util.KsqlConfig;
 
@@ -41,16 +42,19 @@ public class KsqlCacheAccessValidator implements KsqlAccessValidator {
     private static final String UNKNOWN_USER = "";
 
     private final KsqlSecurityContext securityContext;
-    private final String topicName;
+    private final AuthObjectType authObjectType;
+    private final String objectName;
     private final AclOperation operation;
 
     CacheKey(
         final KsqlSecurityContext securityContext,
-        final String topicName,
+        final AuthObjectType authObjectType,
+        final String objectName,
         final AclOperation operation
     ) {
       this.securityContext = securityContext;
-      this.topicName = topicName;
+      this.authObjectType = authObjectType;
+      this.objectName = objectName;
       this.operation = operation;
     }
 
@@ -62,7 +66,8 @@ public class KsqlCacheAccessValidator implements KsqlAccessValidator {
 
       final CacheKey other = (CacheKey)o;
       return getUserName(securityContext).equals(getUserName(other.securityContext))
-          && topicName.equals(other.topicName)
+          && authObjectType.equals(other.authObjectType)
+          && objectName.equals(other.objectName)
           && operation.code() == other.operation.code();
     }
 
@@ -70,7 +75,8 @@ public class KsqlCacheAccessValidator implements KsqlAccessValidator {
     public int hashCode() {
       return Objects.hash(
           getUserName(securityContext),
-          topicName,
+          authObjectType,
+          objectName,
           operation.code()
       );
     }
@@ -124,31 +130,76 @@ public class KsqlCacheAccessValidator implements KsqlAccessValidator {
     return new CacheLoader<CacheKey, CacheValue>() {
       @Override
       public CacheValue load(final CacheKey cacheKey) {
-        try {
-          backendValidator.checkAccess(
-              cacheKey.securityContext,
-              cacheKey.topicName,
-              cacheKey.operation
-          );
-        } catch (KsqlTopicAuthorizationException e) {
-          return new CacheValue(!ALLOW_ACCESS, Optional.of(e));
+        switch (cacheKey.authObjectType) {
+          case TOPIC:
+            return internalTopicAccessValidator(cacheKey);
+          case SUBJECT:
+            return internalSubjectAccessValidator(cacheKey);
+          default:
+            throw new IllegalStateException("Unknown access validator type: "
+                + cacheKey.authObjectType);
         }
-
-        return new CacheValue(ALLOW_ACCESS, Optional.empty());
       }
     };
   }
 
-  @Override
-  public void checkAccess(
-      final KsqlSecurityContext securityContext,
-      final String topicName,
-      final AclOperation operation
-  ) {
-    final CacheKey cacheKey = new CacheKey(securityContext, topicName, operation);
+  private CacheValue internalTopicAccessValidator(final CacheKey cacheKey) {
+    try {
+      backendValidator.checkTopicAccess(
+          cacheKey.securityContext,
+          cacheKey.objectName,
+          cacheKey.operation
+      );
+    } catch (final KsqlTopicAuthorizationException e) {
+      return new CacheValue(!ALLOW_ACCESS, Optional.of(e));
+    }
+
+    return new CacheValue(ALLOW_ACCESS, Optional.empty());
+  }
+
+  private CacheValue internalSubjectAccessValidator(final CacheKey cacheKey) {
+    try {
+      backendValidator.checkSubjectAccess(
+          cacheKey.securityContext,
+          cacheKey.objectName,
+          cacheKey.operation
+      );
+    } catch (final KsqlSchemaAuthorizationException e) {
+      return new CacheValue(!ALLOW_ACCESS, Optional.of(e));
+    }
+
+    return new CacheValue(ALLOW_ACCESS, Optional.empty());
+  }
+
+  private void checkAccess(final CacheKey cacheKey) {
     final CacheValue cacheValue = cache.getUnchecked(cacheKey);
     if (!cacheValue.allowAccess) {
       throw cacheValue.denialReason.get();
     }
+  }
+
+  @Override
+  public void checkTopicAccess(
+      final KsqlSecurityContext securityContext,
+      final String topicName,
+      final AclOperation operation
+  ) {
+    checkAccess(new CacheKey(securityContext,
+        AuthObjectType.TOPIC,
+        topicName,
+        operation));
+
+  }
+
+  @Override
+  public void checkSubjectAccess(
+      final KsqlSecurityContext securityContext,
+      final String subjectName,
+      final AclOperation operation
+  ) {
+    checkAccess(new CacheKey(securityContext,
+        AuthObjectType.SUBJECT,
+        subjectName,
+        operation));
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlProvidedAccessValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlProvidedAccessValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.security;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.kafka.common.acl.AclOperation;
+
+/**
+ * An implementation of {@link KsqlAccessValidator} that provides authorization checks
+ * from a external authorization provider.
+ */
+public class KsqlProvidedAccessValidator implements KsqlAccessValidator {
+  private final KsqlAuthorizationProvider authorizationProvider;
+
+  public KsqlProvidedAccessValidator(final KsqlAuthorizationProvider authorizationProvider) {
+    this.authorizationProvider = requireNonNull(authorizationProvider, "authorizationProvider");
+  }
+
+  @Override
+  public void checkTopicAccess(
+      final KsqlSecurityContext securityContext,
+      final String topicName,
+      final AclOperation operation
+  ) {
+    authorizationProvider.checkPrivileges(
+        securityContext,
+        AuthObjectType.TOPIC,
+        topicName,
+        ImmutableList.of(operation)
+    );
+  }
+
+  @Override
+  public void checkSubjectAccess(
+      final KsqlSecurityContext securityContext,
+      final String subjectName,
+      final AclOperation operation
+  ) {
+    authorizationProvider.checkPrivileges(
+        securityContext,
+        AuthObjectType.SUBJECT,
+        subjectName,
+        ImmutableList.of(operation)
+    );
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.topic;
 
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
@@ -32,20 +33,20 @@ import java.util.Set;
  * Helper class that extracts all source topics from a query node.
  */
 public class SourceTopicsExtractor extends DefaultTraversalVisitor<AstNode, Void> {
-  private final Set<String> sourceTopics = new HashSet<>();
+  private final Set<KsqlTopic> sourceTopics = new HashSet<>();
   private final MetaStore metaStore;
 
-  private String primaryKafkaTopicName = null;
+  private KsqlTopic primarySourceTopic = null;
 
   public SourceTopicsExtractor(final MetaStore metaStore) {
     this.metaStore = metaStore;
   }
 
-  public String getPrimaryKafkaTopicName() {
-    return primaryKafkaTopicName;
+  public KsqlTopic getPrimarySourceTopic() {
+    return primarySourceTopic;
   }
 
-  public Set<String> getSourceTopics() {
+  public Set<KsqlTopic> getSourceTopics() {
     return Collections.unmodifiableSet(sourceTopics);
   }
 
@@ -65,11 +66,11 @@ public class SourceTopicsExtractor extends DefaultTraversalVisitor<AstNode, Void
     }
 
     // This method is called first with the primary kafka topic (or the node.getFrom() node)
-    if (primaryKafkaTopicName == null) {
-      primaryKafkaTopicName = source.getKafkaTopicName();
+    if (primarySourceTopic == null) {
+      primarySourceTopic = source.getKsqlTopic();
     }
 
-    sourceTopics.add(source.getKafkaTopicName());
+    sourceTopics.add(source.getKsqlTopic());
     return node;
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -147,7 +147,7 @@ public class TopicCreateInjector implements Injector {
 
     final SourceTopicsExtractor extractor = new SourceTopicsExtractor(metaStore);
     extractor.process(statement.getStatement().getQuery(), null);
-    final String sourceTopicName = extractor.getPrimaryKafkaTopicName();
+    final String sourceTopicName = extractor.getPrimarySourceTopic().getKafkaTopicName();
 
     topicPropertiesBuilder
         .withName(prefix + createAsSelect.getName().text())

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorFactoryTest.java
@@ -59,6 +59,8 @@ public class KsqlAuthorizationValidatorFactoryTest {
   private ServiceContext serviceContext;
   @Mock
   private AdminClient adminClient;
+  @Mock
+  private KsqlAuthorizationProvider authorizationProvider;
 
   private Node node;
 
@@ -72,30 +74,72 @@ public class KsqlAuthorizationValidatorFactoryTest {
   }
 
   @Test
-  public void shouldReturnAuthorizationValidator() {
-    // Given:
-    givenKafkaAuthorizer("an-authorizer-class", Collections.emptySet());
-
-    // When:
-    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
-        ksqlConfig,
-        serviceContext
-    );
-
-    // Then
-    assertThat("validator should be present", validator.isPresent());
-    assertThat(validator.get(), is(instanceOf(KsqlAuthorizationValidatorImpl.class)));
-  }
-
-  @Test
-  public void shouldReturnEmptyValidator() {
+  public void shouldReturnProvidedAuthorizationValidatorWhenAuthorizationProviderIsNonEmpty() {
     // Given:
     givenKafkaAuthorizer("", Collections.emptySet());
 
     // When:
     final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
-        serviceContext
+        serviceContext,
+        Optional.of(authorizationProvider)
+    );
+
+    // Then
+    assertThat("validator should be present", validator.isPresent());
+    assertThat(validator.get(), is(instanceOf(KsqlAuthorizationValidatorImpl.class)));
+    assertThat(((KsqlAuthorizationValidatorImpl)validator.get()).getAccessValidator(),
+        is(instanceOf(KsqlProvidedAccessValidator.class)));
+  }
+
+  @Test
+  public void shouldReturnBackendAuthorizationValidatorWhenKafkaAuthorizerIsSet() {
+    // Given:
+    givenKafkaAuthorizer("an-authorizer-class", Collections.emptySet());
+
+    // When:
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
+        ksqlConfig,
+        serviceContext,
+        Optional.empty()
+    );
+
+    // Then
+    assertThat("validator should be present", validator.isPresent());
+    assertThat(validator.get(), is(instanceOf(KsqlAuthorizationValidatorImpl.class)));
+    assertThat(((KsqlAuthorizationValidatorImpl)validator.get()).getAccessValidator(),
+        is(instanceOf(KsqlBackendAccessValidator.class)));
+  }
+  
+  @Test
+  public void shouldChooseProvidedAuthorizationValidatorOverKafkaBackendValidator() {
+    // Given:
+    givenKafkaAuthorizer("an-authorizer-class", Collections.emptySet());
+
+    // When:
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
+        ksqlConfig,
+        serviceContext,
+        Optional.of(authorizationProvider)
+    );
+
+    // Then
+    assertThat("validator should be present", validator.isPresent());
+    assertThat(validator.get(), is(instanceOf(KsqlAuthorizationValidatorImpl.class)));
+    assertThat(((KsqlAuthorizationValidatorImpl)validator.get()).getAccessValidator(),
+        is(instanceOf(KsqlProvidedAccessValidator.class)));
+  }
+
+  @Test
+  public void shouldReturnEmptyAuthorizationValidatorWhenNoAuthorizationProviderIsFound() {
+    // Given:
+    givenKafkaAuthorizer("", Collections.emptySet());
+
+    // When:
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
+        ksqlConfig,
+        serviceContext,
+        Optional.empty()
     );
 
     // Then
@@ -103,15 +147,17 @@ public class KsqlAuthorizationValidatorFactoryTest {
   }
 
   @Test
-  public void shouldReturnEmptyValidatorIfNotEnabled() {
+  public void shouldReturnEmptyAuthorizationValidatorKafkaAuthorizerIsSetButNotEnabled() {
     // Given:
+    givenKafkaAuthorizer("an-authorizer-class", Collections.emptySet());
     when(ksqlConfig.getString(KsqlConfig.KSQL_ENABLE_TOPIC_ACCESS_VALIDATOR))
         .thenReturn(KsqlConfig.KSQL_ACCESS_VALIDATOR_OFF);
 
     // When:
     final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
-        serviceContext
+        serviceContext,
+        Optional.empty()
     );
 
     // Then:
@@ -130,7 +176,8 @@ public class KsqlAuthorizationValidatorFactoryTest {
     // When:
     final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
-        serviceContext
+        serviceContext,
+        Optional.empty()
     );
 
     // Then:
@@ -142,7 +189,28 @@ public class KsqlAuthorizationValidatorFactoryTest {
   }
 
   @Test
-  public void shouldReturnAuthorizationValidatorWithCacheExpiryTimeIsPositive() {
+  public void shouldReturnProvidedAuthorizationValidatorWhenCacheIsEnabled() {
+    // Given:
+    givenKafkaAuthorizer("", Collections.emptySet());
+    when(ksqlConfig.getLong(KsqlConfig.KSQL_AUTH_CACHE_EXPIRY_TIME_SECS)).thenReturn(1L);
+
+    // When:
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
+        ksqlConfig,
+        serviceContext,
+        Optional.of(authorizationProvider)
+    );
+
+    // Then:
+    assertThat("validator should be present", validator.isPresent());
+    assertThat(validator.get(), is(instanceOf(KsqlAuthorizationValidatorImpl.class)));
+    assertThat(((KsqlAuthorizationValidatorImpl)validator.get()).getAccessValidator(),
+        is(instanceOf(KsqlCacheAccessValidator.class)));
+    verifyNoMoreInteractions(adminClient);
+  }
+
+  @Test
+  public void shouldReturnAuthorizationValidatorWhenCacheIsEnabled() {
     // Given:
     when(ksqlConfig.getString(KsqlConfig.KSQL_ENABLE_TOPIC_ACCESS_VALIDATOR))
         .thenReturn(KsqlConfig.KSQL_ACCESS_VALIDATOR_ON);
@@ -152,7 +220,8 @@ public class KsqlAuthorizationValidatorFactoryTest {
     // When:
     final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
-        serviceContext
+        serviceContext,
+        Optional.empty()
     );
 
     // Then:
@@ -171,7 +240,8 @@ public class KsqlAuthorizationValidatorFactoryTest {
     // When:
     final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
-        serviceContext
+        serviceContext,
+        Optional.empty()
     );
 
     // Then
@@ -188,7 +258,8 @@ public class KsqlAuthorizationValidatorFactoryTest {
     // When:
     final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
-        serviceContext
+        serviceContext,
+        Optional.empty()
     );
 
     // Then
@@ -211,7 +282,8 @@ public class KsqlAuthorizationValidatorFactoryTest {
     // When:
     final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
-        serviceContext
+        serviceContext,
+        Optional.empty()
     );
 
     // Then

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlBackendAccessValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlBackendAccessValidatorTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.security;
 
-import static org.apache.kafka.common.acl.AclOperation.READ;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
@@ -72,7 +71,7 @@ public class KsqlBackendAccessValidatorTest {
     givenTopicPermissions(TOPIC_1, null);
 
     // When/Then:
-    accessValidator.checkAccess(securityContext, TOPIC_NAME_1, AclOperation.READ);
+    accessValidator.checkTopicAccess(securityContext, TOPIC_NAME_1, AclOperation.READ);
   }
 
   @Test
@@ -81,7 +80,7 @@ public class KsqlBackendAccessValidatorTest {
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.READ));
 
     // When/Then:
-    accessValidator.checkAccess(securityContext, TOPIC_NAME_1, AclOperation.READ);
+    accessValidator.checkTopicAccess(securityContext, TOPIC_NAME_1, AclOperation.READ);
   }
 
   @Test
@@ -92,7 +91,7 @@ public class KsqlBackendAccessValidatorTest {
     // When:
     final Exception e = assertThrows(
         KsqlTopicAuthorizationException.class,
-        () -> accessValidator.checkAccess(securityContext, TOPIC_NAME_1, AclOperation.READ)
+        () -> accessValidator.checkTopicAccess(securityContext, TOPIC_NAME_1, AclOperation.READ)
     );
 
     // Then:
@@ -110,7 +109,7 @@ public class KsqlBackendAccessValidatorTest {
     // When:
     assertThrows(
         KafkaResponseGetFailedException.class,
-        () -> accessValidator.checkAccess(securityContext, TOPIC_NAME_1, READ)
+        () -> accessValidator.checkTopicAccess(securityContext, TOPIC_NAME_1, AclOperation.READ)
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlProvidedAccessValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/KsqlProvidedAccessValidatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.security;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.kafka.common.acl.AclOperation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlProvidedAccessValidatorTest {
+    private KsqlProvidedAccessValidator accessValidator;
+
+    @Mock
+    private KsqlSecurityContext securityContext;
+    @Mock
+    private KsqlAuthorizationProvider authorizationProvider;
+
+    @Before
+    public void setup() {
+        accessValidator = new KsqlProvidedAccessValidator(authorizationProvider);
+    }
+
+    @Test
+    public void shouldCheckTopicPrivilegesOnProvidedAccessValidator() {
+        // When
+        accessValidator.checkTopicAccess(securityContext, "topic1", AclOperation.WRITE);
+
+        // Then
+        verify(authorizationProvider, times(1))
+            .checkPrivileges(
+                securityContext,
+                AuthObjectType.TOPIC,
+                "topic1",
+                ImmutableList.of(AclOperation.WRITE));
+    }
+
+    @Test
+    public void shouldCheckSubjectTopicPrivilegesOnProvidedAccessValidator() {
+        // When
+        accessValidator.checkSubjectAccess(securityContext, "subject1", AclOperation.READ);
+
+        // Then
+        verify(authorizationProvider, times(1))
+            .checkPrivileges(
+                securityContext,
+                AuthObjectType.SUBJECT,
+                "subject1",
+                ImmutableList.of(AclOperation.READ));
+    }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -313,7 +313,8 @@ public final class KsqlRestApplication implements Executable {
     this.serverMetadataResource = ServerMetadataResource.create(serviceContext, ksqlConfigNoPort);
     final StatementParser statementParser = new StatementParser(ksqlEngine);
     final Optional<KsqlAuthorizationValidator> authorizationValidator =
-        KsqlAuthorizationValidatorFactory.create(ksqlConfigNoPort, serviceContext);
+        KsqlAuthorizationValidatorFactory.create(ksqlConfigNoPort, serviceContext,
+            securityExtension.getAuthorizationProvider());
     final Errors errorHandler = new Errors(restConfig.getConfiguredInstance(
         KsqlRestConfig.KSQL_SERVER_ERROR_MESSAGES,
         ErrorMessages.class
@@ -759,7 +760,8 @@ public final class KsqlRestApplication implements Executable {
         restConfig);
 
     final Optional<KsqlAuthorizationValidator> authorizationValidator =
-        KsqlAuthorizationValidatorFactory.create(ksqlConfig, serviceContext);
+        KsqlAuthorizationValidatorFactory.create(ksqlConfig, serviceContext,
+            securityExtension.getAuthorizationProvider());
 
     final Errors errorHandler = new Errors(restConfig.getConfiguredInstance(
         KsqlRestConfig.KSQL_SERVER_ERROR_MESSAGES,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/AuthTest.java
@@ -27,7 +27,9 @@ import io.confluent.ksql.api.server.Server;
 import io.confluent.ksql.api.utils.InsertsResponse;
 import io.confluent.ksql.api.utils.QueryResponse;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.security.AuthObjectType;
 import io.confluent.ksql.security.KsqlAuthorizationProvider;
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.security.KsqlUserContextProvider;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
@@ -42,12 +44,15 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import java.security.Principal;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+
+import org.apache.kafka.common.acl.AclOperation;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -546,9 +551,23 @@ public class AuthTest extends ApiTest {
     stopServer();
     stopClient();
     AtomicReference<Boolean> authorizationCallReference = new AtomicReference<>(false);
-    this.authorizationProvider = (user, method, path) -> {
-      authorizationCallReference.set(true);
+    this.authorizationProvider = new KsqlAuthorizationProvider() {
+      @Override
+      public void checkEndpointAccess(final Principal user,
+                                      final String method,
+                                      final String path) {
+        authorizationCallReference.set(true);
+      }
+
+      @Override
+      public void checkPrivileges(final KsqlSecurityContext securityContext,
+                                  final AuthObjectType objectType,
+                                  final String objectName,
+                                  final List<AclOperation> privileges) {
+        // Not required for vert.x authX as it only authorizes endpoints
+      }
     };
+
     createServer(createServerConfig());
     client = createClient();
     action.run();
@@ -563,12 +582,26 @@ public class AuthTest extends ApiTest {
     AtomicReference<Principal> principalAtomicReference = new AtomicReference<>();
     AtomicReference<String> methodAtomicReference = new AtomicReference<>();
     AtomicReference<String> pathAtomicReference = new AtomicReference<>();
-    this.authorizationProvider = (user, method, path) -> {
-      throwIfNullPrincipal(user);
-      principalAtomicReference.set(user);
-      methodAtomicReference.set(method);
-      pathAtomicReference.set(path);
+    this.authorizationProvider = new KsqlAuthorizationProvider() {
+      @Override
+      public void checkEndpointAccess(final Principal user,
+                                      final String method,
+                                      final String path) {
+        throwIfNullPrincipal(user);
+        principalAtomicReference.set(user);
+        methodAtomicReference.set(method);
+        pathAtomicReference.set(path);
+      }
+
+      @Override
+      public void checkPrivileges(final KsqlSecurityContext securityContext,
+                                  final AuthObjectType objectType,
+                                  final String objectName,
+                                  final List<AclOperation> privileges) {
+        // Not required for vert.x authX as it only authorizes endpoints
+      }
     };
+
     createServer(createServerConfig());
     client = createClient();
     action.run();
@@ -581,9 +614,23 @@ public class AuthTest extends ApiTest {
       ExceptionThrowingRunnable runnable) throws Exception {
     stopServer();
     stopClient();
-    this.authorizationProvider = (user, method, path) -> {
-      throw new KsqlException("Forbidden");
+    this.authorizationProvider = new KsqlAuthorizationProvider() {
+      @Override
+      public void checkEndpointAccess(final Principal user,
+                                      final String method,
+                                      final String path) {
+        throw new KsqlException("Forbidden");
+      }
+
+      @Override
+      public void checkPrivileges(final KsqlSecurityContext securityContext,
+                                  final AuthObjectType objectType,
+                                  final String objectName,
+                                  final List<AclOperation> privileges) {
+        // Not required for vert.x authX as it only authorizes endpoints
+      }
     };
+
     createServer(createServerConfig());
     client = createClient();
     runnable.run();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/MockKsqlSecurityExtension.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/MockKsqlSecurityExtension.java
@@ -1,9 +1,14 @@
 package io.confluent.ksql.rest.integration;
 
+import io.confluent.ksql.security.AuthObjectType;
 import io.confluent.ksql.security.KsqlAuthorizationProvider;
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.security.KsqlUserContextProvider;
 import io.confluent.ksql.util.KsqlConfig;
+import org.apache.kafka.common.acl.AclOperation;
+import java.security.Principal;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -22,9 +27,23 @@ public class MockKsqlSecurityExtension implements KsqlSecurityExtension {
 
   @Override
   public Optional<KsqlAuthorizationProvider> getAuthorizationProvider() {
-    return Optional.of(
-        (user, method, path) -> MockKsqlSecurityExtension.provider
-            .checkEndpointAccess(user, method, path));
+    return Optional.of(new KsqlAuthorizationProvider() {
+      @Override
+      public void checkEndpointAccess(final Principal user,
+                                      final String method,
+                                      final String path) {
+        MockKsqlSecurityExtension.provider.checkEndpointAccess(user, method, path);
+      }
+
+      @Override
+      public void checkPrivileges(final KsqlSecurityContext securityContext,
+                                  final AuthObjectType objectType,
+                                  final String objectName,
+                                  final List<AclOperation> privileges) {
+        MockKsqlSecurityExtension.provider
+            .checkPrivileges(securityContext, objectType, objectName, privileges);
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
### Description 
KSQL has already validations for Kafka permissions when a new query, DDL or DML statement is executed by a user. This PR adds another validation for Schema Registry permissions.

The idea behind this PR is to let users know exactly what's causing a query or DDL operation to fail and also produce a more generic authorization error message similar to the one we have with Kafka. Currently, some statements show the SR authorization error returned by SR, but queries, for instance, never shown anything. Queries run and do not show any error and users always wonder why there's no data streamed (reason was a SR denied operation).

NOTE
This PR is based on an very old PR (https://github.com/confluentinc/ksql/pull/3323). It was easier to push a new PR with the updates. Also, the comments in that PR suggested we change the SR API to produce the authorization error we want, but that requires more work in SR and KSQL. Also, SR may change error messages in the future. The idea of this PR is to have our own authorization message error, for both SR and Kafka, and no depend from other services when we implement better authorization alternatives (i.e. check against RBAC instead of SR and Kafka).

To help the reviewer understand the workflow of validations. 

1. Start on the `KsqlAuthorizationValidatorImpl`. This validator is called on every KSQL request to check a user has permissions to access a topic (and now a SR subject). It is also called by the DistributedExecutor before writing a command to the command topic to check if the KSQL server will have permissions to access the topic (and now a SR subject) later when the command is processed. If the user or the KSQL server do not have permissions, then it throws an authorization exception. No all perms checks are done in this class. Other perms are checked when calling the SR client directly, which should return the right authorization exception.

2. The new authorization exception for SR is called `KsqlSchemaAuthorizationException` that produces an error message with the denied operation. This is the message the users will see in the CLI. The message is similar to the `KsqlTopicAuthorizationException`.

3. The `KsqlAuthorizationValidatorImpl` calls the internal backed validation `KsqlBackendAccessValidator`, which now has a SR validation. The SR validation only supports READ operations. WRITE operations are not possible yet (need to figure out how). We might need to make changes in SR to have a new API to check permissions, but this may require a design doc for SR to add new REST API (will follow-up later). Other option is to check the permission directly in RBAC, but requires changes in the security plugins (will follow-up  in another PR).

4. The `KsqlCacheAccessValidator` is also updated to cache SR permissions checks. If you ask why a cache?, this cache was implemented in the past to make pull queries perform better.

5. The rest of the changes are places where the SR client is called to fetch or register a schema. Those places just make sure to return the `KsqlSchemaAuthorizationException` in case the returned SR error is 403 or 404.



### Testing done 
Added some unit tests and verified in an environment with RBAC + SR.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

