### PR TITLE
test: remove ambiguity from deleteTopics method call

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -111,7 +111,7 @@ public class KafkaTopicClientImplTest {
     when(adminClient.listTopics()).thenAnswer(listTopicResult());
     when(adminClient.describeTopics(any(), any())).thenAnswer(describeTopicsResult());
     when(adminClient.createTopics(any(), any())).thenAnswer(createTopicsResult());
-    when(adminClient.deleteTopics(any())).thenAnswer(deleteTopicsResult());
+    when(adminClient.deleteTopics(any(Collection.class))).thenAnswer(deleteTopicsResult());
     when(adminClient.describeConfigs(any())).thenAnswer(describeConfigsResult());
     when(adminClient.incrementalAlterConfigs(any())).thenAnswer(alterConfigsResult());
     when(adminClient.alterConfigs(any())).thenAnswer(alterConfigsResult());
@@ -438,7 +438,7 @@ public class KafkaTopicClientImplTest {
     kafkaTopicClient.deleteTopics(ImmutableList.of());
 
     // Then:
-    verify(adminClient, never()).deleteTopics(any());
+    verify(adminClient, never()).deleteTopics(any(Collection.class));
   }
 
   @Test
@@ -465,7 +465,7 @@ public class KafkaTopicClientImplTest {
   @Test
   public void shouldFailToDeleteOnTopicDeletionDisabledException() {
     // Given:
-    when(adminClient.deleteTopics(any()))
+    when(adminClient.deleteTopics(any(Collection.class)))
         .thenAnswer(deleteTopicsResult(new TopicDeletionDisabledException("error")));
 
     // When:
@@ -478,7 +478,7 @@ public class KafkaTopicClientImplTest {
   @Test
   public void shouldFailToDeleteOnTopicAuthorizationException() {
     // Given:
-    when(adminClient.deleteTopics(any()))
+    when(adminClient.deleteTopics(any(Collection.class)))
         .thenAnswer(deleteTopicsResult(new TopicAuthorizationException("error")));
 
     // When:
@@ -495,7 +495,7 @@ public class KafkaTopicClientImplTest {
   @Test
   public void shouldFailToDeleteOnKafkaDeleteTopicsException() {
     // Given:
-    when(adminClient.deleteTopics(any()))
+    when(adminClient.deleteTopics(any(Collection.class)))
         .thenAnswer(deleteTopicsResult(new Exception("error")));
 
     // When:
@@ -508,7 +508,7 @@ public class KafkaTopicClientImplTest {
   @Test
   public void shouldNotThrowKafkaDeleteTopicsExceptionWhenMissingTopic() {
     // Given:
-    when(adminClient.deleteTopics(any()))
+    when(adminClient.deleteTopics(any(Collection.class)))
         .thenAnswer(deleteTopicsResult(new UnknownTopicOrPartitionException("error")));
 
     // When:


### PR DESCRIPTION
### Description 
removes ambiguity from deleteTopics method call in unit tests by bounding the argument type

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

