### PR TITLE
feat: add BYTES type to ksqlDB

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/types/BytesType.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/types/BytesType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.types;
+
+public class BytesType extends ObjectType {
+  public static final BytesType INSTANCE = new BytesType();
+
+  @Override
+  public int hashCode() {
+    return 10;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    return obj instanceof BytesType;
+  }
+
+  @Override
+  public String toString() {
+    return "BYTES";
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/function/types/ParamTypes.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/function/types/ParamTypes.java
@@ -44,6 +44,7 @@ public final class ParamTypes {
   public static final DateType DATE = DateType.INSTANCE;
   public static final TimestampType TIMESTAMP = TimestampType.INSTANCE;
   public static final IntervalUnitType INTERVALUNIT = IntervalUnitType.INSTANCE;
+  public static final BytesType BYTES = BytesType.INSTANCE;
 
   public static boolean areCompatible(final SqlArgument actual, final ParamType declared) {
     return areCompatible(actual, declared, false);
@@ -159,6 +160,7 @@ public final class ParamTypes {
         || base == SqlBaseType.TIME  && declared instanceof TimeType
         || base == SqlBaseType.DATE  && declared instanceof DateType
         || base == SqlBaseType.TIMESTAMP  && declared instanceof TimestampType
+        || base == SqlBaseType.BYTES  && declared instanceof BytesType
         || allowCast && base.canImplicitlyCast(functionToSqlBaseConverter().toBaseType(declared));
     // CHECKSTYLE_RULES.ON: BooleanExpressionComplexity
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -244,9 +245,12 @@ public final class SchemaConverters {
       return handler.apply(schema);
     }
 
-    private static SqlDecimal handleBytes(final Schema schema) {
-      DecimalUtil.requireDecimal(schema);
-      return SqlDecimal.of(DecimalUtil.precision(schema), DecimalUtil.scale(schema));
+    private static SqlType handleBytes(final Schema schema) {
+      if (DecimalUtil.isDecimal(schema)) {
+        return SqlDecimal.of(DecimalUtil.precision(schema), DecimalUtil.scale(schema));
+      } else {
+        return SqlTypes.BYTES;
+      }
     }
 
     private static SqlArray toSqlArray(final Schema schema) {
@@ -293,6 +297,7 @@ public final class SchemaConverters {
             .put(SqlBaseType.TIME, t -> Time.builder().optional())
             .put(SqlBaseType.DATE, t -> Date.builder().optional())
             .put(SqlBaseType.TIMESTAMP, t -> Timestamp.builder().optional())
+            .put(SqlBaseType.BYTES, t -> SchemaBuilder.bytes().optional())
         .build();
 
     @Override
@@ -360,6 +365,7 @@ public final class SchemaConverters {
         .put(java.sql.Time.class, SqlBaseType.TIME)
         .put(java.sql.Date.class, SqlBaseType.DATE)
         .put(java.sql.Timestamp.class, SqlBaseType.TIMESTAMP)
+        .put(ByteBuffer.class, SqlBaseType.BYTES)
         .build();
 
     @Override
@@ -400,6 +406,7 @@ public final class SchemaConverters {
             .put(ParamTypes.TIME, SqlTypes.TIME)
             .put(ParamTypes.DATE, SqlTypes.DATE)
             .put(ParamTypes.TIMESTAMP, SqlTypes.TIMESTAMP)
+            .put(ParamTypes.BYTES, SqlTypes.BYTES)
             .build();
 
     @Override
@@ -444,6 +451,7 @@ public final class SchemaConverters {
             .put(ParamTypes.TIME, SqlBaseType.TIME)
             .put(ParamTypes.DATE, SqlBaseType.DATE)
             .put(ParamTypes.TIMESTAMP, SqlBaseType.TIMESTAMP)
+            .put(ParamTypes.BYTES, SqlBaseType.BYTES)
             .build();
 
     @Override

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SqlTypeWalker.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SqlTypeWalker.java
@@ -46,6 +46,7 @@ public final class SqlTypeWalker {
       .put(SqlBaseType.TIME, (v, t) -> v.visitTime((SqlPrimitiveType) t))
       .put(SqlBaseType.DATE, (v, t) -> v.visitDate((SqlPrimitiveType) t))
       .put(SqlBaseType.TIMESTAMP, (v, t) -> v.visitTimestamp((SqlPrimitiveType) t))
+      .put(SqlBaseType.BYTES, (v, t) -> v.visitBytes((SqlPrimitiveType) t))
       .put(SqlBaseType.ARRAY, SqlTypeWalker::visitArray)
       .put(SqlBaseType.MAP, SqlTypeWalker::visitMap)
       .put(SqlBaseType.STRUCT, SqlTypeWalker::visitStruct)
@@ -97,6 +98,10 @@ public final class SqlTypeWalker {
     }
 
     default S visitTimestamp(final SqlPrimitiveType type) {
+      return visitPrimitive(type);
+    }
+
+    default S visitBytes(final SqlPrimitiveType type) {
       return visitPrimitive(type);
     }
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/OperatorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/OperatorTest.java
@@ -22,6 +22,7 @@ import static io.confluent.ksql.schema.Operator.MULTIPLY;
 import static io.confluent.ksql.schema.Operator.SUBTRACT;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BOOLEAN;
+import static io.confluent.ksql.schema.ksql.types.SqlTypes.BYTES;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.DATE;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.DOUBLE;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.INTEGER;
@@ -66,6 +67,7 @@ public class OperatorTest {
       .put(SqlBaseType.TIME, TIME)
       .put(SqlBaseType.DATE, DATE)
       .put(SqlBaseType.TIMESTAMP, TIMESTAMP)
+      .put(SqlBaseType.BYTES, BYTES)
       .put(SqlBaseType.ARRAY, SqlTypes.array(BIGINT))
       .put(SqlBaseType.MAP, SqlTypes.map(SqlTypes.STRING, INTEGER))
       .put(SqlBaseType.STRUCT, SqlTypes.struct().field("f", INTEGER).build())

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -65,6 +66,7 @@ public class SchemaConvertersTest {
   private static final Schema CONNECT_BIGINT_SCHEMA = SchemaBuilder.int64().optional().build();
   private static final Schema CONNECT_DOUBLE_SCHEMA = SchemaBuilder.float64().optional().build();
   private static final Schema CONNECT_STRING_SCHEMA = SchemaBuilder.string().optional().build();
+  private static final Schema CONNECT_BYTES_SCHEMA = SchemaBuilder.bytes().optional().build();
   private static final Schema CONNECT_TIME_SCHEMA =
       org.apache.kafka.connect.data.Time.builder().optional().schema();
   private static final Schema CONNECT_DATE_SCHEMA =
@@ -81,6 +83,7 @@ public class SchemaConvertersTest {
       .put(SqlTypes.TIME, CONNECT_TIME_SCHEMA)
       .put(SqlTypes.DATE, CONNECT_DATE_SCHEMA)
       .put(SqlTypes.TIMESTAMP, CONNECT_TIMESTAMP_SCHEMA)
+      .put(SqlTypes.BYTES, CONNECT_BYTES_SCHEMA)
       .put(SqlArray.of(SqlTypes.INTEGER), SchemaBuilder
           .array(Schema.OPTIONAL_INT32_SCHEMA)
           .optional()
@@ -115,6 +118,7 @@ public class SchemaConvertersTest {
       .put(SqlBaseType.TIME, Time.class)
       .put(SqlBaseType.DATE, Date.class)
       .put(SqlBaseType.TIMESTAMP, Timestamp.class)
+      .put(SqlBaseType.BYTES, ByteBuffer.class)
       .build();
 
   private static final BiMap<SqlType, ParamType> SQL_TO_FUNCTION = ImmutableBiMap
@@ -127,6 +131,7 @@ public class SchemaConvertersTest {
       .put(SqlTypes.TIME, ParamTypes.TIME)
       .put(SqlTypes.DATE, ParamTypes.DATE)
       .put(SqlTypes.TIMESTAMP, ParamTypes.TIMESTAMP)
+      .put(SqlTypes.BYTES, ParamTypes.BYTES)
       .put(SqlArray.of(SqlTypes.INTEGER), ArrayType.of(ParamTypes.INTEGER))
       .put(SqlDecimal.of(2, 1), ParamTypes.DECIMAL)
       .put(

--- a/ksqldb-engine-common/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksqldb-engine-common/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.schema.ksql;
 import static io.confluent.ksql.schema.ksql.types.SqlBaseType.ARRAY;
 import static io.confluent.ksql.schema.ksql.types.SqlBaseType.BIGINT;
 import static io.confluent.ksql.schema.ksql.types.SqlBaseType.BOOLEAN;
+import static io.confluent.ksql.schema.ksql.types.SqlBaseType.BYTES;
 import static io.confluent.ksql.schema.ksql.types.SqlBaseType.DATE;
 import static io.confluent.ksql.schema.ksql.types.SqlBaseType.DECIMAL;
 import static io.confluent.ksql.schema.ksql.types.SqlBaseType.DOUBLE;
@@ -323,6 +324,8 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
             .put(key(TIMESTAMP, TIMESTAMP), Coercer.PASS_THROUGH)
             .put(key(TIME, TIME), Coercer.PASS_THROUGH)
             .put(key(DATE, DATE), Coercer.PASS_THROUGH)
+            // BYTES:
+            .put(key(BYTES, BYTES), Coercer.PASS_THROUGH)
             .build();
 
     private static final ImmutableMap<SupportedCoercion, Coercer> LAX_ADDITIONAL =

--- a/ksqldb-engine-common/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksqldb-engine-common/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.schema.ksql;
 
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BOOLEAN;
+import static io.confluent.ksql.schema.ksql.types.SqlTypes.BYTES;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.DATE;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.DOUBLE;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.INTEGER;
@@ -50,6 +51,7 @@ import io.confluent.ksql.schema.ksql.types.SqlStruct.Field;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -315,6 +317,11 @@ public class DefaultSqlValueCoercerTest {
             .put(STRING, laxOnly("1990-03-03"))
             .build()
         )
+        // BYTES:
+        .put(ByteBuffer.wrap(new byte[] {110}), ImmutableMap.<SqlType, Object>builder()
+            .put(BYTES, ByteBuffer.wrap(new byte[] {110}))
+            .build()
+        )
         // ARRAY:
         .put(ImmutableList.of(), ImmutableMap.<SqlType, Object>builder()
             .put(array(BOOLEAN), ImmutableList.of())
@@ -329,6 +336,7 @@ public class DefaultSqlValueCoercerTest {
             .put(array(TIME), ImmutableList.of())
             .put(array(DATE), ImmutableList.of())
             .put(array(TIMESTAMP), ImmutableList.of())
+            .put(array(BYTES), ImmutableList.of())
             .build()
         )
         .put(ImmutableList.of(true, false), ImmutableMap.<SqlType, Object>builder()
@@ -431,6 +439,10 @@ public class DefaultSqlValueCoercerTest {
                 .put(
                     struct().field("def", DATE).build(),
                     createStruct(struct().field("def", DATE).build())
+                )
+                .put(
+                    struct().field("ghi", BYTES).build(),
+                    createStruct(struct().field("ghi", BYTES).build())
                 )
                 .build()
         )
@@ -1018,7 +1030,8 @@ public class DefaultSqlValueCoercerTest {
           is(ImmutableSet.of(
               SqlBaseType.BOOLEAN, SqlBaseType.INTEGER, SqlBaseType.BIGINT, SqlBaseType.DECIMAL,
               SqlBaseType.DOUBLE, SqlBaseType.STRING, SqlBaseType.ARRAY, SqlBaseType.MAP,
-              SqlBaseType.STRUCT, SqlBaseType.TIME, SqlBaseType.DATE, SqlBaseType.TIMESTAMP
+              SqlBaseType.STRUCT, SqlBaseType.TIME, SqlBaseType.DATE, SqlBaseType.TIMESTAMP,
+              SqlBaseType.BYTES
           ))
       );
     }
@@ -1092,6 +1105,7 @@ public class DefaultSqlValueCoercerTest {
         .put(SqlBaseType.TIME, SqlTypes.TIME)
         .put(SqlBaseType.DATE, SqlTypes.DATE)
         .put(SqlBaseType.TIMESTAMP, SqlTypes.TIMESTAMP)
+        .put(SqlBaseType.BYTES, BYTES)
         .build();
 
     static SqlType typeInstanceFor(final SqlBaseType baseType) {
@@ -1118,6 +1132,7 @@ public class DefaultSqlValueCoercerTest {
         .put(SqlBaseType.TIME, new Time(1000L))
         .put(SqlBaseType.DATE, new Date(636451200000L))
         .put(SqlBaseType.TIMESTAMP, new Timestamp(1535792475000L))
+        .put(SqlBaseType.BYTES, ByteBuffer.wrap(new byte[] {88, 34, 120}))
         .build();
 
     @SuppressWarnings("fallthrough")
@@ -1225,6 +1240,9 @@ public class DefaultSqlValueCoercerTest {
             .put(SqlBaseType.TIMESTAMP, ImmutableSet.<SqlBaseType>builder()
                 .add(SqlBaseType.TIMESTAMP)
                 .build())
+            .put(SqlBaseType.BYTES, ImmutableSet.<SqlBaseType>builder()
+                .add(SqlBaseType.BYTES)
+                .build())
             .build();
 
     private static final ImmutableMap<SqlBaseType, ImmutableSet<SqlBaseType>> LAX_ADDITIONAL =
@@ -1265,6 +1283,9 @@ public class DefaultSqlValueCoercerTest {
                 .build())
             .put(SqlBaseType.DATE, ImmutableSet.<SqlBaseType>builder()
                 .add(SqlBaseType.STRING)
+                .build())
+            .put(SqlBaseType.BYTES, ImmutableSet.<SqlBaseType>builder()
+                .add(SqlBaseType.BYTES)
                 .build())
             .build();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
@@ -539,6 +540,13 @@ public final class ExpressionTreeRewriter<C> {
     @Override
     public Expression visitTimestampLiteral(
         final TimestampLiteral node,
+        final C context) {
+      return plugin.apply(node, new Context<>(context, this)).orElse(node);
+    }
+
+    @Override
+    public Expression visitBytesLiteral(
+        final BytesLiteral node,
         final C context) {
       return plugin.apply(node, new Context<>(context, this)).orElse(node);
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTypes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTypes.java
@@ -30,6 +30,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -65,6 +66,7 @@ class UdafTypes {
       .add(Function.class)
       .add(BiFunction.class)
       .add(TriFunction.class)
+      .add(ByteBuffer.class)
       .build();
 
   private final Type inputType;

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
@@ -331,6 +332,16 @@ public class SqlToJavaVisitor {
         final InListExpression inListExpression, final Context context
     ) {
       return visitUnsupported(inListExpression);
+    }
+
+    @Override
+    public Pair<String, SqlType> visitBytesLiteral(
+        final BytesLiteral node, final Context context
+    ) {
+      return new Pair<>(
+          node.toString(),
+          SqlTypes.BYTES
+      );
     }
 
     @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/SqlTypeCodeGen.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/SqlTypeCodeGen.java
@@ -81,6 +81,11 @@ public final class SqlTypeCodeGen {
     }
 
     @Override
+    public String visitBytes(final SqlPrimitiveType type) {
+      return "SqlTypes.BYTES";
+    }
+
+    @Override
     public String visitDecimal(final SqlDecimal type) {
       return "SqlTypes.decimal(" + type.getPrecision() + "," + type.getScale() + ")";
     }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -195,7 +195,7 @@ public final class ExpressionFormatter {
     @Override
     public String visitBytesLiteral(final BytesLiteral bytesLiteral, final Context context) {
       return "ByteBuffer.wrap(new byte[]{"
-          + StringUtils.join(bytesLiteral.getByteArray(), ",") + "})";
+          + StringUtils.join(bytesLiteral.getByteArray(), ',') + "})";
     }
 
     @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
@@ -66,6 +67,7 @@ import io.confluent.ksql.util.KsqlConstants;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 public final class ExpressionFormatter {
 
@@ -188,6 +190,12 @@ public final class ExpressionFormatter {
     @Override
     public String visitDecimalLiteral(final DecimalLiteral node, final Context context) {
       return node.getValue().toString();
+    }
+
+    @Override
+    public String visitBytesLiteral(final BytesLiteral bytesLiteral, final Context context) {
+      return "ByteBuffer.wrap(new byte[]{"
+          + StringUtils.join(bytesLiteral.getByteArray(), ",") + "})";
     }
 
     @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BytesLiteral.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BytesLiteral.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.expression.tree;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.NodeLocation;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.lang3.ArrayUtils;
+
+@Immutable
+public class BytesLiteral extends Literal {
+
+  private final ImmutableList<Byte> value;
+
+  public BytesLiteral(final ByteBuffer value) {
+    this(Optional.empty(), value);
+  }
+
+  public BytesLiteral(final Optional<NodeLocation> location, final ByteBuffer value) {
+    super(location);
+    final byte[] bytes = new byte[requireNonNull(value, "value").capacity()];
+    value.get(bytes);
+    this.value = ImmutableList.copyOf(ArrayUtils.toObject(bytes));
+  }
+
+  @Override
+  public ByteBuffer getValue() {
+    return ByteBuffer.wrap(ArrayUtils.toPrimitive(value.toArray(new Byte[0])));
+  }
+
+  public Byte[] getByteArray() {
+    return value.toArray(new Byte[0]);
+  }
+
+  @Override
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
+    return visitor.visitBytesLiteral(this, context);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final BytesLiteral that = (BytesLiteral) o;
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+}

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BytesLiteral.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BytesLiteral.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.nio.ByteBuffer;
-import java.util.Objects;
+import java.util.Arrays;
 import java.util.Optional;
 
 @Immutable
@@ -62,11 +62,11 @@ public class BytesLiteral extends Literal {
     }
 
     final BytesLiteral that = (BytesLiteral) o;
-    return Objects.equals(value, that.value);
+    return Arrays.equals(value, that.value);
   }
 
   @Override
   public int hashCode() {
-    return value.hashCode();
+    return Arrays.hashCode(value);
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BytesLiteral.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BytesLiteral.java
@@ -17,18 +17,16 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.commons.lang3.ArrayUtils;
 
 @Immutable
 public class BytesLiteral extends Literal {
 
-  private final ImmutableList<Byte> value;
+  private final byte[] value;
 
   public BytesLiteral(final ByteBuffer value) {
     this(Optional.empty(), value);
@@ -36,18 +34,17 @@ public class BytesLiteral extends Literal {
 
   public BytesLiteral(final Optional<NodeLocation> location, final ByteBuffer value) {
     super(location);
-    final byte[] bytes = new byte[requireNonNull(value, "value").capacity()];
-    value.get(bytes);
-    this.value = ImmutableList.copyOf(ArrayUtils.toObject(bytes));
+    this.value = new byte[requireNonNull(value, "value").capacity()];
+    value.get(this.value);
   }
 
   @Override
   public ByteBuffer getValue() {
-    return ByteBuffer.wrap(ArrayUtils.toPrimitive(value.toArray(new Byte[0])));
+    return ByteBuffer.wrap(value.clone());
   }
 
-  public Byte[] getByteArray() {
-    return value.toArray(new Byte[0]);
+  public byte[] getByteArray() {
+    return value.clone();
   }
 
   @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BytesLiteral.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BytesLiteral.java
@@ -40,7 +40,7 @@ public class BytesLiteral extends Literal {
 
   @Override
   public ByteBuffer getValue() {
-    return ByteBuffer.wrap(value.clone());
+    return ByteBuffer.wrap(value).asReadOnlyBuffer();
   }
 
   public byte[] getByteArray() {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
@@ -94,4 +94,6 @@ public interface ExpressionVisitor<R, C> {
   R visitLambdaVariable(LambdaVariable exp, C context);
 
   R visitIntervalUnit(IntervalUnit exp, C context);
+
+  R visitBytesLiteral(BytesLiteral exp, C context);
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
@@ -250,6 +250,11 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
   }
 
   @Override
+  public Void visitBytesLiteral(final BytesLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
   public Void visitType(final Type node, final C context) {
     return null;
   }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
@@ -233,4 +233,9 @@ public abstract class VisitParentExpressionVisitor<R, C> implements ExpressionVi
   public R visitIntervalUnit(final IntervalUnit node, final C context) {
     return visitExpression(node, context);
   }
+
+  @Override
+  public R visitBytesLiteral(final BytesLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/UdfUtil.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/function/UdfUtil.java
@@ -32,6 +32,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -61,6 +62,7 @@ public final class UdfUtil {
       .put(Timestamp.class, ParamTypes.TIMESTAMP)
       .put(Time.class, ParamTypes.TIME)
       .put(TimeUnit.class, ParamTypes.INTERVALUNIT)
+      .put(ByteBuffer.class, ParamTypes.BYTES)
       .build();
 
   private UdfUtil() {

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/TermCompiler.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
@@ -353,6 +354,14 @@ public class TermCompiler implements ExpressionVisitor<Term, Context> {
   @Override
   public Term visitIntegerLiteral(
       final IntegerLiteral node,
+      final Context context
+  ) {
+    return LiteralTerms.of(node.getValue());
+  }
+
+  @Override
+  public Term visitBytesLiteral(
+      final BytesLiteral node,
       final Context context
   ) {
     return LiteralTerms.of(node.getValue());

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LiteralTerms.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/interpreter/terms/LiteralTerms.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.execution.interpreter.TermEvaluationContext;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -67,6 +68,10 @@ public final class LiteralTerms {
 
   public static Term of(final TimeUnit value) {
     return new IntervalUnitTermImpl(value);
+  }
+
+  public static Term of(final ByteBuffer value) {
+    return new BytesTermImpl(value);
   }
 
   public static NullTerm ofNull() {
@@ -260,6 +265,25 @@ public final class LiteralTerms {
     @Override
     public SqlType getSqlType() {
       return SqlTypes.DATE;
+    }
+  }
+
+  public static class BytesTermImpl implements Term {
+
+    private final ByteBuffer value;
+
+    public BytesTermImpl(final ByteBuffer bytes) {
+      this.value = bytes;
+    }
+
+    @Override
+    public Object getValue(final TermEvaluationContext context) {
+      return value;
+    }
+
+    @Override
+    public SqlType getSqlType() {
+      return SqlTypes.BYTES;
     }
   }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
@@ -303,6 +304,14 @@ public class ExpressionTypeManager {
         final Context context
     ) {
       context.setSqlType(SqlTypes.STRING);
+      return null;
+    }
+
+    @Override
+    public Void visitBytesLiteral(
+        final BytesLiteral node, final Context context
+    ) {
+      context.setSqlType(SqlTypes.BYTES);
       return null;
     }
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/Literals.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/util/Literals.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.util;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.execution.expression.tree.DateLiteral;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -28,6 +29,7 @@ import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -51,6 +53,7 @@ public final class Literals {
           .put(SqlBaseType.TIME, v -> new TimeLiteral((Time) v))
           .put(SqlBaseType.DATE, v -> new DateLiteral((Date) v))
           .put(SqlBaseType.TIMESTAMP, v -> new TimestampLiteral((Timestamp) v))
+          .put(SqlBaseType.BYTES, v -> new BytesLiteral((ByteBuffer) v))
           .build();
 
   private Literals() {

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ImmutabilityTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.execution;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,6 +76,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedStream.class)
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/helpers/CastEvaluatorTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/helpers/CastEvaluatorTest.java
@@ -53,6 +53,7 @@ import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -674,7 +675,8 @@ public class CastEvaluatorTest {
           is(ImmutableSet.of(
               SqlBaseType.BOOLEAN, SqlBaseType.INTEGER, SqlBaseType.BIGINT, SqlBaseType.DECIMAL,
               SqlBaseType.DOUBLE, SqlBaseType.STRING, SqlBaseType.ARRAY, MAP,
-              SqlBaseType.STRUCT, SqlBaseType.TIME, SqlBaseType.DATE, SqlBaseType.TIMESTAMP
+              SqlBaseType.STRUCT, SqlBaseType.TIME, SqlBaseType.DATE, SqlBaseType.TIMESTAMP,
+              SqlBaseType.BYTES
           ))
       );
     }
@@ -741,6 +743,7 @@ public class CastEvaluatorTest {
         .put(SqlBaseType.TIME, SqlTypes.TIME)
         .put(SqlBaseType.DATE, SqlTypes.DATE)
         .put(SqlBaseType.TIMESTAMP, SqlTypes.TIMESTAMP)
+        .put(SqlBaseType.BYTES, SqlTypes.BYTES)
         .build();
 
     static SqlType typeInstanceFor(final SqlBaseType baseType) {
@@ -767,6 +770,7 @@ public class CastEvaluatorTest {
         .put(SqlBaseType.TIME, new Time(500L))
         .put(SqlBaseType.DATE, new Date(500L))
         .put(SqlBaseType.TIMESTAMP, new Timestamp(500))
+        .put(SqlBaseType.BYTES, ByteBuffer.wrap(new byte[] {123}))
         .build();
 
     @SuppressWarnings("fallthrough")
@@ -899,6 +903,9 @@ public class CastEvaluatorTest {
                 .add(SqlBaseType.TIME)
                 .add(SqlBaseType.DATE)
                 .add(SqlBaseType.STRING)
+                .build())
+            .put(SqlBaseType.BYTES, ImmutableSet.<SqlBaseType>builder()
+                .add(SqlBaseType.BYTES)
                 .build())
             .build();
 

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/helpers/SqlTypeCodeGenTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/helpers/SqlTypeCodeGenTest.java
@@ -46,6 +46,7 @@ public class SqlTypeCodeGenTest {
         .put(SqlBaseType.STRUCT, SqlTypes.struct()
             .field("Bob", SqlTypes.STRING)
             .build())
+        .put(SqlBaseType.BYTES, SqlTypes.BYTES)
         .build();
 
     static SqlType typeInstanceFor(final SqlBaseType baseType) {

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
@@ -72,6 +73,7 @@ import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -87,6 +89,13 @@ public class ExpressionFormatterTest {
   @Test
   public void shouldFormatBooleanLiteral() {
     assertThat(ExpressionFormatter.formatExpression(new BooleanLiteral("true")), equalTo("true"));
+  }
+
+  @Test
+  public void shouldFormatBytesLiteral() {
+    assertThat(ExpressionFormatter.formatExpression(new BytesLiteral(ByteBuffer.wrap(new byte[] {123, 45}))), equalTo("ByteBuffer.wrap(new byte[]{123,45})"));
+    assertThat(ExpressionFormatter.formatExpression(new BytesLiteral(ByteBuffer.wrap(new byte[] {}))), equalTo("ByteBuffer.wrap(new byte[]{})"));
+    assertThat(ExpressionFormatter.formatExpression(new BytesLiteral(ByteBuffer.wrap(new byte[] {123}))), equalTo("ByteBuffer.wrap(new byte[]{123})"));
   }
 
   @Test

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
 import io.confluent.ksql.execution.expression.tree.CreateArrayExpression;
@@ -90,6 +91,7 @@ import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.util.Optional;
@@ -1067,6 +1069,11 @@ public class ExpressionTypeManagerTest {
   @Test
   public void shouldProcessDateLiteral() {
     assertThat(expressionTypeManager.getExpressionSqlType(new DateLiteral(new Date(86400000))), is(SqlTypes.DATE));
+  }
+
+  @Test
+  public void shouldProcessBytesLiteral() {
+    assertThat(expressionTypeManager.getExpressionSqlType(new BytesLiteral(ByteBuffer.wrap(new byte[] {123}))), is(SqlTypes.BYTES));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/util/ApiSqlValueCoercerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/util/ApiSqlValueCoercerTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -59,6 +60,7 @@ public class ApiSqlValueCoercerTest {
       .put(SqlBaseType.TIME, SqlTypes.TIME)
       .put(SqlBaseType.DATE, SqlTypes.DATE)
       .put(SqlBaseType.TIMESTAMP, SqlTypes.TIMESTAMP)
+      .put(SqlBaseType.BYTES, SqlTypes.BYTES)
       .put(SqlBaseType.ARRAY, SqlTypes.array(SqlTypes.BIGINT))
       .put(SqlBaseType.MAP, SqlTypes.map(SqlTypes.STRING, SqlTypes.BIGINT))
       .put(SqlBaseType.STRUCT, SqlTypes.struct().field("fred", SqlTypes.INTEGER).build())
@@ -75,6 +77,7 @@ public class ApiSqlValueCoercerTest {
       .put(SqlBaseType.TIME, new Time(300))
       .put(SqlBaseType.DATE, new Date(300))
       .put(SqlBaseType.TIMESTAMP, new Timestamp(300))
+      .put(SqlBaseType.BYTES, ByteBuffer.wrap(new byte[] {123}))
       .put(SqlBaseType.ARRAY, new JsonArray().add(1L).add(2L))
       .put(SqlBaseType.MAP, new JsonObject().put("k", 1L))
       .put(SqlBaseType.STRUCT, new JsonObject().put("fred", 11))
@@ -108,6 +111,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Timestamp(3213), SqlTypes.BOOLEAN), is(Result.failure()));
     assertThat(coercer.coerce(new Time(3213), SqlTypes.BOOLEAN), is(Result.failure()));
     assertThat(coercer.coerce(new Date(3213), SqlTypes.BOOLEAN), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.BOOLEAN), is(Result.failure()));
   }
 
   @Test
@@ -125,6 +129,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Timestamp(3213), SqlTypes.INTEGER), is(Result.failure()));
     assertThat(coercer.coerce(new Time(3213), SqlTypes.INTEGER), is(Result.failure()));
     assertThat(coercer.coerce(new Date(3213), SqlTypes.INTEGER), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.INTEGER), is(Result.failure()));
   }
 
   @Test
@@ -142,6 +147,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Timestamp(3213), SqlTypes.BIGINT), is(Result.failure()));
     assertThat(coercer.coerce(new Time(3213), SqlTypes.BIGINT), is(Result.failure()));
     assertThat(coercer.coerce(new Date(3213), SqlTypes.BIGINT), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.BIGINT), is(Result.failure()));
   }
 
   @Test
@@ -164,6 +170,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Timestamp(3213), decimalType), is(Result.failure()));
     assertThat(coercer.coerce(new Time(3213), decimalType), is(Result.failure()));
     assertThat(coercer.coerce(new Date(3213), decimalType), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), decimalType), is(Result.failure()));
   }
 
   @Test
@@ -181,6 +188,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Timestamp(3213), SqlTypes.DOUBLE), is(Result.failure()));
     assertThat(coercer.coerce(new Time(3213), SqlTypes.DOUBLE), is(Result.failure()));
     assertThat(coercer.coerce(new Date(3213), SqlTypes.DOUBLE), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.DOUBLE), is(Result.failure()));
   }
 
   @Test
@@ -201,6 +209,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Timestamp(3213), arrayType), is(Result.failure()));
     assertThat(coercer.coerce(new Time(3213), arrayType), is(Result.failure()));
     assertThat(coercer.coerce(new Date(3213), arrayType), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), arrayType), is(Result.failure()));
     assertThat(coercer.coerce(ImmutableMap.of("foo", 1), arrayType), is(Result.failure()));
     assertThat(coercer.coerce(new JsonObject().put("foo", 1), arrayType), is(Result.failure()));
   }
@@ -223,6 +232,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Timestamp(3213), mapType), is(Result.failure()));
     assertThat(coercer.coerce(new Time(3213), mapType), is(Result.failure()));
     assertThat(coercer.coerce(new Date(3213), mapType), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), mapType), is(Result.failure()));
     assertThat(coercer.coerce(ImmutableList.of("foo"), mapType), is(Result.failure()));
     assertThat(coercer.coerce(new JsonArray().add("foo"), mapType), is(Result.failure()));
   }
@@ -312,6 +322,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Time(1000L), SqlTypes.STRING), is(Result.failure()));
     assertThat(coercer.coerce(new Date(1000L), SqlTypes.STRING), is(Result.failure()));
     assertThat(coercer.coerce(new BigDecimal(123), SqlTypes.STRING), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.STRING), is(Result.failure()));
   }
 
   @Test
@@ -330,6 +341,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Time(1000L), SqlTypes.TIMESTAMP), is(Result.failure()));
     assertThat(coercer.coerce(new Date(1000L), SqlTypes.TIMESTAMP), is(Result.failure()));
     assertThat(coercer.coerce(new BigDecimal(123), SqlTypes.TIMESTAMP), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.TIMESTAMP), is(Result.failure()));
   }
 
   @Test
@@ -348,6 +360,7 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Timestamp(1000L), SqlTypes.TIME), is(Result.failure()));
     assertThat(coercer.coerce(new Date(1000L), SqlTypes.TIME), is(Result.failure()));
     assertThat(coercer.coerce(new BigDecimal(123), SqlTypes.TIME), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.TIME), is(Result.failure()));
   }
 
   @Test
@@ -366,6 +379,25 @@ public class ApiSqlValueCoercerTest {
     assertThat(coercer.coerce(new Time(1000L), SqlTypes.DATE), is(Result.failure()));
     assertThat(coercer.coerce(new Timestamp(1000L), SqlTypes.DATE), is(Result.failure()));
     assertThat(coercer.coerce(new BigDecimal(123), SqlTypes.DATE), is(Result.failure()));
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.DATE), is(Result.failure()));
+  }
+
+  @Test
+  public void shouldCoerceToBytes() {
+    assertThat(coercer.coerce(ByteBuffer.wrap(new byte[] {123}), SqlTypes.BYTES), is(Result.of(ByteBuffer.wrap(new byte[] {123}))));
+  }
+
+  @Test
+  public void shouldNotCoerceToBytes() {
+    assertThat(coercer.coerce(true, SqlTypes.BYTES), is(Result.failure()));
+    assertThat(coercer.coerce(1, SqlTypes.BYTES), is(Result.failure()));
+    assertThat(coercer.coerce(1L, SqlTypes.BYTES), is(Result.failure()));
+    assertThat(coercer.coerce(1.0d, SqlTypes.BYTES), is(Result.failure()));
+    assertThat(coercer.coerce("aaa", SqlTypes.BYTES), is(Result.failure()));
+    assertThat(coercer.coerce(new Time(1000L), SqlTypes.BYTES), is(Result.failure()));
+    assertThat(coercer.coerce(new Date(3213), SqlTypes.BYTES), is(Result.failure()));
+    assertThat(coercer.coerce(new Timestamp(1000L), SqlTypes.BYTES), is(Result.failure()));
+    assertThat(coercer.coerce(new BigDecimal(123), SqlTypes.BYTES), is(Result.failure()));
   }
 
   @Test

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/JavaToSqlConverter.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/JavaToSqlConverter.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.utils.SchemaException;
 import io.confluent.ksql.types.KsqlStruct;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -47,6 +48,7 @@ class JavaToSqlConverter implements JavaToSqlTypeConverter {
       .put(Date.class, SqlBaseType.DATE)
       .put(Time.class, SqlBaseType.TIME)
       .put(Timestamp.class, SqlBaseType.TIMESTAMP)
+      .put(ByteBuffer.class, SqlBaseType.BYTES)
       .build();
 
   @Override

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlBaseType.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlBaseType.java
@@ -22,7 +22,8 @@ import java.util.stream.Stream;
  * The SQL types supported by KSQL.
  */
 public enum SqlBaseType {
-  BOOLEAN, INTEGER, BIGINT, DECIMAL, DOUBLE, STRING, ARRAY, MAP, STRUCT, TIME, DATE, TIMESTAMP;
+  BOOLEAN, INTEGER, BIGINT, DECIMAL, DOUBLE, STRING, ARRAY, MAP, STRUCT, TIME, DATE, TIMESTAMP,
+  BYTES;
 
   /**
    * @return {@code true} if numeric type.

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
@@ -39,6 +39,7 @@ public final class SqlPrimitiveType extends SqlType {
           .put(SqlBaseType.TIME, new SqlPrimitiveType(SqlBaseType.TIME))
           .put(SqlBaseType.DATE, new SqlPrimitiveType(SqlBaseType.DATE))
           .put(SqlBaseType.TIMESTAMP, new SqlPrimitiveType(SqlBaseType.TIMESTAMP))
+          .put(SqlBaseType.BYTES, new SqlPrimitiveType(SqlBaseType.BYTES))
           .build();
 
   private static final ImmutableSet<String> PRIMITIVE_TYPE_NAMES = ImmutableSet.<String>builder()

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlTypes.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/schema/ksql/types/SqlTypes.java
@@ -28,6 +28,7 @@ public final class SqlTypes {
   public static final SqlPrimitiveType TIME = SqlPrimitiveType.of(SqlBaseType.TIME);
   public static final SqlPrimitiveType DATE = SqlPrimitiveType.of(SqlBaseType.DATE);
   public static final SqlPrimitiveType TIMESTAMP = SqlPrimitiveType.of(SqlBaseType.TIMESTAMP);
+  public static final SqlPrimitiveType BYTES = SqlPrimitiveType.of(SqlBaseType.BYTES);
 
   public static SqlDecimal decimal(final int precision, final int scale) {
     return SqlDecimal.of(precision, scale);


### PR DESCRIPTION
### Description 
Adds SqlTypes.BYTES and BytesLiteral to ksqlDB. The main KLIP, #7764, is not merged yet but this PR is almost 100% wiring with no logic, so I'm filing this now to prep for future BYTES work.

### Testing done 
Updated unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

