### PR TITLE
test: fix flaky test where FileWatcher might be called multiple times for update

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
@@ -91,7 +91,9 @@ public class FileWatcherTest {
     Files.write(filePath, someBytes);
 
     // Then:
-    verify(callback, timeout(TimeUnit.MINUTES.toMillis(1))).run();
+    // verify that this happens at least once, there's a possibility that the callback
+    // gets called multiple times for one underlying change
+    verify(callback, timeout(TimeUnit.MINUTES.toMillis(1)).atLeastOnce()).run();
   }
 
   @Test


### PR DESCRIPTION
### Description 

This is the counterpart to #6696 except for also file updated, not just created.

### Testing done 

Ran the test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

