### PR TITLE
refactor: wrap SchemaRegistry authorization errors into a KsqlSchemaAuthorizationException

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.exception;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.acl.AclOperation;
+
+public class KsqlSchemaAuthorizationException extends RuntimeException {
+  public KsqlSchemaAuthorizationException(final AclOperation operation, final String objectName) {
+    super(String.format("Authorization denied to %s on Schema Registry subject: [%s]",
+        StringUtils.capitalize(
+            operation.toString().toLowerCase()),
+        objectName));
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegisterInjector.java
@@ -24,6 +24,7 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufSerializer;
 import io.confluent.kafka.serializers.subject.DefaultReferenceSubjectNameStrategy;
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.exception.KsqlSchemaAuthorizationException;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
 import io.confluent.ksql.parser.properties.with.SourcePropertiesUtil;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
@@ -50,6 +51,7 @@ import io.confluent.ksql.util.KsqlStatementException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import org.apache.kafka.common.acl.AclOperation;
 
 public class SchemaRegisterInjector implements Injector {
 
@@ -229,6 +231,16 @@ public class SchemaRegisterInjector implements Injector {
         }
       }
     } catch (IOException | RestClientException e) {
+      if (SchemaRegistryUtil.isAuthErrorCode(e)) {
+        final AclOperation deniedOperation = SchemaRegistryUtil.getDeniedOperation(e.getMessage());
+
+        if (deniedOperation != AclOperation.UNKNOWN) {
+          throw new KsqlSchemaAuthorizationException(
+              deniedOperation,
+              subject);
+        }
+      }
+
       throw new KsqlStatementException(
           "Could not register schema for topic: " + e.getMessage(),
           statementText,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
@@ -172,8 +172,9 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
   private static SchemaResult notFound(final String topicName, final boolean isKey) {
     final String subject = getSRSubject(topicName, isKey);
     return SchemaResult.failure(new KsqlException(
-        "Schema for message " + (isKey ? "keys" : "values") +  " on topic " + topicName
+        "Schema for message " + (isKey ? "keys" : "values") +  " on topic '" + topicName + "'"
             + " does not exist in the Schema Registry."
+            + System.lineSeparator()
             + "Subject: " + subject
             + System.lineSeparator()
             + "Possible causes include:"
@@ -196,7 +197,7 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
             + "\t-> Use the REST API to list available subjects"
             + "\t" + DocumentationLinks.SR_REST_GETSUBJECTS_DOC_URL
             + System.lineSeparator()
-            + "- You do not have permissions to access the Schema Registry.Subject: " + subject
+            + "- You do not have permissions to access the Schema Registry."
             + System.lineSeparator()
             + "\t-> See " + DocumentationLinks.SCHEMA_REGISTRY_SECURITY_DOC_URL));
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -970,7 +970,8 @@ public class InsertValuesExecutorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Not authorized to read Schema Registry subject: [" + KsqlConstants.getSRSubject(TOPIC_NAME, true)));
+        "Authorization denied to Read on Schema Registry subject: ["
+            + KsqlConstants.getSRSubject(TOPIC_NAME, true)));
   }
 
   @Test
@@ -1006,7 +1007,8 @@ public class InsertValuesExecutorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Not authorized to write Schema Registry subject: [" + KsqlConstants.getSRSubject(TOPIC_NAME, true)));
+        "Authorization denied to Write on Schema Registry subject: ["
+            + KsqlConstants.getSRSubject(TOPIC_NAME, true)));
   }
 
   @Test
@@ -1042,7 +1044,8 @@ public class InsertValuesExecutorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Not authorized to write Schema Registry subject: [" + KsqlConstants.getSRSubject(TOPIC_NAME, false)));
+        "Authorization denied to Write on Schema Registry subject: ["
+            + KsqlConstants.getSRSubject(TOPIC_NAME, false)));
   }
 
   private static ConfiguredStatement<InsertValues> givenInsertValues(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplierTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplierTest.java
@@ -290,8 +290,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     final String keyOrValue = isKey ? "keys" : "values";
     final String keyOrValueSuffix = isKey ? "key" : "value";
     assertThat(result.failureReason.get().getMessage(), is(
-        "Schema for message " + keyOrValue + " on topic " + TOPIC_NAME + " does not exist in the Schema Registry.Subject: "
-            + TOPIC_NAME + "-" + keyOrValueSuffix + System.lineSeparator()
+        "Schema for message " + keyOrValue + " on topic '" + TOPIC_NAME + "' does not exist in the Schema Registry." + System.lineSeparator()
+            + "Subject: " + TOPIC_NAME + "-" + keyOrValueSuffix + System.lineSeparator()
             + "Possible causes include:" + System.lineSeparator()
             + "- The topic itself does not exist" + System.lineSeparator()
             + "\t-> Use SHOW TOPICS; to check" + System.lineSeparator()
@@ -301,7 +301,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
             + "\t-> See https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html" + System.lineSeparator()
             + "- The schema is registered on a different instance of the Schema Registry" + System.lineSeparator()
             + "\t-> Use the REST API to list available subjects\thttps://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects" + System.lineSeparator()
-            + "- You do not have permissions to access the Schema Registry.Subject: " + TOPIC_NAME + "-" + keyOrValueSuffix + System.lineSeparator()
+            + "- You do not have permissions to access the Schema Registry." + System.lineSeparator()
             + "\t-> See https://docs.confluent.io/current/schema-registry/docs/security.html"));
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -254,7 +254,7 @@ public class StandaloneExecutorFunctionalTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Schema for message values on topic topic-without-schema does not exist in the Schema Registry"));
+        "Schema for message values on topic 'topic-without-schema' does not exist in the Schema Registry"));
   }
 
   @Test


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
Part of https://github.com/confluentinc/ksql/pull/7773. This only added a new exception to manage SchemaRegistry authorization errors and calls it where it is needed.

https://github.com/confluentinc/ksql/pull/7773 requires other changes to provide better SR permissions checks. 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

