### PR TITLE
test: increase time out for migrations test

### DIFF
--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -631,6 +631,7 @@ public class MigrationsTest {
 
   private static List<StreamedRow> waitForNumRows(final String pullQuery, final int numRows) {
     return assertThatEventually(
+        "Query '" + pullQuery + "' never got " + numRows + " rows",
         () -> {
           try {
             return makeKsqlQuery(pullQuery);
@@ -644,7 +645,9 @@ public class MigrationsTest {
             }
           }
         },
-        hasSize(numRows)
+        hasSize(numRows),
+        1,
+        TimeUnit.MINUTES
     );
   }
 }


### PR DESCRIPTION
### Description 

There were some times when the `shouldApplyMigrationsAndDisplayInfo` was failing due to a materialized view not being available within 30s. I've seen this happen before on really slow Jenkins nodes, so we're just increasing the timeout and hoping it doesn't happen again. The integration test is worth keeping.

### Testing done 

Ran the test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

