### PR TITLE
docs: building from tagged source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contributing
 
-Thanks for helping us to make KSQL even better!
+Thanks for helping us to make ksqlDB even better!
 
-If you have any questions about how to contribute, either [create a GH issue](https://github.com/confluentinc/ksql/issues) or ask your question in the #ksql channel in our public [Confluent Community Slack](https://slackpass.io/confluentcommunity) (account registration is free and self-service).
+If you have any questions about how to contribute, either [create a GH issue](https://github.com/confluentinc/ksql/issues) or ask your question in the #ksqldb channel in our public [Confluent Community Slack](https://slackpass.io/confluentcommunity) (account registration is free and self-service).
 
 
-## Developing KSQL
+## Developing ksqlDB
 
 ### About the Apache Maven wrapper
 
-Development versions of KSQL use version ranges for dependencies
+Development versions of ksqlDB use version ranges for dependencies
 on other Confluent projects, and due to
 [a bug in Apache Maven](https://issues.apache.org/jira/browse/MRESOLVER-164),
 you may find that both Maven and your IDE download hundreds or thousands
@@ -44,9 +44,9 @@ Finally, you may need to restart the IDE to get it to reload the Maven binary.
 
 There is likely a similar option available for other IDEs.
 
-### Building and running KSQL locally
+### Building and running ksqlDB locally
 
-To build and run KSQL locally, run the following commands:
+To build and run ksqlDB locally, run the following commands:
 
 ```shell
 $ ./mvnw clean package -DskipTests
@@ -54,12 +54,29 @@ $ ./bin/ksql-server-start -daemon config/ksql-server.properties
 $ ./bin/ksql
 ```
 
-This will start the KSQL server in the background and the KSQL CLI in the
+This will start the ksqlDB server in the background and the ksqlDB CLI in the
 foreground. Check the `logs` folder for the log files that the server writes 
 including any errors.
 
-If you would rather have the KSQL server logs spool to the console, then
+If you would rather have the ksqlDB server logs spool to the console, then
 drop the `-daemon` switch, and start the CLI in a second console.
+
+#### Building a released version
+
+The source for standalone ksqlDB versions is tagged with the pattern vN.NN.N-ksqldb. For
+example, the tag for the 0.18.0 standalone release is v0.18.0-ksqldb.
+
+If you wish to build a released version, run the following commands, replacing `0.18.0`
+with the desired version:
+
+```shell
+$ git fetch origin --tags
+$ git checkout v0.18.0-ksqldb
+$ ./mvnw --settings maven-settings.xml clean package -DskipTests
+```
+
+Note that the `--settings maven-settings.xml` argument is necessary to ensure all dependencies
+can be pulled respective to the target version.
 
 #### Running in an IDE
 
@@ -184,7 +201,7 @@ where the `type` is one of
  * "perf", "style", "build", "ci", or "chore": as described in the [Angular specification][https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type] for Conventional Commits.
 
 The (optional) scope is a noun describing the section of the codebase affected by the change.
-Examples that could make sense for KSQL include "parser", "analyzer", "rest server", "testing tool",
+Examples that could make sense for ksqlDB include "parser", "analyzer", "rest server", "testing tool",
 "cli", "processing log", and "metrics", to name a few.
 
 The optional body and footer are for specifying additional information, such as linking to issues fixed by the commit
@@ -218,7 +235,7 @@ Breaking changes must be called out in commit messages, PR descriptions, and upg
 
 This project has [commitlint][https://github.com/conventional-changelog/commitlint] configured
 to ensure that commit messages are of the expected format.
-To enable commitlint, simply run `npm install` from the root directory of the KSQL repo
+To enable commitlint, simply run `npm install` from the root directory of the ksqlDB repo
 (after [installing `npm`][https://www.npmjs.com/get-npm].)
 Once enabled, commitlint will reject commits with improperly formatted commit messages.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can get help, learn how to contribute to ksqlDB, and find the latest news by
 For more general questions about the Confluent Platform please post in the [Confluent Google group](https://groups.google.com/forum/#!forum/confluent-platform).
 
 
-# Contributing
+# Contributing and building from source
 
 Contributions to the code, examples, documentation, etc. are very much appreciated.
 


### PR DESCRIPTION
Based on feedback from @jaceklaskowski, make it more clear how to build from source, including from release tags. See the `Building a released version` section.

This also updates some project name references from KSQL to ksqlDB.