### PR TITLE
feat: implement serdes for bytes

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -279,6 +279,7 @@ public class DefaultSchemaInjectorFunctionalTest {
             .nullableString("STRING", "bar")
             .endRecord(),
         SchemaBuilder.struct()
+            .field("FIXED_FIELD", Schema.OPTIONAL_BYTES_SCHEMA)
             .field("STRING", Schema.OPTIONAL_STRING_SCHEMA)
             .optional()
             .build()
@@ -286,13 +287,14 @@ public class DefaultSchemaInjectorFunctionalTest {
   }
 
   @Test
-  public void shouldIgnoreBytes() {
+  public void shouldInferBytes() {
     shouldInferType(
         org.apache.avro.SchemaBuilder.record("foo").fields()
             .nullableBytes("bytes", new byte[]{})
             .nullableString("STRING", "bar")
             .endRecord(),
         SchemaBuilder.struct()
+            .field("BYTES", Schema.OPTIONAL_BYTES_SCHEMA)
             .field("STRING", Schema.OPTIONAL_STRING_SCHEMA)
             .optional()
             .build()

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -139,6 +139,7 @@ public class SqlToJavaVisitor {
       "java.sql.Time",
       "java.sql.Date",
       "java.sql.Timestamp",
+      "java.nio.ByteBuffer",
       "java.util.Arrays",
       "java.util.HashMap",
       "java.util.Map",

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.test.serde;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -25,6 +27,7 @@ import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -197,8 +200,9 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
             }
 
             throw new TestFrameworkException("DECIMAL type requires JSON number in test data");
+          } else {
+            return spec.toString().getBytes(UTF_8);
           }
-          throw new RuntimeException("Unexpected BYTES type " + schema.name());
         default:
           throw new RuntimeException(
               "This test does not support the data type yet: " + schema.type());
@@ -283,8 +287,14 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
             if (data instanceof BigDecimal) {
               return data;
             }
+            throw new RuntimeException("Unexpected BYTES type " + schema.name());
+          } else {
+            if (data instanceof byte[]) {
+              return ByteBuffer.wrap((byte[]) data);
+            } else {
+              return data;
+            }
           }
-          throw new RuntimeException("Unexpected BYTES type " + schema.name());
         default:
           throw new RuntimeException("Test cannot handle data of type: " + schema.type());
       }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_should_not_filter_out_bytes/7.1.0_1626301943478/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_should_not_filter_out_bytes/7.1.0_1626301943478/plan.json
@@ -1,0 +1,153 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (EXPECTED INTEGER, C1 BYTES, C2 BYTES) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO', VALUE_SCHEMA_ID=1);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`EXPECTED` INTEGER, `C1` BYTES, `C2` BYTES",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`EXPECTED` INTEGER, `C1` BYTES, `C2` BYTES",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "AVRO"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "AVRO"
+              }
+            },
+            "sourceSchema" : "`EXPECTED` INTEGER, `C1` BYTES, `C2` BYTES"
+          },
+          "selectExpressions" : [ "EXPECTED AS EXPECTED", "C1 AS C1", "C2 AS C2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_should_not_filter_out_bytes/7.1.0_1626301943478/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_should_not_filter_out_bytes/7.1.0_1626301943478/spec.json
@@ -1,0 +1,163 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626301943478,
+  "path" : "query-validation-tests/avro.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`EXPECTED` INTEGER, `C1` BYTES, `C2` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`EXPECTED` INTEGER, `C1` BYTES, `C2` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "should not filter out bytes",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "expected" : 1,
+        "c1" : null,
+        "c2" : null,
+        "c3" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "EXPECTED" : 1,
+        "c1" : null,
+        "c2" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "blah",
+        "fields" : [ {
+          "name" : "expected",
+          "type" : "int"
+        }, {
+          "name" : "c1",
+          "type" : [ "null", "bytes" ]
+        }, {
+          "name" : "c2",
+          "type" : [ "null", {
+            "type" : "fixed",
+            "name" : "md5",
+            "size" : 16
+          } ]
+        } ]
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='AvRo');", "CREATE STREAM OUTPUT AS SELECT * FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`EXPECTED` INTEGER, `C1` BYTES, `C2` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`EXPECTED` INTEGER, `C1` BYTES, `C2` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 1,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "blah",
+            "fields" : [ {
+              "name" : "expected",
+              "type" : "int"
+            }, {
+              "name" : "c1",
+              "type" : [ "null", "bytes" ],
+              "default" : null
+            }, {
+              "name" : "c2",
+              "type" : [ "null", {
+                "type" : "fixed",
+                "name" : "md5",
+                "size" : 16,
+                "connect.parameters" : {
+                  "connect.fixed.size" : "16"
+                },
+                "connect.name" : "md5"
+              } ],
+              "default" : null
+            } ],
+            "connect.name" : "blah"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "EXPECTED",
+              "type" : [ "null", "int" ],
+              "default" : null
+            }, {
+              "name" : "C1",
+              "type" : [ "null", "bytes" ],
+              "default" : null
+            }, {
+              "name" : "C2",
+              "type" : [ "null", "bytes" ],
+              "default" : null
+            } ]
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_should_not_filter_out_bytes/7.1.0_1626301943478/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/avro_-_should_not_filter_out_bytes/7.1.0_1626301943478/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_DELIMITED_in_out/7.1.0_1626301945718/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_DELIMITED_in_out/7.1.0_1626301945718/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, B BYTES) WITH (KAFKA_TOPIC='test', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 AS SELECT *\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "topicName" : "TEST2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TEST2",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TEST2"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `B` BYTES"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "B AS B" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "TEST2"
+      },
+      "queryId" : "CSAS_TEST2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_DELIMITED_in_out/7.1.0_1626301945718/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_DELIMITED_in_out/7.1.0_1626301945718/spec.json
@@ -1,0 +1,92 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626301945718,
+  "path" : "query-validation-tests/bytes.json",
+  "schemas" : {
+    "CSAS_TEST2_0.TEST2" : {
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_TEST2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "DELIMITED in/out",
+    "inputs" : [ {
+      "topic" : "test",
+      "key" : null,
+      "value" : "dmFyaWF0aW9ucw=="
+    } ],
+    "outputs" : [ {
+      "topic" : "TEST2",
+      "key" : null,
+      "value" : "dmFyaWF0aW9ucw=="
+    } ],
+    "topics" : [ {
+      "name" : "TEST2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, b BYTES) WITH (kafka_topic='test', value_format='DELIMITED');", "CREATE STREAM TEST2 AS SELECT * FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST2",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TEST2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_DELIMITED_in_out/7.1.0_1626301945718/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_DELIMITED_in_out/7.1.0_1626301945718/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_JSON_in_out/7.1.0_1626301945734/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_JSON_in_out/7.1.0_1626301945734/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, B BYTES) WITH (KAFKA_TOPIC='test', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 AS SELECT *\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "topicName" : "TEST2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TEST2",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TEST2"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `B` BYTES"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "B AS B" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "TEST2"
+      },
+      "queryId" : "CSAS_TEST2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_JSON_in_out/7.1.0_1626301945734/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_JSON_in_out/7.1.0_1626301945734/spec.json
@@ -1,0 +1,96 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626301945734,
+  "path" : "query-validation-tests/bytes.json",
+  "schemas" : {
+    "CSAS_TEST2_0.TEST2" : {
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_TEST2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "JSON in/out",
+    "inputs" : [ {
+      "topic" : "test",
+      "key" : null,
+      "value" : {
+        "B" : "dmFyaWF0aW9ucw=="
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "TEST2",
+      "key" : null,
+      "value" : {
+        "B" : "dmFyaWF0aW9ucw=="
+      }
+    } ],
+    "topics" : [ {
+      "name" : "TEST2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, b BYTES) WITH (kafka_topic='test', value_format='JSON');", "CREATE STREAM TEST2 AS SELECT * FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST2",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TEST2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_JSON_in_out/7.1.0_1626301945734/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_JSON_in_out/7.1.0_1626301945734/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_bytes_in_complex_types/7.1.0_1626301945751/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_bytes_in_complex_types/7.1.0_1626301945751/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, S STRUCT<B BYTES>, A ARRAY<BYTES>, M MAP<STRING, BYTES>) WITH (KAFKA_TOPIC='test', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `S` STRUCT<`B` BYTES>, `A` ARRAY<BYTES>, `M` MAP<STRING, BYTES>",
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 AS SELECT\n  TEST.ID ID,\n  TEST.S->B S,\n  TEST.A[1] A,\n  TEST.M['B'] M\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` STRING KEY, `S` BYTES, `A` BYTES, `M` BYTES",
+      "topicName" : "TEST2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TEST2",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TEST2"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `S` STRUCT<`B` BYTES>, `A` ARRAY<BYTES>, `M` MAP<STRING, BYTES>"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "S->B AS S", "A[1] AS A", "M['B'] AS M" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "TEST2"
+      },
+      "queryId" : "CSAS_TEST2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_bytes_in_complex_types/7.1.0_1626301945751/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_bytes_in_complex_types/7.1.0_1626301945751/spec.json
@@ -1,0 +1,104 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626301945751,
+  "path" : "query-validation-tests/bytes.json",
+  "schemas" : {
+    "CSAS_TEST2_0.TEST2" : {
+      "schema" : "`ID` STRING KEY, `S` BYTES, `A` BYTES, `M` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_TEST2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `S` STRUCT<`B` BYTES>, `A` ARRAY<BYTES>, `M` MAP<STRING, BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "bytes in complex types",
+    "inputs" : [ {
+      "topic" : "test",
+      "key" : null,
+      "value" : {
+        "S" : {
+          "B" : "ew=="
+        },
+        "A" : [ "ew==", "ew==" ],
+        "M" : {
+          "B" : "ew=="
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "TEST2",
+      "key" : null,
+      "value" : {
+        "S" : "ew==",
+        "A" : "ew==",
+        "M" : "ew=="
+      }
+    } ],
+    "topics" : [ {
+      "name" : "TEST2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, S STRUCT<B BYTES>, A ARRAY<BYTES>, M MAP<STRING, BYTES>) WITH (kafka_topic='test', value_format='JSON');", "CREATE STREAM TEST2 AS SELECT ID, S -> B AS S, A[1] AS A, M['B'] AS M FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `S` STRUCT<`B` BYTES>, `A` ARRAY<BYTES>, `M` MAP<STRING, BYTES>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TEST2",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `S` BYTES, `A` BYTES, `M` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TEST2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_bytes_in_complex_types/7.1.0_1626301945751/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_bytes_in_complex_types/7.1.0_1626301945751/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_should_not_filter_out_bytes/7.1.0_1626302235245/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_should_not_filter_out_bytes/7.1.0_1626302235245/plan.json
@@ -1,0 +1,153 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (EXPECTED INTEGER, C2 BYTES) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF', VALUE_SCHEMA_ID=1);",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`EXPECTED` INTEGER, `C2` BYTES",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`EXPECTED` INTEGER, `C2` BYTES",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "sourceSchema" : "`EXPECTED` INTEGER, `C2` BYTES"
+          },
+          "selectExpressions" : [ "EXPECTED AS EXPECTED", "C2 AS C2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_should_not_filter_out_bytes/7.1.0_1626302235245/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_should_not_filter_out_bytes/7.1.0_1626302235245/spec.json
@@ -1,0 +1,102 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626302235245,
+  "path" : "query-validation-tests/protobuf.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`EXPECTED` INTEGER, `C2` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`EXPECTED` INTEGER, `C2` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "should not filter out bytes",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : null,
+      "value" : {
+        "expected" : 1,
+        "c4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "EXPECTED" : 1,
+        "c2" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "valueSchema" : "syntax = \"proto3\";\n\nmessage ConfluentDefault1 {\n  int32 expected = 1;\n  bytes c2 = 2;\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='PROTOBUF');", "CREATE STREAM OUTPUT AS SELECT * FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`EXPECTED` INTEGER, `C2` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`EXPECTED` INTEGER, `C2` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 1,
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ConfluentDefault1 {\n  int32 expected = 1;\n  bytes c2 = 2;\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  int32 EXPECTED = 1;\n  bytes C2 = 2;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_should_not_filter_out_bytes/7.1.0_1626302235245/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_should_not_filter_out_bytes/7.1.0_1626302235245/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/avro.json
@@ -576,7 +576,7 @@
       }
     },
     {
-      "name": "should filter out columns with unsupported types",
+      "name": "should not filter out bytes",
       "statements": [
         "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='AvRo');",
         "CREATE STREAM OUTPUT AS SELECT * FROM input;"
@@ -592,11 +592,11 @@
           ]}
         }
       ],
-      "inputs": [{"topic": "input", "value": {"expected": 1, "c2": null, "c3": null}}],
-      "outputs": [{"topic": "OUTPUT", "value": {"EXPECTED": 1}}],
+      "inputs": [{"topic": "input", "value": {"expected": 1, "c1": null, "c2": null, "c3": null}}],
+      "outputs": [{"topic": "OUTPUT", "value": {"EXPECTED": 1, "c1": null, "c2": null}}],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "EXPECTED INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "EXPECTED INT, C1 BYTES, C2 BYTES"}
         ]
       }
     },

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes.json
@@ -1,0 +1,44 @@
+{
+  "comments": ["tests for decimal functionality"],
+  "tests": [
+    {
+      "name": "DELIMITED in/out",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, b BYTES) WITH (kafka_topic='test', value_format='DELIMITED');",
+        "CREATE STREAM TEST2 AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "value": "dmFyaWF0aW9ucw=="}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "value": "dmFyaWF0aW9ucw=="}
+      ]
+    },
+    {
+      "name": "JSON in/out",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, b BYTES) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM TEST2 AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "value": {"B": "dmFyaWF0aW9ucw=="}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "value": {"B": "dmFyaWF0aW9ucw=="}}
+      ]
+    },
+    {
+      "name": "bytes in complex types",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, S STRUCT<B BYTES>, A ARRAY<BYTES>, M MAP<STRING, BYTES>) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM TEST2 AS SELECT ID, S -> B AS S, A[1] AS A, M['B'] AS M FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "value": {"S": {"B": "ew=="}, "A":  ["ew==", "ew=="], "M":  {"B": "ew=="}}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "value": {"S": "ew==", "A":  "ew==", "M": "ew=="}}
+      ]
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -560,7 +560,7 @@
       ]
     },
     {
-      "name": "should filter out columns with unsupported types",
+      "name": "should not filter out bytes",
       "statements": [
         "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='PROTOBUF');",
         "CREATE STREAM OUTPUT AS SELECT * FROM input;"
@@ -573,10 +573,10 @@
         }
       ],
       "inputs": [{"topic": "input", "value": {"expected": 1, "c4": null}}],
-      "outputs": [{"topic": "OUTPUT", "value": {"EXPECTED": 1}}],
+      "outputs": [{"topic": "OUTPUT", "value": {"EXPECTED": 1, "c2": null}}],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "EXPECTED INT"}
+          {"name": "OUTPUT", "type": "stream", "schema": "EXPECTED INT, C2 BYTES"}
         ]
       }
     },

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/ApiJsonMapperTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/ApiJsonMapperTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.DecimalNode;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -98,5 +99,14 @@ public class ApiJsonMapperTest {
 
     // Then:
     assertThat(result, is("\"1970-01-11\""));
+  }
+
+  @Test
+  public void shouldFormatByteBuffer() throws Exception {
+    // When:
+    final String result = OBJECT_MAPPER.writeValueAsString(ByteBuffer.wrap(new byte[] {123}));
+
+    // Then:
+    assertThat(result, is("\"ew==\""));
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -120,7 +120,11 @@ public class AvroDataTranslator implements DataTranslator {
       case STRUCT:
         return convertStruct((Struct) object, schema);
       case BYTES:
-        return DecimalUtil.ensureFit((BigDecimal) object, schema);
+        if (DecimalUtil.isDecimal(schema)) {
+          return DecimalUtil.ensureFit((BigDecimal) object, schema);
+        } else {
+          return object;
+        }
       default:
         return object;
     }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroUtil.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroUtil.java
@@ -15,10 +15,8 @@
 
 package io.confluent.ksql.serde.avro;
 
-import com.google.common.base.Preconditions;
 import io.confluent.ksql.schema.connect.SchemaWalker;
 import io.confluent.ksql.schema.connect.SchemaWalker.Visitor;
-import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
@@ -37,14 +35,6 @@ final class AvroUtil {
         if (schema.keySchema().type() != Type.STRING) {
           throw new KsqlException("Avro only supports MAPs with STRING keys");
         }
-        return null;
-      }
-
-      @Override
-      public Void visitBytes(final Schema schema) {
-        Preconditions.checkArgument(
-            DecimalUtil.isDecimal(schema),
-            "Avro only supports DECIMAL for BYTES type.");
         return null;
       }
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
@@ -16,17 +16,12 @@
 package io.confluent.ksql.serde.connect;
 
 import io.confluent.ksql.serde.SerdeUtils;
-import io.confluent.ksql.util.DecimalUtil;
-import io.confluent.ksql.util.KsqlPreconditions;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
 import org.apache.kafka.connect.data.Date;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -94,18 +89,6 @@ public class ConnectDataTranslator implements DataTranslator {
   private static void validateType(
       final String pathStr,
       final Schema schema,
-      final Schema connectSchema,
-      final Predicate<Schema> requirement
-  ) {
-    if (requirement.test(connectSchema)) {
-      return;
-    }
-    throwTypeMismatchException(pathStr, schema, connectSchema);
-  }
-
-  private static void validateType(
-      final String pathStr,
-      final Schema schema,
       final Schema connectSchema
   ) {
     if (!connectSchema.type().equals(schema.type())) {
@@ -154,6 +137,7 @@ public class ConnectDataTranslator implements DataTranslator {
       case ARRAY:
       case MAP:
       case STRUCT:
+      case BYTES:
         validateType(pathStr, schema, connectSchema);
         break;
       case STRING:
@@ -167,9 +151,6 @@ public class ConnectDataTranslator implements DataTranslator {
         break;
       case FLOAT64:
         validateType(pathStr, schema, connectSchema, FLOAT64_ACCEPTABLE_TYPES);
-        break;
-      case BYTES:
-        validateType(pathStr, schema, connectSchema, s -> Decimal.LOGICAL_NAME.equals(s.name()));
         break;
       default:
         throw new RuntimeException(
@@ -185,8 +166,6 @@ public class ConnectDataTranslator implements DataTranslator {
       return connectValue;
     }
     switch  (connectSchema.name()) {
-      case Decimal.LOGICAL_NAME:
-        return connectValue;
       case Date.LOGICAL_NAME:
         return Date.fromLogical(connectSchema, (java.util.Date) connectValue);
       case Time.LOGICAL_NAME:
@@ -237,8 +216,6 @@ public class ConnectDataTranslator implements DataTranslator {
         }
       case FLOAT64:
         return ((Number) convertedValue).doubleValue();
-      case BYTES:
-        return toKsqlBytes(convertedValue, connectSchema);
       case ARRAY:
         return toKsqlArray(
             schema.valueSchema(), connectSchema.valueSchema(), (List) convertedValue, pathStr);
@@ -254,17 +231,6 @@ public class ConnectDataTranslator implements DataTranslator {
       default:
         return convertedValue;
     }
-  }
-
-  private Object toKsqlBytes(
-      final Object convertedValue,
-      final Schema schema
-  ) {
-    KsqlPreconditions.checkArgument(DecimalUtil.isDecimal(schema), "BYTES type must be DECIMAL");
-    KsqlPreconditions.checkArgument(convertedValue instanceof BigDecimal,
-        "must serialize decimal type as BigDecimal. Got: " + convertedValue.getClass());
-
-    return convertedValue;
   }
 
   private List<?> toKsqlArray(

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectSchemaUtil.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectSchemaUtil.java
@@ -132,8 +132,9 @@ public final class ConnectSchemaUtil {
   private static Schema toKsqlBytesSchema(final Schema schema) {
     if (DecimalUtil.isDecimal(schema)) {
       return schema;
+    } else {
+      return Schema.OPTIONAL_BYTES_SCHEMA;
     }
-    throw new UnsupportedTypeException("BYTES type must be DECIMAL schema.");
   }
 
   private static Schema toKsqlMapSchema(final Schema schema) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Base64.Decoder;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,8 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 
 class KsqlDelimitedDeserializer implements Deserializer<List<?>> {
+
+  private static Decoder BASE64_DECODER = Base64.getMimeDecoder();
 
   private interface Parser {
 
@@ -151,7 +154,7 @@ class KsqlDelimitedDeserializer implements Deserializer<List<?>> {
   private static Parser toBytes(final SqlType sqlType) {
     return v -> {
       try {
-        return ByteBuffer.wrap(Base64.getMimeDecoder().decode(v));
+        return ByteBuffer.wrap(BASE64_DECODER.decode(v));
       } catch (IllegalArgumentException e) {
         throw new KsqlException("Value is not a valid Base64 encoded string: " + v);
       }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
@@ -26,6 +26,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Base64;
+import java.util.Base64.Encoder;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,8 @@ import org.apache.kafka.common.serialization.Serializer;
 
 
 class KsqlDelimitedSerializer implements Serializer<List<?>> {
+
+  private static Encoder BASE64_ENCODER = Base64.getMimeEncoder();
 
   private final PersistenceSchema schema;
   private final CSVFormat csvFormat;
@@ -112,9 +115,7 @@ class KsqlDelimitedSerializer implements Serializer<List<?>> {
 
     private static String handleBytes(final ByteBuffer value) {
       // Return base64 encoding
-      return value == null
-          ? null
-          : Base64.getMimeEncoder().encodeToString(value.array());
+      return value == null ? null : BASE64_ENCODER.encodeToString(value.array());
     }
 
     private static Integer handleTime(final Time value) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
@@ -20,10 +20,12 @@ import io.confluent.ksql.schema.ksql.SimpleColumn;
 import io.confluent.ksql.serde.SerdeUtils;
 import java.io.StringWriter;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -95,6 +97,8 @@ class KsqlDelimitedSerializer implements Serializer<List<?>> {
       switch (column.type().baseType()) {
         case DECIMAL:
           return handleDecimal((BigDecimal) value);
+        case BYTES:
+          return handleBytes((ByteBuffer) value);
         case TIME:
           return handleTime((Time) value);
         case DATE:
@@ -104,6 +108,13 @@ class KsqlDelimitedSerializer implements Serializer<List<?>> {
         default:
           return value;
       }
+    }
+
+    private static String handleBytes(final ByteBuffer value) {
+      // Return base64 encoding
+      return value == null
+          ? null
+          : Base64.getMimeEncoder().encodeToString(value.array());
     }
 
     private static Integer handleTime(final Time value) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.NumericNode;

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
@@ -215,14 +216,14 @@ public class KsqlJsonDeserializer<T> implements Deserializer<T> {
       if (context.val instanceof TextNode) {
         return DecimalUtil.ensureFit(new BigDecimal(context.val.textValue()), context.schema);
       }
-    } else {
+    } else if (context.val.isTextual()) {
       try {
         return ByteBuffer.wrap(context.val.binaryValue());
       } catch (IOException e) {
-        throw invalidConversionException(context.val, context.schema);
+        throw new IllegalArgumentException("Value is not a valid Base64 encoded string: "
+            + context.val.textValue());
       }
     }
-
     throw invalidConversionException(context.val, context.schema);
   }
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
@@ -347,4 +347,16 @@ public class AvroDataTranslatorTest {
         e.getMessage(),
         containsString("Cannot fit decimal '123.4' into DECIMAL(3, 0) without rounding. (Requires 4,1)"));
   }
+
+  @Test
+  public void shouldReturnBytes() {
+    // When:
+    final AvroDataTranslator translator =
+        new AvroDataTranslator(Schema.BYTES_SCHEMA, AvroProperties.DEFAULT_AVRO_SCHEMA_FULL_NAME);
+
+    // Then:
+    assertThat(
+        translator.toKsqlRow(Schema.BYTES_SCHEMA, new byte[] {123}),
+        is(new byte[] {123}));
+  }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.serde.avro;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_BYTES_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1370,8 +1371,8 @@ public class KsqlAvroDeserializerTest {
 
     final Map<org.apache.avro.Schema, Object> validCoercions = ImmutableMap
         .<org.apache.avro.Schema, Object>builder()
-        .put(BYTES_AVRO_SCHEMA, "abc".getBytes())
-        .put(OPTIONAL_BYTES_AVRO_SCHEMA, "def".getBytes())
+        .put(BYTES_AVRO_SCHEMA, "abc".getBytes(UTF_8))
+        .put(OPTIONAL_BYTES_AVRO_SCHEMA, "def".getBytes(UTF_8))
         .build();
 
     validCoercions.forEach((schema, value) -> {

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.serde.avro;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_BOOLEAN_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_BYTES_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA;
@@ -906,9 +907,9 @@ public class KsqlAvroSerializerTest {
   public void shouldSerializeBytesField() {
     shouldSerializeFieldTypeCorrectly(
         OPTIONAL_BYTES_SCHEMA,
-        "abc".getBytes(),
+        "abc".getBytes(UTF_8),
         org.apache.avro.SchemaBuilder.builder().bytesType(),
-        ByteBuffer.wrap("abc".getBytes())
+        ByteBuffer.wrap("abc".getBytes(UTF_8))
     );
   }
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.serde.avro;
 
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_BOOLEAN_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.OPTIONAL_BYTES_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_INT32_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA;
@@ -898,6 +899,16 @@ public class KsqlAvroSerializerTest {
         OPTIONAL_INT64_SCHEMA,
         123L,
         org.apache.avro.SchemaBuilder.builder().longType()
+    );
+  }
+
+  @Test
+  public void shouldSerializeBytesField() {
+    shouldSerializeFieldTypeCorrectly(
+        OPTIONAL_BYTES_SCHEMA,
+        "abc".getBytes(),
+        org.apache.avro.SchemaBuilder.builder().bytesType(),
+        ByteBuffer.wrap("abc".getBytes())
     );
   }
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectDataTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectDataTranslatorTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -371,5 +372,18 @@ public class ConnectDataTranslatorTest {
     // Then:
     assertTrue(row instanceof Long);
     assertThat(row, is(100L));
+  }
+
+  @Test
+  public void shouldReturnBytesType() {
+    // Given:
+    final ConnectDataTranslator connectToKsqlTranslator = new ConnectDataTranslator(SchemaBuilder.OPTIONAL_BYTES_SCHEMA);
+
+    // When:
+    final Object row = connectToKsqlTranslator.toKsqlRow(Schema.BYTES_SCHEMA, ByteBuffer.wrap(new byte[] {123}));
+
+    // Then:
+    assertTrue(row instanceof ByteBuffer);
+    assertThat(row, is(ByteBuffer.wrap(new byte[] {123})));
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSchemaUtilTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSchemaUtilTest.java
@@ -201,12 +201,11 @@ public class ConnectSchemaUtilTest {
   }
 
   @Test
-  public void shouldIgnoreUnsupportedType() {
+  public void shouldHandleBytesType() {
     // Given:
     final Schema connectSchema = SchemaBuilder
         .struct()
-        .field("unsupported", Schema.BYTES_SCHEMA)
-        .field("supported", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("abc", Schema.BYTES_SCHEMA)
         .build();
 
     // When:
@@ -214,28 +213,6 @@ public class ConnectSchemaUtilTest {
 
     // Then:
     assertThat(ksqlSchema.fields(), hasSize(1));
-    assertThat(ksqlSchema.fields().get(0).name(), is("SUPPORTED"));
-  }
-
-  @Test
-  public void shouldThrowIfAllUnsupportedTypes() {
-    // Given:
-    final Schema connectSchema = SchemaBuilder
-        .struct()
-        .field("bytesField", Schema.BYTES_SCHEMA)
-        .build();
-
-    // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> ConnectSchemaUtil.toKsqlSchema(connectSchema)
-    );
-
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "Schema does not include any columns with "
-            + "types that ksqlDB supports."
-            + System.lineSeparator()
-            + "schema: bytesField BYTES"));
+    assertThat(ksqlSchema.fields().get(0).name(), is("ABC"));
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSchemaUtilTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSchemaUtilTest.java
@@ -22,11 +22,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThrows;
 
-import io.confluent.ksql.util.KsqlException;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -46,6 +42,7 @@ public class ConnectSchemaUtilTest {
         .field("doubleField", Schema.FLOAT64_SCHEMA)
         .field("stringField", Schema.STRING_SCHEMA)
         .field("booleanField", Schema.BOOLEAN_SCHEMA)
+        .field("bytesField", Schema.BYTES_SCHEMA)
         .build();
 
     final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
@@ -198,21 +195,5 @@ public class ConnectSchemaUtilTest {
     assertThat(ksqlSchema.field("TIMEFIELD").schema(), equalTo(OPTIONAL_TIME_SCHEMA));
     assertThat(ksqlSchema.field("DATEFIELD").schema(), equalTo(OPTIONAL_DATE_SCHEMA));
     assertThat(ksqlSchema.field("TIMESTAMPFIELD").schema(), equalTo(OPTIONAL_TIMESTAMP_SCHEMA));
-  }
-
-  @Test
-  public void shouldHandleBytesType() {
-    // Given:
-    final Schema connectSchema = SchemaBuilder
-        .struct()
-        .field("abc", Schema.BYTES_SCHEMA)
-        .build();
-
-    // When:
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
-
-    // Then:
-    assertThat(ksqlSchema.fields(), hasSize(1));
-    assertThat(ksqlSchema.fields().get(0).name(), is("ABC"));
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeFeatures;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Time;
@@ -52,6 +53,7 @@ public class KsqlDelimitedSerializerTest {
           .valueColumn(ColumnName.of("TIME"), SqlTypes.TIME)
           .valueColumn(ColumnName.of("DATE"), SqlTypes.DATE)
           .valueColumn(ColumnName.of("TIMESTAMP"), SqlTypes.TIMESTAMP)
+          .valueColumn(ColumnName.of("BYTES"), SqlTypes.BYTES)
           .build().value(),
       SerdeFeatures.of()
   );
@@ -68,27 +70,28 @@ public class KsqlDelimitedSerializerTest {
   @Test
   public void shouldSerializeRowCorrectly() {
     // Given:
-    final List<?> values = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, new Time(100), new Date(864000000L), new Timestamp(100));
+    final List<?> values = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, new Time(100), new Date(864000000L), new Timestamp(100),
+        ByteBuffer.wrap(new byte[] {123}));
 
     // When:
     final byte[] bytes = serializer.serialize("t1", values);
 
     // Then:
     final String delimitedString = new String(bytes, StandardCharsets.UTF_8);
-    assertThat(delimitedString, equalTo("1511897796092,1,item_1,10.0,100,10,100"));
+    assertThat(delimitedString, equalTo("1511897796092,1,item_1,10.0,100,10,100,ew=="));
   }
 
   @Test
   public void shouldSerializeRowWithNull() {
     // Given:
-    final List<?> values = Arrays.asList(1511897796092L, 1L, "item_1", null, null, null, null);
+    final List<?> values = Arrays.asList(1511897796092L, 1L, "item_1", null, null, null, null, null);
 
     // When:
     final byte[] bytes = serializer.serialize("t1", values);
 
     // Then:
     final String delimitedString = new String(bytes, StandardCharsets.UTF_8);
-    assertThat(delimitedString, equalTo("1511897796092,1,item_1,,,,"));
+    assertThat(delimitedString, equalTo("1511897796092,1,item_1,,,,,"));
   }
 
   @Test
@@ -207,7 +210,7 @@ public class KsqlDelimitedSerializerTest {
   @Test
   public void shouldSerializeRowCorrectlyWithDifferentDelimiter() {
     // Given:
-    final List<?> values = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, new Time(100), new Date(864000000L), new Timestamp(100));
+    final List<?> values = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, new Time(100), new Date(864000000L), new Timestamp(100), ByteBuffer.wrap(new byte[] {123}));
 
     final KsqlDelimitedSerializer serializer1 =
         new KsqlDelimitedSerializer(SCHEMA, CSVFormat.DEFAULT.withDelimiter('\t'));
@@ -216,13 +219,13 @@ public class KsqlDelimitedSerializerTest {
     final byte[] bytes = serializer1.serialize("t1", values);
 
     // Then:
-    assertThat(new String(bytes, StandardCharsets.UTF_8), is("1511897796092\t1\titem_1\t10.0\t100\t10\t100"));
+    assertThat(new String(bytes, StandardCharsets.UTF_8), is("1511897796092\t1\titem_1\t10.0\t100\t10\t100\tew=="));
   }
 
   @Test
   public void shouldThrowOnArrayField() {
     // Given:
-    final List<?> values = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, new Time(100), new Date(864000000L), new Timestamp(100));
+    final List<?> values = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, new Time(100), new Date(864000000L), new Timestamp(100), ByteBuffer.wrap(new byte[] {123}));
 
     final KsqlDelimitedSerializer serializer1 =
         new KsqlDelimitedSerializer(SCHEMA, CSVFormat.DEFAULT.withDelimiter('\t'));
@@ -231,7 +234,7 @@ public class KsqlDelimitedSerializerTest {
     final byte[] bytes = serializer1.serialize("t1", values);
 
     // Then:
-    assertThat(new String(bytes, StandardCharsets.UTF_8), is("1511897796092\t1\titem_1\t10.0\t100\t10\t100"));
+    assertThat(new String(bytes, StandardCharsets.UTF_8), is("1511897796092\t1\titem_1\t10.0\t100\t10\t100\tew=="));
   }
 
   @Test

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
@@ -707,6 +707,22 @@ public class KsqlJsonDeserializerTest {
   }
 
   @Test
+  public void shouldThrowOnInvalidBytes() {
+    // Given:
+    final KsqlJsonDeserializer<ByteBuffer> deserializer =
+        givenDeserializerForSchema(Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.class);
+
+    final byte[] bytes = serializeJson("abc");
+
+    // When:
+    final Exception e = assertThrows(SerializationException.class,
+        () -> deserializer.deserialize(SOME_TOPIC, bytes));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Value is not a valid Base64 encoded string: abc"));
+  }
+
+  @Test
   public void shouldThrowIfCanNotCoerceToTime() {
     // Given:
     final KsqlJsonDeserializer<java.sql.Time> deserializer =

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufDeserializerTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.serde.protobuf;
 
 import com.google.common.collect.ImmutableMap;
+import java.nio.ByteBuffer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
@@ -145,6 +146,26 @@ public class KsqlProtobufDeserializerTest {
 
     // Then:
     assertThat(result, is(value));
+  }
+
+  @Test
+  public void shouldDeserializeBytesField() {
+    final ConnectSchema schema = (ConnectSchema) SchemaBuilder.struct()
+        .field("f0", Schema.BYTES_SCHEMA)
+        .build();
+
+    // Given:
+    final Deserializer<Struct> deserializer =
+        givenDeserializerForSchema(schema,
+            Struct.class);
+    final Struct value = new Struct(schema).put("f0", ByteBuffer.wrap(new byte[] {123}));
+    final byte[] bytes = givenConnectSerialized(value, schema);
+
+    // When:
+    final Object result = deserializer.deserialize(SOME_TOPIC, bytes);
+
+    // Then:
+    assertThat(((Struct) result).getBytes("f0"), is(value.getBytes("f0")));
   }
 
   private byte[] givenConnectSerialized(

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
@@ -48,6 +48,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.protobuf.type.Decimal;
 import io.confluent.protobuf.type.utils.DecimalUtils;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -153,10 +154,10 @@ public class KsqlProtobufSerializerTest {
 
   @Test
   public void shouldSerializeBytesField() {
-    final Message record = serializeValue(Schema.BYTES_SCHEMA, ByteBuffer.wrap("abc".getBytes()));
+    final Message record = serializeValue(Schema.BYTES_SCHEMA, ByteBuffer.wrap("abc".getBytes(UTF_8)));
     assertThat(record.getAllFields().size(), equalTo(1));
     Descriptors.FieldDescriptor field = record.getDescriptorForType().findFieldByName("field0");
-    assertThat(((ByteString) record.getField(field)).toByteArray(), equalTo("abc".getBytes()));
+    assertThat(((ByteString) record.getField(field)).toByteArray(), equalTo("abc".getBytes(UTF_8)));
   }
 
 

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
@@ -16,11 +16,14 @@
 package io.confluent.ksql.serde.protobuf;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import com.google.type.Date;
 import com.google.type.TimeOfDay;
+import java.nio.ByteBuffer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.ConnectSchema;
@@ -148,6 +151,14 @@ public class KsqlProtobufSerializerTest {
     );
   }
 
+  @Test
+  public void shouldSerializeBytesField() {
+    final Message record = serializeValue(Schema.BYTES_SCHEMA, ByteBuffer.wrap("abc".getBytes()));
+    assertThat(record.getAllFields().size(), equalTo(1));
+    Descriptors.FieldDescriptor field = record.getDescriptorForType().findFieldByName("field0");
+    assertThat(((ByteString) record.getField(field)).toByteArray(), equalTo("abc".getBytes()));
+  }
+
 
   @SuppressWarnings("unchecked")
   private <T> T deserialize(final byte[] serializedRow) {
@@ -158,8 +169,15 @@ public class KsqlProtobufSerializerTest {
       final Schema ksqlSchema,
       final Object ksqlValue,
       final ParsedSchema parsedSchema,
-      final Message protobufValue
+      final Object protobufValue
   ) {
+    final Message record = serializeValue(ksqlSchema, ksqlValue);
+    assertThat(record.getAllFields().size(), equalTo(1));
+    Descriptors.FieldDescriptor field = record.getDescriptorForType().findFieldByName("field0");
+    assertThat(record.getField(field).toString(), equalTo(protobufValue.toString()));
+  }
+
+  private Message serializeValue(final Schema ksqlSchema, final Object ksqlValue) {
     // Given:
     final Schema schema = SchemaBuilder.struct()
         .field("field0", ksqlSchema)
@@ -174,10 +192,7 @@ public class KsqlProtobufSerializerTest {
     final byte[] bytes = serializer.serialize(SOME_TOPIC, ksqlRecord);
 
     // Then:
-    final Message record = deserialize(bytes);
-    assertThat(record.getAllFields().size(), equalTo(1));
-    Descriptors.FieldDescriptor field = record.getDescriptorForType().findFieldByName("field0");
-    assertThat(record.getField(field).toString(), equalTo(protobufValue.toString()));
+    return deserialize(bytes);
   }
 
   private <T> Serializer<T> givenSerializerForSchema(


### PR DESCRIPTION
### Description 
serdes for BYTES. Delimited and JSON serialize ByteBuffer to Base64 strings, and deserialize Base64 strings to ByteBuffer. Avro and Protobuf serialize and deserialize ByteBuffer to ByteBuffer.

### Testing done 
Unit tests, and QTT for delimited/json. QTTs for Avro/Protobuf will be in a later PR. 
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

