### PR TITLE
chore: upgrade to VertX 3.9.8 and Netty 4.1.65.Final to avoid CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.7</vertx.version>
+        <vertx.version>3.9.8</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -133,8 +133,8 @@
 
         <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
-        <netty.version>4.1.60.Final</netty.version>
-        <netty-codec-http2-version>4.1.60.Final</netty-codec-http2-version>
+        <netty.version>4.1.65.Final</netty.version>
+        <netty-codec-http2-version>4.1.65.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
     </properties>
 


### PR DESCRIPTION
### Description 

We temporarily used Netty 4.1.60 despite known CVEs because VertX did not support later versions of netty. This PR addresses that issue.

### Testing done 

Tested end-to-end with basic auth (which was the symptom of the incompatibility the first time around)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

