### PR TITLE
feat: support BYTES column types in Java client API

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ColumnType.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ColumnType.java
@@ -20,7 +20,7 @@ package io.confluent.ksql.api.client;
  */
 public interface ColumnType {
 
-  enum Type { STRING, INTEGER, BIGINT, DOUBLE, BOOLEAN, DECIMAL, ARRAY, MAP, STRUCT }
+  enum Type { STRING, INTEGER, BIGINT, DOUBLE, BOOLEAN, DECIMAL, BYTES, ARRAY, MAP, STRUCT }
 
   /**
    * Returns the type.

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlArray.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlArray.java
@@ -176,6 +176,18 @@ public class KsqlArray {
   }
 
   /**
+   * Returns the value at a specified index as a byte array.
+   *
+   * @param pos the index
+   * @return the value
+   * @throws IndexOutOfBoundsException if the index is invalid
+   * @throws IllegalArgumentException if the array value is not a Base64 encoded string
+   */
+  public byte[] getBytes(final int pos) {
+    return delegate.getBinary(pos);
+  }
+
+  /**
    * Returns the value at a specified index as a {@code KsqlArray}.
    *
    * @param pos the index
@@ -285,6 +297,17 @@ public class KsqlArray {
     // Vert.x JsonArray does not accept BigDecimal values. Instead we store the value as a string
     // so as to not lose precision.
     delegate.add(value.toString());
+    return this;
+  }
+
+  /**
+   * Appends the specified value to the end of the array.
+   *
+   * @param value the value to append
+   * @return a reference to this
+   */
+  public KsqlArray add(final byte[] value) {
+    delegate.add(value);
     return this;
   }
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlObject.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/KsqlObject.java
@@ -199,6 +199,19 @@ public class KsqlObject {
   }
 
   /**
+   * Returns the value associated with the specified key as a byte array. Returns null if
+   * the key is not present.
+   *
+   * @param key the key
+   * @return the value
+   * @throws ClassCastException if the value is not a {@code String}
+   * @throws IllegalArgumentException if the column value is not a base64 encoded string
+   */
+  public byte[] getBytes(final String key) {
+    return delegate.getBinary(key);
+  }
+
+  /**
    * Returns the value associated with the specified key as a {@link KsqlArray}. Returns null if the
    * key is not present.
    *
@@ -303,6 +316,11 @@ public class KsqlObject {
     // Vert.x JsonObject does not accept BigDecimal values. Instead we store the value as a string
     // so as to not lose precision.
     delegate.put(key, value.toString());
+    return this;
+  }
+
+  public KsqlObject put(final String key, final byte[] value) {
+    delegate.put(key, value);
     return this;
   }
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Row.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Row.java
@@ -213,6 +213,28 @@ public interface Row {
   BigDecimal getDecimal(String columnName);
 
   /**
+   * Returns the value for a particular column of the {@code Row} as a byte array.
+   *
+   * @param columnIndex index of column (1-indexed)
+   * @return column value
+   * @throws ClassCastException if the column value is not a {@code String}
+   * @throws IllegalArgumentException if the column value is not a base64 encoded string
+   * @throws IndexOutOfBoundsException if the index is invalid
+   */
+  byte[] getBytes(int columnIndex);
+
+  /**
+   * Returns the value for a particular column of the {@code Row} as byte array.
+   *
+   * @param columnName name of column
+   * @return column value
+   * @throws ClassCastException if the column value is not a {@code String}
+   * @throws IllegalArgumentException if the column name is invalid or the column value is not
+   *                                  a base64 encoded string
+   */
+  byte[] getBytes(String columnName);
+
+  /**
    * Returns the value for a particular column of the {@code Row} as a {@link KsqlObject}.
    * Useful for {@code MAP} and {@code STRUCT} column types.
    *

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/RowImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/RowImpl.java
@@ -144,6 +144,16 @@ public class RowImpl implements Row {
   }
 
   @Override
+  public byte[] getBytes(final int columnIndex) {
+    return values.getBytes(columnIndex - 1);
+  }
+
+  @Override
+  public byte[] getBytes(final String columnName) {
+    return getBytes(indexFromName(columnName));
+  }
+
+  @Override
   public KsqlObject getKsqlObject(final int columnIndex) {
     return values.getKsqlObject(columnIndex - 1);
   }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -1777,6 +1777,7 @@ public class ClientTest extends BaseApiTest {
     assertThat(row.getLong("f_long"), is(((long) index) * index));
     assertThat(row.getDouble("f_double"), is(index + 0.1111));
     assertThat(row.getDecimal("f_decimal"), is(BigDecimal.valueOf(index + 0.1)));
+    assertThat(row.getBytes("f_bytes"), is(new byte[]{0, 1, 2, 3, 4, 5}));
     final KsqlArray arrayVal = row.getKsqlArray("f_array");
     assertThat(arrayVal, is(new KsqlArray().add("s" + index).add("t" + index)));
     assertThat(arrayVal.getString(0), is("s" + index));
@@ -1810,10 +1811,11 @@ public class ClientTest extends BaseApiTest {
     assertThat(values.getLong(3), is(row.getLong("f_long")));
     assertThat(values.getDouble(4), is(row.getDouble("f_double")));
     assertThat(values.getDecimal(5), is(row.getDecimal("f_decimal")));
-    assertThat(values.getKsqlArray(6), is(row.getKsqlArray("f_array")));
-    assertThat(values.getKsqlObject(7), is(row.getKsqlObject("f_map")));
-    assertThat(values.getKsqlObject(8), is(row.getKsqlObject("f_struct")));
-    assertThat(values.getValue(9), is(nullValue()));
+    assertThat(values.getBytes(6), is(row.getBytes("f_bytes")));
+    assertThat(values.getKsqlArray(7), is(row.getKsqlArray("f_array")));
+    assertThat(values.getKsqlObject(8), is(row.getKsqlObject("f_map")));
+    assertThat(values.getKsqlObject(9), is(row.getKsqlObject("f_struct")));
+    assertThat(values.getValue(10), is(nullValue()));
     assertThat(values.toJsonString(), is((new JsonArray(values.getList())).toString()));
     assertThat(values.toString(), is(values.toJsonString()));
 
@@ -1828,6 +1830,7 @@ public class ClientTest extends BaseApiTest {
     assertThat(obj.getLong("f_long"), is(row.getLong("f_long")));
     assertThat(obj.getDouble("f_double"), is(row.getDouble("f_double")));
     assertThat(obj.getDecimal("f_decimal"), is(row.getDecimal("f_decimal")));
+    assertThat(obj.getBytes("f_bytes"), is(row.getBytes("f_bytes")));
     assertThat(obj.getKsqlArray("f_array"), is(row.getKsqlArray("f_array")));
     assertThat(obj.getKsqlObject("f_map"), is(row.getKsqlObject("f_map")));
     assertThat(obj.getKsqlObject("f_struct"), is(row.getKsqlObject("f_struct")));
@@ -1860,6 +1863,7 @@ public class ClientTest extends BaseApiTest {
           .put("f_long", i * i)
           .put("f_double", i + 0.1111)
           .put("f_decimal", new BigDecimal(i + 0.1))
+          .put("f_bytes", new byte[]{0, 1, 2, 3, 4, 5})
           .put("f_array", new KsqlArray().add("s" + i).add("t" + i))
           .put("f_map", new KsqlObject().put("k" + i, "v" + i))
           .put("f_struct", new KsqlObject().put("F1", "v" + i).put("F2", i))

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -97,6 +97,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -139,9 +140,10 @@ public class ClientIntegrationTest {
   private static final String TEST_STREAM = TEST_DATA_PROVIDER.sourceName();
   private static final int TEST_NUM_ROWS = TEST_DATA_PROVIDER.data().size();
   private static final List<String> TEST_COLUMN_NAMES =
-      ImmutableList.of("K", "STR", "LONG", "DEC", "ARRAY", "MAP", "STRUCT", "COMPLEX");
+      ImmutableList.of("K", "STR", "LONG", "DEC", "BYTES_", "ARRAY", "MAP", "STRUCT", "COMPLEX");
   private static final List<ColumnType> TEST_COLUMN_TYPES =
-      RowUtil.columnTypesFromStrings(ImmutableList.of("STRUCT", "STRING", "BIGINT", "DECIMAL", "ARRAY", "MAP", "STRUCT", "STRUCT"));
+      RowUtil.columnTypesFromStrings(ImmutableList.of("STRUCT", "STRING", "BIGINT", "DECIMAL",
+          "BYTES", "ARRAY", "MAP", "STRUCT", "STRUCT"));
   private static final List<KsqlArray> TEST_EXPECTED_ROWS =
       convertToClientRows(TEST_DATA_PROVIDER.data());
 
@@ -615,6 +617,7 @@ public class ClientIntegrationTest {
         .put("str", "HELLO") // Column names are case-insensitive
         .put("`LONG`", 100L) // Backticks may be used to preserve case-sensitivity
         .put("\"DEC\"", new BigDecimal("13.31")) // Double quotes may also be used to preserve case-sensitivity
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new KsqlArray().add("v1").add("v2"))
         .put("MAP", new KsqlObject().put("some_key", "a_value").put("another_key", ""))
         .put("STRUCT", new KsqlObject().put("f1", 12)) // Nested field names are case-insensitive
@@ -633,6 +636,7 @@ public class ClientIntegrationTest {
     assertThat(rows.get(0).getString("STR"), is("HELLO"));
     assertThat(rows.get(0).getLong("LONG"), is(100L));
     assertThat(rows.get(0).getDecimal("DEC"), is(new BigDecimal("13.31")));
+    assertThat(rows.get(0).getBytes("BYTES_"), is(new byte[]{0, 1, 2}));
     assertThat(rows.get(0).getKsqlArray("ARRAY"), is(new KsqlArray().add("v1").add("v2")));
     assertThat(rows.get(0).getKsqlObject("MAP"), is(new KsqlObject().put("some_key", "a_value").put("another_key", "")));
     assertThat(rows.get(0).getKsqlObject("STRUCT"), is(new KsqlObject().put("F1", 12)));
@@ -670,6 +674,7 @@ public class ClientIntegrationTest {
         .put("STR", "Value_shouldStreamQueryWithProperties")
         .put("LONG", 2000L)
         .put("DEC", new BigDecimal("12.34"))
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new KsqlArray().add("v1_shouldStreamQueryWithProperties").add("v2_shouldStreamQueryWithProperties"))
         .put("MAP", new KsqlObject().put("test_name", "shouldStreamQueryWithProperties"))
         .put("STRUCT", new KsqlObject().put("F1", 4))
@@ -693,6 +698,7 @@ public class ClientIntegrationTest {
     assertThat(row.getString("STR"), is("Value_shouldStreamQueryWithProperties"));
     assertThat(row.getLong("LONG"), is(2000L));
     assertThat(row.getDecimal("DEC"), is(new BigDecimal("12.34")));
+    assertThat(row.getBytes("BYTES_"), is(new byte[]{0, 1, 2}));
     assertThat(row.getKsqlArray("ARRAY"), is(new KsqlArray().add("v1_shouldStreamQueryWithProperties").add("v2_shouldStreamQueryWithProperties")));
     assertThat(row.getKsqlObject("MAP"), is(new KsqlObject().put("test_name", "shouldStreamQueryWithProperties")));
     assertThat(row.getKsqlObject("STRUCT"), is(new KsqlObject().put("F1", 4)));
@@ -711,6 +717,7 @@ public class ClientIntegrationTest {
         .put("STR", "Value_shouldExecuteQueryWithProperties")
         .put("LONG", 2000L)
         .put("DEC", new BigDecimal("12.34"))
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new KsqlArray().add("v1_shouldExecuteQueryWithProperties").add("v2_shouldExecuteQueryWithProperties"))
         .put("MAP", new KsqlObject().put("test_name", "shouldExecuteQueryWithProperties"))
         .put("STRUCT", new KsqlObject().put("F1", 4))
@@ -749,6 +756,7 @@ public class ClientIntegrationTest {
     assertThat(row.getString("STR"), is("Value_shouldExecuteQueryWithProperties"));
     assertThat(row.getLong("LONG"), is(2000L));
     assertThat(row.getDecimal("DEC"), is(new BigDecimal("12.34")));
+    assertThat(row.getBytes("BYTES_"), is(new byte[]{0, 1, 2}));
     assertThat(row.getKsqlArray("ARRAY"), is(new KsqlArray().add("v1_shouldExecuteQueryWithProperties").add("v2_shouldExecuteQueryWithProperties")));
     assertThat(row.getKsqlObject("MAP"), is(new KsqlObject().put("test_name", "shouldExecuteQueryWithProperties")));
     assertThat(row.getKsqlObject("STRUCT"), is(new KsqlObject().put("F1", 4)));
@@ -774,6 +782,7 @@ public class ClientIntegrationTest {
           .put("STR", "TEST_" + i)
           .put("LONG", i)
           .put("DEC", new BigDecimal("13.31"))
+          .put("BYTES_", new byte[]{0, 1, 2})
           .put("ARRAY", new KsqlArray().add("v_" + i))
           .put("MAP", new KsqlObject().put("k_" + i, "v_" + i))
           .put("COMPLEX", COMPLEX_FIELD_VALUE));
@@ -801,6 +810,7 @@ public class ClientIntegrationTest {
       assertThat(rows.get(i).getString("STR"), is("TEST_" + i));
       assertThat(rows.get(i).getLong("LONG"), is(Long.valueOf(i)));
       assertThat(rows.get(i).getDecimal("DEC"), is(new BigDecimal("13.31")));
+      assertThat(rows.get(i).getBytes("BYTES_"), is(new byte[]{0, 1, 2}));
       assertThat(rows.get(i).getKsqlArray("ARRAY"), is(new KsqlArray().add("v_" + i)));
       assertThat(rows.get(i).getKsqlObject("MAP"), is(new KsqlObject().put("k_" + i, "v_" + i)));
       assertThat(rows.get(i).getKsqlObject("COMPLEX"), is(EXPECTED_COMPLEX_FIELD_VALUE));
@@ -1051,7 +1061,7 @@ public class ClientIntegrationTest {
     assertThat(description.windowType(), is(Optional.empty()));
     assertThat(description.sqlStatement(), is(
         "CREATE STREAM " + TEST_STREAM + " (K STRUCT<F1 ARRAY<STRING>> KEY, STR STRING, LONG BIGINT, DEC DECIMAL(4, 2), "
-            + "ARRAY ARRAY<STRING>, MAP MAP<STRING, STRING>, STRUCT STRUCT<F1 INTEGER>, "
+            + "BYTES_ BYTES, ARRAY ARRAY<STRING>, MAP MAP<STRING, STRING>, STRUCT STRUCT<F1 INTEGER>, "
             + "COMPLEX STRUCT<`DECIMAL` DECIMAL(2, 1), STRUCT STRUCT<F1 STRING, F2 INTEGER>, "
             + "ARRAY_ARRAY ARRAY<ARRAY<STRING>>, ARRAY_STRUCT ARRAY<STRUCT<F1 STRING>>, "
             + "ARRAY_MAP ARRAY<MAP<STRING, INTEGER>>, MAP_ARRAY MAP<STRING, ARRAY<STRING>>, "
@@ -1287,20 +1297,22 @@ public class ClientIntegrationTest {
     assertThat(row.getString("STR"), is(expectedRow.getString(1)));
     assertThat(row.getLong("LONG"), is(expectedRow.getLong(2)));
     assertThat(row.getDecimal("DEC"), is(expectedRow.getDecimal(3)));
-    assertThat(row.getKsqlArray("ARRAY"), is(expectedRow.getKsqlArray(4)));
-    assertThat(row.getKsqlObject("MAP"), is(expectedRow.getKsqlObject(5)));
-    assertThat(row.getKsqlObject("STRUCT"), is(expectedRow.getKsqlObject(6)));
-    assertThat(row.getKsqlObject("COMPLEX"), is(expectedRow.getKsqlObject(7)));
+    assertThat(row.getBytes("BYTES_"), is(expectedRow.getBytes(4)));
+    assertThat(row.getKsqlArray("ARRAY"), is(expectedRow.getKsqlArray(5)));
+    assertThat(row.getKsqlObject("MAP"), is(expectedRow.getKsqlObject(6)));
+    assertThat(row.getKsqlObject("STRUCT"), is(expectedRow.getKsqlObject(7)));
+    assertThat(row.getKsqlObject("COMPLEX"), is(expectedRow.getKsqlObject(8)));
 
     // verify index-based getters are 1-indexed
     assertThat(row.getKsqlObject(1), is(row.getKsqlObject("K")));
     assertThat(row.getString(2), is(row.getString("STR")));
     assertThat(row.getLong(3), is(row.getLong("LONG")));
     assertThat(row.getDecimal(4), is(row.getDecimal("DEC")));
-    assertThat(row.getKsqlArray(5), is(row.getKsqlArray("ARRAY")));
-    assertThat(row.getKsqlObject(6), is(row.getKsqlObject("MAP")));
-    assertThat(row.getKsqlObject(7), is(row.getKsqlObject("STRUCT")));
-    assertThat(row.getKsqlObject(8), is(row.getKsqlObject("COMPLEX")));
+    assertThat(row.getBytes(5), is(row.getBytes("BYTES_")));
+    assertThat(row.getKsqlArray(6), is(row.getKsqlArray("ARRAY")));
+    assertThat(row.getKsqlObject(7), is(row.getKsqlObject("MAP")));
+    assertThat(row.getKsqlObject(8), is(row.getKsqlObject("STRUCT")));
+    assertThat(row.getKsqlObject(9), is(row.getKsqlObject("COMPLEX")));
 
     // verify isNull() evaluation
     assertThat(row.isNull("STR"), is(false));
@@ -1316,10 +1328,11 @@ public class ClientIntegrationTest {
     assertThat(values.getString(1), is(row.getString("STR")));
     assertThat(values.getLong(2), is(row.getLong("LONG")));
     assertThat(values.getDecimal(3), is(row.getDecimal("DEC")));
-    assertThat(values.getKsqlArray(4), is(row.getKsqlArray("ARRAY")));
-    assertThat(values.getKsqlObject(5), is(row.getKsqlObject("MAP")));
-    assertThat(values.getKsqlObject(6), is(row.getKsqlObject("STRUCT")));
-    assertThat(values.getKsqlObject(7), is(row.getKsqlObject("COMPLEX")));
+    assertThat(values.getBytes(4), is(row.getBytes("BYTES_")));
+    assertThat(values.getKsqlArray(5), is(row.getKsqlArray("ARRAY")));
+    assertThat(values.getKsqlObject(6), is(row.getKsqlObject("MAP")));
+    assertThat(values.getKsqlObject(7), is(row.getKsqlObject("STRUCT")));
+    assertThat(values.getKsqlObject(8), is(row.getKsqlObject("COMPLEX")));
     assertThat(values.toJsonString(), is((new JsonArray(values.getList())).toString()));
     assertThat(values.toString(), is(values.toJsonString()));
 
@@ -1332,6 +1345,7 @@ public class ClientIntegrationTest {
     assertThat(obj.getString("STR"), is(row.getString("STR")));
     assertThat(obj.getLong("LONG"), is(row.getLong("LONG")));
     assertThat(obj.getDecimal("DEC"), is(row.getDecimal("DEC")));
+    assertThat(obj.getBytes("BYTES_"), is(row.getBytes("BYTES_")));
     assertThat(obj.getKsqlArray("ARRAY"), is(row.getKsqlArray("ARRAY")));
     assertThat(obj.getKsqlObject("MAP"), is(row.getKsqlObject("MAP")));
     assertThat(obj.getKsqlObject("STRUCT"), is(row.getKsqlObject("STRUCT")));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/StructuredTypesDataProvider.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.connect.ConnectSchemas;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ public class StructuredTypesDataProvider extends TestDataProvider {
       .valueColumn(ColumnName.of("STR"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("LONG"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("DEC"), SqlTypes.decimal(4, 2))
+      .valueColumn(ColumnName.of("BYTES_"), SqlTypes.BYTES)
       .valueColumn(ColumnName.of("ARRAY"), SqlTypes.array(SqlTypes.STRING))
       .valueColumn(ColumnName.of("MAP"), SqlTypes.map(SqlTypes.STRING, SqlTypes.STRING))
       .valueColumn(ColumnName.of("STRUCT"), SqlTypes.struct().field("F1", SqlTypes.INTEGER).build())
@@ -86,13 +88,19 @@ public class StructuredTypesDataProvider extends TestDataProvider {
 
   private static final Multimap<GenericKey, GenericRow> ROWS = ImmutableListMultimap
       .<GenericKey, GenericRow>builder()
-      .put(genericKey(generateStructKey("a")), genericRow("FOO", 1L, new BigDecimal("1.11"), Collections.singletonList("a"), Collections.singletonMap("k1", "v1"), generateSimpleStructValue(2), generateComplexStructValue(0)))
-      .put(genericKey(generateStructKey("b")), genericRow("BAR", 2L, new BigDecimal("2.22"), Collections.emptyList(), Collections.emptyMap(), generateSimpleStructValue(3), generateComplexStructValue(1)))
-      .put(genericKey(generateStructKey("c")), genericRow("BAZ", 3L, new BigDecimal("30.33"), Collections.singletonList("b"), Collections.emptyMap(), generateSimpleStructValue(null), generateComplexStructValue(2)))
-      .put(genericKey(generateStructKey("d")), genericRow("BUZZ", 4L, new BigDecimal("40.44"), ImmutableList.of("c", "d"), Collections.emptyMap(), generateSimpleStructValue(88), generateComplexStructValue(3)))
+      .put(genericKey(generateStructKey("a")), genericRow("FOO", 1L, new BigDecimal("1.11"), new byte[]{1},
+          Collections.singletonList("a"), Collections.singletonMap("k1", "v1"), generateSimpleStructValue(2), generateComplexStructValue(0)))
+      .put(genericKey(generateStructKey("b")), genericRow("BAR", 2L, new BigDecimal("2.22"), new byte[]{2},
+          Collections.emptyList(), Collections.emptyMap(), generateSimpleStructValue(3), generateComplexStructValue(1)))
+      .put(genericKey(generateStructKey("c")), genericRow("BAZ", 3L, new BigDecimal("30.33"), new byte[]{3},
+          Collections.singletonList("b"), Collections.emptyMap(), generateSimpleStructValue(null), generateComplexStructValue(2)))
+      .put(genericKey(generateStructKey("d")), genericRow("BUZZ", 4L, new BigDecimal("40.44"), new byte[]{4},
+          ImmutableList.of("c", "d"), Collections.emptyMap(), generateSimpleStructValue(88), generateComplexStructValue(3)))
       // Additional entries for repeated keys
-      .put(genericKey(generateStructKey("c")), genericRow("BAZ", 5L, new BigDecimal("12.0"), ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2"), generateSimpleStructValue(0), generateComplexStructValue(4)))
-      .put(genericKey(generateStructKey("d")), genericRow("BUZZ", 6L, new BigDecimal("10.1"), ImmutableList.of("f", "g"), Collections.emptyMap(), generateSimpleStructValue(null), generateComplexStructValue(5)))
+      .put(genericKey(generateStructKey("c")), genericRow("BAZ", 5L, new BigDecimal("12.0"), new byte[]{15},
+          ImmutableList.of("e"), ImmutableMap.of("k1", "v1", "k2", "v2"), generateSimpleStructValue(0), generateComplexStructValue(4)))
+      .put(genericKey(generateStructKey("d")), genericRow("BUZZ", 6L, new BigDecimal("10.1"), new byte[]{6},
+          ImmutableList.of("f", "g"), Collections.emptyMap(), generateSimpleStructValue(null), generateComplexStructValue(5)))
       .build();
 
   public StructuredTypesDataProvider() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KeyValueExtractor.java
@@ -22,10 +22,14 @@ import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlValueCoercer;
+import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.JsonUtil;
 import io.vertx.core.json.JsonObject;
+
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 public final class KeyValueExtractor {
@@ -61,12 +65,21 @@ public final class KeyValueExtractor {
     final List<Object> vals = new ArrayList<>(valColumns.size());
     for (Column column : valColumns) {
       final String colName = column.name().text();
-      final Object val = values.getValue(colName);
+
+      // Need to decode JSON bytes because they are base64 encoded
+      final Object val = (column.type().baseType() == SqlBaseType.BYTES)
+          ? decodeJsonBytes((String) values.getValue(colName))
+          : values.getValue(colName);
+
       final Object coercedValue =
           val == null ? null : coerceObject(val, column.type(), sqlValueCoercer);
       vals.add(coercedValue);
     }
     return GenericRow.fromList(vals);
+  }
+
+  private static ByteBuffer decodeJsonBytes(final String value) {
+    return (value != null) ? ByteBuffer.wrap(Base64.getDecoder().decode(value)) : null;
   }
 
   static JsonObject convertColumnNameCase(final JsonObject jsonObjectWithCaseInsensitiveFields) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -65,10 +65,10 @@ public class BaseApiTest {
   protected static final Logger log = LoggerFactory.getLogger(BaseApiTest.class);
 
   protected static final JsonArray DEFAULT_COLUMN_NAMES = new JsonArray().add("f_str").add("f_int")
-      .add("f_bool").add("f_long").add("f_double").add("f_decimal")
+      .add("f_bool").add("f_long").add("f_double").add("f_decimal").add("f_bytes")
       .add("f_array").add("f_map").add("f_struct").add("f_null");
   protected static final JsonArray DEFAULT_COLUMN_TYPES = new JsonArray().add("STRING").add("INTEGER")
-      .add("BOOLEAN").add("BIGINT").add("DOUBLE").add("DECIMAL(4, 2)")
+      .add("BOOLEAN").add("BIGINT").add("DOUBLE").add("DECIMAL(4, 2)").add("BYTES")
       .add("ARRAY<STRING>").add("MAP<STRING, STRING>").add("STRUCT<`F1` STRING, `F2` INTEGER>").add("INTEGER");
   protected static final Schema F_STRUCT_SCHEMA = SchemaBuilder.struct()
         .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
@@ -263,6 +263,7 @@ public class BaseApiTest {
         index * index,
         index + 0.1111,
         BigDecimal.valueOf(index + 0.1),
+        new byte[]{0, 1, 2, 3, 4, 5},
         ImmutableList.of("s" + index, "t" + index),
         ImmutableMap.of("k" + index, "v" + index),
         structField,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -164,9 +164,12 @@ public class ApiIntegrationTest {
     // Then:
     assertThat(response.rows, hasSize(2));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(
-        new JsonArray().add("K").add("STR").add("LONG").add("DEC").add("ARRAY").add("MAP").add("STRUCT").add("COMPLEX")));
+        new JsonArray().add("K").add("STR").add("LONG").add("DEC").add("BYTES_").add("ARRAY")
+            .add("MAP").add("STRUCT").add("COMPLEX")));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(
-        new JsonArray().add("STRUCT<`F1` ARRAY<STRING>>").add("STRING").add("BIGINT").add("DECIMAL(4, 2)").add("ARRAY<STRING>").add("MAP<STRING, STRING>").add("STRUCT<`F1` INTEGER>")
+        new JsonArray().add("STRUCT<`F1` ARRAY<STRING>>").add("STRING").add("BIGINT")
+            .add("DECIMAL(4, 2)").add("BYTES").add("ARRAY<STRING>").add("MAP<STRING, STRING>")
+            .add("STRUCT<`F1` INTEGER>")
             .add("STRUCT<`DECIMAL` DECIMAL(2, 1), `STRUCT` STRUCT<`F1` STRING, `F2` INTEGER>, "
                 + "`ARRAY_ARRAY` ARRAY<ARRAY<STRING>>, `ARRAY_STRUCT` ARRAY<STRUCT<`F1` STRING>>, "
                 + "`ARRAY_MAP` ARRAY<MAP<STRING, INTEGER>>, `MAP_ARRAY` MAP<STRING, ARRAY<STRING>>, "
@@ -485,6 +488,7 @@ public class ApiIntegrationTest {
         .put("K", new JsonObject().put("F1", new JsonArray().add("my_key")))
         .put("STR", "HELLO")
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
         .put("STRUCT", new JsonObject().put("F1", 3))
@@ -503,6 +507,7 @@ public class ApiIntegrationTest {
         .put("k", new JsonObject().put("f1", new JsonArray().add("my_key")))
         .put("str", "HELLO")
         .put("dec", 12.21) // JsonObject does not accept BigDecimal
+        .put("bytes_", new byte[]{0, 1, 2})
         .put("array", new JsonArray().add("a").add("b"))
         .put("map", new JsonObject().put("k1", "v1").put("k2", "v2"))
         .put("struct", new JsonObject().put("f1", 3))
@@ -521,6 +526,7 @@ public class ApiIntegrationTest {
         .put("STR", "HELLO")
         .put("LONG", 1000L)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
         .put("STRUCT", new JsonObject().put("F1", 3))
@@ -539,6 +545,7 @@ public class ApiIntegrationTest {
         .put("STR", "HELLO")
         .put("LONG", 1000L)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
         .put("STRUCT", new JsonObject().put("F1", 3))
@@ -556,6 +563,7 @@ public class ApiIntegrationTest {
         .put("STR", "HELLO")
         .put("LONG", 1000L)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
         .put("STRUCT", new JsonObject().put("F1", 3))
@@ -573,6 +581,7 @@ public class ApiIntegrationTest {
         .put("STR", "HELLO")
         .put("LONG", 1000L)
         .put("DEC", 12.21) // JsonObject does not accept BigDecimal
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new JsonArray().add("a").add("b"))
         .put("MAP", new JsonObject().put("k1", "v1").put("k2", "v2"))
         .put("STRUCT", new JsonObject().put("F1", 3))
@@ -612,6 +621,7 @@ public class ApiIntegrationTest {
         .put("STR", "Value_shouldExecutePushQueryFromLatestOffset")
         .put("LONG", 2000L)
         .put("DEC", 12.34) // JsonObject does not accept BigDecimal
+        .put("BYTES_", new byte[]{0, 1, 2})
         .put("ARRAY", new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset"))
         .put("MAP", new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset"))
         .put("STRUCT", new JsonObject().put("F1", 3))
@@ -636,10 +646,11 @@ public class ApiIntegrationTest {
     assertThat(queryResponse.rows.get(0).getString(1), is("Value_shouldExecutePushQueryFromLatestOffset"));
     assertThat(queryResponse.rows.get(0).getLong(2), is(2000L));
     assertThat(queryResponse.rows.get(0).getDouble(3), is(12.34));
-    assertThat(queryResponse.rows.get(0).getJsonArray(4), is(new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset")));
-    assertThat(queryResponse.rows.get(0).getJsonObject(5), is(new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset")));
-    assertThat(queryResponse.rows.get(0).getJsonObject(6), is(new JsonObject().put("F1", 3)));
-    assertThat(queryResponse.rows.get(0).getJsonObject(7), is(COMPLEX_FIELD_VALUE));
+    assertThat(queryResponse.rows.get(0).getBinary(4), is(new byte[]{0, 1, 2}));
+    assertThat(queryResponse.rows.get(0).getJsonArray(5), is(new JsonArray().add("a_shouldExecutePushQueryFromLatestOffset")));
+    assertThat(queryResponse.rows.get(0).getJsonObject(6), is(new JsonObject().put("k1", "v1_shouldExecutePushQueryFromLatestOffset")));
+    assertThat(queryResponse.rows.get(0).getJsonObject(7), is(new JsonObject().put("F1", 3)));
+    assertThat(queryResponse.rows.get(0).getJsonObject(8), is(COMPLEX_FIELD_VALUE));
 
     // Check that query is cleaned up on the server
     assertThatEventually(engine::numberOfLiveQueries, is(1));

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
@@ -47,7 +47,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 
 class KsqlDelimitedDeserializer implements Deserializer<List<?>> {
 
-  private static Decoder BASE64_DECODER = Base64.getMimeDecoder();
+  private static Decoder BASE64_DECODER = Base64.getDecoder();
 
   private interface Parser {
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
@@ -39,7 +39,7 @@ import org.apache.kafka.common.serialization.Serializer;
 
 class KsqlDelimitedSerializer implements Serializer<List<?>> {
 
-  private static Encoder BASE64_ENCODER = Base64.getMimeEncoder();
+  private static Encoder BASE64_ENCODER = Base64.getEncoder();
 
   private final PersistenceSchema schema;
   private final CSVFormat csvFormat;


### PR DESCRIPTION
### Description 
Adding support for the new `BYTES` column type in the Java client API. The API will accept and return byte arrays as the new type. 

```
Row
 byte[] getBytes(String columnName);
 byte[] getBytes(int columnIndex);

KsqlObject
  KsqlObject put(final String key, final byte[] value);
  byte[] getBytes(final String key);

KsqlArray
  KsqlArray add(final byte[] value);
  byte[] getBytes(final int pos);
```

Internally, the `byte[]` value is encoded to a base64 string by the internal JSON object converters. This allows the client to send/receive bytes between the client and the server.

In the Server, though, the base64 string is decoded and converted to a `ByteBuffer`, which is later used to serialize the JSON row to the topic. This JSON row is serialized by the Connect JSON converters, which understand `ByteBuffer` objects as bytes.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

