### PR TITLE
chore: fix CVE with apache io-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <jetty.version>9.4.28.v20200408</jetty.version>
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
         <scala.version>2.13.2</scala.version>
-        <apache.io.version>2.6</apache.io.version>
+        <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>6.1.3-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
 


### PR DESCRIPTION
### Description 

Fix CVE with apache commons IO by bumping to 2.7

### Testing done 

```
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ ksqldb-docker ---
[INFO] io.confluent.ksql:ksqldb-docker:jar:6.1.3-0
[INFO] \- io.confluent.ksql:ksqldb-functional-tests:jar:6.1.3-0:compile
[INFO]    \- commons-io:commons-io:jar:2.7:compile
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

