### PR TITLE
fix: log4j doesn't print connector error

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -24,6 +24,14 @@ log4j.appender.streams=org.apache.log4j.ConsoleAppender
 log4j.appender.streams.layout=org.apache.log4j.PatternLayout
 log4j.appender.streams.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
+log4j.appender.clients=org.apache.log4j.ConsoleAppender
+log4j.appender.clients.layout=org.apache.log4j.PatternLayout
+log4j.appender.clients.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.appender.connect=org.apache.log4j.ConsoleAppender
+log4j.appender.connect.layout=org.apache.log4j.PatternLayout
+log4j.appender.connect.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
 # loggers
 
 log4j.logger.org.reflections=ERROR, stdout


### PR DESCRIPTION
### Description 
The log4j of ksqlDB doesn't print connector error
Detail: https://github.com/confluentinc/ksql/issues/7826

### Testing done 
I tested it in my local with docker-compose.
But I don't have no idea to test this bug, please teach how to test it

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

