### PR TITLE
docs: update platform dependencies tag

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -250,7 +250,7 @@ extra:
         # Build-related string tokens
         kafkaversion: 2.8
         ksqldbversion: 0.19.0
-        kstreamsbetatag: 6.2.0-beta210310224144-cp8
+        kstreamsbetatag: 7.0.0-beta210604105212-cp7
         kstreamsbetabuild: 1
         cprelease: 6.2.0
         releasepostbranch: 6.2.0-post


### PR DESCRIPTION
Sets the beta tag so that Confluent Platform dependencies for this release can be correctly referenced in the docs.

