### PR TITLE
feat: add TO_BYTES/FROM_BYTES functions for bytes/string conversions

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -738,7 +738,7 @@ FROM_BYTES(bytes, encoding)
 ```
 
 Converts a BYTES column to a STRING in the specified encoding type.
-Supported encoding types are: 'hex', 'utf8', 'ascii', 'base64'.
+Supported encoding types are: `hex`, `utf8`, `ascii`, and `base64`.
 
 ### `INITCAP`
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -729,6 +729,17 @@ multiple elements, like those containing wildcards, aren't supported.
 
     `CREATE STREAM LOGS (LOG STRUCT<CLOUD STRING, APP STRING, INSTANCE INT>, ...) WITH (VALUE_FORMAT='JSON', ...)`
 
+### `FROM_BYTES`
+
+Since: - 0.21
+
+```sql
+FROM_BYTES(bytes, encoding)
+```
+
+Converts a BYTES column to a STRING in the specified encoding type.
+Supported encoding types are: 'hex', 'utf8', 'ascii', 'base64'.
+
 ### `INITCAP`
 
 Since: 0.6.0
@@ -1045,6 +1056,17 @@ the string.
 
 For example, `SUBSTRING("stream", 1, 4)`
 returns "stre".
+
+### `TO_BYTES`
+
+Since: - 0.21
+
+```sql
+TO_BYTES(string, encoding)
+```
+
+Converts a STRING column in the specified encoding type to a BYTES column.
+Supported encoding types are: 'hex', 'utf8', 'ascii', 'base64'.
 
 ### `TRIM`
 

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -1066,7 +1066,7 @@ TO_BYTES(string, encoding)
 ```
 
 Converts a STRING column in the specified encoding type to a BYTES column.
-Supported encoding types are: 'hex', 'utf8', 'ascii', 'base64'.
+Supported encoding types are: `hex`, `utf8`, `ascii`, and `base64`.
 
 ### `TRIM`
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class BytesUtils {
+  private static final Base64.Encoder BASE64_ENCODER = Base64.getMimeEncoder();
+  private static final Base64.Decoder BASE64_DECODER = Base64.getMimeDecoder();
+
+  enum Encoding {
+    HEX,
+    UTF8,
+    ASCII,
+    BASE64;
+
+    public static Encoding from(final String value) {
+      if (value.equalsIgnoreCase("hex")) {
+        return HEX;
+      } else if (value.equalsIgnoreCase("utf8")) {
+        return UTF8;
+      } else if (value.equalsIgnoreCase("ascii")) {
+        return ASCII;
+      } else if (value.equalsIgnoreCase("base64")) {
+        return BASE64;
+      }
+
+      throw new IllegalArgumentException("Unknown encoding type '" + value + "'. "
+          + "Supported formats are 'hex', 'utf8', 'ascii', and 'base64'.");
+    }
+  }
+
+  private BytesUtils() {
+  }
+
+  private static final Map<Encoding, Function<byte[], String>> ENCODERS = ImmutableMap.of(
+      Encoding.HEX, v -> hexEncoding(v),
+      Encoding.UTF8, v -> utf8Encoding(v),
+      Encoding.ASCII, v -> asciiEncoding(v),
+      Encoding.BASE64, v -> base64Encoding(v)
+  );
+
+  private static final Map<Encoding, Function<String, byte[]>> DECODERS = ImmutableMap.of(
+      Encoding.HEX, v -> hexDecoding(v),
+      Encoding.UTF8, v -> utf8Decoding(v),
+      Encoding.ASCII, v -> asciiDecoding(v),
+      Encoding.BASE64, v -> base64Decoding(v)
+  );
+
+  public static String encode(final byte[] value, final String encoding) {
+    final Function<byte[], String> encoder = ENCODERS.get(Encoding.from(encoding));
+    if (encoder == null) {
+      throw new IllegalStateException(String.format("Unknown encoding type '%s'. "
+          + "Supported formats are 'hex', 'utf8', 'ascii', and 'base64'.", encoding));
+    }
+
+    return encoder.apply(value);
+  }
+
+  public static byte[] decode(final String value, final String encoding) {
+    final Function<String, byte[]> decoder = DECODERS.get(Encoding.from(encoding));
+    if (decoder == null) {
+      throw new IllegalStateException(String.format("Unknown encoding type '%s'. "
+          + "Supported formats are 'hex', 'utf8', 'ascii', and 'base64'.", encoding));
+    }
+
+    return decoder.apply(value);
+  }
+
+  private static String hexEncoding(final byte[] value) {
+    return BaseEncoding.base16().encode(value);
+  }
+
+  private static byte[] hexDecoding(final String value) {
+    return BaseEncoding.base16().decode(value);
+  }
+
+  private static String utf8Encoding(final byte[] value) {
+    return new String(value, StandardCharsets.UTF_8);
+  }
+
+  private static byte[] utf8Decoding(final String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static String asciiEncoding(final byte[] value) {
+    return new String(value, StandardCharsets.US_ASCII);
+  }
+
+  private static byte[] asciiDecoding(final String value) {
+    return value.getBytes(StandardCharsets.US_ASCII);
+  }
+
+  private static String base64Encoding(final byte[] value) {
+    return BASE64_ENCODER.encodeToString(value);
+  }
+
+  private static byte[] base64Decoding(final String value) {
+    return BASE64_DECODER.decode(value);
+  }
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
@@ -83,6 +84,22 @@ public final class BytesUtils {
     }
 
     return decoder.apply(value);
+  }
+
+  public static byte[] getByteArray(final ByteBuffer buffer) {
+    if (buffer == null) {
+      return null;
+    }
+
+    // ByteBuffer.array() throws an exception if it is in read-only state. Protobuf usually
+    // returns ByteBuffer in read-only, so this util allows us to get the internal byte array.
+    if (buffer.isReadOnly()) {
+      final byte[] internalByteArray = new byte[buffer.capacity()];
+      buffer.get(internalByteArray);
+      return internalByteArray;
+    }
+
+    return buffer.array();
   }
 
   private static String hexEncoding(final byte[] value) {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/BytesUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/BytesUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class BytesUtilTest {
+    @Test
+    public void shouldReturnByteArrayOnReadOnlyByteBuffer() {
+        // Given
+        final ByteBuffer buffer = ByteBuffer.wrap(new byte[]{5}).asReadOnlyBuffer();
+
+        // When
+        final byte[] bytes = BytesUtils.getByteArray(buffer);
+
+        // Then
+        assertThat(bytes, is(new byte[]{5}));
+    }
+
+    @Test
+    public void shouldReturnByteArrayOnWritableByteBuffer() {
+        // Given
+        final ByteBuffer buffer = ByteBuffer.wrap(new byte[]{5});
+
+        // When
+        final byte[] bytes = BytesUtils.getByteArray(buffer);
+
+        // Then
+        assertThat(bytes, is(new byte[]{5}));
+    }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/FromBytes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/FromBytes.java
@@ -33,6 +33,6 @@ public class FromBytes {
   @Udf(description = "Converts a BYTES value to STRING in the specified encoding. "
       + "The accepted encoders are 'hex', 'utf8', 'ascii', and 'base64'.")
   public String fromBytes(final ByteBuffer value, final String encoding) {
-    return (value == null) ? null : BytesUtils.encode(value.array(), encoding);
+    return (value == null) ? null : BytesUtils.encode(BytesUtils.getByteArray(value), encoding);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/FromBytes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/FromBytes.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.BytesUtils;
+import io.confluent.ksql.util.KsqlConstants;
+
+import java.nio.ByteBuffer;
+
+@UdfDescription(
+    name = "from_bytes",
+    category = FunctionCategory.STRING,
+    description = "Converts a BYTES value to STRING in the specified encoding. "
+        + "The accepted encoders are 'hex', 'utf8', 'ascii', and 'base64'.",
+    author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public class FromBytes {
+  @Udf(description = "Converts a BYTES value to STRING in the specified encoding. "
+      + "The accepted encoders are 'hex', 'utf8', 'ascii', and 'base64'.")
+  public String fromBytes(final ByteBuffer value, final String encoding) {
+    return (value == null) ? null : BytesUtils.encode(value.array(), encoding);
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/ToBytes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/ToBytes.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.BytesUtils;
+import io.confluent.ksql.util.KsqlConstants;
+
+import java.nio.ByteBuffer;
+
+@UdfDescription(
+    name = "to_bytes",
+    category = FunctionCategory.STRING,
+    description = "Converts a STRING value in the specified encoding to BYTES. "
+        + "The accepted encoders are 'hex', 'utf8', 'ascii', and 'base64'.",
+    author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public class ToBytes {
+  @Udf(description = "Converts a STRING value in the specified encoding to BYTES. "
+      + "The accepted encoders are 'hex', 'utf8', 'ascii', and 'base64'.")
+  public ByteBuffer toBytes(final String value, final String encoding) {
+    return (value == null) ? null : ByteBuffer.wrap(BytesUtils.decode(value, encoding));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/FromBytesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/FromBytesTest.java
@@ -37,24 +37,32 @@ public class FromBytesTest {
     public void shouldConvertBytesToHexString() {
         assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{33}), "hex"),
             is("21"));
+        assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{}), "hex"),
+            is(""));
     }
 
     @Test
     public void shouldConvertBytesToUtf8String() {
         assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{33}), "utf8"),
             is("!"));
+        assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{}), "utf8"),
+            is(""));
     }
 
     @Test
     public void shouldConvertAsciiStringToBytes() {
         assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{33}), "ascii"),
             is("!"));
+        assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{}), "ascii"),
+            is(""));
     }
 
     @Test
     public void shouldConvertBase64StringToBytes() {
         assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{33}), "base64"),
             is("IQ=="));
+        assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{}), "base64"),
+            is(""));
     }
 
     @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/FromBytesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/FromBytesTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+public class FromBytesTest {
+    private FromBytes udf;
+
+    @Before
+    public void setUp() {
+        udf = new FromBytes();
+    }
+
+    @Test
+    public void shouldConvertBytesToHexString() {
+        assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{33}), "hex"),
+            is("21"));
+    }
+
+    @Test
+    public void shouldConvertBytesToUtf8String() {
+        assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{33}), "utf8"),
+            is("!"));
+    }
+
+    @Test
+    public void shouldConvertAsciiStringToBytes() {
+        assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{33}), "ascii"),
+            is("!"));
+    }
+
+    @Test
+    public void shouldConvertBase64StringToBytes() {
+        assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{33}), "base64"),
+            is("IQ=="));
+    }
+
+    @Test
+    public void shouldReturnNullOnNullBytes() {
+        assertThat(udf.fromBytes(null, "base64"), nullValue());
+    }
+
+    @Test
+    public void shouldThrowOnUnknownEncodingType() {
+        final Exception e = assertThrows(IllegalArgumentException.class,
+            () -> udf.fromBytes(ByteBuffer.wrap(new byte[]{0, 1, 2}), "base5000"));
+
+        assertThat(e.getMessage(), containsString("Unknown encoding type 'base5000'"));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/ToBytesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/ToBytesTest.java
@@ -38,24 +38,32 @@ public class ToBytesTest {
     public void shouldConvertHexStringToBytes() {
         assertThat(udf.toBytes("21", "hex"),
             is(ByteBuffer.wrap(new byte[]{33})));
+        assertThat(udf.toBytes("", "hex"),
+            is(ByteBuffer.wrap(new byte[]{})));
     }
 
     @Test
     public void shouldConvertUtf8StringToBytes() {
         assertThat(udf.toBytes("!", "utf8"),
             is(ByteBuffer.wrap(new byte[]{33})));
+        assertThat(udf.toBytes("", "utf8"),
+            is(ByteBuffer.wrap(new byte[]{})));
     }
 
     @Test
     public void shouldConvertAsciiStringToBytes() {
         assertThat(udf.toBytes("!", "ascii"),
             is(ByteBuffer.wrap(new byte[]{33})));
+        assertThat(udf.toBytes("", "ascii"),
+            is(ByteBuffer.wrap(new byte[]{})));
     }
 
     @Test
     public void shouldConvertBase64StringToBytes() {
         assertThat(udf.toBytes("IQ==", "base64"),
             is(ByteBuffer.wrap(new byte[]{33})));
+        assertThat(udf.toBytes("", "base64"),
+            is(ByteBuffer.wrap(new byte[]{})));
     }
 
     @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/ToBytesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/ToBytesTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class ToBytesTest {
+    private ToBytes udf;
+
+    @Before
+    public void setUp() {
+        udf = new ToBytes();
+    }
+
+
+    @Test
+    public void shouldConvertHexStringToBytes() {
+        assertThat(udf.toBytes("21", "hex"),
+            is(ByteBuffer.wrap(new byte[]{33})));
+    }
+
+    @Test
+    public void shouldConvertUtf8StringToBytes() {
+        assertThat(udf.toBytes("!", "utf8"),
+            is(ByteBuffer.wrap(new byte[]{33})));
+    }
+
+    @Test
+    public void shouldConvertAsciiStringToBytes() {
+        assertThat(udf.toBytes("!", "ascii"),
+            is(ByteBuffer.wrap(new byte[]{33})));
+    }
+
+    @Test
+    public void shouldConvertBase64StringToBytes() {
+        assertThat(udf.toBytes("IQ==", "base64"),
+            is(ByteBuffer.wrap(new byte[]{33})));
+    }
+
+    @Test
+    public void shouldReturnNullOnNullBytes() {
+        assertThat(udf.toBytes(null, "base64"), nullValue());
+    }
+
+    @Test
+    public void shouldThrowOnUnknownEncodingType() {
+        final Exception e = assertThrows(IllegalArgumentException.class,
+            () -> udf.toBytes("AAEC", "base5000"));
+
+        assertThat(e.getMessage(), containsString("Unknown encoding type 'base5000'"));
+    }
+}

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
@@ -35,7 +35,6 @@ public class PlannedTestGeneratorTest {
    * with your change. Otherwise, {@link PlannedTestsUpToDateTest} fill fail if there are missing
    * or changed query plans.
    */
-  @Ignore("Comment me out to regenerate the historic plans")
   @Test
   public void manuallyGeneratePlans() {
     PlannedTestGenerator.generatePlans(QueryTranslationTest.findTestCases()

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
@@ -35,6 +35,7 @@ public class PlannedTestGeneratorTest {
    * with your change. Otherwise, {@link PlannedTestsUpToDateTest} fill fail if there are missing
    * or changed query plans.
    */
+  @Ignore("Comment me out to regenerate the historic plans")
   @Test
   public void manuallyGeneratePlans() {
     PlannedTestGenerator.generatePlans(QueryTranslationTest.findTestCases()

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_ASCII_encoded_string/7.1.0_1626808248533/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_ASCII_encoded_string/7.1.0_1626808248533/plan.json
@@ -1,0 +1,153 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (S STRING, B BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`S` STRING, `B` BYTES",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TS AS SELECT\n  FROM_BYTES(TEST.B, 'ascii') ASCII,\n  TO_BYTES(FROM_BYTES(TEST.B, 'ascii'), 'ascii') B1,\n  FROM_BYTES(TO_BYTES(TEST.S, 'ascii'), 'ascii') S1\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TS",
+      "schema" : "`ASCII` STRING, `B1` BYTES, `S1` STRING",
+      "topicName" : "TS",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TS",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TS"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`S` STRING, `B` BYTES"
+          },
+          "selectExpressions" : [ "FROM_BYTES(B, 'ascii') AS ASCII", "TO_BYTES(FROM_BYTES(B, 'ascii'), 'ascii') AS B1", "FROM_BYTES(TO_BYTES(S, 'ascii'), 'ascii') AS S1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "TS"
+      },
+      "queryId" : "CSAS_TS_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_ASCII_encoded_string/7.1.0_1626808248533/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_ASCII_encoded_string/7.1.0_1626808248533/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626808248533,
+  "path" : "query-validation-tests/bytes-and-strings.json",
+  "schemas" : {
+    "CSAS_TS_0.TS" : {
+      "schema" : "`ASCII` STRING, `B1` BYTES, `S1` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_TS_0.KsqlTopic.Source" : {
+      "schema" : "`S` STRING, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "convert bytes to ASCII encoded string",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "!,IQ=="
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "#,Iw=="
+    } ],
+    "outputs" : [ {
+      "topic" : "TS",
+      "key" : null,
+      "value" : "\"!\",IQ==,\"!\""
+    }, {
+      "topic" : "TS",
+      "key" : null,
+      "value" : "\"#\",Iw==,\"#\""
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "TS",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (s STRING, b BYTES) WITH (kafka_topic='test_topic', value_format='DELIMITED');", "CREATE STREAM TS AS select FROM_BYTES(b, 'ascii') AS ascii, TO_BYTES(FROM_BYTES(b, 'ascii'), 'ascii') AS b1, FROM_BYTES(TO_BYTES(s, 'ascii'), 'ascii') AS s1 from test;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`S` STRING, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TS",
+        "type" : "STREAM",
+        "schema" : "`ASCII` STRING, `B1` BYTES, `S1` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TS",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_ASCII_encoded_string/7.1.0_1626808248533/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_ASCII_encoded_string/7.1.0_1626808248533/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_BASE64_encoded_string/7.1.0_1626808248709/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_BASE64_encoded_string/7.1.0_1626808248709/plan.json
@@ -1,0 +1,153 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (S STRING, B BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`S` STRING, `B` BYTES",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TS AS SELECT\n  FROM_BYTES(TEST.B, 'base64') BASE64,\n  TO_BYTES(FROM_BYTES(TEST.B, 'base64'), 'base64') B1,\n  FROM_BYTES(TO_BYTES(TEST.S, 'base64'), 'base64') S1\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TS",
+      "schema" : "`BASE64` STRING, `B1` BYTES, `S1` STRING",
+      "topicName" : "TS",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TS",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TS"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`S` STRING, `B` BYTES"
+          },
+          "selectExpressions" : [ "FROM_BYTES(B, 'base64') AS BASE64", "TO_BYTES(FROM_BYTES(B, 'base64'), 'base64') AS B1", "FROM_BYTES(TO_BYTES(S, 'base64'), 'base64') AS S1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "TS"
+      },
+      "queryId" : "CSAS_TS_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_BASE64_encoded_string/7.1.0_1626808248709/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_BASE64_encoded_string/7.1.0_1626808248709/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626808248709,
+  "path" : "query-validation-tests/bytes-and-strings.json",
+  "schemas" : {
+    "CSAS_TS_0.TS" : {
+      "schema" : "`BASE64` STRING, `B1` BYTES, `S1` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_TS_0.KsqlTopic.Source" : {
+      "schema" : "`S` STRING, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "convert bytes to BASE64 encoded string",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "IQ==,IQ=="
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "Iw==,Iw=="
+    } ],
+    "outputs" : [ {
+      "topic" : "TS",
+      "key" : null,
+      "value" : "IQ==,IQ==,IQ=="
+    }, {
+      "topic" : "TS",
+      "key" : null,
+      "value" : "Iw==,Iw==,Iw=="
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "TS",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (s STRING, b BYTES) WITH (kafka_topic='test_topic', value_format='DELIMITED');", "CREATE STREAM TS AS select FROM_BYTES(b, 'base64') AS base64, TO_BYTES(FROM_BYTES(b, 'base64'), 'base64') AS b1, FROM_BYTES(TO_BYTES(s, 'base64'), 'base64') AS s1 from test;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`S` STRING, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TS",
+        "type" : "STREAM",
+        "schema" : "`BASE64` STRING, `B1` BYTES, `S1` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TS",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_BASE64_encoded_string/7.1.0_1626808248709/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_BASE64_encoded_string/7.1.0_1626808248709/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_HEX_encoded_string/7.1.0_1626808244818/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_HEX_encoded_string/7.1.0_1626808244818/plan.json
@@ -1,0 +1,153 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (S STRING, B BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`S` STRING, `B` BYTES",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TS AS SELECT\n  FROM_BYTES(TEST.B, 'hex') HEX,\n  TO_BYTES(FROM_BYTES(TEST.B, 'hex'), 'hex') B1,\n  FROM_BYTES(TO_BYTES(TEST.S, 'hex'), 'hex') S1\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TS",
+      "schema" : "`HEX` STRING, `B1` BYTES, `S1` STRING",
+      "topicName" : "TS",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TS",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TS"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`S` STRING, `B` BYTES"
+          },
+          "selectExpressions" : [ "FROM_BYTES(B, 'hex') AS HEX", "TO_BYTES(FROM_BYTES(B, 'hex'), 'hex') AS B1", "FROM_BYTES(TO_BYTES(S, 'hex'), 'hex') AS S1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "TS"
+      },
+      "queryId" : "CSAS_TS_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_HEX_encoded_string/7.1.0_1626808244818/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_HEX_encoded_string/7.1.0_1626808244818/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626808244818,
+  "path" : "query-validation-tests/bytes-and-strings.json",
+  "schemas" : {
+    "CSAS_TS_0.TS" : {
+      "schema" : "`HEX` STRING, `B1` BYTES, `S1` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_TS_0.KsqlTopic.Source" : {
+      "schema" : "`S` STRING, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "convert bytes to HEX encoded string",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "21,IQ=="
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "23,Iw=="
+    } ],
+    "outputs" : [ {
+      "topic" : "TS",
+      "key" : null,
+      "value" : "21,IQ==,21"
+    }, {
+      "topic" : "TS",
+      "key" : null,
+      "value" : "23,Iw==,23"
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "TS",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (s STRING, b BYTES) WITH (kafka_topic='test_topic', value_format='DELIMITED');", "CREATE STREAM TS AS select FROM_BYTES(b, 'hex') AS hex, TO_BYTES(FROM_BYTES(b, 'hex'), 'hex') AS b1, FROM_BYTES(TO_BYTES(s, 'hex'), 'hex') AS s1 from test;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`S` STRING, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TS",
+        "type" : "STREAM",
+        "schema" : "`HEX` STRING, `B1` BYTES, `S1` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TS",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_HEX_encoded_string/7.1.0_1626808244818/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_HEX_encoded_string/7.1.0_1626808244818/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_UTF8_encoded_string/7.1.0_1626808248632/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_UTF8_encoded_string/7.1.0_1626808248632/plan.json
@@ -1,0 +1,153 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (S STRING, B BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`S` STRING, `B` BYTES",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TS AS SELECT\n  FROM_BYTES(TEST.B, 'utf8') UTF8,\n  TO_BYTES(FROM_BYTES(TEST.B, 'utf8'), 'utf8') B1,\n  FROM_BYTES(TO_BYTES(TEST.S, 'utf8'), 'utf8') S1\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TS",
+      "schema" : "`UTF8` STRING, `B1` BYTES, `S1` STRING",
+      "topicName" : "TS",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TS",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TS"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`S` STRING, `B` BYTES"
+          },
+          "selectExpressions" : [ "FROM_BYTES(B, 'utf8') AS UTF8", "TO_BYTES(FROM_BYTES(B, 'utf8'), 'utf8') AS B1", "FROM_BYTES(TO_BYTES(S, 'utf8'), 'utf8') AS S1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "TS"
+      },
+      "queryId" : "CSAS_TS_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_UTF8_encoded_string/7.1.0_1626808248632/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_UTF8_encoded_string/7.1.0_1626808248632/spec.json
@@ -1,0 +1,100 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1626808248632,
+  "path" : "query-validation-tests/bytes-and-strings.json",
+  "schemas" : {
+    "CSAS_TS_0.TS" : {
+      "schema" : "`UTF8` STRING, `B1` BYTES, `S1` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_TS_0.KsqlTopic.Source" : {
+      "schema" : "`S` STRING, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "convert bytes to UTF8 encoded string",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "!,IQ=="
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "#,Iw=="
+    } ],
+    "outputs" : [ {
+      "topic" : "TS",
+      "key" : null,
+      "value" : "\"!\",IQ==,\"!\""
+    }, {
+      "topic" : "TS",
+      "key" : null,
+      "value" : "\"#\",Iw==,\"#\""
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "TS",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (s STRING, b BYTES) WITH (kafka_topic='test_topic', value_format='DELIMITED');", "CREATE STREAM TS AS select FROM_BYTES(b, 'utf8') AS utf8, TO_BYTES(FROM_BYTES(b, 'utf8'), 'utf8') AS b1, FROM_BYTES(TO_BYTES(s, 'utf8'), 'utf8') AS s1 from test;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`S` STRING, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "TS",
+        "type" : "STREAM",
+        "schema" : "`UTF8` STRING, `B1` BYTES, `S1` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TS",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_UTF8_encoded_string/7.1.0_1626808248632/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-and-strings_-_convert_bytes_to_UTF8_encoded_string/7.1.0_1626808248632/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TS)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes-and-strings.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes-and-strings.json
@@ -1,0 +1,87 @@
+{
+  "comments": [
+    "Tests covering conversions of BYTES to STRINGS and viceversa using different encodings."
+  ],
+  "tests": [
+    {
+      "name": "convert bytes to HEX encoded string",
+      "statements": [
+        "CREATE STREAM TEST (s STRING, b BYTES) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM TS AS select FROM_BYTES(b, 'hex') AS hex, TO_BYTES(FROM_BYTES(b, 'hex'), 'hex') AS b1, FROM_BYTES(TO_BYTES(s, 'hex'), 'hex') AS s1 from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": null, "value": "21,IQ=="},
+        {"topic": "test_topic", "key": null, "value": "23,Iw=="}
+      ],
+      "outputs": [
+        {"topic": "TS", "key": null, "value": "21,IQ==,21"},
+        {"topic": "TS", "key": null, "value": "23,Iw==,23"}
+      ],
+      "post": {
+        "sources": [
+          {"name": "TS", "type": "stream", "schema": "hex STRING, b1 BYTES, s1 STRING"}
+        ]
+      }
+    },
+    {
+      "name": "convert bytes to ASCII encoded string",
+      "statements": [
+        "CREATE STREAM TEST (s STRING, b BYTES) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM TS AS select FROM_BYTES(b, 'ascii') AS ascii, TO_BYTES(FROM_BYTES(b, 'ascii'), 'ascii') AS b1, FROM_BYTES(TO_BYTES(s, 'ascii'), 'ascii') AS s1 from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": null, "value": "!,IQ=="},
+        {"topic": "test_topic", "key": null, "value": "#,Iw=="}
+      ],
+      "outputs": [
+        {"topic": "TS", "key": null, "value": "\"!\",IQ==,\"!\""},
+        {"topic": "TS", "key": null, "value": "\"#\",Iw==,\"#\""}
+      ],
+      "post": {
+        "sources": [
+          {"name": "TS", "type": "stream", "schema": "ascii STRING, b1 BYTES, s1 STRING"}
+        ]
+      }
+    },
+    {
+      "name": "convert bytes to UTF8 encoded string",
+      "statements": [
+        "CREATE STREAM TEST (s STRING, b BYTES) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM TS AS select FROM_BYTES(b, 'utf8') AS utf8, TO_BYTES(FROM_BYTES(b, 'utf8'), 'utf8') AS b1, FROM_BYTES(TO_BYTES(s, 'utf8'), 'utf8') AS s1 from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": null, "value": "!,IQ=="},
+        {"topic": "test_topic", "key": null, "value": "#,Iw=="}
+      ],
+      "outputs": [
+        {"topic": "TS", "key": null, "value": "\"!\",IQ==,\"!\""},
+        {"topic": "TS", "key": null, "value": "\"#\",Iw==,\"#\""}
+      ],
+      "post": {
+        "sources": [
+          {"name": "TS", "type": "stream", "schema": "utf8 STRING, b1 BYTES, s1 STRING"}
+        ]
+      }
+    },
+    {
+      "name": "convert bytes to BASE64 encoded string",
+      "statements": [
+        "CREATE STREAM TEST (s STRING, b BYTES) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM TS AS select FROM_BYTES(b, 'base64') AS base64, TO_BYTES(FROM_BYTES(b, 'base64'), 'base64') AS b1, FROM_BYTES(TO_BYTES(s, 'base64'), 'base64') AS s1 from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": null, "value": "IQ==,IQ=="},
+        {"topic": "test_topic", "key": null, "value": "Iw==,Iw=="}
+      ],
+      "outputs": [
+        {"topic": "TS", "key": null, "value": "IQ==,IQ==,IQ=="},
+        {"topic": "TS", "key": null, "value": "Iw==,Iw==,Iw=="}
+      ],
+      "post": {
+        "sources": [
+          {"name": "TS", "type": "stream", "schema": "base64 STRING, b1 BYTES, s1 STRING"}
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
Adds `TO_BYTES` and `FROM_BYTES` functions. Supported encodings are `hex`, `ascii`, `utf8`, and `base64`.



### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

