### PR TITLE
chore: avoid interpreting requests as file uploads

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -139,14 +139,14 @@ public class ServerVerticle extends AbstractVerticle {
     router.route(HttpMethod.POST, "/query-stream")
         .produces(DELIMITED_CONTENT_TYPE)
         .produces(JSON_CONTENT_TYPE)
-        .handler(BodyHandler.create())
+        .handler(BodyHandler.create(false))
         .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server));
     router.route(HttpMethod.POST, "/inserts-stream")
         .produces(DELIMITED_CONTENT_TYPE)
         .produces(JSON_CONTENT_TYPE)
         .handler(new InsertsStreamHandler(context, endpoints, server.getWorkerExecutor()));
     router.route(HttpMethod.POST, "/close-query")
-        .handler(BodyHandler.create())
+        .handler(BodyHandler.create(false))
         .handler(new CloseQueryHandler(server));
 
     // The old API which we continue to support as-is
@@ -155,17 +155,17 @@ public class ServerVerticle extends AbstractVerticle {
     router.route(HttpMethod.GET, "/")
         .handler(ServerVerticle::handleInfoRedirect);
     router.route(HttpMethod.POST, "/ksql")
-        .handler(BodyHandler.create())
+        .handler(BodyHandler.create(false))
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleKsqlRequest);
     router.route(HttpMethod.POST, "/ksql/terminate")
-        .handler(BodyHandler.create())
+        .handler(BodyHandler.create(false))
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleTerminateRequest);
     router.route(HttpMethod.POST, "/query")
-        .handler(BodyHandler.create())
+        .handler(BodyHandler.create(false))
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleQueryRequest);
@@ -174,7 +174,7 @@ public class ServerVerticle extends AbstractVerticle {
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleInfoRequest);
     router.route(HttpMethod.POST, "/heartbeat")
-        .handler(BodyHandler.create())
+        .handler(BodyHandler.create(false))
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleHeartbeatRequest);
@@ -191,7 +191,7 @@ public class ServerVerticle extends AbstractVerticle {
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleAllStatusesRequest);
     router.route(HttpMethod.POST, "/lag")
-        .handler(BodyHandler.create())
+        .handler(BodyHandler.create(false))
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
         .handler(this::handleLagReportRequest);


### PR DESCRIPTION
The Vert.x BodyHandler's `create()` convenience constructor configures the handler to field file uploads by default. This means some requests, including those that don't specify a Content-Type header can be interpreted as file uploads.

This change disables the file upload support, since ksqlDB doesn't support such requests.
