### PR TITLE
test: Exposes raw streams statuses in "show query" response for stabler tests

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/scalable-push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/scalable-push-queries.json
@@ -445,7 +445,7 @@
           {"finalMessage":"Limit Reached"}
         ]}
       ]
-    },
+    } ,
     {
       "name": "out-of-order columns",
       "statements": [

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.rest.entity.QueryDescription;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.QueryStatusCount;
+import io.confluent.ksql.rest.entity.RawQueryStatusCount;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -42,6 +43,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.state.HostInfo;
 
 @SuppressFBWarnings("SE_BAD_FIELD")
@@ -100,6 +102,7 @@ public final class ListQueriesExecutor {
                     q.getQueryId(),
                     QueryStatusCount.fromStreamsStateCounts(
                         Collections.singletonMap(q.getState(), 1)),
+                    new RawQueryStatusCount(Collections.singletonMap(q.getState(), 1)),
                     q.getQueryType());
               }
 
@@ -110,6 +113,7 @@ public final class ListQueriesExecutor {
                   q.getQueryId(),
                   QueryStatusCount.fromStreamsStateCounts(
                       Collections.singletonMap(q.getState(), 1)),
+                  new RawQueryStatusCount(Collections.singletonMap(q.getState(), 1)),
                   q.getQueryType());
             }
         ));
@@ -138,6 +142,13 @@ public final class ListQueriesExecutor {
               .get(queryId)
               .getStatusCount()
               .updateStatusCount(entry.getKey(), entry.getValue());
+        }
+        for (Map.Entry<KafkaStreams.State, Integer> entry :
+            q.getRawStatusCount().getStatuses().entrySet()) {
+          allResults
+              .get(queryId)
+              .getRawStatusCount()
+              .updateRawStatusCount(entry.getKey(), entry.getValue());
         }
       } else {
         allResults.put(queryId, q);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.QueryOffsetSummary;
 import io.confluent.ksql.rest.entity.QueryStatusCount;
 import io.confluent.ksql.rest.entity.QueryTopicOffsetSummary;
+import io.confluent.ksql.rest.entity.RawQueryStatusCount;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SourceDescription;
 import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
@@ -438,6 +439,7 @@ public final class ListSourceExecutor {
             q.getQueryId(),
             QueryStatusCount.fromStreamsStateCounts(
                 Collections.singletonMap(q.getState(), 1)),
+            new RawQueryStatusCount(Collections.singletonMap(q.getState(), 1)),
             KsqlConstants.KsqlQueryType.PERSISTENT)).collect(Collectors.toList());
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.QueryStatusCount;
+import io.confluent.ksql.rest.entity.RawQueryStatusCount;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
 import io.confluent.ksql.rest.entity.SourceDescriptionFactory;
@@ -353,6 +354,8 @@ public class ListSourceExecutorTest {
     // Then:
     final QueryStatusCount queryStatusCount = QueryStatusCount.fromStreamsStateCounts(
         Collections.singletonMap(metadata.getState(), 1));
+    final RawQueryStatusCount rawQueryStatusCount = new RawQueryStatusCount(
+        Collections.singletonMap(metadata.getState(), 1));
 
     assertThat(sourceDescription.getSourceDescription(),
         equalTo(SourceDescriptionFactory.create(
@@ -365,6 +368,7 @@ public class ListSourceExecutorTest {
                 ImmutableSet.of(metadata.getResultTopic().getKafkaTopicName()),
                 metadata.getQueryId(),
                 queryStatusCount,
+                rawQueryStatusCount,
                 KsqlConstants.KsqlQueryType.PERSISTENT)),
             Optional.empty(),
             ImmutableList.of(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -124,6 +124,7 @@ import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.QueryStatusCount;
+import io.confluent.ksql.rest.entity.RawQueryStatusCount;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SimpleFunctionInfo;
 import io.confluent.ksql.rest.entity.SourceDescription;
@@ -2297,7 +2298,9 @@ public class KsqlResourceTest {
             ImmutableSet.of(md.getResultTopic().getKafkaTopicName()),
             md.getQueryId(),
             QueryStatusCount.fromStreamsStateCounts(
-                Collections.singletonMap(md.getState(), 1)), KsqlConstants.KsqlQueryType.PERSISTENT)
+                Collections.singletonMap(md.getState(), 1)),
+            new RawQueryStatusCount(Collections.singletonMap(md.getState(), 1)),
+            KsqlConstants.KsqlQueryType.PERSISTENT)
     ).collect(Collectors.toList());
   }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RawQueryStatusCount.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RawQueryStatusCount.java
@@ -1,0 +1,70 @@
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Joiner;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
+
+/**
+ * Used to keep track of a the state of KafkaStreams application
+ * across multiple servers. Used in {@link RunningQuery}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawQueryStatusCount {
+
+  private final EnumMap<State, Integer> statuses;
+
+  public RawQueryStatusCount() {
+    this(Collections.emptyMap());
+  }
+
+  @JsonCreator
+  public RawQueryStatusCount(final Map<KafkaStreams.State, Integer> states) {
+    this.statuses = states.isEmpty()
+        ? new EnumMap<>(KafkaStreams.State.class)
+        : new EnumMap<>(states);
+  }
+
+  public void updateRawStatusCount(final KafkaStreams.State state, final int change) {
+    this.statuses.compute(state, (key, existing) ->
+        existing == null
+            ? change
+            : existing + change);
+  }
+
+  @JsonValue
+  public Map<KafkaStreams.State, Integer> getStatuses() {
+    return Collections.unmodifiableMap(statuses);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final RawQueryStatusCount that = (RawQueryStatusCount) o;
+    return Objects.equals(statuses, that.statuses);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(statuses);
+  }
+
+  @Override
+  public String toString() {
+    return Joiner.on(",").withKeyValueSeparator(":").join(this.statuses);
+  }
+
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -34,6 +34,7 @@ public class RunningQuery {
   private final Set<String> sinkKafkaTopics;
   private final QueryId id;
   private final QueryStatusCount statusCount;
+  private final RawQueryStatusCount rawQueryStatusCount;
   private final KsqlConstants.KsqlQueryType queryType;
 
   @JsonCreator
@@ -43,6 +44,7 @@ public class RunningQuery {
       @JsonProperty("sinkKafkaTopics") final Set<String> sinkKafkaTopics,
       @JsonProperty("id") final QueryId id,
       @JsonProperty("statusCount") final QueryStatusCount statusCount,
+      @JsonProperty("rawStatusCount") final RawQueryStatusCount rawQueryStatusCount,
       @JsonProperty("queryType") final KsqlQueryType queryType
   ) {
     this.queryString = Objects.requireNonNull(queryString, "queryString");
@@ -50,6 +52,7 @@ public class RunningQuery {
     this.sinks = Objects.requireNonNull(sinks, "sinks");
     this.id = Objects.requireNonNull(id, "id");
     this.statusCount = Objects.requireNonNull(statusCount, "statusCount");
+    this.rawQueryStatusCount = Objects.requireNonNull(rawQueryStatusCount, "rawQueryStatusCount");
     this.queryType = Objects.requireNonNull(queryType, "queryType");
   }
 
@@ -82,6 +85,10 @@ public class RunningQuery {
 
   public QueryStatusCount getStatusCount() {
     return statusCount;
+  }
+
+  public RawQueryStatusCount getRawStatusCount() {
+    return rawQueryStatusCount;
   }
 
   public KsqlQueryType getQueryType() {

--- a/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/RawQueryStatusCountTest.java
+++ b/ksqldb-rest-model/src/test/java/io/confluent/ksql/rest/entity/RawQueryStatusCountTest.java
@@ -1,0 +1,46 @@
+package io.confluent.ksql.rest.entity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RawQueryStatusCountTest {
+
+  private RawQueryStatusCount rawQueryStatusCount;
+
+  @Before
+  public void setup() {
+    rawQueryStatusCount = new RawQueryStatusCount();
+  }
+
+  @Test
+  public void shouldUpdateExistingStatusCount() {
+    rawQueryStatusCount.updateRawStatusCount(KafkaStreams.State.RUNNING, 2);
+    assertThat(
+        rawQueryStatusCount.getStatuses().get(KafkaStreams.State.RUNNING),
+        is(2));
+
+    rawQueryStatusCount.updateRawStatusCount(KafkaStreams.State.RUNNING, 4);
+    assertThat(
+        rawQueryStatusCount.getStatuses().get(KafkaStreams.State.RUNNING),
+        is(6));
+
+    rawQueryStatusCount.updateRawStatusCount(KafkaStreams.State.CREATED, 2);
+    assertThat(
+        rawQueryStatusCount.getStatuses().get(KafkaStreams.State.CREATED),
+        is(2));
+
+    rawQueryStatusCount.updateRawStatusCount(KafkaStreams.State.ERROR, 1);
+    assertThat(
+        rawQueryStatusCount.getStatuses().get(KafkaStreams.State.ERROR),
+        is(1));
+
+    rawQueryStatusCount.updateRawStatusCount(KafkaStreams.State.ERROR, 3);
+    assertThat(
+        rawQueryStatusCount.getStatuses().get(KafkaStreams.State.ERROR),
+        is(4));
+  }
+}


### PR DESCRIPTION
### Description 
Currently, the RQTT tests for scalable push queries poll the query itself until it doesn't error.  Rather that do this to infer that the underlying push query is running, we want to issue the query `show queries;` directly and use that to know.  The only issue is that we don't expose raw kafka streams states, but rather a user friendly enum.  This adds the raw states to the response, which is ignored by the CLI, but can be used in tests as this one. 

### Testing done 
Ran updated tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

