### PR TITLE
feat: allow Java clients to set HTTP/2 multiplex limit

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ClientOptions.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ClientOptions.java
@@ -25,6 +25,7 @@ public interface ClientOptions {
   String DEFAULT_HOST = "localhost";
   int DEFAULT_HOST_PORT = 8088;
   int DEFAULT_EXECUTE_QUERY_MAX_RESULT_ROWS = 10000;
+  int DEFAULT_HTTP2_MULTIPLEXING_LIMIT = -1;
 
   /**
    * Sets the host name of the ksqlDB server to connect to. Defaults to "localhost".
@@ -135,6 +136,14 @@ public interface ClientOptions {
   ClientOptions setExecuteQueryMaxResultRows(int maxRows);
 
   /**
+   * Sets the maximum number of requests per HTTP/2 connection. Defaults to -1.
+   *
+   * @param http2MultiplexingLimit number of requests
+   * @return a reference to this
+   */
+  ClientOptions setHttp2MultiplexingLimit(int http2MultiplexingLimit);
+
+  /**
    * Returns the host name of the ksqlDB server to connect to.
    *
    * @return host name
@@ -238,6 +247,13 @@ public interface ClientOptions {
    * @return number of rows
    */
   int getExecuteQueryMaxResultRows();
+
+  /**
+   * Returns the maximum number of requests per HTTP/2 connection.
+   *
+   * @return number of requests
+   */
+  int getHttp2MultiplexingLimit();
 
   /**
    * Creates a copy of these {@code ClientOptions}.

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -621,7 +621,8 @@ public class ClientImpl implements Client {
         .setHttp2ClearTextUpgrade(false)
         .setVerifyHost(clientOptions.isVerifyHost())
         .setDefaultHost(clientOptions.getHost())
-        .setDefaultPort(clientOptions.getPort());
+        .setDefaultPort(clientOptions.getPort())
+        .setHttp2MultiplexingLimit(clientOptions.getHttp2MultiplexingLimit());
     if (clientOptions.isUseTls() && !clientOptions.getTrustStore().isEmpty()) {
       final JksOptions jksOptions = VertxSslOptionsFactory.getJksTrustStoreOptions(
           clientOptions.getTrustStore(),

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
@@ -234,7 +234,9 @@ public class ClientOptionsImpl implements ClientOptions {
   }
 
   @Override
-  public int getHttp2MultiplexingLimit() { return http2MultiplexingLimit; }
+  public int getHttp2MultiplexingLimit() {
+    return http2MultiplexingLimit;
+  }
 
   @Override
   public ClientOptions copy() {

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
@@ -35,6 +35,7 @@ public class ClientOptionsImpl implements ClientOptions {
   private String basicAuthUsername;
   private String basicAuthPassword;
   private int executeQueryMaxResultRows = ClientOptions.DEFAULT_EXECUTE_QUERY_MAX_RESULT_ROWS;
+  private int http2MultiplexingLimit = ClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
 
   /**
    * {@code ClientOptions} should be instantiated via {@link ClientOptions#create}, NOT via this
@@ -52,7 +53,7 @@ public class ClientOptionsImpl implements ClientOptions {
       final String trustStorePath, final String trustStorePassword,
       final String keyStorePath, final String keyStorePassword, final String keyPassword,
       final String keyAlias, final String basicAuthUsername, final String basicAuthPassword,
-      final int executeQueryMaxResultRows) {
+      final int executeQueryMaxResultRows, final int http2MultiplexingLimit) {
     this.host = Objects.requireNonNull(host);
     this.port = port;
     this.useTls = useTls;
@@ -68,6 +69,7 @@ public class ClientOptionsImpl implements ClientOptions {
     this.basicAuthUsername = basicAuthUsername;
     this.basicAuthPassword = basicAuthPassword;
     this.executeQueryMaxResultRows = executeQueryMaxResultRows;
+    this.http2MultiplexingLimit = http2MultiplexingLimit;
   }
 
   @Override
@@ -151,6 +153,12 @@ public class ClientOptionsImpl implements ClientOptions {
   }
 
   @Override
+  public ClientOptions setHttp2MultiplexingLimit(final int http2MultiplexingLimit) {
+    this.http2MultiplexingLimit = http2MultiplexingLimit;
+    return this;
+  }
+
+  @Override
   public String getHost() {
     return host == null ? "" : host;
   }
@@ -226,6 +234,9 @@ public class ClientOptionsImpl implements ClientOptions {
   }
 
   @Override
+  public int getHttp2MultiplexingLimit() { return http2MultiplexingLimit; }
+
+  @Override
   public ClientOptions copy() {
     return new ClientOptionsImpl(
         host, port,
@@ -234,7 +245,7 @@ public class ClientOptionsImpl implements ClientOptions {
         trustStorePath, trustStorePassword,
         keyStorePath, keyStorePassword, keyPassword, keyAlias,
         basicAuthUsername, basicAuthPassword,
-        executeQueryMaxResultRows);
+        executeQueryMaxResultRows, http2MultiplexingLimit);
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
@@ -261,14 +272,15 @@ public class ClientOptionsImpl implements ClientOptions {
         && Objects.equals(keyPassword, that.keyPassword)
         && Objects.equals(keyAlias, that.keyAlias)
         && Objects.equals(basicAuthUsername, that.basicAuthUsername)
-        && Objects.equals(basicAuthPassword, that.basicAuthPassword);
+        && Objects.equals(basicAuthPassword, that.basicAuthPassword)
+        && http2MultiplexingLimit == that.http2MultiplexingLimit;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(host, port, useTls, verifyHost, useAlpn, trustStorePath,
         trustStorePassword, keyStorePath, keyStorePassword, keyPassword, keyAlias,
-        basicAuthUsername, basicAuthPassword, executeQueryMaxResultRows);
+        basicAuthUsername, basicAuthPassword, executeQueryMaxResultRows, http2MultiplexingLimit);
   }
 
   @Override
@@ -287,7 +299,8 @@ public class ClientOptionsImpl implements ClientOptions {
         + ", keyAlias='" + keyAlias + '\''
         + ", basicAuthUsername='" + basicAuthUsername + '\''
         + ", basicAuthPassword='" + basicAuthPassword + '\''
-        + ", executeQueryMaxResultRows=" + executeQueryMaxResultRows
+        + ", executeQueryMaxResultRows=" + executeQueryMaxResultRows + '\''
+        + ", http2MultiplexingLimit=" + http2MultiplexingLimit
         + '}';
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientOptionsImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientOptionsImplTest.java
@@ -63,6 +63,9 @@ public class ClientOptionsImplTest {
         .addEqualityGroup(
             ClientOptions.create().setExecuteQueryMaxResultRows(10)
         )
+        .addEqualityGroup(
+            ClientOptions.create().setHttp2MultiplexingLimit(5)
+        )
         .testEquals();
   }
 


### PR DESCRIPTION
### Description 
Fixes #7426. Allow Java API clients to customize the max number of requests per connection. In some cases, the default value of -1 does not work when the connection traverses a proxy or firewall that enforces other limits on this value.

With the change, clients can optionally provide a value here. If no value is provided, the behavior is as before since we reuse the Vert.x default.

### Testing done 
Updated unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

