### PR TITLE
Improves RQTT by using offsets to measure readiness

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -88,7 +88,8 @@ public class RestQueryTranslationTest {
           StreamsConfig.EXACTLY_ONCE_V2 // To stabilize tests
       )
       // Setting to anything lower will cause the tests to fail because we won't correctly commit
-      // transaction marker offsets.
+      // transaction marker offsets. This was previously set to 0 to presumably avoid flakiness,
+      // so we should keep an eye out for this.
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 2000)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "set")

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -83,6 +83,13 @@ public class RestQueryTranslationTest {
           KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG,
           TestUtils.tempDirectory().toAbsolutePath().toString()
       )
+      .withProperty(
+          KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.PROCESSING_GUARANTEE_CONFIG,
+          StreamsConfig.EXACTLY_ONCE_V2 // To stabilize tests
+      )
+      // Setting to anything lower will cause the tests to fail because we won't correctly commit
+      // transaction marker offsets.
+      .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 2000)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "set")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -83,10 +83,6 @@ public class RestQueryTranslationTest {
           KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG,
           TestUtils.tempDirectory().toAbsolutePath().toString()
       )
-      .withProperty(
-          KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.PROCESSING_GUARANTEE_CONFIG,
-          StreamsConfig.EXACTLY_ONCE_V2 // To stabilize tests
-      )
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "set")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -647,7 +647,7 @@ public class RestTestExecutor implements Closeable {
             kafkaCluster.getConsumerGroupOffset(queryApplicationId);
         Map<TopicPartition, Long> endOffsets = kafkaCluster.getEndOffsets(topicPartitions,
             // Since we're doing At Least Once, we can do read uncommitted.
-            IsolationLevel.READ_UNCOMMITTED);
+            IsolationLevel.READ_COMMITTED);
 
         for (final TopicPartition tp : topicPartitions) {
             if (!currentOffsets.containsKey(tp) && endOffsets.get(tp) > 0) {

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -657,9 +657,10 @@ public class RestTestExecutor implements Closeable {
             }
         }
 
-        for (TopicPartition tp : currentOffsets.keySet()) {
-          long currentOffset = currentOffsets.get(tp);
-          long endOffset = endOffsets.get(tp);
+        for (final Map.Entry<TopicPartition, Long> entry : currentOffsets.entrySet()) {
+          final TopicPartition tp = entry.getKey();
+          final long currentOffset = entry.getValue();
+          final long endOffset = endOffsets.get(tp);
           if (currentOffset < endOffset) {
             LOG.info("Offsets are not caught up current: " + currentOffsets + " end: "
                 + endOffsets);

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -841,7 +841,7 @@
         {"admin": {"@type": "currentStatus"}},
         {"query": [
            {"header":{"schema":"`ID` STRING KEY, `WINDOWSTART` BIGINT KEY, `WINDOWEND` BIGINT KEY, `COUNT` BIGINT"}},
-          {"row":{"columns":["10", 1582501512000, 1582501513000, 1]}}
+          {"row":{"columns":["10", 1582501512000, 1582501513000, 2]}}
         ]}
       ]
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -380,7 +380,7 @@
         "CREATE STREAM S1 (K INT KEY, ID bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='2 SECONDS');",
         "CREATE STREAM S2 (K INT KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='2 SECOND');",
         "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.K = S2.K;",
-        "SELECT * FROM OUTPUT EMIT CHANGES LIMIT 2;"
+        "SELECT * FROM OUTPUT EMIT CHANGES LIMIT 3;"
       ],
       "inputs": [
         {"topic": "left_topic", "key": 1, "value": {"ID": 1}, "timestamp": 0, "window": {"start": 0, "end": 2000, "type": "time"}},
@@ -396,6 +396,7 @@
         {"query": [
           {"header":{"schema":"`S1_K` INTEGER, `WINDOWSTART` BIGINT, `WINDOWEND` BIGINT, `S1_WINDOWSTART` BIGINT, `S1_WINDOWEND` BIGINT, `S1_ID` BIGINT, `S2_K` INTEGER, `S2_WINDOWSTART` BIGINT, `S2_WINDOWEND` BIGINT, `S2_ID` BIGINT"}},
           {"row":{"columns":[1, 0, 2000, 0, 2000, 1, 1, 0, 2000, 4]}},
+          {"row":{"columns":[1, 0, 2000, 0, 2000, 2, 1, 0, 2000, 4]}},
           {"row":{"columns":[1, 2000, 4000, 2000, 4000, 3, 1, 2000, 4000, 5]}},
           {"finalMessage":"Limit Reached"}
         ]}
@@ -407,7 +408,7 @@
         "CREATE STREAM S1 (K INT KEY, ID bigint) WITH (kafka_topic='left_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='2 SECONDS');",
         "CREATE STREAM S2 (K INT KEY, ID bigint) WITH (kafka_topic='right_topic', value_format='JSON', WINDOW_TYPE='Tumbling', WINDOW_SIZE='2 SECOND');",
         "CREATE STREAM OUTPUT as SELECT * FROM S1 JOIN S2 WITHIN 1 MINUTE ON S1.K = S2.K;",
-        "SELECT ROWTIME, * FROM OUTPUT EMIT CHANGES LIMIT 2;"
+        "SELECT ROWTIME, * FROM OUTPUT EMIT CHANGES LIMIT 3;"
       ],
       "inputs": [
         {"topic": "left_topic", "key": 1, "value": {"ID": 1}, "timestamp": 0, "window": {"start": 0, "end": 2000, "type": "time"}},
@@ -423,6 +424,7 @@
         {"query": [
           {"header":{"schema":"`ROWTIME` BIGINT, `S1_K` INTEGER, `WINDOWSTART` BIGINT, `WINDOWEND` BIGINT, `S1_WINDOWSTART` BIGINT, `S1_WINDOWEND` BIGINT, `S1_ID` BIGINT, `S2_K` INTEGER, `S2_WINDOWSTART` BIGINT, `S2_WINDOWEND` BIGINT, `S2_ID` BIGINT"}},
           {"row":{"columns":[0, 1, 0, 2000, 0, 2000, 1, 1, 0, 2000, 4]}},
+          {"row":{"columns":[1000, 1, 0, 2000, 0, 2000, 2, 1, 0, 2000, 4]}},
           {"row":{"columns":[2000, 1, 2000, 4000, 2000, 4000, 3, 1, 2000, 4000, 5]}},
           {"finalMessage":"Limit Reached"}
         ]}

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -55,13 +55,20 @@ import kafka.security.authorizer.AclAuthorizer;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsOptions;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
@@ -154,12 +161,12 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
     tmpFolder.create();
 
-    installJaasConfig();
+    //installJaasConfig();
     zookeeper = new ZooKeeperEmbedded();
     broker = new KafkaEmbedded(buildBrokerConfig(tmpFolder.newFolder().getAbsolutePath()));
 
-    initialAcls.forEach((key, ops) ->
-        addUserAcl(key.userName, AclPermissionType.ALLOW, key.resourcePattern, ops));
+//    initialAcls.forEach((key, ops) ->
+//        addUserAcl(key.userName, AclPermissionType.ALLOW, key.resourcePattern, ops));
   }
 
   @Override
@@ -521,6 +528,36 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
       adminClient.deleteAcls(filters);
     }
+  }
+
+  /**
+   * Clear all ACLs from the cluster.
+   */
+  public Map<TopicPartition, Long> getConsumerGroupOffset(String consumerGroup) {
+    return broker.getConsumerGroupOffset(consumerGroup);
+  }
+
+  /**
+   * Clear all ACLs from the cluster.
+   */
+  public Map<TopicPartition, Long> getEndOffsets(
+      final Collection<TopicPartition> topicPartitions,
+      final IsolationLevel isolationLevel) {
+    return broker.getEndOffsets(topicPartitions, isolationLevel);
+  }
+
+  /**
+   * Clear all ACLs from the cluster.
+   */
+  public Map<String, Integer> getPartitionCount(final Collection<String> topics) {
+    return broker.getPartitionCount(topics);
+  }
+
+  /**
+   * Clear all ACLs from the cluster.
+   */
+  public Set<String> getTopics() {
+    return broker.getTopics();
   }
 
   public static Builder newBuilder() {

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -55,14 +55,9 @@ import kafka.security.authorizer.AclAuthorizer;
 import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
-import org.apache.kafka.clients.admin.ListOffsetsOptions;
-import org.apache.kafka.clients.admin.ListOffsetsResult;
-import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -161,12 +156,12 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
     tmpFolder.create();
 
-    //installJaasConfig();
+    installJaasConfig();
     zookeeper = new ZooKeeperEmbedded();
     broker = new KafkaEmbedded(buildBrokerConfig(tmpFolder.newFolder().getAbsolutePath()));
 
-//    initialAcls.forEach((key, ops) ->
-//        addUserAcl(key.userName, AclPermissionType.ALLOW, key.resourcePattern, ops));
+    initialAcls.forEach((key, ops) ->
+        addUserAcl(key.userName, AclPermissionType.ALLOW, key.resourcePattern, ops));
   }
 
   @Override
@@ -531,14 +526,14 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   }
 
   /**
-   * Clear all ACLs from the cluster.
+   * Returns mapping of all TopicPartitions to current offsets for a given consumer group.
    */
-  public Map<TopicPartition, Long> getConsumerGroupOffset(String consumerGroup) {
+  public Map<TopicPartition, Long> getConsumerGroupOffset(final String consumerGroup) {
     return broker.getConsumerGroupOffset(consumerGroup);
   }
 
   /**
-   * Clear all ACLs from the cluster.
+   * The end offsets for a given collection of TopicPartitions
    */
   public Map<TopicPartition, Long> getEndOffsets(
       final Collection<TopicPartition> topicPartitions,
@@ -547,14 +542,14 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   }
 
   /**
-   * Clear all ACLs from the cluster.
+   * Gets the partition count for a given collection of topics.
    */
   public Map<String, Integer> getPartitionCount(final Collection<String> topics) {
     return broker.getPartitionCount(topics);
   }
 
   /**
-   * Clear all ACLs from the cluster.
+   * Gets all topics on this broker.
    */
   public Set<String> getTopics() {
     return broker.getTopics();

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -239,7 +239,6 @@ class KafkaEmbedded {
 
       final Supplier<Collection<String>> remaining = () -> {
         final Set<String> names = getTopicNames(adminClient);
-        System.out.println("NAMES ARE " + names);
         names.retainAll(required);
         return names;
       };

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/ThreadTestUtil.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/ThreadTestUtil.java
@@ -65,7 +65,8 @@ public final class ThreadTestUtil {
       final Map<Thread, StackTraceElement[]> currentThreads
   ) {
     final Set<Thread> system = currentThreads.keySet().stream()
-        .filter(thread -> thread.getThreadGroup().getName().equals(SYSTEM_THREAD_GROUP_NAME))
+        .filter(thread -> thread.getThreadGroup() != null
+            && thread.getThreadGroup().getName().equals(SYSTEM_THREAD_GROUP_NAME))
         .collect(Collectors.toSet());
     final Map<Thread, StackTraceElement[]> difference = new HashMap<>(currentThreads);
     difference.keySet().removeAll(previousThreads);


### PR DESCRIPTION
### Description 
Rather than constantly comparing pull query outputs against expected results as a basis for checking correctness, this ensures that persistent queries have consumed input by looking at offsets and ensuring the consumer groups have reached the end.

This has a couple advantages:
- Partial results can't be matched against expected values, prematurely calling the output correct.  This can otherwise lead to flaky tests.
- With the current code, when output doesn't match, it retries over and over, which leads to bad error messages that usually take the form of timeouts rather than assertion errors.

### Testing done 
Ran tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

