### PR TITLE
feat: added missing tostring method

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/logging/query/QueryLoggerMessage.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/logging/query/QueryLoggerMessage.java
@@ -38,6 +38,14 @@ public final class QueryLoggerMessage {
     return query;
   }
 
+  public String toString() {
+    if (queryGuid == null) {
+      return String.format("%s: %s", message, query);
+    }
+
+    return String.format("%s (%s): %s", message, queryGuid.getQueryGuid(), query);
+  }
+
   public QueryGuid getQueryIdentifier() {
     return queryGuid;
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/logging/query/QueryLoggerMessageTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/logging/query/QueryLoggerMessageTest.java
@@ -1,0 +1,24 @@
+package io.confluent.ksql.logging.query;
+
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.ksql.util.QueryGuid;
+import org.junit.Test;
+
+public class QueryLoggerMessageTest {
+  private static final String TEST_QUERY = "describe stream1;";
+  private static final String TEST_MESSAGE = "test message";
+  private static final QueryGuid GUID = new QueryGuid("test_namespace", TEST_MESSAGE, TEST_MESSAGE);
+
+
+  @Test
+  public void toStringShouldReturnCorrectQueryLoggerMessageString() {
+    // without query guid
+    QueryLoggerMessage message = new QueryLoggerMessage(TEST_MESSAGE, TEST_QUERY);
+    assertEquals("test message: describe stream1;", message.toString());
+
+    // with query guid
+    message = new QueryLoggerMessage(TEST_MESSAGE, TEST_QUERY, GUID);
+    assertEquals(String.format("test message (%s): describe stream1;", GUID.getQueryGuid()), message.toString());
+  }
+}


### PR DESCRIPTION
Jira: [KCI-778](https://confluentinc.atlassian.net/browse/KCI-778)

### Description 
Anonymized queries were printed out wrongly due to a missing `toString` method in `QueryLogger`. This PR adds this missing method. 

### Testing done 
- Made sure tests still run and manually checked if logged queries are printed out correctly now.,
 
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

