### PR TITLE
test: fix race condition in RQTT

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -134,7 +134,8 @@ public class RestQueryTranslationTest {
     REST_APP.dropSourcesExcept();
     TEST_HARNESS.getKafkaCluster().deleteAllTopics(TestKsqlRestApp.getCommandTopicName());
 
-    if (STARTING_THREADS.get() == null) {
+    final ThreadSnapshot thread = STARTING_THREADS.get();
+    if (thread == null) {
       // Only set once one full run completed to ensure all persistent threads created:
       STARTING_THREADS.set(ThreadTestUtil.threadSnapshot(filterBuilder()
           .excludeTerminated()
@@ -144,7 +145,7 @@ public class RestQueryTranslationTest {
           .nameMatches(name -> !name.startsWith("pull-query-executor"))
           .build()));
     } else {
-      STARTING_THREADS.get().assertSameThreads();
+      thread.assertSameThreads();
     }
   }
 


### PR DESCRIPTION
### Description 
Saw this test failing multiple times with
```
ava.lang.NullPointerException
	at io.confluent.ksql.test.rest.RestQueryTranslationTest.tearDown(RestQueryTranslationTest.java:147)
```

We should not call `get()` twice on an `AtomicReference` as there is not guarantee that it does not change between both calls.
