### PR TITLE
docs: cherry-pick: update KStreams beta tag for 0.20.0 docs (DOCS-9243)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -250,7 +250,7 @@ extra:
         # Build-related string tokens
         kafkaversion: 2.8
         ksqldbversion: 0.20.0
-        kstreamsbetatag: 6.2.0-beta210310224144-cp8
+        kstreamsbetatag: v7.0.0-beta210713231623-cp1
         kstreamsbetabuild: 1
         cprelease: 6.2.0
         releasepostbranch: 6.2.0-post


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/7884.