### PR TITLE
feat: enable BYTES for LPAD and RPAD

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -810,7 +810,7 @@ LPAD(input, length, padding)
 Pads the input string or bytes, starting from the left, with the specified padding of the same type until the target length is reached. 
 If the input is longer than the specified target length, it is truncated.
 
-If the padding string or bytes is empty or NULL, or the target length is negative, NULL is returned.
+If the padding string or byte array is empty or NULL, or the target length is negative, NULL is returned.
 
 Examples:
 ```sql
@@ -990,7 +990,7 @@ RPAD(input, length, padding)
 Pads the input string or bytes, starting from the end, with the specified padding of the same type until the target length is reached. 
 If the input is longer than the specified target length, it is truncated. 
 
-If the padding string or bytes is empty or NULL, or the target length is negative, NULL is returned.
+If the padding string or byte array is empty or NULL, or the target length is negative, NULL is returned.
 
 Examples:
 ```sql

--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -807,10 +807,10 @@ Since: 0.10.0
 LPAD(input, length, padding)
 ```
 
-Pads the input string, beginning from the left, with the specified padding string, until the target length is reached. 
-If the input string is longer than the specified target length, it is truncated.
+Pads the input string or bytes, starting from the left, with the specified padding of the same type until the target length is reached. 
+If the input is longer than the specified target length, it is truncated.
 
-If the padding string is empty or NULL, or the target length is negative, NULL is returned.
+If the padding string or bytes is empty or NULL, or the target length is negative, NULL is returned.
 
 Examples:
 ```sql
@@ -987,9 +987,10 @@ Since: 0.10.0
 RPAD(input, length, padding)
 ```
 
-Pads the input string, starting from the end, with the specified padding string until the target length is reached. If the input string is longer than the specified target length it will be truncated. 
+Pads the input string or bytes, starting from the end, with the specified padding of the same type until the target length is reached. 
+If the input is longer than the specified target length, it is truncated. 
 
-If the padding string is empty or NULL, or the target length is negative, then NULL is returned.
+If the padding string or bytes is empty or NULL, or the target length is negative, NULL is returned.
 
 Examples:
 ```sql

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LPad.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LPad.java
@@ -18,14 +18,17 @@ import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.BytesUtils;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 @UdfDescription(
     name = "LPad",
     category = FunctionCategory.STRING,
-    description = "Pads the input string, beginning from the left, with the specified padding"
-        + " string until the target length is reached. If the input string is longer than the"
-        + " specified target length it will be truncated. If the padding string is empty or"
-        + " NULL, or the target length is negative, then NULL is returned.")
+    description = "Pads the input string or bytes, starting from the beginning, with the specified"
+        + " padding string until the target length is reached. If the input string or bytes are"
+        + " longer than the specified target length it will be truncated. If the padding string or"
+        + " bytes are empty or NULL, or the target length is negative, then NULL is returned.")
 public class LPad {
 
   @Udf
@@ -49,5 +52,43 @@ public class LPad {
     sb.append(input);
     sb.setLength(targetLen);
     return sb.toString();
+  }
+
+  @Udf
+  public ByteBuffer lpad(
+      @UdfParameter(description = "Bytes to be padded") final ByteBuffer input,
+      @UdfParameter(description = "Target length") final Integer targetLen,
+      @UdfParameter(description = "Padding bytes") final ByteBuffer padding) {
+
+    if (input == null) {
+      return null;
+    }
+    if (padding == null
+        || BytesUtils.getByteArray(padding).length == 0
+        || targetLen == null
+        || targetLen < 0) {
+      return null;
+    }
+
+    final byte[] start = BytesUtils.getByteArray(input);
+
+    if (start.length > targetLen) {
+      return ByteBuffer.wrap(Arrays.copyOfRange(start, 0, targetLen));
+    }
+
+    final byte[] padded = new byte[targetLen];
+    final byte[] paddingArray = BytesUtils.getByteArray(padding);
+
+    for (int i = 0; i < targetLen; i++) {
+      final int buffer = targetLen - start.length;
+      if (i >= buffer) {
+        padded[i] = start[i - buffer];
+      } else {
+        final int paddingIndex = i % paddingArray.length;
+        padded[i] = paddingArray[paddingIndex];
+      }
+
+    }
+    return ByteBuffer.wrap(padded);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LPad.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/LPad.java
@@ -64,7 +64,7 @@ public class LPad {
       return null;
     }
     if (padding == null
-        || BytesUtils.getByteArray(padding).length == 0
+        || padding.capacity() == 0
         || targetLen == null
         || targetLen < 0) {
       return null;
@@ -80,9 +80,9 @@ public class LPad {
     final byte[] paddingArray = BytesUtils.getByteArray(padding);
 
     for (int i = 0; i < targetLen; i++) {
-      final int buffer = targetLen - start.length;
-      if (i >= buffer) {
-        padded[i] = start[i - buffer];
+      final int padUpTo = targetLen - start.length;
+      if (i >= padUpTo) {
+        padded[i] = start[i - padUpTo];
       } else {
         final int paddingIndex = i % paddingArray.length;
         padded[i] = paddingArray[paddingIndex];

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RPad.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RPad.java
@@ -63,7 +63,7 @@ public class RPad {
       return null;
     }
     if (padding == null
-        || BytesUtils.getByteArray(padding).length == 0
+        || padding.capacity() == 0
         || targetLen == null
         || targetLen < 0) {
       return null;
@@ -78,14 +78,11 @@ public class RPad {
     final byte[] padded = new byte[targetLen];
     final byte[] paddingArray = BytesUtils.getByteArray(padding);
 
-    for (int i = 0; i < targetLen; i++) {
-      if (i < start.length) {
-        padded[i] = start[i];
-      } else {
-        final int paddingIndex = (i - start.length) % paddingArray.length;
-        padded[i] = paddingArray[paddingIndex];
-      }
+    System.arraycopy(start, 0, padded, 0, start.length);
 
+    for (int i = start.length; i < targetLen; i++) {
+      final int paddingIndex = (i - start.length) % paddingArray.length;
+      padded[i] = paddingArray[paddingIndex];
     }
     return ByteBuffer.wrap(padded);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RPad.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/RPad.java
@@ -18,14 +18,17 @@ import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.BytesUtils;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 @UdfDescription(
     name = "RPad",
     category = FunctionCategory.STRING,
-    description = "Pads the input string, starting from the end, with the specified padding"
-        + " string until the target length is reached. If the input string is longer than the"
-        + " specified target length it will be truncated. If the padding string is empty or"
-        + " NULL, or the target length is negative, then NULL is returned.")
+    description = "Pads the input string or bytes, starting from the end, with the specified"
+        + " padding string until the target length is reached. If the input string or bytes are"
+        + " longer than the specified target length it will be truncated. If the padding string or"
+        + " bytes are empty or NULL, or the target length is negative, then NULL is returned.")
 public class RPad {
 
   @Udf
@@ -48,5 +51,42 @@ public class RPad {
     }
     sb.setLength(targetLen);
     return sb.toString();
+  }
+
+  @Udf
+  public ByteBuffer rpad(
+      @UdfParameter(description = "Bytes to be padded") final ByteBuffer input,
+      @UdfParameter(description = "Target length") final Integer targetLen,
+      @UdfParameter(description = "Padding bytes") final ByteBuffer padding) {
+
+    if (input == null) {
+      return null;
+    }
+    if (padding == null
+        || BytesUtils.getByteArray(padding).length == 0
+        || targetLen == null
+        || targetLen < 0) {
+      return null;
+    }
+
+    final byte[] start = BytesUtils.getByteArray(input);
+
+    if (start.length > targetLen) {
+      return ByteBuffer.wrap(Arrays.copyOfRange(start, 0, targetLen));
+    }
+
+    final byte[] padded = new byte[targetLen];
+    final byte[] paddingArray = BytesUtils.getByteArray(padding);
+
+    for (int i = 0; i < targetLen; i++) {
+      if (i < start.length) {
+        padded[i] = start[i];
+      } else {
+        final int paddingIndex = (i - start.length) % paddingArray.length;
+        padded[i] = paddingArray[paddingIndex];
+      }
+
+    }
+    return ByteBuffer.wrap(padded);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/LPadTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/LPadTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import io.confluent.ksql.util.BytesUtils;
 import java.nio.ByteBuffer;
 import org.junit.Test;
 
@@ -32,8 +33,20 @@ public class LPadTest {
 
   @Test
   public void shouldPadInputBytes() {
-    final ByteBuffer result = udf.lpad(input(), 7, padding());
+    final ByteBuffer result = udf.lpad(BYTES_123, 7, BYTES_45);
     assertThat(result, is(ByteBuffer.wrap(new byte[]{4,5,4,5,1,2,3})));
+  }
+
+  @Test
+  public void shouldAppendPartialPaddingString() {
+    final String result = udf.lpad("foo", 4, "Bar");
+    assertThat(result, is("Bfoo"));
+  }
+
+  @Test
+  public void shouldAppendPartialPaddingBytes() {
+    final ByteBuffer result = udf.lpad(BYTES_123, 4, BYTES_45);
+    assertThat(BytesUtils.getByteArray(result), is(new byte[]{4,1,2,3}));
   }
 
   @Test
@@ -44,7 +57,7 @@ public class LPadTest {
 
   @Test
   public void shouldReturnNullForNullInputBytes() {
-    final ByteBuffer result = udf.lpad(null, 4, padding());
+    final ByteBuffer result = udf.lpad(null, 4, BYTES_45);
     assertThat(result, is(nullValue()));
   }
 
@@ -56,7 +69,7 @@ public class LPadTest {
 
   @Test
   public void shouldReturnNullForNullPaddingBytes() {
-    final ByteBuffer result = udf.lpad(input(), 4, null);
+    final ByteBuffer result = udf.lpad(BYTES_123, 4, null);
     assertThat(result, is(nullValue()));
   }
 
@@ -68,7 +81,7 @@ public class LPadTest {
 
   @Test
   public void shouldReturnNullForEmptyPaddingBytes() {
-    final ByteBuffer result = udf.lpad(input(), 4, empty());
+    final ByteBuffer result = udf.lpad(BYTES_123, 4, EMPTY_BYTES);
     assertThat(result, is(nullValue()));
   }
 
@@ -80,7 +93,7 @@ public class LPadTest {
 
   @Test
   public void shouldPadEmptyInputBytes() {
-    final ByteBuffer result = udf.lpad(empty(), 4, padding());
+    final ByteBuffer result = udf.lpad(EMPTY_BYTES, 4, BYTES_45);
     assertThat(result, is(ByteBuffer.wrap(new byte[]{4,5,4,5})));
   }
 
@@ -92,7 +105,7 @@ public class LPadTest {
 
   @Test
   public void shouldTruncateInputIfTargetLengthTooSmallBytes() {
-    final ByteBuffer result = udf.lpad(input(), 2, padding());
+    final ByteBuffer result = udf.lpad(BYTES_123, 2, BYTES_45);
     assertThat(result, is(ByteBuffer.wrap(new byte[]{1,2})));
   }
 
@@ -104,7 +117,7 @@ public class LPadTest {
 
   @Test
   public void shouldReturnNullForNegativeLengthBytes() {
-    final ByteBuffer result = udf.lpad(input(), -1, padding());
+    final ByteBuffer result = udf.lpad(BYTES_123, -1, BYTES_45);
     assertThat(result, is(nullValue()));
   }
 
@@ -116,7 +129,7 @@ public class LPadTest {
 
   @Test
   public void shouldReturnNullForNullLengthBytes() {
-    final ByteBuffer result = udf.lpad(input(), null, padding());
+    final ByteBuffer result = udf.lpad(BYTES_123, null, BYTES_45);
     assertThat(result, is(nullValue()));
   }
 
@@ -128,20 +141,12 @@ public class LPadTest {
 
   @Test
   public void shouldReturnEmptyByteBufferForZeroLength() {
-    final ByteBuffer result = udf.lpad(input(), 0, padding());
-    assertThat(result, is(empty()));
+    final ByteBuffer result = udf.lpad(BYTES_123, 0, BYTES_45);
+    assertThat(result, is(EMPTY_BYTES));
   }
 
-  private ByteBuffer input(){
-    return ByteBuffer.wrap(new byte[]{1,2,3});
-  }
-
-  private ByteBuffer padding() {
-    return ByteBuffer.wrap(new byte[]{4,5});
-  }
-
-  private ByteBuffer empty(){
-    return ByteBuffer.wrap(new byte[]{});
-  }
+  private final ByteBuffer BYTES_123 = ByteBuffer.wrap(new byte[]{1,2,3});
+  private final ByteBuffer BYTES_45 = ByteBuffer.wrap(new byte[]{4,5});
+  private final ByteBuffer EMPTY_BYTES = ByteBuffer.wrap(new byte[]{});
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/LPadTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/LPadTest.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 
 public class LPadTest {
   private final LPad udf = new LPad();
+  private static final ByteBuffer BYTES_123 = ByteBuffer.wrap(new byte[]{1,2,3});
+  private static final ByteBuffer BYTES_45 = ByteBuffer.wrap(new byte[]{4,5});
+  private static final ByteBuffer EMPTY_BYTES = ByteBuffer.wrap(new byte[]{});
 
   @Test
   public void shouldPadInputString() {
@@ -144,9 +147,5 @@ public class LPadTest {
     final ByteBuffer result = udf.lpad(BYTES_123, 0, BYTES_45);
     assertThat(result, is(EMPTY_BYTES));
   }
-
-  private final ByteBuffer BYTES_123 = ByteBuffer.wrap(new byte[]{1,2,3});
-  private final ByteBuffer BYTES_45 = ByteBuffer.wrap(new byte[]{4,5});
-  private final ByteBuffer EMPTY_BYTES = ByteBuffer.wrap(new byte[]{});
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/LPadTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/LPadTest.java
@@ -18,56 +18,105 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.nio.ByteBuffer;
 import org.junit.Test;
 
 public class LPadTest {
   private final LPad udf = new LPad();
 
   @Test
-  public void shouldPadInput() {
+  public void shouldPadInputString() {
     final String result = udf.lpad("foo", 7, "Bar");
     assertThat(result, is("BarBfoo"));
   }
 
   @Test
-  public void shouldReturnNullForNullInput() {
+  public void shouldPadInputBytes() {
+    final ByteBuffer result = udf.lpad(input(), 7, padding());
+    assertThat(result, is(ByteBuffer.wrap(new byte[]{4,5,4,5,1,2,3})));
+  }
+
+  @Test
+  public void shouldReturnNullForNullInputString() {
     final String result = udf.lpad(null, 4, "foo");
     assertThat(result, is(nullValue()));
   }
 
   @Test
-  public void shouldReturnNullForNullPadding() {
+  public void shouldReturnNullForNullInputBytes() {
+    final ByteBuffer result = udf.lpad(null, 4, padding());
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullPaddingString() {
     final String result = udf.lpad("foo", 4, null);
     assertThat(result, is(nullValue()));
   }
 
   @Test
-  public void shouldReturnNullForEmptyPadding() {
+  public void shouldReturnNullForNullPaddingBytes() {
+    final ByteBuffer result = udf.lpad(input(), 4, null);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForEmptyPaddingString() {
     final String result = udf.lpad("foo", 4, "");
     assertThat(result, is(nullValue()));
   }
 
   @Test
-  public void shouldPadEmptyInput() {
+  public void shouldReturnNullForEmptyPaddingBytes() {
+    final ByteBuffer result = udf.lpad(input(), 4, empty());
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldPadEmptyInputString() {
     final String result = udf.lpad("", 4, "foo");
     assertThat(result, is("foof"));
   }
 
   @Test
-  public void shouldTruncateInputIfTargetLengthTooSmall() {
+  public void shouldPadEmptyInputBytes() {
+    final ByteBuffer result = udf.lpad(empty(), 4, padding());
+    assertThat(result, is(ByteBuffer.wrap(new byte[]{4,5,4,5})));
+  }
+
+  @Test
+  public void shouldTruncateInputIfTargetLengthTooSmallString() {
     final String result = udf.lpad("foo", 2, "bar");
     assertThat(result, is("fo"));
   }
 
   @Test
-  public void shouldReturnNullForNegativeLength() {
+  public void shouldTruncateInputIfTargetLengthTooSmallBytes() {
+    final ByteBuffer result = udf.lpad(input(), 2, padding());
+    assertThat(result, is(ByteBuffer.wrap(new byte[]{1,2})));
+  }
+
+  @Test
+  public void shouldReturnNullForNegativeLengthString() {
     final String result = udf.lpad("foo", -1, "bar");
     assertThat(result, is(nullValue()));
   }
 
   @Test
-  public void shouldReturnNullForNullLength() {
+  public void shouldReturnNullForNegativeLengthBytes() {
+    final ByteBuffer result = udf.lpad(input(), -1, padding());
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullLengthString() {
     final String result = udf.lpad("foo", null, "bar");
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnNullForNullLengthBytes() {
+    final ByteBuffer result = udf.lpad(input(), null, padding());
     assertThat(result, is(nullValue()));
   }
 
@@ -75,6 +124,24 @@ public class LPadTest {
   public void shouldReturnEmptyStringForZeroLength() {
     final String result = udf.lpad("foo", 0, "bar");
     assertThat(result, is(""));
+  }
+
+  @Test
+  public void shouldReturnEmptyByteBufferForZeroLength() {
+    final ByteBuffer result = udf.lpad(input(), 0, padding());
+    assertThat(result, is(empty()));
+  }
+
+  private ByteBuffer input(){
+    return ByteBuffer.wrap(new byte[]{1,2,3});
+  }
+
+  private ByteBuffer padding() {
+    return ByteBuffer.wrap(new byte[]{4,5});
+  }
+
+  private ByteBuffer empty(){
+    return ByteBuffer.wrap(new byte[]{});
   }
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/RPadTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/RPadTest.java
@@ -33,7 +33,7 @@ public class RPadTest {
 
   @Test
   public void shouldPadInputBytes() {
-    final ByteBuffer result = udf.rpad(input(), 7, padding());
+    final ByteBuffer result = udf.rpad(BYTES_123, 7, BYTES_45);
     assertThat(BytesUtils.getByteArray(result), is(new byte[]{1,2,3,4,5,4,5}));
   }
 
@@ -44,7 +44,7 @@ public class RPadTest {
   }
 
   @Test public void shouldAppendPartialPaddingBytes() {
-    final ByteBuffer result = udf.rpad(input(), 4, padding());
+    final ByteBuffer result = udf.rpad(BYTES_123, 4, BYTES_45);
     assertThat(BytesUtils.getByteArray(result), is(new byte[]{1,2,3,4}));
   }
 
@@ -56,7 +56,7 @@ public class RPadTest {
 
   @Test
   public void shouldReturnNullForNullInputBytes() {
-    final ByteBuffer result = udf.rpad(null, 4, padding());
+    final ByteBuffer result = udf.rpad(null, 4, BYTES_45);
     assertThat(result, is(nullValue()));
   }
 
@@ -68,7 +68,7 @@ public class RPadTest {
 
   @Test
   public void shouldReturnNullForNullPaddingBytes() {
-    final ByteBuffer result = udf.rpad(input(), 4, null);
+    final ByteBuffer result = udf.rpad(BYTES_123, 4, null);
     assertThat(result, is(nullValue()));
   }
 
@@ -80,7 +80,7 @@ public class RPadTest {
 
   @Test
   public void shouldReturnNullForEmptyPaddingBytes() {
-    final ByteBuffer result = udf.rpad(input(), 4, empty());
+    final ByteBuffer result = udf.rpad(BYTES_123, 4, EMPTY_BYTES);
     assertThat(result, is(nullValue()));
   }
 
@@ -92,7 +92,7 @@ public class RPadTest {
 
   @Test
   public void shouldPadEmptyInputBytes() {
-    final ByteBuffer result = udf.rpad(empty(), 4, padding());
+    final ByteBuffer result = udf.rpad(EMPTY_BYTES, 4, BYTES_45);
     assertThat(result, is(ByteBuffer.wrap(new byte[]{4,5,4,5})));
   }
 
@@ -104,7 +104,7 @@ public class RPadTest {
 
   @Test
   public void shouldTruncateInputIfTargetLengthTooSmallBytes() {
-    final ByteBuffer result = udf.rpad(input(), 2, padding());
+    final ByteBuffer result = udf.rpad(BYTES_123, 2, BYTES_45);
     assertThat(result, is(ByteBuffer.wrap(new byte[]{1,2})));
   }
 
@@ -116,7 +116,7 @@ public class RPadTest {
 
   @Test
   public void shouldReturnNullForNegativeLengthBytes() {
-    final ByteBuffer result = udf.rpad(input(), -1, padding());
+    final ByteBuffer result = udf.rpad(BYTES_123, -1, BYTES_45);
     assertThat(result, is(nullValue()));
   }
 
@@ -128,8 +128,8 @@ public class RPadTest {
 
   @Test
   public void shouldReturnEmptyByteBufferForZeroLength() {
-    final ByteBuffer result = udf.rpad(input(), 0, padding());
-    assertThat(result, is(empty()));
+    final ByteBuffer result = udf.rpad(BYTES_123, 0, BYTES_45);
+    assertThat(result, is(EMPTY_BYTES));
   }
 
   @Test
@@ -140,20 +140,12 @@ public class RPadTest {
 
   @Test
   public void shouldReturnNullForNullLengthBytes() {
-    final ByteBuffer result = udf.rpad(input(), null, padding());
+    final ByteBuffer result = udf.rpad(BYTES_123, null, BYTES_45);
     assertThat(result, is(nullValue()));
   }
 
-  private ByteBuffer input(){
-    return ByteBuffer.wrap(new byte[]{1,2,3});
-  }
-
-  private ByteBuffer padding() {
-    return ByteBuffer.wrap(new byte[]{4,5});
-  }
-
-  private ByteBuffer empty(){
-    return ByteBuffer.wrap(new byte[]{});
-  }
+  private final ByteBuffer BYTES_123 = ByteBuffer.wrap(new byte[]{1,2,3});
+  private final ByteBuffer BYTES_45 = ByteBuffer.wrap(new byte[]{4,5});
+  private final ByteBuffer EMPTY_BYTES = ByteBuffer.wrap(new byte[]{});
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/RPadTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/RPadTest.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 
 public class RPadTest {
   private final RPad udf = new RPad();
+  private static final ByteBuffer BYTES_123 = ByteBuffer.wrap(new byte[]{1,2,3});
+  private static final ByteBuffer BYTES_45 = ByteBuffer.wrap(new byte[]{4,5});
+  private static final ByteBuffer EMPTY_BYTES = ByteBuffer.wrap(new byte[]{});
 
   @Test
   public void shouldPadInputString() {
@@ -43,7 +46,8 @@ public class RPadTest {
     assertThat(result, is("fooB"));
   }
 
-  @Test public void shouldAppendPartialPaddingBytes() {
+  @Test
+  public void shouldAppendPartialPaddingBytes() {
     final ByteBuffer result = udf.rpad(BYTES_123, 4, BYTES_45);
     assertThat(BytesUtils.getByteArray(result), is(new byte[]{1,2,3,4}));
   }
@@ -143,9 +147,5 @@ public class RPadTest {
     final ByteBuffer result = udf.rpad(BYTES_123, null, BYTES_45);
     assertThat(result, is(nullValue()));
   }
-
-  private final ByteBuffer BYTES_123 = ByteBuffer.wrap(new byte[]{1,2,3});
-  private final ByteBuffer BYTES_45 = ByteBuffer.wrap(new byte[]{4,5});
-  private final ByteBuffer EMPTY_BYTES = ByteBuffer.wrap(new byte[]{});
 
 }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_LPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359830/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_LPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359830/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, SUBJECT BYTES, LEN INTEGER, PADDING BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `SUBJECT` BYTES, `LEN` INTEGER, `PADDING` BYTES",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  LPAD(INPUT.SUBJECT, INPUT.LEN, INPUT.PADDING) RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` BYTES",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `SUBJECT` BYTES, `LEN` INTEGER, `PADDING` BYTES"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "LPAD(SUBJECT, LEN, PADDING) AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_LPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359830/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_LPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359830/spec.json
@@ -1,0 +1,224 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1627442359830,
+  "path" : "query-validation-tests/bytes-lpad-rpad.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `SUBJECT` BYTES, `LEN` INTEGER, `PADDING` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `RESULT` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "LPAD with all args from record - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 8,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 5,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 3,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 2,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 0,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r6",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : -1,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r7",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 3,
+        "padding" : ""
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r8",
+      "value" : {
+        "subject" : null,
+        "len" : 8,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r9",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : null,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r10",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 8,
+        "padding" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : "bm9ub255ZXM="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : "bm95ZXM="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "RESULT" : "eWVz"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "RESULT" : "eWU="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "RESULT" : ""
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r6",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r7",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r8",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r9",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r10",
+      "value" : {
+        "RESULT" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, subject BYTES, len INT, padding BYTES) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, lpad(subject, len, padding) AS result FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `SUBJECT` BYTES, `LEN` INTEGER, `PADDING` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `RESULT` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_LPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359830/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_LPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359830/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_RPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359873/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_RPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359873/plan.json
@@ -1,0 +1,154 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID STRING KEY, SUBJECT BYTES, LEN INTEGER, PADDING BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` STRING KEY, `SUBJECT` BYTES, `LEN` INTEGER, `PADDING` BYTES",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  RPAD(INPUT.SUBJECT, INPUT.LEN, INPUT.PADDING) RESULT\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` STRING KEY, `RESULT` BYTES",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`ID` STRING KEY, `SUBJECT` BYTES, `LEN` INTEGER, `PADDING` BYTES"
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "RPAD(SUBJECT, LEN, PADDING) AS RESULT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_RPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359873/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_RPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359873/spec.json
@@ -1,0 +1,224 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1627442359873,
+  "path" : "query-validation-tests/bytes-lpad-rpad.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `SUBJECT` BYTES, `LEN` INTEGER, `PADDING` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` STRING KEY, `RESULT` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "RPAD with all args from record - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "r1",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 8,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r2",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 5,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r3",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 3,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r4",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 2,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r5",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 0,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r6",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : -1,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r7",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : 3,
+        "padding" : ""
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r8",
+      "value" : {
+        "subject" : null,
+        "len" : 3,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r9",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : null,
+        "padding" : "bm8="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "r10",
+      "value" : {
+        "subject" : "eWVz",
+        "len" : -1,
+        "padding" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "r1",
+      "value" : {
+        "RESULT" : "eWVzbm9ub24="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r2",
+      "value" : {
+        "RESULT" : "eWVzbm8="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r3",
+      "value" : {
+        "RESULT" : "eWVz"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r4",
+      "value" : {
+        "RESULT" : "eWU="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r5",
+      "value" : {
+        "RESULT" : ""
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r6",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r7",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r8",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r9",
+      "value" : {
+        "RESULT" : null
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "r10",
+      "value" : {
+        "RESULT" : null
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (id STRING KEY, subject BYTES, len INT, padding BYTES) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT id, rpad(subject, len, padding) AS RESULT FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `SUBJECT` BYTES, `LEN` INTEGER, `PADDING` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `RESULT` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_RPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359873/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes-lpad-rpad_-_RPAD_with_all_args_from_record_-_JSON/7.1.0_1627442359873/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes-lpad-rpad.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes-lpad-rpad.json
@@ -67,7 +67,6 @@
         {"topic": "OUTPUT", "key": "r8", "value": {"RESULT": null}},
         {"topic": "OUTPUT", "key": "r9", "value": {"RESULT": null}},
         {"topic": "OUTPUT", "key": "r10", "value": {"RESULT": null}}
-
       ]
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes-lpad-rpad.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes-lpad-rpad.json
@@ -1,0 +1,74 @@
+{
+  "comments": [
+    "Tests covering usage of the LPAD and RPAD bytes functions."
+  ],
+  "tests": [
+    {
+      "name": "LPAD with all args from record",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, subject BYTES, len INT, padding BYTES) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, lpad(subject, len, padding) AS result FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"subject": "eWVz", "len": 8, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r2", "value": {"subject": "eWVz", "len": 5, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r3", "value": {"subject": "eWVz", "len": 3, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r4", "value": {"subject": "eWVz", "len": 2, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r5", "value": {"subject": "eWVz", "len": 0, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r6", "value": {"subject": "eWVz", "len": -1, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r7", "value": {"subject": "eWVz", "len": 3, "padding": ""}},
+        {"topic": "test_topic", "key": "r8", "value": {"subject": null, "len": 8, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r9", "value": {"subject": "eWVz", "len": null, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r10", "value": {"subject": "eWVz", "len": 8, "padding": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": "bm9ub255ZXM="}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": "bm95ZXM="}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"RESULT": "eWVz"}},
+        {"topic": "OUTPUT", "key": "r4", "value": {"RESULT": "eWU="}},
+        {"topic": "OUTPUT", "key": "r5", "value": {"RESULT": ""}},
+        {"topic": "OUTPUT", "key": "r6", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r7", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r8", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r9", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r10", "value": {"RESULT": null}}
+      ]
+    },
+    {
+      "name": "RPAD with all args from record",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM INPUT (id STRING KEY, subject BYTES, len INT, padding BYTES) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT id, rpad(subject, len, padding) AS RESULT FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "r1", "value": {"subject": "eWVz", "len": 8, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r2", "value": {"subject": "eWVz", "len": 5, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r3", "value": {"subject": "eWVz", "len": 3, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r4", "value": {"subject": "eWVz", "len": 2, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r5", "value": {"subject": "eWVz", "len": 0, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r6", "value": {"subject": "eWVz", "len": -1, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r7", "value": {"subject": "eWVz", "len": 3, "padding": ""}},
+        {"topic": "test_topic", "key": "r8", "value": {"subject": null, "len": 3, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r9", "value": {"subject": "eWVz", "len": null, "padding": "bm8="}},
+        {"topic": "test_topic", "key": "r10", "value": {"subject": "eWVz", "len": -1, "padding": null}}
+
+
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "r1", "value": {"RESULT": "eWVzbm9ub24="}},
+        {"topic": "OUTPUT", "key": "r2", "value": {"RESULT": "eWVzbm8="}},
+        {"topic": "OUTPUT", "key": "r3", "value": {"RESULT": "eWVz"}},
+        {"topic": "OUTPUT", "key": "r4", "value": {"RESULT": "eWU="}},
+        {"topic": "OUTPUT", "key": "r5", "value": {"RESULT": ""}},
+        {"topic": "OUTPUT", "key": "r6", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r7", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r8", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r9", "value": {"RESULT": null}},
+        {"topic": "OUTPUT", "key": "r10", "value": {"RESULT": null}}
+
+      ]
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes.json
@@ -1,5 +1,5 @@
 {
-  "comments": ["tests for decimal functionality"],
+  "comments": ["tests for bytes functionality"],
   "tests": [
     {
       "name": "DELIMITED in/out",


### PR DESCRIPTION
### Description 
This PR enables LPAD and RPAD UDFs to accept BYTES as a parameter

### Testing done 
Unit testing and QTTs

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

