### PR TITLE
fix: increase default command response timeout

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -68,6 +68,7 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.StreamedRow.DataRow;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -143,6 +144,7 @@ public class CliTest {
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withProperty(KsqlConfig.SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY,
           KsqlConstants.defaultSinkWindowChangeLogAdditionalRetention + 1)
+      .withProperty(KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG, 30000L)
       .build();
 
   @Rule

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -540,7 +540,7 @@ public class KsqlRestConfig extends AbstractConfig {
         ).define(
             DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG,
             Type.LONG,
-            5000L,
+            15000L,
             Importance.LOW,
             DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_DOC
         ).define(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -198,10 +198,10 @@ public class KsqlRestConfig extends AbstractConfig {
           + "JSON; this helps proactively determine if the connection has been terminated in "
           + "order to avoid keeping the created streams job alive longer than necessary";
 
-  static final String DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG =
+  public static final String DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG =
       KSQL_CONFIG_PREFIX + "server.command.response.timeout.ms";
 
-  private static final String DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_DOC =
+  protected static final String DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_DOC =
             "How long to wait for a distributed command to be executed by the local node before "
               + "returning a response";
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -540,7 +540,7 @@ public class KsqlRestConfig extends AbstractConfig {
         ).define(
             DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG,
             Type.LONG,
-            15000L,
+            5000L,
             Importance.LOW,
             DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_DOC
         ).define(


### PR DESCRIPTION
### Description 
The CI machine appears to be overloaded and is being slow, so it seems to be timing out when reading from the command topic. This results in several flaky tests such as `shouldRunScriptOnRunScript`,`shouldRunScriptOnRunInteractively`, `shouldHandlePullQuery` which all fail due to `Timeout while waiting for command topic consumer to process command topic`.


### Testing done 
Ran locally several hundred times but unable to easily reproduce bug as the MacBook is too fast. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

