### PR TITLE
chore: remove \r\n chars from Base64 encoded strings

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
@@ -26,10 +26,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 public final class BytesUtils {
-  private static final Base64.Encoder BASE64_ENCODER = Base64.getMimeEncoder();
-  private static final Base64.Decoder BASE64_DECODER = Base64.getMimeDecoder();
-
-  enum Encoding {
+  public enum Encoding {
     HEX,
     UTF8,
     ASCII,
@@ -68,21 +65,19 @@ public final class BytesUtils {
       Encoding.BASE64, v -> base64Decoding(v)
   );
 
-  public static String encode(final byte[] value, final String encoding) {
-    final Function<byte[], String> encoder = ENCODERS.get(Encoding.from(encoding));
+  public static String encode(final byte[] value, final Encoding encoding) {
+    final Function<byte[], String> encoder = ENCODERS.get(encoding);
     if (encoder == null) {
-      throw new IllegalStateException(String.format("Unknown encoding type '%s'. "
-          + "Supported formats are 'hex', 'utf8', 'ascii', and 'base64'.", encoding));
+      throw new IllegalStateException(String.format("Unsupported encoding type '%s'. ", encoding));
     }
 
     return encoder.apply(value);
   }
 
-  public static byte[] decode(final String value, final String encoding) {
-    final Function<String, byte[]> decoder = DECODERS.get(Encoding.from(encoding));
+  public static byte[] decode(final String value, final Encoding encoding) {
+    final Function<String, byte[]> decoder = DECODERS.get(encoding);
     if (decoder == null) {
-      throw new IllegalStateException(String.format("Unknown encoding type '%s'. "
-          + "Supported formats are 'hex', 'utf8', 'ascii', and 'base64'.", encoding));
+      throw new IllegalStateException(String.format("Unsupported encoding type '%s'. ", encoding));
     }
 
     return decoder.apply(value);
@@ -208,10 +203,11 @@ public final class BytesUtils {
   }
 
   private static String base64Encoding(final byte[] value) {
-    return BASE64_ENCODER.encodeToString(value);
+    // Use getEncoder() because it does not add \r\n to the base64 string
+    return Base64.getEncoder().encodeToString(value);
   }
 
   private static byte[] base64Decoding(final String value) {
-    return BASE64_DECODER.decode(value);
+    return Base64.getDecoder().decode(value);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/FromBytes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/FromBytes.java
@@ -35,6 +35,7 @@ public class FromBytes {
   public String fromBytes(
       @UdfParameter(description = "The bytes value to convert.") final ByteBuffer value,
       @UdfParameter(description = "The encoding to use on conversion.") final String encoding) {
-    return (value == null) ? null : BytesUtils.encode(BytesUtils.getByteArray(value), encoding);
+    return (value == null) ? null : BytesUtils.encode(BytesUtils.getByteArray(value),
+        BytesUtils.Encoding.from(encoding));
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/ToBytes.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/string/ToBytes.java
@@ -35,6 +35,7 @@ public class ToBytes {
   public ByteBuffer toBytes(
       @UdfParameter(description = "The string to convert.") final String value,
       @UdfParameter(description = "The type of encoding.") final String encoding) {
-    return (value == null) ? null : ByteBuffer.wrap(BytesUtils.decode(value, encoding));
+    return (value == null) ? null : ByteBuffer.wrap(BytesUtils.decode(value,
+        BytesUtils.Encoding.from(encoding)));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/FromBytesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/FromBytesTest.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -63,6 +64,18 @@ public class FromBytesTest {
             is("IQ=="));
         assertThat(udf.fromBytes(ByteBuffer.wrap(new byte[]{}), "base64"),
             is(""));
+    }
+
+    @Test
+    public void shouldNotAddNewLinesToBase64EncodedBytes() {
+        final byte[] b = new byte[200];
+        Arrays.fill(b, (byte) 33);
+
+        assertThat(udf.fromBytes(ByteBuffer.wrap(b), "base64"),
+            is("ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEh"
+                + "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE"
+                + "hISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE"
+                + "hISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISE="));
     }
 
     @Test


### PR DESCRIPTION
### Description 
When encoding bytes with to_bytes(..., 'base64'), I noticed that `\r\n` characters were added to the string. This PR sure not to add those \r\n characters.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

