### PR TITLE
fix: default port URL composition issue

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -240,7 +240,8 @@ public final class KsqlRestClient implements Closeable {
     try {
       final URL url = new URL(serverAddress);
       if (url.getPort() == -1) {
-        return new URL(serverAddress.concat(":") + url.getDefaultPort()).toURI();
+        return new URL(url.getProtocol(), url.getHost(), url.getDefaultPort(),
+          url.getFile()).toURI();
       }
       return url.toURI();
     } catch (final Exception e) {

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
@@ -141,6 +141,34 @@ public class KsqlRestClientTest {
     assertThat(ksqlRestClient.getServerAddress(), is(serverURI));
   }
 
+  @Test
+  public void shouldParseHttpAddressWithoutPortUsingLocation() throws Exception {
+    // Given:
+    final String serverAddress = "http://singleServer";
+    final String location = "/location";
+    final URI serverURI = new URI(serverAddress.concat(":80").concat(location));
+
+    // When:
+    KsqlRestClient ksqlRestClient = clientWithServerAddresses(serverAddress.concat(location));
+
+    // Then:
+    assertThat(ksqlRestClient.getServerAddress(), is(serverURI));
+  }
+
+  @Test
+  public void shouldParseHttpsAddressWithoutPortUsingLocation() throws Exception {
+    // Given:
+    final String serverAddress = "https://singleServer";
+    final String location = "/location";
+    final URI serverURI = new URI(serverAddress.concat(":443").concat(location));
+
+    // When:
+    KsqlRestClient ksqlRestClient = clientWithServerAddresses(serverAddress.concat(location));
+
+    // Then:
+    assertThat(ksqlRestClient.getServerAddress(), is(serverURI));
+  }
+
   private KsqlRestClient clientWithServerAddresses(final String serverAddresses) {
     return KsqlRestClient.create(
         serverAddresses,


### PR DESCRIPTION
### Description 
I was struggling to connect in ksql using ksql-cli. I configured ksql behind a reverse proxy using a location, after some time I realized that providing the url to ksql cli:

`https://ksqlab.confluent.io/lab1` it was changing to `https://ksqlab.confluent.io/lab1:443`
or
`http://ksqlab.confluent.io/lab1` it was changing to `http://ksqlab.confluent.io/lab1:80`


### Testing done 
Added two unit test for the scenario described above

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

