### PR TITLE
refactor: support BYTES on QTT for Protobuf

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/ConnectSerdeSupplier.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.test.serde;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -201,7 +199,7 @@ public abstract class ConnectSerdeSupplier<T extends ParsedSchema>
 
             throw new TestFrameworkException("DECIMAL type requires JSON number in test data");
           } else {
-            return spec.toString().getBytes(UTF_8);
+            return spec;
           }
         default:
           throw new RuntimeException(

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/ExpectedRecordComparator.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/ExpectedRecordComparator.java
@@ -72,7 +72,13 @@ public final class ExpectedRecordComparator {
     final Iterator<Entry<String, JsonNode>> fields = expected.fields();
     while (fields.hasNext()) {
       final Entry<String, JsonNode> field = fields.next();
-      if (!comparator(field.getValue()).test(getter.apply(field.getKey()), field.getValue())) {
+
+      Object key = getter.apply(field.getKey());
+      if (key == null) {
+        key = getter.apply(field.getKey().toUpperCase());
+      }
+
+      if (!comparator(field.getValue()).test(key, field.getValue())) {
         return false;
       }
     }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes.json
@@ -28,6 +28,31 @@
       ]
     },
     {
+      "name": "PROTOBUF in/out",
+      "statements": [
+        "CREATE STREAM TEST WITH (kafka_topic='test', value_format='PROTOBUF');",
+        "CREATE STREAM TEST2 AS SELECT * FROM TEST;"
+      ],
+      "topics": [
+        {
+          "name": "test",
+          "valueFormat": "PROTOBUF",
+          "valueSchema": "syntax = \"proto3\"; message ConfluentDefault1 {bytes b = 1;}"
+        }
+      ],
+      "inputs": [
+        {"topic": "test", "value": {"b": "dmFyaWF0aW9ucw=="}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "value": {"B": "dmFyaWF0aW9ucw=="}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "TEST2", "type": "stream", "schema": "B BYTES"}
+        ]
+      }
+    },
+    {
       "name": "bytes in complex types",
       "statements": [
         "CREATE STREAM TEST (ID STRING KEY, S STRUCT<B BYTES>, A ARRAY<BYTES>, M MAP<STRING, BYTES>) WITH (kafka_topic='test', value_format='JSON');",


### PR DESCRIPTION
### Description 
Allow QTT run tests with Protobuf bytes. The tests in JSON require bytes to be encoded using base64 encodind and also define the protobuf schema as part of the QTT test. QTT will identify there's a schema with the bytes type and attempt to decode the base64 string to a ByteBuffer. This ByteBuffer is written to the input topics.

Later, when the test is executed, the QTT gets the ByteBuffer from the output topics, and then is converted to base64 in order to compare it with the base64 string used in the QTT output topic.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

