### PR TITLE
fix: migrate integration tests to use the working directory for state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ node/
 node_modules/
 logs/
 
+# Test directories
+junit*/
+
 # IntelliJ data
 *.iml
 *.iws

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/KsqlTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/KsqlTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.cli.Cli;
 import io.confluent.ksql.cli.Options;
 import io.confluent.ksql.cli.console.OutputFormat;
 import io.confluent.ksql.rest.client.KsqlRestClient;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -49,7 +50,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsqlTest {
 
   @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
+  public static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   @Mock
   private Options options;

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.UpgradeRejectedException;
 import io.vertx.core.json.JsonObject;
@@ -59,7 +60,7 @@ import org.junit.rules.TemporaryFolder;
 @Category({IntegrationTest.class})
 public class BasicAuthFunctionalTest {
 
-  private static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  private static final TemporaryFolder TMP_FOLDER = KsqlTestFolder.temporaryFolder();
 
   static {
     createTmpFolder();

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -76,6 +76,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
@@ -148,7 +149,7 @@ public class CliTest {
       .build();
 
   @Rule
-  public final TemporaryFolder TMP = new TemporaryFolder();
+  public final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -47,7 +48,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class JLineReaderTest {
 
   @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  public TemporaryFolder tempFolder = KsqlTestFolder.temporaryFolder();
 
   @Mock
   private Predicate<String> cliLinePredicate;

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RunScriptTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RunScriptTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.cli.KsqlRequestExecutor;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlException;
 import java.io.File;
 import java.io.PrintWriter;
@@ -47,7 +48,7 @@ public class RunScriptTest {
   private static final String FILE_CONTENT = "some scripts;" + System.lineSeparator() + "more;";
 
   @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
+  public static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   @Mock
   private KsqlRequestExecutor requestExecutor;

--- a/ksqldb-common/src/test/java/io/confluent/ksql/properties/PropertiesUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/properties/PropertiesUtilTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlException;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -40,7 +41,7 @@ import org.junit.rules.TemporaryFolder;
 public class PropertiesUtilTest {
 
   @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
+  public static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   private File propsFile;
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/VertxSslOptionsFactoryTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/VertxSslOptionsFactoryTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.util;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.test.util.secure.ServerKeyStore;
 import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.PfxOptions;
@@ -38,7 +39,7 @@ public class VertxSslOptionsFactoryTest {
   private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
 
   @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
+  public static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   @Test
   public void shouldBuildTrustStoreJksOptionsWithPathAndPassword() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
@@ -115,11 +115,14 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
     public void run() {
       try {
         final Path pathName = Paths.get(stateDir + "/" + appId);
-        FileUtils.deleteDirectory(new File(String.valueOf(pathName.normalize())));
-        LOG.warn("Deleted local state store for non-existing query {}. "
-            + "This is not expected and was likely due to a "
-            + "race condition when the query was dropped before.",
-            appId);
+        final File directory = new File(String.valueOf(pathName.normalize()));
+        if (directory.exists()) {
+          FileUtils.deleteDirectory(directory);
+          LOG.warn("Deleted local state store for non-existing query {}. "
+                  + "This is not expected and was likely due to a "
+                  + "race condition when the query was dropped before.",
+              appId);
+        }
       } catch (Exception e) {
         LOG.error("Error cleaning up state directory {}\n. {}", appId, e);
       }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -60,6 +60,7 @@ import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.io.File;
@@ -113,7 +114,7 @@ public class UdfLoaderTest {
       SchemaBuilder.struct().field("a", Schema.OPTIONAL_STRING_SCHEMA).build();
 
   @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  public TemporaryFolder tempFolder = KsqlTestFolder.temporaryFolder();
 
   @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
   @Before

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -62,6 +62,7 @@ import io.confluent.ksql.test.parser.SqlTestLoader;
 import io.confluent.ksql.test.parser.TestDirective;
 import io.confluent.ksql.test.parser.TestStatement;
 import io.confluent.ksql.test.tools.TestFunctionRegistry;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -108,7 +109,7 @@ public class KsqlTesterTest {
       .build();
 
   @Rule
-  public final TemporaryFolder tmpFolder = TemporaryFolder.builder().build();
+  public final TemporaryFolder tmpFolder = KsqlTestFolder.temporaryFolder();
 
   // parameterized
   private final Path file;

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/parser/SqlTestReaderTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.parser.ParsingException;
 import io.confluent.ksql.parser.tree.AssertValues;
 import io.confluent.ksql.test.parser.TestDirective.Type;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +38,7 @@ import org.junit.rules.TemporaryFolder;
 public class SqlTestReaderTest {
 
   @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  public final TemporaryFolder temporaryFolder = KsqlTestFolder.temporaryFolder();
 
   private static final NodeLocation LOC = new NodeLocation(1, 1);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicIntegrationTest.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
 import io.confluent.ksql.rest.server.restore.KsqlRestoreCommandTopic;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.io.File;
@@ -79,7 +80,7 @@ public class RestoreCommandTopicIntegrationTest {
       .around(TEST_HARNESS);
 
   @ClassRule
-  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  public static final TemporaryFolder TMP_FOLDER = KsqlTestFolder.temporaryFolder();
 
   private static File BACKUP_LOCATION;
   private static TestKsqlRestApp REST_APP;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/FileWatcherTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import io.confluent.ksql.api.server.FileWatcher.Callback;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -45,7 +46,7 @@ import org.mockito.verification.Timeout;
 public class FileWatcherTest {
 
   @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
+  public static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   @Mock
   private Callback callback;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/BackupRollbackIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/BackupRollbackIntegrationTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import kafka.zookeeper.ZooKeeperClientException;
@@ -77,7 +78,7 @@ public class BackupRollbackIntegrationTest {
       .around(TEST_HARNESS);
 
   @ClassRule
-  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  public static final TemporaryFolder TMP_FOLDER = KsqlTestFolder.temporaryFolder();
 
   private static File BACKUP_LOCATION;
   private static TestKsqlRestApp REST_APP;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/CommandTopicFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/CommandTopicFunctionalTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PageViewDataProvider;
 import io.confluent.ksql.util.ReservedInternalTopics;
@@ -55,7 +56,7 @@ public class CommandTopicFunctionalTest {
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
   @Rule
-  public TemporaryFolder backupLocation = new TemporaryFolder();
+  public TemporaryFolder backupLocation = KsqlTestFolder.temporaryFolder();
 
   private TestKsqlRestApp REST_APP_1;
   private TestKsqlRestApp REST_APP_2;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/LagReportingAgentFunctionalTest.java
@@ -16,6 +16,7 @@ import io.confluent.ksql.rest.entity.StateStoreLags;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.PageViewDataProvider;
 import java.io.IOException;
 import java.util.Comparator;
@@ -41,7 +42,7 @@ import org.slf4j.LoggerFactory;
 @Category({IntegrationTest.class})
 public class LagReportingAgentFunctionalTest {
   private static final Logger LOG = LoggerFactory.getLogger(LagReportingAgentFunctionalTest.class);
-  private static final TemporaryFolder TMP = new TemporaryFolder();
+  private static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   static {
     try {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.UserDataProvider;
@@ -74,7 +75,7 @@ import org.junit.rules.TemporaryFolder;
 @Category({IntegrationTest.class})
 public class PullQueryFunctionalTest {
 
-  private static final TemporaryFolder TMP = new TemporaryFolder();
+  private static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   static {
     try {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -58,6 +58,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.UserDataProvider;
@@ -105,7 +106,7 @@ public class PullQueryRoutingFunctionalTest {
   private static final UserDataProvider USER_PROVIDER = new UserDataProvider();
   private static final int HEADER = 1;
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
-  private static final TemporaryFolder TMP = new TemporaryFolder();
+  private static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
   private static final int BASE_TIME = 1_000_000;
   private final static String KEY = USER_PROVIDER.getStringKey(0);
   private final static String KEY1 = USER_PROVIDER.getStringKey(1);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQuerySingleNodeFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQuerySingleNodeFunctionalTest.java
@@ -49,6 +49,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.UserDataProvider;
@@ -121,7 +122,7 @@ public class PullQuerySingleNodeFunctionalTest {
       .build();
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
-  private static final TemporaryFolder TMP = new TemporaryFolder();
+  private static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
   private static final int INT_PORT_0 = TestUtils.findFreeLocalPort();
   private static final KsqlHostInfoEntity host0 = new KsqlHostInfoEntity("localhost", INT_PORT_0);
   private static final Shutoffs APP_SHUTOFFS_0 = new Shutoffs();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.security.KsqlAuthorizationProvider;
 import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.test.util.secure.MultiNodeKeyStore;
 import io.confluent.ksql.test.util.secure.MultiNodeTrustStore;
 import io.confluent.ksql.test.util.secure.ServerKeyStore;
@@ -77,7 +78,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SystemAuthenticationFunctionalTest {
   private static final ServerKeyStore SERVER_KEY_STORE = new ServerKeyStore();
   @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
+  public static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
   private static PageViewDataProvider PAGE_VIEWS_PROVIDER;
   private static String PAGE_VIEW_TOPIC;
   private static final BiFunction<Integer, String, SocketAddress> LOCALHOST_FACTORY =

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
 import java.io.IOException;
@@ -40,7 +41,7 @@ public class BackupReplayFileTest {
   private static final String REPLAY_FILE_NAME = "backup_command_topic_1";
 
   @Rule
-  public TemporaryFolder backupLocation = new TemporaryFolder();
+  public TemporaryFolder backupLocation = KsqlTestFolder.temporaryFolder();
 
   private BackupReplayFile replayFile;
   private File internalReplayFile;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicBackupImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.rest.server.resources.CommandTopicCorruptionException;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
@@ -55,7 +56,7 @@ public class CommandTopicBackupImplTest {
   private Supplier<Long> ticker;
 
   @Rule
-  public TemporaryFolder backupLocation = new TemporaryFolder();
+  public TemporaryFolder backupLocation = KsqlTestFolder.temporaryFolder();
 
   private CommandTopicBackupImpl commandTopicBackup;
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsFileTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsFileTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -43,7 +44,7 @@ public class LocalCommandsFileTest {
           "_confluent-ksql-default_transient_123457300573686369_1606940012343");
 
   @Rule
-  public TemporaryFolder commandsDir = new TemporaryFolder();
+  public TemporaryFolder commandsDir = KsqlTestFolder.temporaryFolder();
 
   private LocalCommandsFile localCommandsFile;
   private File internalCommandsFile;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.File;
@@ -68,7 +69,7 @@ public class LocalCommandsTest {
   private LocalCommandsFile localCommandsFile;
 
   @Rule
-  public TemporaryFolder commandsDir = new TemporaryFolder();
+  public TemporaryFolder commandsDir = KsqlTestFolder.temporaryFolder();
 
   @Before
   public void setup() throws IOException {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.OrderDataProvider;
@@ -70,7 +71,7 @@ public class StandaloneExecutorFunctionalTest {
   public static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
   @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
+  public static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
 
   private static final String AVRO_TOPIC = "avro-topic";
   private static final String JSON_TOPIC = "json-topic";

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.rest.server.TemporaryEngine;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -54,7 +55,7 @@ public class ListPropertiesExecutorTest {
   public final TemporaryEngine engine = new TemporaryEngine();
 
   @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  public TemporaryFolder folder = KsqlTestFolder.temporaryFolder();
 
   private String connectPropsFile;
 

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -119,7 +119,7 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   private final String previousJassConfig;
   private final Map<String, Object> customBrokerConfig;
   private final Map<String, Object> customClientConfig;
-  private final TemporaryFolder tmpFolder = new TemporaryFolder();
+  private final TemporaryFolder tmpFolder = KsqlTestFolder.temporaryFolder();
   private final List<AclBinding> addedAcls = new ArrayList<>();
   private final Map<AclKey, Set<AclOperation>> initialAcls;
 

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KsqlTestFolder.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KsqlTestFolder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.util;
+
+import java.io.File;
+import java.lang.ref.WeakReference;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * A Utility class to consolidate where we allocate state folders for tests.
+ */
+public final class KsqlTestFolder {
+
+  /**
+   * Uninstantiable static utility class
+   */
+  private KsqlTestFolder() { }
+
+
+  /**
+   * Create a temporary folder for testing. Rather than the system default
+   * temp directory, use the current working directory to avoid directories
+   * being deleted during tests.
+   */
+  public static TemporaryFolder temporaryFolder() {
+    final TemporaryFolder temporaryFolder = TemporaryFolder
+        .builder()
+        .parentFolder(new File(System.getProperty("user.dir")))
+        .build();
+
+    // Just in case the JVM exits without a proper test failure.
+    // Using a weak reference to avoid keeping all the temp folder references around
+    // for the whole duration of the JVM.
+    final WeakReference<TemporaryFolder> reference = new WeakReference<>(temporaryFolder);
+    final Thread hook = new Thread(() -> {
+      final TemporaryFolder folder = reference.get();
+      if (folder != null) {
+        folder.delete();
+      }
+    });
+
+    // I wish we had a way to intercept deletes to unregister these hooks.
+    // As it is, as tests complete, the folders themselves will get deleted,
+    // and the TemporaryFolder instances will get GCed after the tests, but the
+    // Thread instances will live in the Runtime until the end of the build.
+    // It shouldn't cause a problem, but in case it does, I think the next step would
+    // be to implement ExternalResource here and remove these references in the after()
+    // method.
+    Runtime.getRuntime().addShutdownHook(hook);
+
+    return temporaryFolder;
+  }
+}

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.api.client.KsqlArray;
 import io.confluent.ksql.api.client.KsqlObject;
 import io.confluent.ksql.api.client.Row;
 import io.confluent.ksql.api.client.SourceDescription;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil.MigrationState;
@@ -99,7 +100,7 @@ public class ApplyMigrationCommandTest {
       + "INSERT INTO FOO VALUES ('${str}');";
 
   @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  public TemporaryFolder folder = KsqlTestFolder.temporaryFolder();
 
   @Mock
   private MigrationConfig config;

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/CreateMigrationCommandTest.java
@@ -25,6 +25,7 @@ import com.github.rvesse.airline.parser.errors.ParseArgumentsMissingException;
 import com.github.rvesse.airline.parser.errors.ParseOptionOutOfRangeException;
 import com.github.rvesse.airline.parser.errors.ParseTooManyArgumentsException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.io.File;
 import java.nio.file.Paths;
 import org.junit.Before;
@@ -41,7 +42,7 @@ public class CreateMigrationCommandTest {
   private static final String EXPECTED_FILE_SUFFIX = "migration_file_description.sql";
 
   @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  public TemporaryFolder folder = KsqlTestFolder.temporaryFolder();
 
   private String migrationsDir;
   private CreateMigrationCommand command;

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/MigrationInfoCommandTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.Row;
 import io.confluent.ksql.api.client.ServerInfo;
 import io.confluent.ksql.api.client.SourceDescription;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil.MigrationState;
@@ -70,7 +71,7 @@ public class MigrationInfoCommandTest {
   private static final String MIGRATIONS_TABLE = "migrations_table";
 
   @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  public TemporaryFolder folder = KsqlTestFolder.temporaryFolder();
 
   @Mock
   private MigrationConfig config;

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/NewMigrationCommandTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.is;
 
 import com.github.rvesse.airline.SingleCommand;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -65,7 +66,7 @@ public class NewMigrationCommandTest {
       "# ksql.auth.basic.password=\n";
 
   @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  public TemporaryFolder folder = KsqlTestFolder.temporaryFolder();
 
   private String testDir;
   private NewMigrationCommand command;

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ValidateMigrationsCommandTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.api.client.BatchedQueryResult;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.Row;
 import io.confluent.ksql.api.client.SourceDescription;
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil;
 import io.confluent.ksql.tools.migrations.util.MetadataUtil.MigrationState;
@@ -65,7 +66,7 @@ public class ValidateMigrationsCommandTest {
   private static final String MIGRATIONS_TABLE = "migrations_table";
 
   @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  public TemporaryFolder folder = KsqlTestFolder.temporaryFolder();
 
   @Mock
   private MigrationConfig config;

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtilTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/MigrationsDirectoryUtilTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.tools.migrations.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
@@ -33,7 +34,7 @@ import org.junit.rules.TemporaryFolder;
 public class MigrationsDirectoryUtilTest {
 
   @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  public TemporaryFolder folder = KsqlTestFolder.temporaryFolder();
 
   private String testDir;
 


### PR DESCRIPTION
Previously, we would default to `/tmp`, but are seeing occasional test failures when the `/tmp` directory gets cleared during the tests by the OS.

### Testing done 
I ran the tests on my machine and made sure that no `junit` files are created in `/tmp`, and that I do see them in the working directory. I also verified that the files are deleted when tests finish, and also if I terminate the test process.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

