### PR TITLE
feat: add CREATE SOURCE TABLE syntax and metadata info

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -144,7 +144,7 @@ public final class CreateSourceFactory {
         Formats.from(outputNode.getKsqlTopic()),
         outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
         Optional.of(outputNode.getOrReplace()),
-        Optional.of(CreateTable.Type.NORMAL.name())
+        Optional.of(false)
     );
   }
 
@@ -192,7 +192,7 @@ public final class CreateSourceFactory {
         buildFormats(statement.getName(), schema, props, ksqlConfig),
         getWindowInfo(props),
         Optional.of(statement.isOrReplace()),
-        Optional.of(statement.getType().name())
+        Optional.of(statement.isSource())
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -134,6 +134,7 @@ public final class CreateSourceFactory {
     );
   }
 
+  // This method is called by CREATE_AS statements
   public CreateTableCommand createTableCommand(final KsqlStructuredDataOutputNode outputNode) {
     return new CreateTableCommand(
         outputNode.getSinkName().get(),
@@ -142,10 +143,12 @@ public final class CreateSourceFactory {
         outputNode.getKsqlTopic().getKafkaTopicName(),
         Formats.from(outputNode.getKsqlTopic()),
         outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
-        Optional.of(outputNode.getOrReplace())
+        Optional.of(outputNode.getOrReplace()),
+        Optional.of(CreateTable.Type.NORMAL.name())
     );
   }
 
+  // This method is called by simple CREATE statements
   public CreateTableCommand createTableCommand(
       final CreateTable statement,
       final KsqlConfig ksqlConfig
@@ -188,7 +191,8 @@ public final class CreateSourceFactory {
         topicName,
         buildFormats(statement.getName(), schema, props, ksqlConfig),
         getWindowInfo(props),
-        Optional.of(statement.isOrReplace())
+        Optional.of(statement.isOrReplace()),
+        Optional.of(statement.getType().name())
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.ddl.commands;
 
-import com.google.common.base.Enums;
 import io.confluent.ksql.execution.ddl.commands.AlterSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
@@ -33,7 +32,6 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.KeyFormat;
@@ -121,10 +119,6 @@ public class DdlCommandExec {
                 sourceName, sourceType.toLowerCase()));
       }
 
-      final CreateTable.Type tableType = createTable.getType()
-          .map(typeStr -> Enums.getIfPresent(CreateTable.Type.class, typeStr).orNull())
-          .orElse(CreateTable.Type.NORMAL);
-
       final KsqlTable<?> ksqlTable = new KsqlTable<>(
           sql,
           createTable.getSourceName(),
@@ -132,8 +126,7 @@ public class DdlCommandExec {
           createTable.getTimestampColumn(),
           withQuery,
           getKsqlTopic(createTable),
-          tableType == CreateTable.Type.SOURCE,
-          tableType == CreateTable.Type.SOURCE
+          createTable.isSource()
       );
       metaStore.putSource(ksqlTable, createTable.isOrReplace());
       metaStore.addSourceReferences(ksqlTable.getName(), withQuerySources);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -198,7 +198,7 @@ public class CommandFactoriesTest {
         TableElements.of(
             tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
             tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties, CreateTable.Type.NORMAL);
+        false, true, withProperties, false);
 
     // When:
     final DdlCommand result = commandFactories
@@ -216,7 +216,7 @@ public class CommandFactoriesTest {
         TableElements.of(
             tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
             tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties, CreateTable.Type.SOURCE);
+        false, true, withProperties, true);
 
     // When:
     final DdlCommand result = commandFactories
@@ -234,7 +234,7 @@ public class CommandFactoriesTest {
         TableElements.of(
             tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
             tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties, CreateTable.Type.NORMAL);
+        false, true, withProperties, false);
 
     // When:
     commandFactories.create(sqlExpression, statement, SessionConfig.of(ksqlConfig, OVERRIDES));
@@ -373,7 +373,7 @@ public class CommandFactoriesTest {
 
     final DdlStatement statement =
         new CreateTable(SOME_NAME, ELEMENTS_WITH_PK,
-            false, true, withProperties, CreateTable.Type.NORMAL);
+            false, true, withProperties, false);
 
     // When:
     final DdlCommand cmd = commandFactories

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -210,6 +210,24 @@ public class CommandFactoriesTest {
   }
 
   @Test
+  public void shouldCreateCommandForCreateSourceTable() {
+    // Given:
+    final CreateTable statement = new CreateTable(SOME_NAME,
+        TableElements.of(
+            tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
+            tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
+        false, true, withProperties, CreateTable.Type.SOURCE);
+
+    // When:
+    final DdlCommand result = commandFactories
+        .create(sqlExpression, statement, SessionConfig.of(ksqlConfig, emptyMap()));
+
+    // Then:
+    assertThat(result, is(createTableCommand));
+    verify(createSourceFactory).createTableCommand(statement, ksqlConfig);
+  }
+
+  @Test
   public void shouldCreateCommandForCreateTableWithOverriddenProperties() {
     // Given:
     final CreateTable statement = new CreateTable(SOME_NAME,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -198,7 +198,7 @@ public class CommandFactoriesTest {
         TableElements.of(
             tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
             tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties);
+        false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final DdlCommand result = commandFactories
@@ -216,7 +216,7 @@ public class CommandFactoriesTest {
         TableElements.of(
             tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
             tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties);
+        false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     commandFactories.create(sqlExpression, statement, SessionConfig.of(ksqlConfig, OVERRIDES));
@@ -354,7 +354,8 @@ public class CommandFactoriesTest {
     );
 
     final DdlStatement statement =
-        new CreateTable(SOME_NAME, ELEMENTS_WITH_PK, false, true, withProperties);
+        new CreateTable(SOME_NAME, ELEMENTS_WITH_PK,
+            false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final DdlCommand cmd = commandFactories

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -293,7 +293,7 @@ public class CreateSourceFactoryTest {
         TableElements.of(
             tableElement(PRIMARY_KEY, "COL1", new Type(BIGINT)),
             tableElement(VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties, CreateTable.Type.NORMAL);
+        false, true, withProperties, false);
 
     // When:
     final CreateTableCommand result = createSourceFactory
@@ -302,6 +302,26 @@ public class CreateSourceFactoryTest {
     // Then:
     assertThat(result.getSourceName(), is(SOME_NAME));
     assertThat(result.getTopicName(), is(TOPIC_NAME));
+    assertThat(result.isSource(), is(false));
+  }
+
+  @Test
+  public void shouldCreateCommandForCreateSourceTable() {
+    // Given:
+    final CreateTable ddlStatement = new CreateTable(SOME_NAME,
+        TableElements.of(
+            tableElement(PRIMARY_KEY, "COL1", new Type(BIGINT)),
+            tableElement(VALUE, "COL2", new Type(SqlTypes.STRING))),
+        false, true, withProperties, true);
+
+    // When:
+    final CreateTableCommand result = createSourceFactory
+        .createTableCommand(ddlStatement, ksqlConfig);
+
+    // Then:
+    assertThat(result.getSourceName(), is(SOME_NAME));
+    assertThat(result.getTopicName(), is(TOPIC_NAME));
+    assertThat(result.isSource(), is(true));
   }
 
   @Test
@@ -380,7 +400,7 @@ public class CreateSourceFactoryTest {
 
     final CreateTable statement =
         new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE,
-            false, true, withProperties, CreateTable.Type.NORMAL);
+            false, true, withProperties, false);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -402,7 +422,7 @@ public class CreateSourceFactoryTest {
 
     final CreateTable statement =
         new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE,
-            false, true, withProperties, CreateTable.Type.NORMAL);
+            false, true, withProperties, false);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -418,7 +438,7 @@ public class CreateSourceFactoryTest {
     // Given:
     final CreateTable statement =
         new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE,
-            false, true, withProperties, CreateTable.Type.NORMAL);
+            false, true, withProperties, false);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -450,7 +470,7 @@ public class CreateSourceFactoryTest {
     // Given:
     final CreateTable statement
         = new CreateTable(SOME_NAME, TableElements.of(),
-        false, true, withProperties, CreateTable.Type.NORMAL);
+        false, true, withProperties, false);
 
     // When:
     final Exception e = assertThrows(
@@ -480,7 +500,7 @@ public class CreateSourceFactoryTest {
     // Given:
     final CreateTable statement =
         new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE,
-            false, true, withProperties, CreateTable.Type.NORMAL);
+            false, true, withProperties, false);
 
     // When:
     createSourceFactory.createTableCommand(statement, ksqlConfig);
@@ -615,7 +635,7 @@ public class CreateSourceFactoryTest {
     );
     final CreateTable statement =
         new CreateTable(SOME_NAME, TABLE_ELEMENTS,
-            false, true, withProperties, CreateTable.Type.NORMAL);
+            false, true, withProperties, false);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory.createTableCommand(
@@ -737,7 +757,7 @@ public class CreateSourceFactoryTest {
     // Given:
     givenCommandFactoriesWithMocks();
     final CreateTable statement = new CreateTable(SOME_NAME, TABLE_ELEMENTS, false, true,
-        withProperties, CreateTable.Type.NORMAL);
+        withProperties, false);
 
     when(valueSerdeFactory.create(
         FormatInfo.of(JSON.name()),
@@ -1017,7 +1037,7 @@ public class CreateSourceFactoryTest {
 
     final CreateTable statement =
         new CreateTable(SOME_NAME, noKey,
-            false, true, withProperties, CreateTable.Type.NORMAL);
+            false, true, withProperties, false);
 
     // When:
     final Exception e = assertThrows(
@@ -1067,7 +1087,7 @@ public class CreateSourceFactoryTest {
         TableElements.of(
             tableElement(PRIMARY_KEY, "COL1", new Type(BIGINT)),
             tableElement(VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties, CreateTable.Type.NORMAL);
+        false, true, withProperties, false);
 
     // When:
     final CreateTableCommand result = createSourceFactory
@@ -1084,7 +1104,7 @@ public class CreateSourceFactoryTest {
         TableElements.of(
             tableElement(PRIMARY_KEY, "COL1", new Type(BIGINT)),
             tableElement(VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, false, withProperties, CreateTable.Type.NORMAL);
+        false, false, withProperties, false);
 
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -293,7 +293,7 @@ public class CreateSourceFactoryTest {
         TableElements.of(
             tableElement(PRIMARY_KEY, "COL1", new Type(BIGINT)),
             tableElement(VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties);
+        false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final CreateTableCommand result = createSourceFactory
@@ -379,7 +379,8 @@ public class CreateSourceFactoryTest {
     givenProperty(CommonCreateConfigs.WRAP_SINGLE_VALUE, new BooleanLiteral("false"));
 
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, false, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE,
+            false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -400,7 +401,8 @@ public class CreateSourceFactoryTest {
     ));
 
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, false, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE,
+            false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -415,7 +417,8 @@ public class CreateSourceFactoryTest {
   public void shouldCreateTableCommandWithSingleValueWrappingFromDefaultConfig() {
     // Given:
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, false, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE,
+            false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory
@@ -446,7 +449,8 @@ public class CreateSourceFactoryTest {
   public void shouldThrowOnNoElementsInCreateTable() {
     // Given:
     final CreateTable statement
-        = new CreateTable(SOME_NAME, TableElements.of(), false, true, withProperties);
+        = new CreateTable(SOME_NAME, TableElements.of(),
+        false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final Exception e = assertThrows(
@@ -475,7 +479,8 @@ public class CreateSourceFactoryTest {
   public void shouldNotThrowWhenThereAreElementsInCreateTable() {
     // Given:
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE, false, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS_1_VALUE,
+            false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     createSourceFactory.createTableCommand(statement, ksqlConfig);
@@ -609,7 +614,8 @@ public class CreateSourceFactoryTest {
         new StringLiteral(quote(ELEMENT2.getName().text()))
     );
     final CreateTable statement =
-        new CreateTable(SOME_NAME, TABLE_ELEMENTS, false, true, withProperties);
+        new CreateTable(SOME_NAME, TABLE_ELEMENTS,
+            false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final CreateTableCommand cmd = createSourceFactory.createTableCommand(
@@ -731,7 +737,7 @@ public class CreateSourceFactoryTest {
     // Given:
     givenCommandFactoriesWithMocks();
     final CreateTable statement = new CreateTable(SOME_NAME, TABLE_ELEMENTS, false, true,
-        withProperties);
+        withProperties, CreateTable.Type.NORMAL);
 
     when(valueSerdeFactory.create(
         FormatInfo.of(JSON.name()),
@@ -1010,7 +1016,8 @@ public class CreateSourceFactoryTest {
     final TableElements noKey = TableElements.of(ELEMENT1);
 
     final CreateTable statement =
-        new CreateTable(SOME_NAME, noKey, false, true, withProperties);
+        new CreateTable(SOME_NAME, noKey,
+            false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final Exception e = assertThrows(
@@ -1060,7 +1067,7 @@ public class CreateSourceFactoryTest {
         TableElements.of(
             tableElement(PRIMARY_KEY, "COL1", new Type(BIGINT)),
             tableElement(VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, true, withProperties);
+        false, true, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final CreateTableCommand result = createSourceFactory
@@ -1077,7 +1084,7 @@ public class CreateSourceFactoryTest {
         TableElements.of(
             tableElement(PRIMARY_KEY, "COL1", new Type(BIGINT)),
             tableElement(VALUE, "COL2", new Type(SqlTypes.STRING))),
-        false, false, withProperties);
+        false, false, withProperties, CreateTable.Type.NORMAL);
 
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -260,9 +261,12 @@ public class DdlCommandExecTest {
   @Test
   public void shouldThrowOnDropTableWhenConstraintExist() {
     // Given:
-    final CreateTableCommand table1 = buildCreateTable(SourceName.of("t1"), false);
-    final CreateTableCommand table2 = buildCreateTable(SourceName.of("t2"), false);
-    final CreateTableCommand table3 = buildCreateTable(SourceName.of("t3"), false);
+    final CreateTableCommand table1 = buildCreateTable(SourceName.of("t1"),
+        false, CreateTable.Type.NORMAL);
+    final CreateTableCommand table2 = buildCreateTable(SourceName.of("t2"),
+        false, CreateTable.Type.NORMAL);
+    final CreateTableCommand table3 = buildCreateTable(SourceName.of("t3"),
+        false, CreateTable.Type.NORMAL);
     cmdExec.execute(SQL_TEXT, table1, true, Collections.emptySet());
     cmdExec.execute(SQL_TEXT, table2, true, Collections.singleton(SourceName.of("t1")));
     cmdExec.execute(SQL_TEXT, table3, true, Collections.singleton(SourceName.of("t1")));
@@ -470,7 +474,7 @@ public class DdlCommandExecTest {
     cmdExec.execute(SQL_TEXT, createTable, false, NO_QUERY_SOURCES);
 
     // When:
-    givenCreateTable(false);
+    givenCreateTable();
     final DdlCommandResult result =cmdExec.execute(SQL_TEXT, createTable,
         false, NO_QUERY_SOURCES);
 
@@ -546,21 +550,19 @@ public class DdlCommandExecTest {
             SerdeFeatures.of()
         ),
         Optional.of(windowInfo),
-        Optional.of(false)
+        Optional.of(false),
+        Optional.of(CreateTable.Type.NORMAL.name())
     );
   }
 
   private void givenCreateTable() {
-    createTable = buildCreateTable(TABLE_NAME, false);
-  }
-
-  private void givenCreateTable(final boolean allowReplace) {
-    createTable = buildCreateTable(TABLE_NAME, allowReplace);
+    createTable = buildCreateTable(TABLE_NAME, false, CreateTable.Type.NORMAL);
   }
 
   private CreateTableCommand buildCreateTable(
       final SourceName sourceName,
-      final boolean allowReplace
+      final boolean allowReplace,
+      final CreateTable.Type type
   ) {
     return new CreateTableCommand(
         sourceName,
@@ -574,7 +576,8 @@ public class DdlCommandExecTest {
             SerdeFeatures.of()
         ),
         Optional.empty(),
-        Optional.of(allowReplace)
+        Optional.of(allowReplace),
+        Optional.of(type.name())
     );
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -260,12 +260,12 @@ public class DdlCommandExecTest {
   }
 
   @Test
-  public void shouldAddNormalTableOnEmptyType() {
+  public void shouldAddNormalTableWhenNoTypeIsSpecified() {
     // Given:
     final CreateTableCommand cmd = buildCreateTable(
         SourceName.of("t1"),
         false,
-        ""
+        null
     );
 
     // When:
@@ -614,7 +614,7 @@ public class DdlCommandExecTest {
         ),
         Optional.empty(),
         Optional.of(allowReplace),
-        Optional.of(type)
+        Optional.ofNullable(type)
     );
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -273,8 +272,7 @@ public class DdlCommandExecTest {
 
     // Then:
     final KsqlTable ksqlTable = (KsqlTable) metaStore.getSource(SourceName.of("t1"));
-    assertThat(ksqlTable.isReadOnly(), is(false));
-    assertThat(ksqlTable.isMaterialized(), is(false));
+    assertThat(ksqlTable.isSource(), is(false));
   }
 
   @Test
@@ -283,7 +281,7 @@ public class DdlCommandExecTest {
     final CreateTableCommand cmd = buildCreateTable(
         SourceName.of("t1"),
         false,
-        CreateTable.Type.SOURCE.name()
+        true
     );
 
     // When:
@@ -291,19 +289,18 @@ public class DdlCommandExecTest {
 
     // Then:
     final KsqlTable ksqlTable = (KsqlTable) metaStore.getSource(SourceName.of("t1"));
-    assertThat(ksqlTable.isReadOnly(), is(true));
-    assertThat(ksqlTable.isMaterialized(), is(true));
+    assertThat(ksqlTable.isSource(), is(true));
   }
 
   @Test
   public void shouldThrowOnDropTableWhenConstraintExist() {
     // Given:
     final CreateTableCommand table1 = buildCreateTable(SourceName.of("t1"),
-        false, CreateTable.Type.NORMAL.name());
+        false, false);
     final CreateTableCommand table2 = buildCreateTable(SourceName.of("t2"),
-        false, CreateTable.Type.NORMAL.name());
+        false, false);
     final CreateTableCommand table3 = buildCreateTable(SourceName.of("t3"),
-        false, CreateTable.Type.NORMAL.name());
+        false, false);
     cmdExec.execute(SQL_TEXT, table1, true, Collections.emptySet());
     cmdExec.execute(SQL_TEXT, table2, true, Collections.singleton(SourceName.of("t1")));
     cmdExec.execute(SQL_TEXT, table3, true, Collections.singleton(SourceName.of("t1")));
@@ -588,18 +585,18 @@ public class DdlCommandExecTest {
         ),
         Optional.of(windowInfo),
         Optional.of(false),
-        Optional.of(CreateTable.Type.NORMAL.name())
+        Optional.of(false)
     );
   }
 
   private void givenCreateTable() {
-    createTable = buildCreateTable(TABLE_NAME, false, CreateTable.Type.NORMAL.name());
+    createTable = buildCreateTable(TABLE_NAME, false, false);
   }
 
   private CreateTableCommand buildCreateTable(
       final SourceName sourceName,
       final boolean allowReplace,
-      final String type
+      final Boolean isSource
   ) {
     return new CreateTableCommand(
         sourceName,
@@ -614,7 +611,7 @@ public class DdlCommandExecTest {
         ),
         Optional.empty(),
         Optional.of(allowReplace),
-        Optional.ofNullable(type)
+        Optional.ofNullable(isSource)
     );
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -660,7 +660,7 @@ public class StatementRewriterTest {
         false,
         false,
         sourceProperties,
-        CreateTable.Type.NORMAL
+        false
     );
     when(mockRewriter.apply(tableElement1, context)).thenReturn(rewrittenTableElement1);
     when(mockRewriter.apply(tableElement2, context)).thenReturn(rewrittenTableElement2);
@@ -679,7 +679,7 @@ public class StatementRewriterTest {
                 false,
                 false,
                 sourceProperties,
-                CreateTable.Type.NORMAL
+                false
             )
         )
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -660,7 +660,7 @@ public class StatementRewriterTest {
         false,
         false,
         sourceProperties,
-        CreateTable.Type.SOURCE
+        CreateTable.Type.NORMAL
     );
     when(mockRewriter.apply(tableElement1, context)).thenReturn(rewrittenTableElement1);
     when(mockRewriter.apply(tableElement2, context)).thenReturn(rewrittenTableElement2);
@@ -679,7 +679,7 @@ public class StatementRewriterTest {
                 false,
                 false,
                 sourceProperties,
-                CreateTable.Type.SOURCE
+                CreateTable.Type.NORMAL
             )
         )
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -659,7 +659,8 @@ public class StatementRewriterTest {
         TableElements.of(tableElement1, tableElement2),
         false,
         false,
-        sourceProperties
+        sourceProperties,
+        CreateTable.Type.SOURCE
     );
     when(mockRewriter.apply(tableElement1, context)).thenReturn(rewrittenTableElement1);
     when(mockRewriter.apply(tableElement2, context)).thenReturn(rewrittenTableElement2);
@@ -677,7 +678,8 @@ public class StatementRewriterTest {
                 TableElements.of(rewrittenTableElement1, rewrittenTableElement2),
                 false,
                 false,
-                sourceProperties
+                sourceProperties,
+                CreateTable.Type.SOURCE
             )
         )
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -245,7 +245,6 @@ public class DataSourceNodeTest {
             KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()), SerdeFeatures.of()),
             ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()), SerdeFeatures.of())
         ),
-        false,
         false
     );
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -244,7 +244,9 @@ public class DataSourceNodeTest {
             "topic2",
             KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()), SerdeFeatures.of()),
             ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()), SerdeFeatures.of())
-        )
+        ),
+        false,
+        false
     );
 
     node = new DataSourceNode(

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 @JsonIgnoreProperties({"keyField"}) // Removed at version 0.10
 @Immutable
 public class CreateTableCommand extends CreateSourceCommand {
+  private final Optional<String> type;
 
   public CreateTableCommand(
       @JsonProperty(value = "sourceName", required = true) final SourceName sourceName,
@@ -36,7 +37,8 @@ public class CreateTableCommand extends CreateSourceCommand {
       @JsonProperty(value = "topicName", required = true) final String topicName,
       @JsonProperty(value = "formats", required = true) final Formats formats,
       @JsonProperty(value = "windowInfo") final Optional<WindowInfo> windowInfo,
-      @JsonProperty(value = "orReplace", defaultValue = "false") final Optional<Boolean> orReplace
+      @JsonProperty(value = "orReplace", defaultValue = "false") final Optional<Boolean> orReplace,
+      @JsonProperty(value = "type", defaultValue = "NORMAL") final Optional<String> type
   ) {
     super(
         sourceName,
@@ -51,6 +53,12 @@ public class CreateTableCommand extends CreateSourceCommand {
     if (schema.key().isEmpty()) {
       throw new UnsupportedOperationException("Tables require key columns");
     }
+
+    this.type = type;
+  }
+
+  public Optional<String> getType() {
+    return type;
   }
 
   @Override

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 @JsonIgnoreProperties({"keyField"}) // Removed at version 0.10
 @Immutable
 public class CreateTableCommand extends CreateSourceCommand {
-  private final Optional<String> type;
+  private final Optional<Boolean> isSource;
 
   public CreateTableCommand(
       @JsonProperty(value = "sourceName", required = true) final SourceName sourceName,
@@ -38,7 +38,7 @@ public class CreateTableCommand extends CreateSourceCommand {
       @JsonProperty(value = "formats", required = true) final Formats formats,
       @JsonProperty(value = "windowInfo") final Optional<WindowInfo> windowInfo,
       @JsonProperty(value = "orReplace", defaultValue = "false") final Optional<Boolean> orReplace,
-      @JsonProperty(value = "type", defaultValue = "NORMAL") final Optional<String> type
+      @JsonProperty(value = "isSource", defaultValue = "false") final Optional<Boolean> isSource
   ) {
     super(
         sourceName,
@@ -54,11 +54,14 @@ public class CreateTableCommand extends CreateSourceCommand {
       throw new UnsupportedOperationException("Tables require key columns");
     }
 
-    this.type = type;
+    this.isSource = isSource;
   }
 
-  public Optional<String> getType() {
-    return type;
+  // This can be in CreateSourceCommand, but it fails deserializing the JSON property when
+  // loading a CreateStreamCommand because it is not supported there yet. We should move this
+  // source variable and method to the CreateSourceCommand after supporting source streams.
+  public Boolean isSource() {
+    return isSource.orElse(false);
   }
 
   @Override

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
@@ -103,4 +103,9 @@ public interface DataSource {
    * @return a new DataSource object with all attributes the same as this, but with a new schema
    */
   DataSource with(String sql, LogicalSchema schema);
+
+  /**
+   * @return returns true if this source is read-only
+   */
+  boolean isReadOnly();
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
@@ -107,5 +107,5 @@ public interface DataSource {
   /**
    * @return returns true if this source is read-only
    */
-  boolean isReadOnly();
+  boolean isSource();
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
@@ -40,7 +40,8 @@ public class KsqlStream<K> extends StructuredDataSource<K> {
         timestampExtractionPolicy,
         DataSourceType.KSTREAM,
         isKsqlSink,
-        ksqlTopic
+        ksqlTopic,
+        false
     );
   }
 

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 @Immutable
 public class KsqlTable<K> extends StructuredDataSource<K> {
+  private final boolean materialized;
 
   public KsqlTable(
       final String sqlExpression,
@@ -31,7 +32,9 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
       final LogicalSchema schema,
       final Optional<TimestampColumn> timestampExtractionPolicy,
       final boolean isKsqlSink,
-      final KsqlTopic ksqlTopic
+      final KsqlTopic ksqlTopic,
+      final boolean readOnly,
+      final boolean materialized
   ) {
     super(
         sqlExpression,
@@ -40,8 +43,15 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
         timestampExtractionPolicy,
         DataSourceType.KTABLE,
         isKsqlSink,
-        ksqlTopic
+        ksqlTopic,
+        readOnly
     );
+
+    this.materialized = materialized;
+  }
+
+  public boolean isMaterialized() {
+    return materialized;
   }
 
   @Override
@@ -52,7 +62,9 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
         schema,
         getTimestampColumn(),
         isCasTarget(),
-        getKsqlTopic()
+        getKsqlTopic(),
+        isReadOnly(),
+        isMaterialized()
     );
   }
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
@@ -24,8 +24,6 @@ import java.util.Optional;
 
 @Immutable
 public class KsqlTable<K> extends StructuredDataSource<K> {
-  private final boolean materialized;
-
   public KsqlTable(
       final String sqlExpression,
       final SourceName datasourceName,
@@ -33,8 +31,7 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
       final Optional<TimestampColumn> timestampExtractionPolicy,
       final boolean isKsqlSink,
       final KsqlTopic ksqlTopic,
-      final boolean readOnly,
-      final boolean materialized
+      final boolean isSourceTable
   ) {
     super(
         sqlExpression,
@@ -44,14 +41,8 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
         DataSourceType.KTABLE,
         isKsqlSink,
         ksqlTopic,
-        readOnly
+        isSourceTable
     );
-
-    this.materialized = materialized;
-  }
-
-  public boolean isMaterialized() {
-    return materialized;
   }
 
   @Override
@@ -63,8 +54,7 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
         getTimestampColumn(),
         isCasTarget(),
         getKsqlTopic(),
-        isReadOnly(),
-        isMaterialized()
+        isSource()
     );
   }
 }

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -47,6 +47,7 @@ abstract class StructuredDataSource<K> implements DataSource {
   private final KsqlTopic ksqlTopic;
   private final String sqlExpression;
   private final boolean casTarget;
+  private final boolean readOnly;
 
   private static final ImmutableList<Property<?>> PROPERTIES = ImmutableList.of(
       new Property<>("name", DataSource::getName),
@@ -64,7 +65,8 @@ abstract class StructuredDataSource<K> implements DataSource {
       final Optional<TimestampColumn> tsExtractionPolicy,
       final DataSourceType dataSourceType,
       final boolean casTarget,
-      final KsqlTopic ksqlTopic
+      final KsqlTopic ksqlTopic,
+      final boolean readOnly
   ) {
     this.sqlExpression = requireNonNull(sqlExpression, "sqlExpression");
     this.dataSourceName = requireNonNull(dataSourceName, "dataSourceName");
@@ -73,6 +75,7 @@ abstract class StructuredDataSource<K> implements DataSource {
     this.dataSourceType = requireNonNull(dataSourceType, "dataSourceType");
     this.ksqlTopic = requireNonNull(ksqlTopic, "ksqlTopic");
     this.casTarget = casTarget;
+    this.readOnly = readOnly;
 
     if (schema.valueContainsAny(SystemColumns.systemColumnNames())) {
       throw new IllegalArgumentException("Schema contains system columns in value schema");
@@ -124,6 +127,11 @@ abstract class StructuredDataSource<K> implements DataSource {
   @Override
   public String getSqlExpression() {
     return sqlExpression;
+  }
+
+  @Override
+  public boolean isReadOnly() {
+    return readOnly;
   }
 
   @Override

--- a/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksqldb-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -47,7 +47,7 @@ abstract class StructuredDataSource<K> implements DataSource {
   private final KsqlTopic ksqlTopic;
   private final String sqlExpression;
   private final boolean casTarget;
-  private final boolean readOnly;
+  private final boolean isSource;
 
   private static final ImmutableList<Property<?>> PROPERTIES = ImmutableList.of(
       new Property<>("name", DataSource::getName),
@@ -66,7 +66,7 @@ abstract class StructuredDataSource<K> implements DataSource {
       final DataSourceType dataSourceType,
       final boolean casTarget,
       final KsqlTopic ksqlTopic,
-      final boolean readOnly
+      final boolean isSource
   ) {
     this.sqlExpression = requireNonNull(sqlExpression, "sqlExpression");
     this.dataSourceName = requireNonNull(dataSourceName, "dataSourceName");
@@ -75,7 +75,7 @@ abstract class StructuredDataSource<K> implements DataSource {
     this.dataSourceType = requireNonNull(dataSourceType, "dataSourceType");
     this.ksqlTopic = requireNonNull(ksqlTopic, "ksqlTopic");
     this.casTarget = casTarget;
-    this.readOnly = readOnly;
+    this.isSource = isSource;
 
     if (schema.valueContainsAny(SystemColumns.systemColumnNames())) {
       throw new IllegalArgumentException("Schema contains system columns in value schema");
@@ -130,8 +130,8 @@ abstract class StructuredDataSource<K> implements DataSource {
   }
 
   @Override
-  public boolean isReadOnly() {
-    return readOnly;
+  public boolean isSource() {
+    return isSource;
   }
 
   @Override

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -212,7 +212,6 @@ public class StructuredDataSourceTest {
         Optional.empty(),
         true,
         topic,
-        false,
         false
     );
 

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -211,7 +211,9 @@ public class StructuredDataSourceTest {
         SOME_SCHEMA,
         Optional.empty(),
         true,
-        topic
+        topic,
+        false,
+        false
     );
 
     // When:
@@ -369,7 +371,8 @@ public class StructuredDataSourceTest {
           Optional.empty(),
           DataSourceType.KSTREAM,
           false,
-          topic
+          topic,
+          false
       );
     }
 

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -116,7 +116,9 @@ public final class MetaStoreFixture {
         test2Schema,
         Optional.empty(),
         false,
-        ksqlTopic2
+        ksqlTopic2,
+        false,
+        false
     );
 
     metaStore.putSource(ksqlTable, false);
@@ -191,7 +193,9 @@ public final class MetaStoreFixture {
         testTable3,
         Optional.empty(),
         false,
-        ksqlTopic3
+        ksqlTopic3,
+        false,
+        false
     );
 
     metaStore.putSource(ksqlTable3, false);
@@ -294,7 +298,9 @@ public final class MetaStoreFixture {
         testTable5,
         Optional.empty(),
         false,
-        ksqlTopic5
+        ksqlTopic5,
+        false,
+        false
     );
     metaStore.putSource(ksqlTable5, false);
 

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -117,7 +117,6 @@ public final class MetaStoreFixture {
         Optional.empty(),
         false,
         ksqlTopic2,
-        false,
         false
     );
 
@@ -194,7 +193,6 @@ public final class MetaStoreFixture {
         Optional.empty(),
         false,
         ksqlTopic3,
-        false,
         false
     );
 
@@ -299,7 +297,6 @@ public final class MetaStoreFixture {
         Optional.empty(),
         false,
         ksqlTopic5,
-        false,
         false
     );
     metaStore.putSource(ksqlTable5, false);

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -72,7 +72,7 @@ statement
                 (WITH tableProperties)?                                     #createStream
     | CREATE (OR REPLACE)? STREAM (IF NOT EXISTS)? sourceName
             (WITH tableProperties)? AS query                                #createStreamAs
-    | CREATE (OR REPLACE)? TABLE (IF NOT EXISTS)? sourceName
+    | CREATE (OR REPLACE)? (SOURCE)? TABLE (IF NOT EXISTS)? sourceName
                     (tableElements)?
                     (WITH tableProperties)?                                 #createTable
     | CREATE (OR REPLACE)? TABLE (IF NOT EXISTS)? sourceName

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -281,13 +281,18 @@ public class AstBuilder {
 
       final Map<String, Literal> properties = processTableProperties(context.tableProperties());
 
+      final CreateTable.Type type = context.SOURCE() != null
+          ? CreateTable.Type.SOURCE
+          : CreateTable.Type.NORMAL;
+
       return new CreateTable(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
           TableElements.of(elements),
           context.REPLACE() != null,
           context.EXISTS() != null,
-          CreateSourceProperties.from(properties)
+          CreateSourceProperties.from(properties),
+          type
       );
     }
 
@@ -1438,7 +1443,8 @@ public class AstBuilder {
           TableElements.of(elements),
           false,
           false,
-          CreateSourceProperties.from(properties)
+          CreateSourceProperties.from(properties),
+          CreateTable.Type.NORMAL
       );
 
       return new AssertTable(getLocation(context), createTable);

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -281,10 +281,6 @@ public class AstBuilder {
 
       final Map<String, Literal> properties = processTableProperties(context.tableProperties());
 
-      final CreateTable.Type type = context.SOURCE() != null
-          ? CreateTable.Type.SOURCE
-          : CreateTable.Type.NORMAL;
-
       return new CreateTable(
           getLocation(context),
           ParserUtil.getSourceName(context.sourceName()),
@@ -292,7 +288,7 @@ public class AstBuilder {
           context.REPLACE() != null,
           context.EXISTS() != null,
           CreateSourceProperties.from(properties),
-          type
+          context.SOURCE() != null
       );
     }
 
@@ -1444,7 +1440,7 @@ public class AstBuilder {
           false,
           false,
           CreateSourceProperties.from(properties),
-          CreateTable.Type.NORMAL
+          false
       );
 
       return new AssertTable(getLocation(context), createTable);

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -260,7 +260,7 @@ public final class SqlFormatter {
     @Override
     protected Void visitCreateTable(final CreateTable node, final Integer indent) {
       formatCreate(node,
-          node.getType() == CreateTable.Type.SOURCE
+          node.isSource()
               ? "SOURCE TABLE"
               : "TABLE"
       );

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -259,11 +259,7 @@ public final class SqlFormatter {
 
     @Override
     protected Void visitCreateTable(final CreateTable node, final Integer indent) {
-      formatCreate(node,
-          node.isSource()
-              ? "SOURCE TABLE"
-              : "TABLE"
-      );
+      formatCreate(node, "TABLE");
       return null;
     }
 
@@ -609,6 +605,10 @@ public final class SqlFormatter {
 
       if (node.isOrReplace()) {
         builder.append("OR REPLACE ");
+      }
+
+      if (node.isSource()) {
+        builder.append("SOURCE ");
       }
 
       builder.append(type);

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -259,7 +259,11 @@ public final class SqlFormatter {
 
     @Override
     protected Void visitCreateTable(final CreateTable node, final Integer indent) {
-      formatCreate(node, "TABLE");
+      formatCreate(node,
+          node.getType() == CreateTable.Type.SOURCE
+              ? "SOURCE TABLE"
+              : "TABLE"
+      );
       return null;
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSource.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSource.java
@@ -32,6 +32,7 @@ public abstract class CreateSource extends Statement {
   private final boolean notExists;
   private final CreateSourceProperties properties;
   private final boolean orReplace;
+  private final boolean isSource;
 
   CreateSource(
       final Optional<NodeLocation> location,
@@ -39,7 +40,8 @@ public abstract class CreateSource extends Statement {
       final TableElements elements,
       final boolean orReplace,
       final boolean notExists,
-      final CreateSourceProperties properties
+      final CreateSourceProperties properties,
+      final boolean isSource
   ) {
     super(location);
     this.name = requireNonNull(name, "name");
@@ -47,6 +49,7 @@ public abstract class CreateSource extends Statement {
     this.orReplace = orReplace;
     this.notExists = notExists;
     this.properties = requireNonNull(properties, "properties");
+    this.isSource = isSource;
   }
 
   public CreateSourceProperties getProperties() {
@@ -69,11 +72,15 @@ public abstract class CreateSource extends Statement {
     return notExists;
   }
 
+  public boolean isSource() {
+    return isSource;
+  }
+
   public abstract CreateSource copyWith(TableElements elements, CreateSourceProperties properties);
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, elements, orReplace, notExists, properties);
+    return Objects.hash(name, elements, orReplace, notExists, properties, isSource);
   }
 
   @Override
@@ -89,6 +96,7 @@ public abstract class CreateSource extends Statement {
         && orReplace == that.orReplace
         && Objects.equals(name, that.name)
         && Objects.equals(elements, that.elements)
-        && Objects.equals(properties, that.properties);
+        && Objects.equals(properties, that.properties)
+        && isSource == that.isSource;
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -46,7 +46,7 @@ public class CreateStream extends CreateSource implements ExecutableDdlStatement
       final boolean notExists,
       final CreateSourceProperties properties
   ) {
-    super(location, name, elements, orReplace, notExists, properties);
+    super(location, name, elements, orReplace, notExists, properties, false);
 
     throwOnPrimaryKeys(elements);
   }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -27,15 +27,22 @@ import java.util.Optional;
 
 @Immutable
 public class CreateTable extends CreateSource implements ExecutableDdlStatement {
+  public enum Type {
+    SOURCE,
+    NORMAL
+  }
+
+  private final Type type;
 
   public CreateTable(
       final SourceName name,
       final TableElements elements,
       final boolean orReplace,
       final boolean notExists,
-      final CreateSourceProperties properties
+      final CreateSourceProperties properties,
+      final Type type
   ) {
-    this(Optional.empty(), name, elements, orReplace, notExists, properties);
+    this(Optional.empty(), name, elements, orReplace, notExists, properties, type);
   }
 
   public CreateTable(
@@ -44,11 +51,17 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
       final TableElements elements,
       final boolean orReplace,
       final boolean notExists,
-      final CreateSourceProperties properties
+      final CreateSourceProperties properties,
+      final Type type
   ) {
     super(location, name, elements, orReplace, notExists, properties);
+    this.type = type;
 
     throwOnNonPrimaryKeys(elements);
+  }
+
+  public Type getType() {
+    return type;
   }
 
   @Override
@@ -62,7 +75,8 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
         elements,
         isOrReplace(),
         isNotExists(),
-        properties);
+        properties,
+        type);
   }
 
   @Override
@@ -89,6 +103,7 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
         .add("orReplace", isOrReplace())
         .add("notExists", isNotExists())
         .add("properties", getProperties())
+        .add("type", type)
         .toString();
   }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -27,22 +27,15 @@ import java.util.Optional;
 
 @Immutable
 public class CreateTable extends CreateSource implements ExecutableDdlStatement {
-  public enum Type {
-    SOURCE,
-    NORMAL
-  }
-
-  private final Type type;
-
   public CreateTable(
       final SourceName name,
       final TableElements elements,
       final boolean orReplace,
       final boolean notExists,
       final CreateSourceProperties properties,
-      final Type type
+      final boolean isSource
   ) {
-    this(Optional.empty(), name, elements, orReplace, notExists, properties, type);
+    this(Optional.empty(), name, elements, orReplace, notExists, properties, isSource);
   }
 
   public CreateTable(
@@ -52,16 +45,11 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
       final boolean orReplace,
       final boolean notExists,
       final CreateSourceProperties properties,
-      final Type type
+      final boolean isSource
   ) {
-    super(location, name, elements, orReplace, notExists, properties);
-    this.type = type;
+    super(location, name, elements, orReplace, notExists, properties, isSource);
 
     throwOnNonPrimaryKeys(elements);
-  }
-
-  public Type getType() {
-    return type;
   }
 
   @Override
@@ -76,7 +64,7 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
         isOrReplace(),
         isNotExists(),
         properties,
-        type);
+        isSource());
   }
 
   @Override
@@ -103,7 +91,7 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
         .add("orReplace", isOrReplace())
         .add("notExists", isNotExists())
         .add("properties", getProperties())
-        .add("type", type)
+        .add("isSource", isSource())
         .toString();
   }
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.parser.SqlBaseParser.SingleStatementContext;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
+import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.Join;
 import io.confluent.ksql.parser.tree.Query;
@@ -601,6 +602,32 @@ public class AstBuilderTest {
     // Then:
     assertThat("Should be push", result.isPullQuery(), is(false));
     assertThat(result.getRefinement().get().getOutputRefinement(), is(OutputRefinement.FINAL));
+  }
+
+  @Test
+  public void shouldCreateSourceTable() {
+    // Given:
+    final SingleStatementContext stmt =
+        givenQuery("CREATE SOURCE TABLE X WITH (kafka_topic='X');");
+
+    // When:
+    final CreateTable result = (CreateTable) builder.buildStatement(stmt);
+
+    // Then:
+    assertThat(result.getType(), is(CreateTable.Type.SOURCE));
+  }
+
+  @Test
+  public void shouldCreateNormalTable() {
+    // Given:
+    final SingleStatementContext stmt =
+        givenQuery("CREATE TABLE X WITH (kafka_topic='X');");
+
+    // When:
+    final CreateTable result = (CreateTable) builder.buildStatement(stmt);
+
+    // Then:
+    assertThat(result.getType(), is(CreateTable.Type.NORMAL));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -614,7 +614,7 @@ public class AstBuilderTest {
     final CreateTable result = (CreateTable) builder.buildStatement(stmt);
 
     // Then:
-    assertThat(result.getType(), is(CreateTable.Type.SOURCE));
+    assertThat(result.isSource(), is(true));
   }
 
   @Test
@@ -627,7 +627,7 @@ public class AstBuilderTest {
     final CreateTable result = (CreateTable) builder.buildStatement(stmt);
 
     // Then:
-    assertThat(result.getType(), is(CreateTable.Type.NORMAL));
+    assertThat(result.isSource(), is(false));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -180,7 +180,9 @@ public class KsqlParserTest {
         ORDERS_SCHEMA,
         Optional.empty(),
         false,
-        ksqlTopicItems
+        ksqlTopicItems,
+        false,
+        false
     );
 
     metaStore.putSource(ksqlTableOrders, false);

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.Iterables;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression.Sign;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
@@ -48,8 +47,6 @@ import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.execution.windows.WindowTimeClause;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MutableMetaStore;
-import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
@@ -78,7 +75,6 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.RegisterType;
 import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.SetProperty;
-import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
@@ -86,17 +82,11 @@ import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
-import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.FormatInfo;
-import io.confluent.ksql.serde.KeyFormat;
-import io.confluent.ksql.serde.SerdeFeatures;
-import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.math.BigDecimal;
 import java.util.List;
@@ -116,76 +106,9 @@ public class KsqlParserTest {
 
   private MutableMetaStore metaStore;
 
-  private static final SqlType addressSchema = SqlTypes.struct()
-      .field("NUMBER", SqlTypes.BIGINT)
-      .field("STREET", SqlTypes.STRING)
-      .field("CITY", SqlTypes.STRING)
-      .field("STATE", SqlTypes.STRING)
-      .field("ZIPCODE", SqlTypes.BIGINT)
-      .build();
-
-  private static final SqlType categorySchema = SqlTypes.struct()
-      .field("ID", SqlTypes.BIGINT)
-      .field("NAME", SqlTypes.STRING)
-      .build();
-
-  private static final SqlType itemInfoSchema = SqlStruct.builder()
-      .field("ITEMID", SqlTypes.BIGINT)
-      .field("NAME", SqlTypes.STRING)
-      .field("CATEGORY", categorySchema)
-      .build();
-
-  private static final LogicalSchema ORDERS_SCHEMA = LogicalSchema.builder()
-      .keyColumn(ColumnName.of("k0"), SqlTypes.STRING)
-      .valueColumn(ColumnName.of("ORDERTIME"), SqlTypes.BIGINT)
-      .valueColumn(ColumnName.of("ORDERID"), SqlTypes.BIGINT)
-      .valueColumn(ColumnName.of("ITEMID"), SqlTypes.STRING)
-      .valueColumn(ColumnName.of("ITEMINFO"), itemInfoSchema)
-      .valueColumn(ColumnName.of("ORDERUNITS"), SqlTypes.INTEGER)
-      .valueColumn(ColumnName.of("ARRAYCOL"), SqlTypes.array(SqlTypes.DOUBLE))
-      .valueColumn(ColumnName.of("MAPCOL"), SqlTypes.map(SqlTypes.STRING, SqlTypes.DOUBLE))
-      .valueColumn(ColumnName.of("ADDRESS"), addressSchema)
-      .build();
-
   @Before
   public void init() {
     metaStore = MetaStoreFixture.getNewMetaStore(mock(FunctionRegistry.class));
-
-    final KsqlTopic ksqlTopicOrders = new KsqlTopic(
-        "orders_topic",
-        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()), SerdeFeatures.of()),
-        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()), SerdeFeatures.of())
-    );
-
-    final KsqlStream<?> ksqlStreamOrders = new KsqlStream<>(
-        "sqlexpression",
-        SourceName.of("ADDRESS"),
-        ORDERS_SCHEMA,
-        Optional.empty(),
-        false,
-        ksqlTopicOrders
-    );
-
-    metaStore.putSource(ksqlStreamOrders, false);
-
-    final KsqlTopic ksqlTopicItems = new KsqlTopic(
-        "item_topic",
-        KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()), SerdeFeatures.of()),
-        ValueFormat.of(FormatInfo.of(FormatFactory.JSON.name()), SerdeFeatures.of())
-    );
-
-    final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
-        "sqlexpression",
-        SourceName.of("ITEMID"),
-        ORDERS_SCHEMA,
-        Optional.empty(),
-        false,
-        ksqlTopicItems,
-        false,
-        false
-    );
-
-    metaStore.putSource(ksqlTableOrders, false);
   }
 
   @Test
@@ -444,6 +367,17 @@ public class KsqlParserTest {
   public void testReservedColumnIdentifers() {
     assertQuerySucceeds("SELECT ROWTIME as ROWTIME FROM test1 t1;");
     assertQuerySucceeds("SELECT ROWKEY as ROWKEY FROM test1 t1;");
+  }
+
+  @Test
+  public void testCreateSourceTable() {
+    // When:
+    final CreateTable stmt = (CreateTable) KsqlParserTestUtil.buildSingleAst(
+        "CREATE SOURCE TABLE foozball (id VARCHAR PRIMARY KEY) WITH (kafka_topic='foozball', " +
+            "value_format='json', partitions=1, replicas=-1);", metaStore).getStatement();
+
+    // Then:
+    assertThat(stmt.getType(), is(CreateTable.Type.SOURCE));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -377,7 +377,7 @@ public class KsqlParserTest {
             "value_format='json', partitions=1, replicas=-1);", metaStore).getStatement();
 
     // Then:
-    assertThat(stmt.getType(), is(CreateTable.Type.SOURCE));
+    assertThat(stmt.isSource(), is(true));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -203,7 +203,6 @@ public class SqlFormatterTest {
         Optional.empty(),
         false,
         ksqlTopicItems,
-        false,
         false
     );
 
@@ -216,7 +215,6 @@ public class SqlFormatterTest {
         Optional.empty(),
         false,
         ksqlTopicItems,
-        false,
         false
     );
 
@@ -296,7 +294,7 @@ public class SqlFormatterTest {
         false,
         false,
         props,
-        CreateTable.Type.SOURCE);
+        true);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);
@@ -320,7 +318,7 @@ public class SqlFormatterTest {
         true,
         false,
         props,
-        CreateTable.Type.NORMAL);
+        false);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);
@@ -346,7 +344,7 @@ public class SqlFormatterTest {
         false,
         false,
         props,
-        CreateTable.Type.NORMAL);
+        false);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);
@@ -366,7 +364,7 @@ public class SqlFormatterTest {
         false,
         false,
         SOME_WITH_PROPS,
-        CreateTable.Type.NORMAL);
+        false);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);
@@ -385,7 +383,7 @@ public class SqlFormatterTest {
         false,
         false,
         SOME_WITH_PROPS,
-        CreateTable.Type.NORMAL);
+        false);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -279,6 +279,30 @@ public class SqlFormatterTest {
   }
 
   @Test
+  public void shouldFormatCreateSourceTableStatement() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties.from(
+        new ImmutableMap.Builder<String, Literal>()
+            .putAll(SOME_WITH_PROPS.copyOfOriginalLiterals())
+            .build()
+    );
+    final CreateTable createTable = new CreateTable(
+        TEST,
+        ELEMENTS_WITH_PRIMARY_KEY,
+        false,
+        false,
+        props,
+        CreateTable.Type.SOURCE);
+
+    // When:
+    final String sql = SqlFormatter.formatSql(createTable);
+
+    // Then:
+    assertThat(sql, is("CREATE SOURCE TABLE TEST (`k3` STRING PRIMARY KEY, `Foo` STRING) "
+        + "WITH (KAFKA_TOPIC='topic_test', VALUE_FORMAT='JSON');"));
+  }
+
+  @Test
   public void shouldFormatCreateOrReplaceTableStatement() {
     // Given:
     final CreateSourceProperties props = CreateSourceProperties.from(
@@ -291,7 +315,8 @@ public class SqlFormatterTest {
         ELEMENTS_WITH_PRIMARY_KEY,
         true,
         false,
-        props);
+        props,
+        CreateTable.Type.NORMAL);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);
@@ -316,7 +341,8 @@ public class SqlFormatterTest {
         ELEMENTS_WITH_PRIMARY_KEY,
         false,
         false,
-        props);
+        props,
+        CreateTable.Type.NORMAL);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);
@@ -335,7 +361,8 @@ public class SqlFormatterTest {
         ELEMENTS_WITH_PRIMARY_KEY,
         false,
         false,
-        SOME_WITH_PROPS);
+        SOME_WITH_PROPS,
+        CreateTable.Type.NORMAL);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);
@@ -353,7 +380,8 @@ public class SqlFormatterTest {
         ELEMENTS_WITHOUT_KEY,
         false,
         false,
-        SOME_WITH_PROPS);
+        SOME_WITH_PROPS,
+        CreateTable.Type.NORMAL);
 
     // When:
     final String sql = SqlFormatter.formatSql(createTable);

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -202,7 +202,9 @@ public class SqlFormatterTest {
         ITEM_INFO_SCHEMA,
         Optional.empty(),
         false,
-        ksqlTopicItems
+        ksqlTopicItems,
+        false,
+        false
     );
 
     metaStore.putSource(ksqlTableOrders, false);
@@ -213,7 +215,9 @@ public class SqlFormatterTest {
         TABLE_SCHEMA,
         Optional.empty(),
         false,
-        ksqlTopicItems
+        ksqlTopicItems,
+        false,
+        false
     );
 
     metaStore.putSource(ksqlTableTable, false);

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static io.confluent.ksql.parser.tree.CreateTable.Type.NORMAL;
+import static io.confluent.ksql.parser.tree.CreateTable.Type.SOURCE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
@@ -60,25 +62,28 @@ public class CreateTableTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
-            new CreateTable(Optional.of(SOME_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS),
-            new CreateTable(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL),
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL),
+            new CreateTable(Optional.of(SOME_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL),
+            new CreateTable(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL)
         )
         .addEqualityGroup(
-            new CreateTable(SourceName.of("jim"), SOME_ELEMENTS, false, true, SOME_PROPS)
+            new CreateTable(SourceName.of("jim"), SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, TableElements.of(), false, true, SOME_PROPS)
+            new CreateTable(SOME_NAME, TableElements.of(), false, true, SOME_PROPS, NORMAL)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, SOME_PROPS)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, SOME_PROPS, NORMAL)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, true, true, SOME_PROPS)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, true, true, SOME_PROPS, SOURCE)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, OTHER_PROPS)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, OTHER_PROPS, NORMAL)
+        )
+        .addEqualityGroup(
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, OTHER_PROPS, SOURCE)
         )
         .testEquals();
   }
@@ -107,7 +112,7 @@ public class CreateTableTest {
     // When:
     final ParseFailedException e = assertThrows(
         ParseFailedException.class,
-        () -> new CreateTable(SOME_NAME, invalidElements, false, false, SOME_PROPS)
+        () -> new CreateTable(SOME_NAME, invalidElements, false, false, SOME_PROPS, NORMAL)
     );
 
     // Then:

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static io.confluent.ksql.parser.tree.CreateTable.Type.NORMAL;
-import static io.confluent.ksql.parser.tree.CreateTable.Type.SOURCE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThrows;
@@ -62,28 +60,28 @@ public class CreateTableTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL),
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL),
-            new CreateTable(Optional.of(SOME_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL),
-            new CreateTable(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, false),
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, false),
+            new CreateTable(Optional.of(SOME_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, false),
+            new CreateTable(Optional.of(OTHER_LOCATION), SOME_NAME, SOME_ELEMENTS, false, true, SOME_PROPS, false)
         )
         .addEqualityGroup(
-            new CreateTable(SourceName.of("jim"), SOME_ELEMENTS, false, true, SOME_PROPS, NORMAL)
+            new CreateTable(SourceName.of("jim"), SOME_ELEMENTS, false, true, SOME_PROPS, false)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, TableElements.of(), false, true, SOME_PROPS, NORMAL)
+            new CreateTable(SOME_NAME, TableElements.of(), false, true, SOME_PROPS, false)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, SOME_PROPS, NORMAL)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, SOME_PROPS, false)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, true, true, SOME_PROPS, SOURCE)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, true, true, SOME_PROPS, true)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, OTHER_PROPS, NORMAL)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, true, OTHER_PROPS, false)
         )
         .addEqualityGroup(
-            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, OTHER_PROPS, SOURCE)
+            new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, OTHER_PROPS, true)
         )
         .testEquals();
   }
@@ -112,7 +110,7 @@ public class CreateTableTest {
     // When:
     final ParseFailedException e = assertThrows(
         ParseFailedException.class,
-        () -> new CreateTable(SOME_NAME, invalidElements, false, false, SOME_PROPS, NORMAL)
+        () -> new CreateTable(SOME_NAME, invalidElements, false, false, SOME_PROPS, false)
     );
 
     // Then:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -527,7 +527,8 @@ public class StandaloneExecutorTest {
   public void shouldRunCtStatement() {
     // Given:
     final PreparedStatement<CreateTable> ct = PreparedStatement.of("CT",
-        new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, JSON_PROPS));
+        new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, JSON_PROPS,
+            CreateTable.Type.NORMAL));
 
     givenQueryFileParsesTo(ct);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -528,7 +528,7 @@ public class StandaloneExecutorTest {
     // Given:
     final PreparedStatement<CreateTable> ct = PreparedStatement.of("CT",
         new CreateTable(SOME_NAME, SOME_ELEMENTS, false, false, JSON_PROPS,
-            CreateTable.Type.NORMAL));
+            false));
 
     givenQueryFileParsesTo(ct);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -161,7 +161,9 @@ public class TemporaryEngine extends ExternalResource {
                 SCHEMA,
                 Optional.empty(),
                 false,
-                topic
+                topic,
+                false,
+                false
             );
         break;
       default:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -162,7 +162,6 @@ public class TemporaryEngine extends ExternalResource {
                 Optional.empty(),
                 false,
                 topic,
-                false,
                 false
             );
         break;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -1122,7 +1122,6 @@ public class InsertValuesExecutorTest {
           Optional.empty(),
           false,
           topic,
-          false,
           false
       );
     } else {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -1121,7 +1121,9 @@ public class InsertValuesExecutorTest {
           schema,
           Optional.empty(),
           false,
-          topic
+          topic,
+          false,
+          false
       );
     } else {
       dataSource = new KsqlStream<>(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2640,7 +2640,9 @@ public class KsqlResourceTest {
             schema,
             Optional.empty(),
             false,
-            ksqlTopic
+            ksqlTopic,
+            false,
+            false
         );
         break;
       default:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2641,7 +2641,6 @@ public class KsqlResourceTest {
             Optional.empty(),
             false,
             ksqlTopic,
-            false,
             false
         );
         break;

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -181,6 +181,10 @@
         "orReplace" : {
           "type" : "boolean",
           "default" : false
+        },
+        "type" : {
+          "type" : "string",
+          "default" : "NORMAL"
         }
       },
       "title" : "createTableV1",

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -182,9 +182,9 @@
           "type" : "boolean",
           "default" : false
         },
-        "type" : {
-          "type" : "string",
-          "default" : "NORMAL"
+        "isSource" : {
+          "type" : "boolean",
+          "default" : false
         }
       },
       "title" : "createTableV1",


### PR DESCRIPTION
### Description 
This is part of https://github.com/confluentinc/ksql/pull/7474 which adds support of source tables and streams.

This PR just adds new syntax to create source tables using `CREATE SOURCE TABLE` statements. It also marks those tables internally for future reference, such as `CreateTable`, `CreateTableCommand` and `KsqlTable`. 

The `KsqlTable` is the object saved in the metastore. This object contains two new variables, `readOnly` and `materialized`. The `readOnly` just specifies the table is read-only; and `materialized` specifies this table is materialized (or should be materialized). I split the SOURCE keyword into these two variables because they mean different things. Also, we might support source streams in the future which they are read-only objects, but not materialized.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

