### PR TITLE
chore: exclude log4j for CVE purposes, use confluent shaded

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicy.java
@@ -22,7 +22,8 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 public class MetadataTimestampExtractionPolicy implements TimestampExtractionPolicy {
 
   @JsonCreator
-  public MetadataTimestampExtractionPolicy(){}
+  public MetadataTimestampExtractionPolicy() {
+  }
 
   @Override
   public TimestampExtractor create(final int columnIndex) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/placeholder/PlaceholderTableUdaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/placeholder/PlaceholderTableUdaf.java
@@ -24,7 +24,7 @@ public final class PlaceholderTableUdaf implements TableUdaf<Long, Long> {
 
   public static final PlaceholderTableUdaf INSTANCE = new PlaceholderTableUdaf();
 
-  private PlaceholderTableUdaf(){
+  private PlaceholderTableUdaf() {
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ArrayUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ArrayUtil.java
@@ -19,7 +19,8 @@ import java.util.Arrays;
 import java.util.Objects;
 
 public final class ArrayUtil {
-  private ArrayUtil(){}
+  private ArrayUtil() {
+  }
 
   public static <T> int getNullIndex(final T[] array) {
     for (int i = 0; i < array.length; i++) {

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.datagen;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.avro.random.generator.Generator;
 import io.confluent.ksql.util.KsqlConfig;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -72,7 +72,6 @@ import io.confluent.ksql.parser.tree.Window;
 import io.confluent.ksql.parser.tree.WindowFrame;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.ParserUtil;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.util;
 
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.parser.SqlBaseLexer;
-
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 public final class StandaloneExecutorFactory {
   static final String CONFIG_TOPIC_SUFFIX = "configs";
 
-  private StandaloneExecutorFactory(){
+  private StandaloneExecutorFactory() {
   }
 
   public static StandaloneExecutor create(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommandStatus.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommandStatus.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.rest.server.computation;
 
 import io.confluent.ksql.rest.entity.CommandStatus;
-
 import java.time.Duration;
 import java.util.Objects;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/InternalTopicJsonSerdeUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/InternalTopicJsonSerdeUtil.java
@@ -25,7 +25,8 @@ import org.apache.kafka.common.serialization.Serializer;
 
 public final class InternalTopicJsonSerdeUtil {
 
-  private InternalTopicJsonSerdeUtil(){}
+  private InternalTopicJsonSerdeUtil() {
+  }
 
   public static <T> Serializer<T> getJsonSerializer(final boolean isKey) {
     final Serializer<T> result = new KafkaJsonSerializer<>();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/OptionsParser.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/OptionsParser.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 public final class OptionsParser {
 
-  private OptionsParser(){
+  private OptionsParser() {
   }
 
   public static <T> T parse(final String[] args, final Class<T> optionsClass) throws IOException {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -20,13 +20,11 @@ import com.google.common.collect.Iterables;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.serde.connect.ConnectDataTranslator;
 import io.confluent.ksql.serde.connect.DataTranslator;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.serde.connect;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.util.KsqlException;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializer.java
@@ -16,10 +16,8 @@
 package io.confluent.ksql.serde.tls;
 
 import io.confluent.ksql.GenericRow;
-
 import java.util.Map;
 import java.util.function.Supplier;
-
 import org.apache.kafka.common.serialization.Deserializer;
 
 public class ThreadLocalDeserializer implements Deserializer<GenericRow> {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalSerializer.java
@@ -16,10 +16,8 @@
 package io.confluent.ksql.serde.tls;
 
 import io.confluent.ksql.GenericRow;
-
 import java.util.Map;
 import java.util.function.Supplier;
-
 import org.apache.kafka.common.serialization.Serializer;
 
 public class ThreadLocalSerializer implements Serializer<GenericRow> {

--- a/ksql-test-util/pom.xml
+++ b/ksql-test-util/pom.xml
@@ -33,6 +33,13 @@
       <artifactId>curator-test</artifactId>
       <version>${apache.curator.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <!-- Use a repackaged version of log4j with security patches instead-->
+        <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </dependency>
+
+            <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Description 

use Confluent's log4j instead of the CVE version in existing log4j

### Testing done 

spun up a server and made sure logs were getting logged :) 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

