### PR TITLE
feat: fail query if rebalance or error detected

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ProcessingQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ProcessingQueue.java
@@ -37,6 +37,8 @@ public class ProcessingQueue {
   private final int queueSizeLimit;
   private boolean closed = false;
   private boolean droppedRows = false;
+  private boolean hasError = false;
+  private boolean hasStateChange = false;
   private Runnable newRowCallback = () -> { };
 
   public ProcessingQueue(final QueryId queryId) {
@@ -104,6 +106,14 @@ public class ProcessingQueue {
    */
   public synchronized boolean hasDroppedRows() {
     return droppedRows;
+  }
+
+  public synchronized boolean hasError() {
+    return hasError;
+  }
+
+  public synchronized boolean hasStateChange() {
+    return hasStateChange;
   }
 
   public QueryId getQueryId() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ProcessingQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ProcessingQueue.java
@@ -108,11 +108,18 @@ public class ProcessingQueue {
     return droppedRows;
   }
 
-  public synchronized boolean hasError() {
+  public synchronized void onError() {
+    hasError = true;
+  }
+
+  public synchronized boolean getHasError() {
     return hasError;
   }
 
-  public synchronized boolean hasStateChange() {
+  public synchronized void onStateChange() {
+    hasStateChange = true;
+  }
+  public synchronized boolean getHasStateChange() {
     return hasStateChange;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
@@ -87,6 +87,14 @@ public class PushPhysicalPlan {
         closeInternal();
         publisher.reportDroppedRows();
         break;
+      } else if (dataSourceOperator.hasError()) {
+        closeInternal();
+        publisher.reportHasError();
+        break;
+      } else if (dataSourceOperator.hasStateChange()) {
+        closeInternal();
+        publisher.reportHasStateChange();
+        break;
       } else {
         publisher.accept(row);
       }
@@ -150,6 +158,14 @@ public class PushPhysicalPlan {
 
     public void reportDroppedRows() {
       sendError(new RuntimeException("Dropped rows"));
+    }
+
+    public void reportHasError() {
+      sendError(new RuntimeException("Persistent query has error"));
+    }
+
+    public void reportHasStateChange() {
+      sendError(new RuntimeException("Persistent query has rebalanced"));
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
@@ -152,15 +152,14 @@ public class ScalablePushRegistry implements ProcessorSupplier<Object, GenericRo
   }
 
   public void onError() {
-    // enter the same callbacks, implement the same interface
     for (ProcessingQueue queue : processingQueues.values()) {
-      queue.hasError();
+      queue.onError();
     }
   }
 
   public void onStateChange() {
     for (ProcessingQueue queue : processingQueues.values()) {
-      queue.hasStateChange();
+      queue.onStateChange();
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
@@ -157,7 +157,7 @@ public class ScalablePushRegistry implements ProcessorSupplier<Object, GenericRo
   }
 
   public void onError() {
-
+// enter the same callbacks, implement the same interface
   }
 
   private final class PeekProcessor implements Processor<Object, GenericRow, Void, Void> {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
@@ -156,6 +156,10 @@ public class ScalablePushRegistry implements ProcessorSupplier<Object, GenericRo
     return new PeekProcessor();
   }
 
+  public void onError() {
+
+  }
+
   private final class PeekProcessor implements Processor<Object, GenericRow, Void, Void> {
 
     private PeekProcessor() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
@@ -151,13 +151,22 @@ public class ScalablePushRegistry implements ProcessorSupplier<Object, GenericRo
     }
   }
 
+  public void onError() {
+    // enter the same callbacks, implement the same interface
+    for (ProcessingQueue queue : processingQueues.values()) {
+      queue.hasError();
+    }
+  }
+
+  public void onStateChange() {
+    for (ProcessingQueue queue : processingQueues.values()) {
+      queue.hasStateChange();
+    }
+  }
+
   @Override
   public Processor<Object, GenericRow, Void, Void> get() {
     return new PeekProcessor();
-  }
-
-  public void onError() {
-// enter the same callbacks, implement the same interface
   }
 
   private final class PeekProcessor implements Processor<Object, GenericRow, Void, Void> {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
@@ -93,4 +93,14 @@ public class PeekStreamOperator extends AbstractPhysicalOperator implements Push
   public boolean droppedRows() {
     return processingQueue.hasDroppedRows();
   }
+
+  @Override
+  public boolean hasError() {
+    return processingQueue.hasError();
+  }
+
+  @Override
+  public boolean hasStateChange() {
+    return processingQueue.hasStateChange();
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
@@ -96,11 +96,11 @@ public class PeekStreamOperator extends AbstractPhysicalOperator implements Push
 
   @Override
   public boolean hasError() {
-    return processingQueue.hasError();
+    return processingQueue.getHasError();
   }
 
   @Override
   public boolean hasStateChange() {
-    return processingQueue.hasStateChange();
+    return processingQueue.getHasStateChange();
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PushDataSourceOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PushDataSourceOperator.java
@@ -29,4 +29,8 @@ public interface PushDataSourceOperator {
 
   // If rows have been dropped.
   boolean droppedRows();
+
+  boolean hasError();
+
+  boolean hasStateChange();
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -118,6 +118,9 @@ public class PersistentQueryMetadataImpl
           public void onStateChange(final QueryMetadata queryMetadata, final State before,
               final State after) {
 
+            if (before.equals(State.RUNNING) && after.equals(State.REBALANCING)) {
+              scalablePushRegistry.get().onStateChange();
+            }
           }
 
           @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.MaterializationProviderBuilderFactory;
+import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -40,6 +41,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
@@ -105,7 +107,24 @@ public class PersistentQueryMetadataImpl
         maxQueryErrorsQueueSize,
         retryBackoffInitialMs,
         retryBackoffMaxMs,
-        listener
+        new QueryMetadata.Listener() {
+          @Override
+          public void onError(final QueryMetadata queryMetadata, final QueryError error) {
+            listener.onError(queryMetadata, error);
+            scalablePushRegistry.get().onError();
+          }
+
+          @Override
+          public void onStateChange(final QueryMetadata queryMetadata, final State before,
+              final State after) {
+
+          }
+
+          @Override
+          public void onClose(final QueryMetadata queryMetadata) {
+
+          }
+        }
     );
     this.sinkDataSource = requireNonNull(sinkDataSource, "sinkDataSource");
     this.schemas = requireNonNull(schemas, "schemas");

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ProcessingQueueTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ProcessingQueueTest.java
@@ -63,4 +63,22 @@ public class ProcessingQueueTest {
     assertThat(queue.poll(), nullValue());
     assertThat(queue.hasDroppedRows(), is(true));
   }
+
+  @Test
+  public void shouldDefaultToFalseForHasError() {
+    // Given:
+    final ProcessingQueue queue = new ProcessingQueue(new QueryId("a"));
+
+    // Then:
+    assertThat(queue.hasError(),is(false));
+  }
+
+  @Test
+  public void shouldDefaultToFalseForHasStateChange() {
+    // Given:
+    final ProcessingQueue queue = new ProcessingQueue(new QueryId("a"));
+
+    // Then:
+    assertThat(queue.hasStateChange(),is(false));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ProcessingQueueTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ProcessingQueueTest.java
@@ -70,7 +70,7 @@ public class ProcessingQueueTest {
     final ProcessingQueue queue = new ProcessingQueue(new QueryId("a"));
 
     // Then:
-    assertThat(queue.hasError(),is(false));
+    assertThat(queue.getHasError(),is(false));
   }
 
   @Test
@@ -79,6 +79,6 @@ public class ProcessingQueueTest {
     final ProcessingQueue queue = new ProcessingQueue(new QueryId("a"));
 
     // Then:
-    assertThat(queue.hasStateChange(),is(false));
+    assertThat(queue.getHasStateChange(),is(false));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
@@ -124,6 +124,68 @@ public class PushPhysicalPlanTest {
     assertThat(pushPhysicalPlan.isClosed(), is(true));
   }
 
+  @Test
+  public void shouldStopOnHasError() throws InterruptedException {
+    final PushPhysicalPlan pushPhysicalPlan = new PushPhysicalPlan(root, logicalSchema, queryId,
+        scalablePushRegistry, pushDataSourceOperator, context);
+    doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
+    when(pushDataSourceOperator.hasError()).thenReturn(true);
+
+    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
+    final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
+    publisher.subscribe(subscriber);
+
+    context.owner().setPeriodic(50, timerId -> {
+      if (runnableCaptor.getValue() == null) {
+        return;
+      }
+      when(root.next()).thenReturn(ROW1, ROW2, null);
+
+      runnableCaptor.getValue().run();
+      runnableCaptor.getValue().run();
+
+      context.owner().cancelTimer(timerId);
+    });
+//
+    while (subscriber.getError() == null) {
+      Thread.sleep(100);
+    }
+
+    assertThat(subscriber.getError().getMessage(), containsString("Persistent query has error"));
+    assertThat(pushPhysicalPlan.isClosed(), is(true));
+  }
+
+  @Test
+  public void shouldStopOnHasStateChange() throws InterruptedException {
+    final PushPhysicalPlan pushPhysicalPlan = new PushPhysicalPlan(root, logicalSchema, queryId,
+        scalablePushRegistry, pushDataSourceOperator, context);
+    doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
+    when(pushDataSourceOperator.hasStateChange()).thenReturn(true);
+
+    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
+    final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
+    publisher.subscribe(subscriber);
+
+    context.owner().setPeriodic(50, timerId -> {
+      if (runnableCaptor.getValue() == null) {
+        return;
+      }
+      when(root.next()).thenReturn(ROW1, ROW2, null);
+
+      runnableCaptor.getValue().run();
+      runnableCaptor.getValue().run();
+
+      context.owner().cancelTimer(timerId);
+    });
+//
+    while (subscriber.getError() == null) {
+      Thread.sleep(100);
+    }
+
+    assertThat(subscriber.getError().getMessage(), containsString("Persistent query has rebalanced"));
+    assertThat(pushPhysicalPlan.isClosed(), is(true));
+  }
+
   public static class TestSubscriber<T> implements Subscriber<T> {
 
     private Subscription sub;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
@@ -194,26 +194,28 @@ public class ScalablePushRegistryTest {
   }
 
   @Test
-  public void shouldCallHasErrorOnQueue() {
+  public void shouldCallOnErrorOnQueue() {
     // Given
     ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false);
     when(processingQueues.values()).thenReturn(Arrays.asList(processingQueue));
+
     // When
     registry.onError();
 
     // Then:
-    verify(processingQueue).hasError();
+    verify(processingQueue).onError();
   }
 
   @Test
-  public void shouldCallHasStateChangeOnQueue() {
+  public void shouldCallOnStateChangeOnQueue() {
     // Given
     ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false);
     when(processingQueues.values()).thenReturn(Arrays.asList(processingQueue));
+
     // When
-    registry.onError();
+    registry.onStateChange();
 
     // Then:
-    verify(processingQueue).hasStateChange();
+    verify(processingQueue).onStateChange();
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
@@ -19,9 +19,11 @@ import io.confluent.ksql.physical.scalablepush.locator.PushLocator;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -51,6 +53,8 @@ public class ScalablePushRegistryTest {
   private PushLocator locator;
   @Mock
   private ProcessingQueue processingQueue;
+  @Mock
+  private ConcurrentHashMap<QueryId, ProcessingQueue> processingQueues;
   @Mock
   private ProcessorContext<Void, Void> processorContext;
   @Mock
@@ -187,5 +191,29 @@ public class ScalablePushRegistryTest {
 
     // Then
     assertThat(registry.isPresent(), is(false));
+  }
+
+  @Test
+  public void shouldCallHasErrorOnQueue() {
+    // Given
+    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false);
+    when(processingQueues.values()).thenReturn(Arrays.asList(processingQueue));
+    // When
+    registry.onError();
+
+    // Then:
+    verify(processingQueue).hasError();
+  }
+
+  @Test
+  public void shouldCallHasStateChangeOnQueue() {
+    // Given
+    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false);
+    when(processingQueues.values()).thenReturn(Arrays.asList(processingQueue));
+    // When
+    registry.onError();
+
+    // Then:
+    verify(processingQueue).hasStateChange();
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
@@ -35,6 +35,8 @@ public class PeekStreamOperatorTest {
   private TableRow row2;
   @Mock
   private Runnable newRowCallback;
+  @Mock
+  private ProcessingQueue processingQueue;
 
   @Test
   public void shouldGetRowsFromOperator() {
@@ -56,5 +58,27 @@ public class PeekStreamOperatorTest {
     verify(newRowCallback, times(2)).run();
     locator.close();
     verify(registry, times(1)).unregister(processingQueue);
+  }
+
+  @Test
+  public void shouldDefaultToFalseForHasErrorOnQueue() {
+    // Given:
+    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID);
+    // When:
+    locator.open();
+
+    // Then:
+    assertThat(locator.hasError(),is(false));
+  }
+
+  @Test
+  public void shouldDefaultToFalseForHasStateChangeOnQueue() {
+    // Given:
+    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID);
+    // When:
+    locator.open();
+
+    // Then:
+    assertThat(locator.hasStateChange(),is(false));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -93,8 +93,6 @@ public class PersistentQueryMetadataTest {
   @Mock
   private Listener listener;
   @Mock
-  private Optional<ScalablePushRegistry> optionalScalablePushRegistry;
-  @Mock
   private ScalablePushRegistry scalablePushRegistry;
 
   private PersistentQueryMetadata query;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/PersistentQueryMetadataTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.MaterializationProviderBuilderFactory;
 import io.confluent.ksql.query.QueryError;
@@ -91,6 +92,10 @@ public class PersistentQueryMetadataTest {
   private ProcessingLogger processingLogger;
   @Mock
   private Listener listener;
+  @Mock
+  private Optional<ScalablePushRegistry> optionalScalablePushRegistry;
+  @Mock
+  private ScalablePushRegistry scalablePushRegistry;
 
   private PersistentQueryMetadata query;
 
@@ -125,7 +130,7 @@ public class PersistentQueryMetadataTest {
         0L,
         0L,
         listener,
-        Optional.empty()
+        Optional.of(scalablePushRegistry)
     );
 
     query.initialize();


### PR DESCRIPTION
### Description 
Listen for errors or rebalances in the persistent query and if one occurs, fail the scalable push query since there is a chance we can miss something or get redundant rows 
### Testing done 
Unit tests added 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

