### PR TITLE
feat: Allow scalable push queries to handle rebalances

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BasePublisher.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BasePublisher.java
@@ -53,18 +53,14 @@ public abstract class BasePublisher<T> implements Publisher<T> {
    */
   @Override
   public void subscribe(final Subscriber<? super T> subscriber) {
-    System.out.println("subscribe subscribe");
     if (isFailed()) {
-      System.out.println("About to throw exception");
       throw new IllegalStateException(
           "Cannot subscribe to failed publisher. Failure cause: " + failure);
     }
     Objects.requireNonNull(subscriber);
     if (VertxUtils.isEventLoopAndSameContext(ctx)) {
-      System.out.println("subscribe oncontext");
       doSubscribe(subscriber);
     } else {
-      System.out.println("subscribe not on context");
       ctx.runOnContext(v -> doSubscribe(subscriber));
     }
   }
@@ -85,16 +81,12 @@ public abstract class BasePublisher<T> implements Publisher<T> {
   protected final void sendError(final Throwable e) {
     checkContext();
     try {
-      System.out.println("FAILURE IN PUB");
       if (subscriber != null) {
-        System.out.println("Sending error");
         subscriber.onError(e);
       } else {
-        System.out.println("DIDN'T send error");
         log.error("Failure in publisher", e);
       }
       failure = e;
-      System.out.println("Recorded error");
     } catch (Exception ex) {
       logError("Exception encountered in onError", ex);
     }
@@ -173,7 +165,6 @@ public abstract class BasePublisher<T> implements Publisher<T> {
       sendError(new IllegalStateException("Exception encountered in onSubscribe", t));
     }
     if (isFailed()) {
-      System.out.println("doSubscribe: About to throw exception");
       sendError(new IllegalStateException(
           "Cannot subscribe to failed publisher. Failure cause: " + failure));
     }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BasePublisher.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/reactive/BasePublisher.java
@@ -53,14 +53,18 @@ public abstract class BasePublisher<T> implements Publisher<T> {
    */
   @Override
   public void subscribe(final Subscriber<? super T> subscriber) {
+    System.out.println("subscribe subscribe");
     if (isFailed()) {
+      System.out.println("About to throw exception");
       throw new IllegalStateException(
           "Cannot subscribe to failed publisher. Failure cause: " + failure);
     }
     Objects.requireNonNull(subscriber);
     if (VertxUtils.isEventLoopAndSameContext(ctx)) {
+      System.out.println("subscribe oncontext");
       doSubscribe(subscriber);
     } else {
+      System.out.println("subscribe not on context");
       ctx.runOnContext(v -> doSubscribe(subscriber));
     }
   }
@@ -81,12 +85,16 @@ public abstract class BasePublisher<T> implements Publisher<T> {
   protected final void sendError(final Throwable e) {
     checkContext();
     try {
+      System.out.println("FAILURE IN PUB");
       if (subscriber != null) {
+        System.out.println("Sending error");
         subscriber.onError(e);
       } else {
+        System.out.println("DIDN'T send error");
         log.error("Failure in publisher", e);
       }
       failure = e;
+      System.out.println("Recorded error");
     } catch (Exception ex) {
       logError("Exception encountered in onError", ex);
     }
@@ -163,6 +171,11 @@ public abstract class BasePublisher<T> implements Publisher<T> {
       subscriber.onSubscribe(new Sub());
     } catch (final Throwable t) {
       sendError(new IllegalStateException("Exception encountered in onSubscribe", t));
+    }
+    if (isFailed()) {
+      System.out.println("doSubscribe: About to throw exception");
+      sendError(new IllegalStateException(
+          "Cannot subscribe to failed publisher. Failure cause: " + failure));
     }
     afterSubscribe();
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -285,6 +285,13 @@ public class KsqlConfig extends AbstractConfig {
           + "functions, aggregations, or joins, but may include projections and filters.";
   public static final boolean KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT = false;
 
+  public static final String KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY
+      = "ksql.query.push.scalable.new.node.continuity";
+  public static final String KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DOC =
+      "Whether new node continuity is enforced for scalable push queries. This means that it's an "
+          + "error for an existing query to miss data processed on a newly added node";
+  public static final boolean KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DEFAULT = false;
+
   public static final String KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED
       = "ksql.query.push.scalable.interpreter.enabled";
   public static final String KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED_DOC =
@@ -900,6 +907,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PUSH_SCALABLE_ENABLED_DOC
+        )
+        .define(
+            KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY,
+            Type.BOOLEAN,
+            KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DOC
         )
         .define(
             KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlRequestConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlRequestConfig.java
@@ -56,6 +56,12 @@ public class KsqlRequestConfig extends AbstractConfig {
   private static final String KSQL_REQUEST_QUERY_PUSH_SKIP_FORWARDING_DOC =
       "Controls whether a ksql host forwards a push query request to another host";
 
+  public static final String KSQL_REQUEST_QUERY_PUSH_NEW_NODE =
+      "request.ksql.query.push.new.node";
+  public static final boolean KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DEFAULT = false;
+  private static final String KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DOC =
+      "Indicates whether a node has been contacted as a new host";
+
   private static ConfigDef buildConfigDef() {
     final ConfigDef configDef = new ConfigDef()
         .define(
@@ -88,6 +94,12 @@ public class KsqlRequestConfig extends AbstractConfig {
             KSQL_REQUEST_QUERY_PUSH_SKIP_FORWARDING_DEFAULT,
             ConfigDef.Importance.LOW,
             KSQL_REQUEST_QUERY_PUSH_SKIP_FORWARDING_DOC
+        ).define(
+            KSQL_REQUEST_QUERY_PUSH_NEW_NODE,
+            Type.BOOLEAN,
+            KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DEFAULT,
+            ConfigDef.Importance.LOW,
+            KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DOC
         );
     return configDef;
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlRequestConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlRequestConfig.java
@@ -56,11 +56,12 @@ public class KsqlRequestConfig extends AbstractConfig {
   private static final String KSQL_REQUEST_QUERY_PUSH_SKIP_FORWARDING_DOC =
       "Controls whether a ksql host forwards a push query request to another host";
 
-  public static final String KSQL_REQUEST_QUERY_PUSH_NEW_NODE =
-      "request.ksql.query.push.new.node";
-  public static final boolean KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DEFAULT = false;
-  private static final String KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DOC =
-      "Indicates whether a node has been contacted as a new host";
+  public static final String KSQL_REQUEST_QUERY_PUSH_REGISTRY_START =
+      "request.ksql.query.push.registry.start";
+  public static final boolean KSQL_REQUEST_QUERY_PUSH_REGISTRY_START_DEFAULT = false;
+  private static final String KSQL_REQUEST_QUERY_PUSH_REGISTRY_START_DOC =
+      "Indicates whether a connecting node expects to be at the start of the registry data. After a"
+          + "rebalance, this ensures we don't miss any data.";
 
   private static ConfigDef buildConfigDef() {
     final ConfigDef configDef = new ConfigDef()
@@ -95,11 +96,11 @@ public class KsqlRequestConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             KSQL_REQUEST_QUERY_PUSH_SKIP_FORWARDING_DOC
         ).define(
-            KSQL_REQUEST_QUERY_PUSH_NEW_NODE,
+            KSQL_REQUEST_QUERY_PUSH_REGISTRY_START,
             Type.BOOLEAN,
-            KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DEFAULT,
+            KSQL_REQUEST_QUERY_PUSH_REGISTRY_START_DEFAULT,
             ConfigDef.Importance.LOW,
-            KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DOC
+            KSQL_REQUEST_QUERY_PUSH_REGISTRY_START_DOC
         );
     return configDef;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -460,7 +460,7 @@ final class EngineExecutor {
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(
         engineContext.getProcessingLogContext(),
         ScalablePushQueryExecutionUtil.findQuery(engineContext, analysis),
-        pushRoutingOptions
+        pushRoutingOptions.getExpectingStartOfRegistryData()
     );
     return builder.buildPushPhysicalPlan(logicalPlan, context);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.physical.pull.PullQueryQueuePopulator;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.physical.scalablepush.PushPhysicalPlan;
 import io.confluent.ksql.physical.scalablepush.PushPhysicalPlanBuilder;
+import io.confluent.ksql.physical.scalablepush.PushQueryPreparer;
 import io.confluent.ksql.physical.scalablepush.PushQueryQueuePopulator;
 import io.confluent.ksql.physical.scalablepush.PushRouting;
 import io.confluent.ksql.physical.scalablepush.PushRoutingOptions;
@@ -286,12 +287,15 @@ final class EngineExecutor {
       final PushQueryQueuePopulator populator = () ->
           pushRouting.handlePushQuery(serviceContext, physicalPlan, statement, pushRoutingOptions,
               physicalPlan.getOutputSchema(), transientQueryQueue);
+      final PushQueryPreparer preparer = () ->
+          pushRouting.preparePushQuery(physicalPlan, statement, pushRoutingOptions);
       final ScalablePushQueryMetadata metadata = new ScalablePushQueryMetadata(
           physicalPlan.getOutputSchema(),
           physicalPlan.getQueryId(),
           transientQueryQueue,
           resultType,
-          populator
+          populator,
+          preparer
       );
 
       return metadata;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -272,7 +272,8 @@ final class EngineExecutor {
       final PushPhysicalPlan physicalPlan = buildScalablePushPhysicalPlan(
           logicalPlan,
           analysis,
-          context
+          context,
+          pushRoutingOptions
       );
       final TransientQueryQueue transientQueryQueue
           = new TransientQueryQueue(analysis.getLimitClause());
@@ -452,12 +453,14 @@ final class EngineExecutor {
   private PushPhysicalPlan buildScalablePushPhysicalPlan(
       final LogicalPlanNode logicalPlan,
       final ImmutableAnalysis analysis,
-      final Context context
+      final Context context,
+      final PushRoutingOptions pushRoutingOptions
   ) {
 
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(
         engineContext.getProcessingLogContext(),
-        ScalablePushQueryExecutionUtil.findQuery(engineContext, analysis)
+        ScalablePushQueryExecutionUtil.findQuery(engineContext, analysis),
+        pushRoutingOptions
     );
     return builder.buildPushPhysicalPlan(logicalPlan, context);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
@@ -161,6 +161,7 @@ public class PushPhysicalPlan {
     return scalablePushRegistry;
   }
 
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public Context getContext() {
     return context;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
@@ -71,7 +71,6 @@ public class PushPhysicalPlan {
   }
 
   public BufferedPublisher<List<?>> execute() {
-    System.out.println("PushPhysicalPlan execute");
     final Publisher publisher = new Publisher(context);
     context.runOnContext(v -> open(publisher));
     return publisher;
@@ -115,7 +114,6 @@ public class PushPhysicalPlan {
   }
 
   private void open(final Publisher publisher) {
-    System.out.println("PushPhysicalPlan open");
     VertxUtils.checkContext(context);
     try {
       dataSourceOperator.setNewRowCallback(() -> context.runOnContext(v -> maybeNext(publisher)));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilder.java
@@ -49,17 +49,20 @@ public class PushPhysicalPlanBuilder {
 
   private final ProcessingLogContext processingLogContext;
   private final PersistentQueryMetadata persistentQueryMetadata;
+  private final PushRoutingOptions pushRoutingOptions;
   private final Stacker contextStacker;
   private final QueryId queryId;
 
   public PushPhysicalPlanBuilder(
       final ProcessingLogContext processingLogContext,
-      final PersistentQueryMetadata persistentQueryMetadata
+      final PersistentQueryMetadata persistentQueryMetadata,
+      final PushRoutingOptions pushRoutingOptions
   ) {
     this.processingLogContext = Objects.requireNonNull(
         processingLogContext, "processingLogContext");
     this.persistentQueryMetadata = Objects.requireNonNull(
         persistentQueryMetadata, "persistentQueryMetadata");
+    this.pushRoutingOptions = Objects.requireNonNull(pushRoutingOptions, "pushRoutingOptions");
     this.contextStacker = new Stacker();
     queryId = uniqueQueryId();
   }
@@ -160,7 +163,8 @@ public class PushPhysicalPlanBuilder {
     final ScalablePushRegistry scalablePushRegistry =
         persistentQueryMetadata.getScalablePushRegistry()
         .orElseThrow(() -> new IllegalStateException("Scalable push registry cannot be found"));
-    return new PeekStreamOperator(scalablePushRegistry, logicalNode, queryId);
+    return new PeekStreamOperator(scalablePushRegistry, logicalNode, queryId,
+        pushRoutingOptions.isNewlyAddedNode());
   }
 
   private QueryId uniqueQueryId() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilder.java
@@ -49,20 +49,20 @@ public class PushPhysicalPlanBuilder {
 
   private final ProcessingLogContext processingLogContext;
   private final PersistentQueryMetadata persistentQueryMetadata;
-  private final PushRoutingOptions pushRoutingOptions;
+  private final boolean expectingStartOfRegistryData;
   private final Stacker contextStacker;
   private final QueryId queryId;
 
   public PushPhysicalPlanBuilder(
       final ProcessingLogContext processingLogContext,
       final PersistentQueryMetadata persistentQueryMetadata,
-      final PushRoutingOptions pushRoutingOptions
+      final boolean expectingStartOfRegistryData
   ) {
     this.processingLogContext = Objects.requireNonNull(
         processingLogContext, "processingLogContext");
     this.persistentQueryMetadata = Objects.requireNonNull(
         persistentQueryMetadata, "persistentQueryMetadata");
-    this.pushRoutingOptions = Objects.requireNonNull(pushRoutingOptions, "pushRoutingOptions");
+    this.expectingStartOfRegistryData = expectingStartOfRegistryData;
     this.contextStacker = new Stacker();
     queryId = uniqueQueryId();
   }
@@ -164,7 +164,7 @@ public class PushPhysicalPlanBuilder {
         persistentQueryMetadata.getScalablePushRegistry()
         .orElseThrow(() -> new IllegalStateException("Scalable push registry cannot be found"));
     return new PeekStreamOperator(scalablePushRegistry, logicalNode, queryId,
-        pushRoutingOptions.isNewlyAddedNode());
+        expectingStartOfRegistryData);
   }
 
   private QueryId uniqueQueryId() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushQueryPreparer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushQueryPreparer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.physical.scalablepush;
+
+public interface PushQueryPreparer {
+
+  void prepare();
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
@@ -22,4 +22,6 @@ public interface PushRoutingOptions {
 
   // If we should avoid skipping forwarding the request because it's already been forwarded.
   boolean getIsSkipForwardRequest();
+
+  boolean isNewlyAddedNode();
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
@@ -23,5 +23,7 @@ public interface PushRoutingOptions {
   // If we should avoid skipping forwarding the request because it's already been forwarded.
   boolean getIsSkipForwardRequest();
 
-  boolean isNewlyAddedNode();
+  // When a rebalance occurs and we connect to a new node, we don't want to miss anything, so we
+  // set this flag indicating we should error if this expectation isn't met.
+  boolean getExpectingStartOfRegistryData();
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRoutingOptions.java
@@ -21,7 +21,7 @@ package io.confluent.ksql.physical.scalablepush;
 public interface PushRoutingOptions {
 
   // If we should avoid skipping forwarding the request because it's already been forwarded.
-  boolean getIsSkipForwardRequest();
+  boolean getHasBeenForwarded();
 
   // When a rebalance occurs and we connect to a new node, we don't want to miss anything, so we
   // set this flag indicating we should error if this expectation isn't met.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
@@ -86,12 +86,12 @@ public class ScalablePushRegistry implements ProcessorSupplier<Object, GenericRo
 
   public synchronized void register(
       final ProcessingQueue processingQueue,
-      boolean isDynamicallyAddedNode
+      boolean expectingStartOfRegistryData
   ) {
     if (closed) {
       throw new IllegalStateException("Shouldn't register after closing");
     }
-    if (hasReceivedData && isDynamicallyAddedNode) {
+    if (hasReceivedData && expectingStartOfRegistryData) {
       throw new IllegalStateException("New node missed data");
     }
     processingQueues.put(processingQueue.getQueryId(), processingQueue);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
@@ -86,7 +86,7 @@ public class ScalablePushRegistry implements ProcessorSupplier<Object, GenericRo
 
   public synchronized void register(
       final ProcessingQueue processingQueue,
-      boolean expectingStartOfRegistryData
+      final boolean expectingStartOfRegistryData
   ) {
     if (closed) {
       throw new IllegalStateException("Shouldn't register after closing");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
@@ -60,7 +60,6 @@ public class AllHostsLocator implements PushLocator {
     }
 
     return currentQueries.stream()
-        .filter(persistentQueryMetadata -> persistentQueryMetadata.getState() == State.RUNNING)
         .map(QueryMetadata::getAllMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
@@ -48,7 +48,6 @@ public class PeekStreamOperator extends AbstractPhysicalOperator implements Push
 
   @Override
   public void open() {
-    System.out.println("Registering " + processingQueue);
     scalablePushRegistry.register(processingQueue, expectingStartOfRegistryData);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
@@ -32,20 +32,24 @@ public class PeekStreamOperator extends AbstractPhysicalOperator implements Push
   private final DataSourceNode logicalNode;
   private final ScalablePushRegistry scalablePushRegistry;
   private final ProcessingQueue processingQueue;
+  private final boolean isNewlyAddedNode;
 
   public PeekStreamOperator(
       final ScalablePushRegistry scalablePushRegistry,
       final DataSourceNode logicalNode,
-      final QueryId queryId
+      final QueryId queryId,
+      final boolean isNewlyAddedNode
   ) {
     this.scalablePushRegistry = scalablePushRegistry;
     this.logicalNode = logicalNode;
     this.processingQueue = new ProcessingQueue(queryId);
+    this.isNewlyAddedNode = isNewlyAddedNode;
   }
 
   @Override
   public void open() {
-    scalablePushRegistry.register(processingQueue);
+    System.out.println("Registering " + processingQueue);
+    scalablePushRegistry.register(processingQueue, isNewlyAddedNode);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperator.java
@@ -32,24 +32,24 @@ public class PeekStreamOperator extends AbstractPhysicalOperator implements Push
   private final DataSourceNode logicalNode;
   private final ScalablePushRegistry scalablePushRegistry;
   private final ProcessingQueue processingQueue;
-  private final boolean isNewlyAddedNode;
+  private final boolean expectingStartOfRegistryData;
 
   public PeekStreamOperator(
       final ScalablePushRegistry scalablePushRegistry,
       final DataSourceNode logicalNode,
       final QueryId queryId,
-      final boolean isNewlyAddedNode
+      final boolean expectingStartOfRegistryData
   ) {
     this.scalablePushRegistry = scalablePushRegistry;
     this.logicalNode = logicalNode;
     this.processingQueue = new ProcessingQueue(queryId);
-    this.isNewlyAddedNode = isNewlyAddedNode;
+    this.expectingStartOfRegistryData = expectingStartOfRegistryData;
   }
 
   @Override
   public void open() {
     System.out.println("Registering " + processingQueue);
-    scalablePushRegistry.register(processingQueue, isNewlyAddedNode);
+    scalablePushRegistry.register(processingQueue, expectingStartOfRegistryData);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -214,7 +214,8 @@ final class QueryExecutor {
       isTable = false;
     }
     final Optional<ScalablePushRegistry> registry = ScalablePushRegistry.create(schema,
-        allPersistentQueries, isTable, windowed, streamsProperties);
+        allPersistentQueries, isTable, windowed, streamsProperties,
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY));
     registry.ifPresent(r -> stream.process(registry.get()));
     return registry;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/ScalablePushQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/ScalablePushQueryMetadata.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.util;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.physical.scalablepush.PushQueryPreparer;
 import io.confluent.ksql.physical.scalablepush.PushQueryQueuePopulator;
 import io.confluent.ksql.physical.scalablepush.PushRouting.PushConnectionsHandle;
 import io.confluent.ksql.query.BlockingRowQueue;
@@ -34,6 +35,7 @@ public class ScalablePushQueryMetadata implements PushQueryMetadata {
   private final BlockingRowQueue rowQueue;
   private final ResultType resultType;
   private final PushQueryQueuePopulator pushQueryQueuePopulator;
+  private final PushQueryPreparer pushQueryPreparer;
 
   // Future for the start of the connections, which creates a handle
   private CompletableFuture<PushConnectionsHandle> startFuture = new CompletableFuture<>();
@@ -47,26 +49,40 @@ public class ScalablePushQueryMetadata implements PushQueryMetadata {
       final QueryId queryId,
       final BlockingRowQueue blockingRowQueue,
       final ResultType resultType,
-      final PushQueryQueuePopulator pushQueryQueuePopulator
+      final PushQueryQueuePopulator pushQueryQueuePopulator,
+      final PushQueryPreparer pushQueryPreparer
   ) {
     this.logicalSchema = logicalSchema;
     this.queryId = queryId;
     this.rowQueue = blockingRowQueue;
     this.resultType = resultType;
     this.pushQueryQueuePopulator = pushQueryQueuePopulator;
+    this.pushQueryPreparer = pushQueryPreparer;
+  }
+
+  /**
+   * Prepare to start. Any exceptions thrown here will result in an error return code rather than
+   * an error written to the stream.
+   */
+  public void prepare() {
+    // Any exceptions aren't meant to trickle up to the caller.  This will result in non ok error
+    // codes and is good for fast failing.
+    pushQueryPreparer.prepare();
   }
 
   @Override
   public void start() {
-    pushQueryQueuePopulator.run().thenApply(handle -> {
-      startFuture.complete(handle);
-      handle.onException(runningFuture::completeExceptionally);
-      return null;
-    }).exceptionally(t -> {
-      startFuture.completeExceptionally(t);
-      runningFuture.completeExceptionally(t);
-      return null;
-    });
+    CompletableFuture.completedFuture(null)
+        .thenCompose(v -> pushQueryQueuePopulator.run())
+        .thenApply(handle -> {
+          startFuture.complete(handle);
+          handle.onException(runningFuture::completeExceptionally);
+          return null;
+        }).exceptionally(t -> {
+          startFuture.completeExceptionally(t);
+          runningFuture.completeExceptionally(t);
+          return null;
+        });
   }
 
   @Override

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilderTest.java
@@ -91,7 +91,7 @@ public class PushPhysicalPlanBuilderTest {
   public void shouldBuildPhysicalPlan() {
     // Given:
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata, null);
+        persistentQueryMetadata, false);
 
     // When:
     final PushPhysicalPlan pushPhysicalPlan =
@@ -111,7 +111,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(logicalPlanNode.getNode()).thenReturn(Optional.empty());
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata, null);
+        persistentQueryMetadata, false);
 
     // When:
     final Exception e = assertThrows(
@@ -128,7 +128,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(logicalPlanNode.getNode()).thenReturn(Optional.of(mock(OutputNode.class)));
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata, null);
+        persistentQueryMetadata, false);
 
     // When:
     final Exception e = assertThrows(
@@ -147,7 +147,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(ksqlBareOutputNode.getSource()).thenReturn(mock(PlanNode.class));
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata, null);
+        persistentQueryMetadata, false);
 
     // When:
     final Exception e = assertThrows(
@@ -164,7 +164,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(projectNode.getSources()).thenReturn(ImmutableList.of(filterNode, dataSourceNode));
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata, null);
+        persistentQueryMetadata, false);
 
     // When:
     final Exception e = assertThrows(
@@ -182,7 +182,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(filterNode.getSources()).thenReturn(ImmutableList.of());
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata, null);
+        persistentQueryMetadata, false);
 
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanBuilderTest.java
@@ -91,7 +91,7 @@ public class PushPhysicalPlanBuilderTest {
   public void shouldBuildPhysicalPlan() {
     // Given:
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata);
+        persistentQueryMetadata, null);
 
     // When:
     final PushPhysicalPlan pushPhysicalPlan =
@@ -111,7 +111,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(logicalPlanNode.getNode()).thenReturn(Optional.empty());
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata);
+        persistentQueryMetadata, null);
 
     // When:
     final Exception e = assertThrows(
@@ -128,7 +128,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(logicalPlanNode.getNode()).thenReturn(Optional.of(mock(OutputNode.class)));
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata);
+        persistentQueryMetadata, null);
 
     // When:
     final Exception e = assertThrows(
@@ -147,7 +147,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(ksqlBareOutputNode.getSource()).thenReturn(mock(PlanNode.class));
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata);
+        persistentQueryMetadata, null);
 
     // When:
     final Exception e = assertThrows(
@@ -164,7 +164,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(projectNode.getSources()).thenReturn(ImmutableList.of(filterNode, dataSourceNode));
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata);
+        persistentQueryMetadata, null);
 
     // When:
     final Exception e = assertThrows(
@@ -182,7 +182,7 @@ public class PushPhysicalPlanBuilderTest {
     // Given:
     when(filterNode.getSources()).thenReturn(ImmutableList.of());
     final PushPhysicalPlanBuilder builder = new PushPhysicalPlanBuilder(logContext,
-        persistentQueryMetadata);
+        persistentQueryMetadata, null);
 
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
@@ -163,7 +163,6 @@ public class PushPhysicalPlanTest {
     final PushPhysicalPlan pushPhysicalPlan = new PushPhysicalPlan(root, logicalSchema, queryId,
         scalablePushRegistry, pushDataSourceOperator, context);
     doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
-    when(pushDataSourceOperator.droppedRows()).thenReturn(false);
     doThrow(new RuntimeException("Error on open")).when(root).open();
 
     final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -155,6 +156,42 @@ public class PushPhysicalPlanTest {
     assertThat(subscriber.getValues().size(), is(1));
     assertThat(subscriber.getValues().get(0), is(ROW1));
     assertThat(pushPhysicalPlan.isClosed(), is(true));
+  }
+
+  @Test
+  public void shouldThrowErrorOnOpen() throws InterruptedException {
+    final PushPhysicalPlan pushPhysicalPlan = new PushPhysicalPlan(root, logicalSchema, queryId,
+        scalablePushRegistry, pushDataSourceOperator, context);
+    doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
+    when(pushDataSourceOperator.droppedRows()).thenReturn(false);
+    doThrow(new RuntimeException("Error on open")).when(root).open();
+
+    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
+    final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
+    publisher.subscribe(subscriber);
+
+    while (subscriber.getError() == null) {
+      Thread.sleep(100);
+    }
+    assertThat(subscriber.getError().getMessage(), containsString("Error on open"));
+  }
+
+  @Test
+  public void shouldThrowErrorOnNext() throws InterruptedException {
+    final PushPhysicalPlan pushPhysicalPlan = new PushPhysicalPlan(root, logicalSchema, queryId,
+        scalablePushRegistry, pushDataSourceOperator, context);
+    doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
+    when(pushDataSourceOperator.droppedRows()).thenReturn(false);
+    doThrow(new RuntimeException("Error on next")).when(root).next();
+
+    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
+    final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
+    publisher.subscribe(subscriber);
+
+    while (subscriber.getError() == null) {
+      Thread.sleep(100);
+    }
+    assertThat(subscriber.getError().getMessage(), containsString("Error on next"));
   }
 
   public static class TestSubscriber<T> implements Subscriber<T> {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
@@ -103,7 +103,7 @@ public class PushRoutingTest {
     when(ksqlNodeLocal.isLocal()).thenReturn(true);
     when(ksqlNodeRemote.location()).thenReturn(URI.create("http://remote:8088"));
     when(ksqlNodeRemote.isLocal()).thenReturn(false);
-    when(pushRoutingOptions.getIsSkipForwardRequest()).thenReturn(false);
+    when(pushRoutingOptions.getHasBeenForwarded()).thenReturn(false);
 
     transientQueryQueue = new TransientQueryQueue(OptionalInt.empty());
   }
@@ -351,7 +351,7 @@ public class PushRoutingTest {
   @Test
   public void shouldSucceed_justForwarded() throws ExecutionException, InterruptedException {
     // Given:
-    when(pushRoutingOptions.getIsSkipForwardRequest()).thenReturn(true);
+    when(pushRoutingOptions.getHasBeenForwarded()).thenReturn(true);
     final PushRouting routing = new PushRouting();
     BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
     when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
@@ -384,7 +384,7 @@ public class PushRoutingTest {
   @Test
   public void shouldFail_duringPlanExecute() throws ExecutionException, InterruptedException {
     // Given:
-    when(pushRoutingOptions.getIsSkipForwardRequest()).thenReturn(true);
+    when(pushRoutingOptions.getHasBeenForwarded()).thenReturn(true);
     final PushRouting routing = new PushRouting();
     when(pushPhysicalPlan.execute()).thenThrow(new RuntimeException("Error!"));
 
@@ -438,7 +438,7 @@ public class PushRoutingTest {
   public void shouldFail_hitRequestLimitLocal() throws ExecutionException, InterruptedException {
     // Given:
     transientQueryQueue = new TransientQueryQueue(OptionalInt.empty(), 1, 100);
-    when(pushRoutingOptions.getIsSkipForwardRequest()).thenReturn(true);
+    when(pushRoutingOptions.getHasBeenForwarded()).thenReturn(true);
     final PushRouting routing = new PushRouting();
     BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
     when(pushPhysicalPlan.execute()).thenReturn(localPublisher);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
@@ -168,7 +168,7 @@ public class PushRoutingTest {
     // Given:
     final AtomicReference<Set<KsqlNode>> nodes = new AtomicReference<>(
         ImmutableSet.of(ksqlNodeLocal));
-    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50);
+    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50, true);
     BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
     BufferedPublisher<StreamedRow> remotePublisher = new BufferedPublisher<>(context);
     when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
@@ -221,7 +221,7 @@ public class PushRoutingTest {
     // Given:
     final AtomicReference<Set<KsqlNode>> nodes = new AtomicReference<>(
         ImmutableSet.of(ksqlNodeLocal, ksqlNodeRemote));
-    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50);
+    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50, true);
     BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
     BufferedPublisher<StreamedRow> remotePublisher = new BufferedPublisher<>(context);
     when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
@@ -270,7 +270,7 @@ public class PushRoutingTest {
     // Given:
     final AtomicReference<Set<KsqlNode>> nodes = new AtomicReference<>(
         ImmutableSet.of(ksqlNodeLocal, ksqlNodeRemote));
-    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50);
+    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50, false);
     BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
     BufferedPublisher<StreamedRow> remotePublisher = new BufferedPublisher<>(context);
     when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
@@ -318,7 +318,7 @@ public class PushRoutingTest {
     // Given:
     final AtomicReference<Set<KsqlNode>> nodes = new AtomicReference<>(
         ImmutableSet.of(ksqlNodeLocal, ksqlNodeRemote));
-    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50);
+    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50, true);
     BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
     TestRemotePublisher remotePublisher = new TestRemotePublisher(context);
     when(pushPhysicalPlan.execute()).thenReturn(localPublisher);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
@@ -501,7 +501,7 @@ public class PushRoutingTest {
     assertThat(handle.getError().getMessage(), containsString("Hit limit of request queue"));
   }
 
-  private class TestRemotePublisher extends BufferedPublisher<StreamedRow> {
+  private static class TestRemotePublisher extends BufferedPublisher<StreamedRow> {
 
     public TestRemotePublisher(Context ctx) {
       super(ctx);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
@@ -10,10 +10,13 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.physical.scalablepush.PushRouting.PushConnectionsHandle;
+import io.confluent.ksql.physical.scalablepush.PushRouting.RoutingResult;
+import io.confluent.ksql.physical.scalablepush.PushRouting.RoutingResultStatus;
 import io.confluent.ksql.physical.scalablepush.locator.PushLocator;
 import io.confluent.ksql.physical.scalablepush.locator.PushLocator.KsqlNode;
 import io.confluent.ksql.query.TransientQueryQueue;
@@ -25,7 +28,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KeyValue;
-import io.confluent.ksql.util.KsqlConfig;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import java.net.URI;
@@ -36,6 +38,7 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -93,6 +96,7 @@ public class PushRoutingTest {
     when(sessionConfig.getOverrides()).thenReturn(ImmutableMap.of());
     when(serviceContext.getKsqlClient()).thenReturn(simpleKsqlClient);
     when(pushPhysicalPlan.getScalablePushRegistry()).thenReturn(scalablePushRegistry);
+    when(pushPhysicalPlan.getContext()).thenReturn(context);
     when(scalablePushRegistry.getLocator()).thenReturn(locator);
     when(locator.locate()).thenReturn(ImmutableList.of(ksqlNodeLocal, ksqlNodeRemote));
     when(ksqlNodeLocal.location()).thenReturn(URI.create("http://localhost:8088"));
@@ -158,6 +162,191 @@ public class PushRoutingTest {
     assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
     assertThat(rows.contains(REMOTE_ROW2.getRow().get().getColumns()), is(true));
   }
+
+  @Test
+  public void shouldSucceed_addRemoteNode() throws ExecutionException, InterruptedException {
+    // Given:
+    final AtomicReference<Set<KsqlNode>> nodes = new AtomicReference<>(
+        ImmutableSet.of(ksqlNodeLocal));
+    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50);
+    BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
+    BufferedPublisher<StreamedRow> remotePublisher = new BufferedPublisher<>(context);
+    when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
+    when(simpleKsqlClient.makeQueryRequestStreamed(any(), any(), any(), any()))
+        .thenReturn(createFuture(RestResponse.successful(200, remotePublisher)));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    future.get();
+    context.runOnContext(v -> {
+      localPublisher.accept(LOCAL_ROW1);
+      localPublisher.accept(LOCAL_ROW2);
+    });
+
+    Set<List<?>> rows = new HashSet<>();
+    while (rows.size() < 2) {
+      final KeyValue<List<?>, GenericRow> kv = transientQueryQueue.poll();
+      if (kv == null) {
+        Thread.sleep(100);
+        continue;
+      }
+      rows.add(kv.value().values());
+    }
+
+    nodes.set(ImmutableSet.of(ksqlNodeLocal, ksqlNodeRemote));
+    context.runOnContext(v -> {
+      remotePublisher.accept(REMOTE_ROW1);
+      remotePublisher.accept(REMOTE_ROW2);
+    });
+
+    // Then:
+    while (rows.size() < 4) {
+      final KeyValue<List<?>, GenericRow> kv = transientQueryQueue.poll();
+      if (kv == null) {
+        Thread.sleep(100);
+        continue;
+      }
+      rows.add(kv.value().values());
+    }
+    assertThat(rows.contains(LOCAL_ROW1), is(true));
+    assertThat(rows.contains(LOCAL_ROW2), is(true));
+    assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
+    assertThat(rows.contains(REMOTE_ROW2.getRow().get().getColumns()), is(true));
+  }
+
+  @Test
+  public void shouldSucceed_removeRemoteNode() throws ExecutionException, InterruptedException {
+    // Given:
+    final AtomicReference<Set<KsqlNode>> nodes = new AtomicReference<>(
+        ImmutableSet.of(ksqlNodeLocal, ksqlNodeRemote));
+    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50);
+    BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
+    BufferedPublisher<StreamedRow> remotePublisher = new BufferedPublisher<>(context);
+    when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
+    when(simpleKsqlClient.makeQueryRequestStreamed(any(), any(), any(), any()))
+        .thenReturn(createFuture(RestResponse.successful(200, remotePublisher)));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    final PushConnectionsHandle handle = future.get();
+    context.runOnContext(v -> {
+      localPublisher.accept(LOCAL_ROW1);
+      localPublisher.accept(LOCAL_ROW2);
+      remotePublisher.accept(REMOTE_ROW1);
+      remotePublisher.accept(REMOTE_ROW2);
+    });
+
+    Set<List<?>> rows = new HashSet<>();
+    while (rows.size() < 4) {
+      final KeyValue<List<?>, GenericRow> kv = transientQueryQueue.poll();
+      if (kv == null) {
+        Thread.sleep(100);
+        continue;
+      }
+      rows.add(kv.value().values());
+    }
+
+    final RoutingResult result = handle.get(ksqlNodeRemote).get();
+    nodes.set(ImmutableSet.of(ksqlNodeLocal));
+    while (handle.get(ksqlNodeRemote).isPresent()) {
+      Thread.sleep(100);
+      continue;
+    }
+
+    // Then:
+    assertThat(rows.contains(LOCAL_ROW1), is(true));
+    assertThat(rows.contains(LOCAL_ROW2), is(true));
+    assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
+    assertThat(rows.contains(REMOTE_ROW2.getRow().get().getColumns()), is(true));
+    assertThat(result.getStatus(), is(RoutingResultStatus.REMOVED));
+  }
+
+  @Test
+  public void shouldSucceed_remoteNodeComplete() throws ExecutionException, InterruptedException {
+    // Given:
+    final AtomicReference<Set<KsqlNode>> nodes = new AtomicReference<>(
+        ImmutableSet.of(ksqlNodeLocal, ksqlNodeRemote));
+    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50);
+    BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
+    BufferedPublisher<StreamedRow> remotePublisher = new BufferedPublisher<>(context);
+    when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
+    when(simpleKsqlClient.makeQueryRequestStreamed(any(), any(), any(), any()))
+        .thenReturn(createFuture(RestResponse.successful(200, remotePublisher)));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    final PushConnectionsHandle handle = future.get();
+    context.runOnContext(v -> {
+      localPublisher.accept(LOCAL_ROW1);
+      localPublisher.accept(LOCAL_ROW2);
+      remotePublisher.accept(REMOTE_ROW1);
+      remotePublisher.accept(REMOTE_ROW2);
+      remotePublisher.complete();
+    });
+
+    Set<List<?>> rows = new HashSet<>();
+    while (rows.size() < 4) {
+      final KeyValue<List<?>, GenericRow> kv = transientQueryQueue.poll();
+      if (kv == null) {
+        Thread.sleep(100);
+        continue;
+      }
+      rows.add(kv.value().values());
+    }
+    while (!handle.get(ksqlNodeRemote).isPresent()
+        || handle.get(ksqlNodeRemote).get().getStatus() != RoutingResultStatus.COMPLETE) {
+      Thread.sleep(100);
+      continue;
+    }
+
+    // Then:
+    assertThat(rows.contains(LOCAL_ROW1), is(true));
+    assertThat(rows.contains(LOCAL_ROW2), is(true));
+    assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
+    assertThat(rows.contains(REMOTE_ROW2.getRow().get().getColumns()), is(true));
+    assertThat(handle.get(ksqlNodeRemote).get().getStatus(), is(RoutingResultStatus.COMPLETE));
+  }
+
+  @Test
+  public void shouldFail_remoteNodeException() throws ExecutionException, InterruptedException {
+    // Given:
+    final AtomicReference<Set<KsqlNode>> nodes = new AtomicReference<>(
+        ImmutableSet.of(ksqlNodeLocal, ksqlNodeRemote));
+    final PushRouting routing = new PushRouting(sqr -> nodes.get(), 50);
+    BufferedPublisher<List<?>> localPublisher = new BufferedPublisher<>(context);
+    TestRemotePublisher remotePublisher = new TestRemotePublisher(context);
+    when(pushPhysicalPlan.execute()).thenReturn(localPublisher);
+    when(simpleKsqlClient.makeQueryRequestStreamed(any(), any(), any(), any()))
+        .thenReturn(createFuture(RestResponse.successful(200, remotePublisher)));
+
+    // When:
+    CompletableFuture<PushConnectionsHandle> future =
+        routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
+            outputSchema, transientQueryQueue);
+    final PushConnectionsHandle handle = future.get();
+    final AtomicReference<Throwable> exception = new AtomicReference<>(null);
+    handle.onException(exception::set);
+    context.runOnContext(v -> {
+      localPublisher.accept(LOCAL_ROW1);
+      localPublisher.accept(LOCAL_ROW2);
+      remotePublisher.error(new RuntimeException("Random error"));
+    });
+
+    while (exception.get() == null) {
+      Thread.sleep(100);
+      continue;
+    }
+
+    // Then:
+    assertThat(exception.get().getMessage(), containsString("Random error"));
+  }
+
 
   @Test
   public void shouldSucceed_justForwarded() throws ExecutionException, InterruptedException {
@@ -310,5 +499,16 @@ public class PushRoutingTest {
     }
     assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
     assertThat(handle.getError().getMessage(), containsString("Hit limit of request queue"));
+  }
+
+  private class TestRemotePublisher extends BufferedPublisher<StreamedRow> {
+
+    public TestRemotePublisher(Context ctx) {
+      super(ctx);
+    }
+
+    public void error(final Throwable e) {
+      sendError(e);
+    }
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
@@ -211,8 +211,8 @@ public class ScalablePushRegistryTest {
   @Test
   public void shouldCallOnErrorOnQueue() {
     // Given
-    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false);
-    registry.register(processingQueue);
+    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false, false);
+    registry.register(processingQueue, false);
 
     // When
     registry.onError();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
@@ -80,7 +80,7 @@ public class ScalablePushRegistryTest {
     when(genericRow.values()).thenAnswer(a -> VALUE);
 
     // When:
-    registry.register(processingQueue);
+    registry.register(processingQueue, false);
     assertThat(registry.numRegistered(), is(1));
 
     // Then:
@@ -107,7 +107,7 @@ public class ScalablePushRegistryTest {
 
 
     // When:
-    registry.register(processingQueue);
+    registry.register(processingQueue, false);
     assertThat(registry.numRegistered(), is(1));
 
     // Then:
@@ -133,7 +133,7 @@ public class ScalablePushRegistryTest {
     when(processingQueue.offer(any())).thenThrow(new RuntimeException("Error!"));
 
     // When:
-    registry.register(processingQueue);
+    registry.register(processingQueue, false);
 
     // Then:
     final Processor<Object, GenericRow, Void, Void> processor = registry.get();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistryTest.java
@@ -72,7 +72,7 @@ public class ScalablePushRegistryTest {
   @Test
   public void shouldRegisterAndGetQueueOffer_nonWindowed() {
     // Given:
-    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false);
+    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false, false);
     when(record.key()).thenReturn(genericKey);
     when(record.value()).thenReturn(genericRow);
     when(record.timestamp()).thenReturn(TIMESTAMP);
@@ -96,7 +96,7 @@ public class ScalablePushRegistryTest {
   @Test
   public void shouldRegisterAndGetQueueOffer_windowed() {
     // Given:
-    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, true, true);
+    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, true, true, false);
     when(record.key()).thenReturn(windowed);
     when(record.value()).thenReturn(genericRow);
     when(record.timestamp()).thenReturn(TIMESTAMP);
@@ -122,9 +122,27 @@ public class ScalablePushRegistryTest {
   }
 
   @Test
+  public void shouldEnforceNewNodeContinuity() {
+    // Given:
+    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, true, true, true);
+    when(record.key()).thenReturn(windowed);
+    when(record.value()).thenReturn(genericRow);
+
+    // When:
+    final Processor<Object, GenericRow, Void, Void> processor = registry.get();
+    processor.init(processorContext);
+    processor.process(record);
+    final Exception e = assertThrows(IllegalStateException.class,
+        () -> registry.register(processingQueue, true));
+
+    // Then:
+    assertThat(e.getMessage(), containsString("New node missed data"));
+  }
+
+  @Test
   public void shouldCatchException() {
     // Given:
-    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false);
+    ScalablePushRegistry registry = new ScalablePushRegistry(locator, SCHEMA, false, false, false);
     when(record.key()).thenReturn(genericKey);
     when(record.value()).thenReturn(genericRow);
     when(record.timestamp()).thenReturn(TIMESTAMP);
@@ -146,7 +164,8 @@ public class ScalablePushRegistryTest {
     // When:
     final Optional<ScalablePushRegistry> registry =
         ScalablePushRegistry.create(SCHEMA, Collections::emptyList, false, false,
-            ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, "http://localhost:8088"));
+            ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, "http://localhost:8088"),
+            false);
 
     // Then:
     assertThat(registry.isPresent(), is(true));
@@ -158,7 +177,7 @@ public class ScalablePushRegistryTest {
     final Exception e = assertThrows(
         IllegalArgumentException.class,
         () -> ScalablePushRegistry.create(SCHEMA, Collections::emptyList, false, false,
-            ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, 123))
+            ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, 123), false)
     );
 
     // Then
@@ -171,7 +190,7 @@ public class ScalablePushRegistryTest {
     final Exception e = assertThrows(
         IllegalArgumentException.class,
         () -> ScalablePushRegistry.create(SCHEMA, Collections::emptyList, false, false,
-            ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, "abc"))
+            ImmutableMap.of(StreamsConfig.APPLICATION_SERVER_CONFIG, "abc"), false)
     );
 
     // Then
@@ -183,7 +202,7 @@ public class ScalablePushRegistryTest {
     // When
     final Optional<ScalablePushRegistry> registry =
         ScalablePushRegistry.create(SCHEMA, Collections::emptyList, false, false,
-            ImmutableMap.of());
+            ImmutableMap.of(), false);
 
     // Then
     assertThat(registry.isPresent(), is(false));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
@@ -65,7 +65,8 @@ public class PeekStreamOperatorTest {
   @Test
   public void shouldDefaultToFalseForHasErrorOnQueue() {
     // Given:
-    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID);
+    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID,
+        false);
     // When:
     locator.open();
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
@@ -3,6 +3,7 @@ package io.confluent.ksql.physical.scalablepush.operators;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -41,14 +42,15 @@ public class PeekStreamOperatorTest {
   @Test
   public void shouldGetRowsFromOperator() {
     // Given:
-    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID, false);
+    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID,
+        false);
     locator.setNewRowCallback(newRowCallback);
 
     // When:
     locator.open();
 
     // Then:
-    verify(registry, times(1)).register(processingQueueCaptor.capture(), false);
+    verify(registry, times(1)).register(processingQueueCaptor.capture(), eq(false));
     final ProcessingQueue processingQueue = processingQueueCaptor.getValue();
     processingQueue.offer(row1);
     processingQueue.offer(row2);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/operators/PeekStreamOperatorTest.java
@@ -41,14 +41,14 @@ public class PeekStreamOperatorTest {
   @Test
   public void shouldGetRowsFromOperator() {
     // Given:
-    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID);
+    final PeekStreamOperator locator = new PeekStreamOperator(registry, dataSourceNode, QUERY_ID, false);
     locator.setNewRowCallback(newRowCallback);
 
     // When:
     locator.open();
 
     // Then:
-    verify(registry, times(1)).register(processingQueueCaptor.capture());
+    verify(registry, times(1)).register(processingQueueCaptor.capture(), false);
     final ProcessingQueue processingQueue = processingQueueCaptor.getValue();
     processingQueue.offer(row1);
     processingQueue.offer(row2);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/ScalablePushQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/ScalablePushQueryMetadataTest.java
@@ -62,7 +62,8 @@ public class ScalablePushQueryMetadataTest {
         new QueryId("queryid"),
         blockingRowQueue,
         ResultType.STREAM,
-        populator
+        populator,
+        () -> { }
     );
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -179,6 +179,7 @@ public class QueryEndpoint {
     final ScalablePushQueryMetadata query = ksqlEngine
         .executeScalablePushQuery(analysis, serviceContext, statement, pushRouting, routingOptions,
             plannerOptions, context);
+    query.prepare();
 
 
     publisher.setQueryHandle(new KsqlQueryHandle(query), false, true);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedQueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedQueryStreamResponseWriter.java
@@ -62,7 +62,6 @@ public class DelimitedQueryStreamResponseWriter implements QueryStreamResponseWr
 
   @Override
   public QueryStreamResponseWriter writeError(final KsqlErrorMessage error) {
-    System.out.println("ALAN: Writing error message " + error);
     response.write(ServerUtils.serializeObject(error).appendString("\n"));
     return this;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedQueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedQueryStreamResponseWriter.java
@@ -62,6 +62,7 @@ public class DelimitedQueryStreamResponseWriter implements QueryStreamResponseWr
 
   @Override
   public QueryStreamResponseWriter writeError(final KsqlErrorMessage error) {
+    System.out.println("ALAN: Writing error message " + error);
     response.write(ServerUtils.serializeObject(error).appendString("\n"));
     return this;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
@@ -38,4 +38,13 @@ public class PushQueryConfigRoutingOptions implements PushRoutingOptions {
     }
     return KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_SKIP_FORWARDING_DEFAULT;
   }
+
+  @Override
+  public boolean isNewlyAddedNode() {
+    if (requestProperties.containsKey(KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_NEW_NODE)) {
+      return (Boolean) requestProperties.get(
+          KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_NEW_NODE);
+    }
+    return KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DEFAULT;
+  }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
@@ -31,7 +31,7 @@ public class PushQueryConfigRoutingOptions implements PushRoutingOptions {
   }
 
   @Override
-  public boolean getIsSkipForwardRequest() {
+  public boolean getHasBeenForwarded() {
     if (requestProperties.containsKey(KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_SKIP_FORWARDING)) {
       return (Boolean) requestProperties.get(
           KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_SKIP_FORWARDING);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
@@ -40,11 +40,11 @@ public class PushQueryConfigRoutingOptions implements PushRoutingOptions {
   }
 
   @Override
-  public boolean isNewlyAddedNode() {
-    if (requestProperties.containsKey(KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_NEW_NODE)) {
+  public boolean getExpectingStartOfRegistryData() {
+    if (requestProperties.containsKey(KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_REGISTRY_START)) {
       return (Boolean) requestProperties.get(
-          KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_NEW_NODE);
+          KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_REGISTRY_START);
     }
-    return KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_NEW_NODE_DEFAULT;
+    return KsqlRequestConfig.KSQL_REQUEST_QUERY_PUSH_REGISTRY_START_DEFAULT;
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KeyValue;
 import io.confluent.ksql.util.PushQueryMetadata;
+import io.confluent.ksql.util.ScalablePushQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
 import java.util.Collection;
@@ -139,10 +140,11 @@ final class PushQueryPublisher implements Flow.Publisher<Collection<StreamedRow>
 
       final ImmutableAnalysis analysis =
           ksqlEngine.analyzeQueryWithNoOutputTopic(query.getStatement(), query.getStatementText());
-
-      queryMetadata = ksqlEngine
+      final ScalablePushQueryMetadata pushQueryMetadata = ksqlEngine
           .executeScalablePushQuery(analysis, serviceContext, query, pushRouting, routingOptions,
               plannerOptions, context);
+      pushQueryMetadata.prepare();
+      queryMetadata = pushQueryMetadata;
     } else {
       queryMetadata = ksqlEngine
           .executeTransientQuery(serviceContext, query, true);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -508,6 +508,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
     final ScalablePushQueryMetadata query = ksqlEngine
         .executeScalablePushQuery(analysis, serviceContext, configured, pushRouting, routingOptions,
             plannerOptions, context);
+    query.prepare();
 
     final QueryStreamWriter queryStreamWriter = new QueryStreamWriter(
         query,

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
@@ -42,6 +42,7 @@ public final class KsqlTargetUtil {
   }
 
   public static StreamedRow toRowFromDelimited(final Buffer buff) {
+    System.out.println("Parsing buff " + buff);
     try {
       final QueryResponseMetadata metadata = deserialize(buff, QueryResponseMetadata.class);
       return StreamedRow.header(new QueryId(Strings.nullToEmpty(metadata.queryId)),
@@ -51,9 +52,11 @@ public final class KsqlTargetUtil {
     }
     try {
       final KsqlErrorMessage error = deserialize(buff, KsqlErrorMessage.class);
+      System.out.println("Got error " + error);
       return StreamedRow.error(new RuntimeException(error.getMessage()), error.getErrorCode());
     } catch (KsqlRestClientException e) {
       // Not a {@link KsqlErrorMessage}
+      System.out.println("NOT A KsqlErrorMessage");
     }
     try {
       final List<?> row = deserialize(buff, List.class);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
@@ -42,7 +42,6 @@ public final class KsqlTargetUtil {
   }
 
   public static StreamedRow toRowFromDelimited(final Buffer buff) {
-    System.out.println("Parsing buff " + buff);
     try {
       final QueryResponseMetadata metadata = deserialize(buff, QueryResponseMetadata.class);
       return StreamedRow.header(new QueryId(Strings.nullToEmpty(metadata.queryId)),
@@ -52,11 +51,9 @@ public final class KsqlTargetUtil {
     }
     try {
       final KsqlErrorMessage error = deserialize(buff, KsqlErrorMessage.class);
-      System.out.println("Got error " + error);
       return StreamedRow.error(new RuntimeException(error.getMessage()), error.getErrorCode());
     } catch (KsqlRestClientException e) {
       // Not a {@link KsqlErrorMessage}
-      System.out.println("NOT A KsqlErrorMessage");
     }
     try {
       final List<?> row = deserialize(buff, List.class);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/StreamPublisher.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/StreamPublisher.java
@@ -72,6 +72,7 @@ public class StreamPublisher<T> extends BufferedPublisher<T> {
           }
         })
         .endHandler(v -> complete());
+    response.request().connection().closeHandler(v ->  complete());
   }
 
   public void close() {


### PR DESCRIPTION
### Description 
Currently, we don't handle rebalances explicitly in SPQ.  If a new node joins the cluster or is removed from the cluster, we don't do anything.  In this PR, it attempts to start a new request to the node or expects the node to drop out of the cluster and tries to keep the connections ongoing, ensuring now data is missed.

### Testing done 
Ran unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

