### PR TITLE
fix: Fixes pull query latency distribution metrics

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/PullQueryExecutorMetrics.java
@@ -50,6 +50,8 @@ public class PullQueryExecutorMetrics implements Closeable {
 
   private static final String PULL_QUERY_METRIC_GROUP = "pull-query";
   private static final String PULL_REQUESTS = "pull-query-requests";
+  private static final long MAX_LATENCY_BUCKET_VALUE_MICROS = TimeUnit.SECONDS.toMicros(10);
+  private static final int NUM_LATENCY_BUCKETS = 1000;
 
   private final List<Sensor> sensors;
   private final Sensor localRequestsSensor;
@@ -475,10 +477,9 @@ public class PullQueryExecutorMetrics implements Closeable {
     );
 
     sensor.add(new Percentiles(
-        100,
-        0,
-        1000,
-        BucketSizing.CONSTANT,
+        4 * NUM_LATENCY_BUCKETS,
+        MAX_LATENCY_BUCKET_VALUE_MICROS,
+        BucketSizing.LINEAR,
         new Percentile(metrics.metricName(
             metricNamePrefix + "-distribution-50",
             servicePrefix + PULL_QUERY_METRIC_GROUP,


### PR DESCRIPTION
### Description 
Fixes the distribution metrics since they were not setup correctly.

Previously, the max value was set to be 1000 microseconds, which is much less than the single digit milliseconds we generally get.  I also changed it to be a "linear" bucketizer so as to have finer grained smaller metrics, even though the max value is ten seconds.

### Testing done 
Manual and unit testing.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

