### PR TITLE
test: fix drop statement tests in QTT

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -217,6 +217,7 @@ public class TestExecutor implements Closeable {
             try {
               topicInfoCache.get(name);
             } catch (Exception e) {
+              e.printStackTrace(System.out);
             }
           });
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -213,7 +213,12 @@ public class TestExecutor implements Closeable {
 
       kafka.getAllTopics().stream()
           .map(Topic::getName)
-          .forEach(topicInfoCache::get);
+          .forEach(name -> {
+            try {
+              topicInfoCache.get(name);
+            } catch (Exception e) {
+            }
+          });
 
       final List<PostTopicNode> knownTopics = topicInfoCache.all().stream()
           .map(ti -> {

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/drop_source_-_drop_and_delete_topic/7.1.0_1628789417998/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/drop_source_-_drop_and_delete_topic/7.1.0_1628789417998/plan.json
@@ -1,0 +1,179 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM ABC (K STRING KEY, DATA STRING) WITH (KAFKA_TOPIC='abc', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "ABC",
+      "schema" : "`K` STRING KEY, `DATA` STRING",
+      "topicName" : "abc",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K STRING KEY, DATA STRING) WITH (KAFKA_TOPIC='input', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `DATA` STRING",
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `DATA` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `DATA` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "DATA AS DATA" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "DROP STREAM ABC DELETE TOPIC",
+    "ddlCommand" : {
+      "@type" : "dropSourceV1",
+      "sourceName" : "ABC"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/drop_source_-_drop_and_delete_topic/7.1.0_1628789417998/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/drop_source_-_drop_and_delete_topic/7.1.0_1628789417998/spec.json
@@ -1,0 +1,103 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1628789417998,
+  "path" : "query-validation-tests/drop_source.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `DATA` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `DATA` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "drop and delete topic",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : "k1",
+      "value" : "v1"
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "k1",
+      "value" : "v1"
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "abc",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM abc (K STRING KEY, data VARCHAR) WITH (kafka_topic='abc', value_format='DELIMITED');", "CREATE STREAM input (K STRING KEY, data VARCHAR) WITH (kafka_topic='input', value_format='DELIMITED');", "CREATE STREAM output AS SELECT * FROM input;", "DROP STREAM abc DELETE TOPIC;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `DATA` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `DATA` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ]
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ],
+        "blackList" : "abc"
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/drop_source_-_drop_and_delete_topic/7.1.0_1628789417998/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/drop_source_-_drop_and_delete_topic/7.1.0_1628789417998/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/drop_source.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/drop_source.json
@@ -56,6 +56,40 @@
       "outputs": [
         {"topic": "OUTPUT", "key": "k1", "value": "v1"}
       ]
+    },
+    {
+      "name": "drop and delete topic",
+      "statements": [
+        "CREATE STREAM abc (K STRING KEY, data VARCHAR) WITH (kafka_topic='abc', value_format='DELIMITED');",
+        "CREATE STREAM input (K STRING KEY, data VARCHAR) WITH (kafka_topic='input', value_format='DELIMITED');",
+        "CREATE STREAM output AS SELECT * FROM input;",
+        "DROP STREAM abc DELETE TOPIC;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": "k1", "value": "v1"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "k1", "value": "v1"}
+      ],
+      "post": {
+        "topics": {
+          "blacklist": "abc",
+          "topics": [
+            {
+              "name": "OUTPUT",
+              "keyFormat": {"format": "KAFKA"},
+              "valueFormat": {"format": "DELIMITED"},
+              "partitions":4
+            },
+            {
+              "name": "input",
+              "keyFormat": {"format": "KAFKA"},
+              "valueFormat": {"format": "DELIMITED"},
+              "partitions":4
+            }
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

Fixed because it is needed for #7474.

In the drop_sources.json QTT test, all of the drop statements dropped streams that shared a topic with another stream, for example.

```
"CREATE STREAM input2 (K STRING KEY, data VARCHAR) WITH (kafka_topic='input', value_format='DELIMITED');",
"DROP STREAM IF EXISTS input2;",
"CREATE STREAM input (K STRING KEY, data VARCHAR) WITH (kafka_topic='input', value_format='DELIMITED');",
"CREATE STREAM output AS SELECT * FROM input;"
```

This is because the QTT would have thrown an error if the dropped source had a topic that was only referenced once.

This PR catches and ignores the error so that we could run DROP tests without forcing streams/tables to share topics:

```
"CREATE SOURCE STREAM abc (K STRING KEY, data VARCHAR) WITH (kafka_topic='abc', value_format='DELIMITED');",
"CREATE STREAM input (K STRING KEY, data VARCHAR) WITH (kafka_topic='input', value_format='DELIMITED');",
"CREATE STREAM output AS SELECT * FROM input;",
"DROP STREAM abc DELETE TOPIC;"
```

The DROP statements still doesn't completely work though - the following test runs, but the test code thinks that the topic `abc` was deleted even though it wasn't.

```
"CREATE STREAM abc (K STRING KEY, data VARCHAR) WITH (kafka_topic='abc', value_format='DELIMITED');",
"CREATE STREAM input (K STRING KEY, data VARCHAR) WITH (kafka_topic='input', value_format='DELIMITED');",
"CREATE STREAM output AS SELECT * FROM input;",
"DROP STREAM abc;"
```

However, if we just want to use these tests to check the behavior of `DROP` vs `DROP.... DELETE TOPIC;` for `SOURCE` sources without actually checking the topics, then this is good enough.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

