### PR TITLE
chore: pin commons-compress to avoid transitive CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <airline.version>2.6.0</airline.version>
         <antlr.version>4.7.1</antlr.version>
         <csv.version>1.4</csv.version>
+        <commons.compress.version>1.21</commons.compress.version>
         <lang3.version>3.3.1</lang3.version>
         <guava.version>30.1.1-jre</guava.version>
         <inject.version>1</inject.version>
@@ -291,6 +292,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
                 <version>${csv.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons.compress.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### Description 
chore, 1.20 of commons compress had a known vulnerability - it's pulled in transitively via avro, but we're pinning in here instead because upgrading avro historically has caused some issues.

### Testing done 
ran the test suite and also spun up a ksql cluster and created/tested some topics with AVRO encoding.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

