### PR TITLE
feat: reject INSERT statements on SOURCE streams and tables

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -125,9 +125,7 @@ final class EngineExecutor {
   }
 
   ExecuteResult execute(final KsqlPlan plan) {
-    final Optional<QueryPlan> queryPlan = plan.getQueryPlan();
-
-    if (!queryPlan.isPresent()) {
+    if (!plan.getQueryPlan().isPresent()) {
       final String ddlResult = plan
           .getDdlCommand()
           .map(ddl -> executeDdl(ddl, plan.getStatementText(), false, Collections.emptySet()))
@@ -137,8 +135,16 @@ final class EngineExecutor {
       return ExecuteResult.of(ddlResult);
     }
 
+    final QueryPlan queryPlan = plan.getQueryPlan().get();
+    final DataSource sinkSource = engineContext.getMetaStore().getSource(queryPlan.getSink());
+
+    if (sinkSource != null && sinkSource.isSource()) {
+      throw new KsqlException(String.format("Cannot insert into read-only %s: %s",
+          sinkSource.getDataSourceType().getKsqlType().toLowerCase(), sinkSource.getName().text()));
+    }
+
     final Optional<String> ddlResult = plan.getDdlCommand().map(ddl ->
-        executeDdl(ddl, plan.getStatementText(), true, queryPlan.get().getSources()));
+        executeDdl(ddl, plan.getStatementText(), true, queryPlan.getSources()));
 
     // Return if the source to create already exists.
     if (ddlResult.isPresent() && ddlResult.get().contains("already exists")) {
@@ -146,7 +152,7 @@ final class EngineExecutor {
     }
 
     return ExecuteResult.of(executePersistentQuery(
-        queryPlan.get(),
+        queryPlan,
         plan.getStatementText(),
         plan.getDdlCommand().isPresent())
     );

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -185,6 +185,11 @@ public class InsertValuesExecutor {
           + dataSource.getKafkaTopicName());
     }
 
+    if (dataSource.isSource()) {
+      throw new KsqlException(String.format("Cannot insert values into read-only %s: %s",
+          dataSource.getDataSourceType().getKsqlType().toLowerCase(), dataSource.getName().text()));
+    }
+
     return dataSource;
   }
 


### PR DESCRIPTION
### Description 
This PR adds a check to prevent running INSERT statements onto source streams and tables.


### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

