### PR TITLE
fix: date parsing functions: case-insensitive name parsing

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
@@ -21,6 +21,7 @@ import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
@@ -38,7 +39,10 @@ public class StringToTimestampParser {
   private final DateTimeFormatter formatter;
 
   public StringToTimestampParser(final String pattern) {
-    formatter = DateTimeFormatter.ofPattern(pattern, Locale.ROOT);
+    formatter = new DateTimeFormatterBuilder()
+        .parseCaseInsensitive()
+        .appendPattern(pattern)
+        .toFormatter(Locale.ROOT);
   }
 
   /**

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
@@ -130,6 +130,19 @@ public class StringToTimestampParserTest {
   }
 
   @Test
+  public void shouldParseMonthNameCaseInsensitively() {
+    // Given
+    final String format = "dd-MMM-yyyy";
+    final String timestamp = "05-NoV-1605";
+
+    // When
+    final ZonedDateTime ts = new StringToTimestampParser(format).parseZoned(timestamp, ZID);
+
+    // Then
+    assertThat(ts, is(sameInstant(FIFTH_OF_NOVEMBER)));
+  }
+
+  @Test
   public void shouldParseFullLocalDateWithPassedInTimeZone() {
     // Given
     final String format = "yyyy-MM-dd HH";

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/ParseDate.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/ParseDate.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.util.KsqlConstants;
 import java.sql.Date;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
@@ -47,7 +48,10 @@ public class ParseDate {
   private final LoadingCache<String, DateTimeFormatter> formatters =
       CacheBuilder.newBuilder()
           .maximumSize(1000)
-          .build(CacheLoader.from(DateTimeFormatter::ofPattern));
+          .build(CacheLoader.from(pattern -> new DateTimeFormatterBuilder()
+              .parseCaseInsensitive()
+              .appendPattern(pattern)
+              .toFormatter()));
 
   @Udf(description = "Converts a string representation of a date in the given format"
       + " into a DATE value.")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/ParseTime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/ParseTime.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.util.KsqlConstants;
 import java.sql.Time;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
@@ -46,7 +47,10 @@ public class ParseTime {
   private final LoadingCache<String, DateTimeFormatter> formatters =
       CacheBuilder.newBuilder()
           .maximumSize(1000)
-          .build(CacheLoader.from(DateTimeFormatter::ofPattern));
+          .build(CacheLoader.from(pattern -> new DateTimeFormatterBuilder()
+              .parseCaseInsensitive()
+              .appendPattern(pattern)
+              .toFormatter()));
 
   @Udf(description = "Converts a string representation of a time in the given format"
       + " into the TIME value.")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.concurrent.ExecutionException;
 
 @UdfDescription(
@@ -44,7 +45,10 @@ public class StringToDate {
   private final LoadingCache<String, DateTimeFormatter> formatters =
       CacheBuilder.newBuilder()
           .maximumSize(1000)
-          .build(CacheLoader.from(DateTimeFormatter::ofPattern));
+          .build(CacheLoader.from(pattern -> new DateTimeFormatterBuilder()
+              .parseCaseInsensitive()
+              .appendPattern(pattern)
+              .toFormatter()));
 
   @Udf(description = "Converts a string representation of a date in the given format"
       + " into the number of days since 1970-01-01 00:00:00 UTC/GMT.")

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseDateTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseDateTest.java
@@ -46,6 +46,15 @@ public class ParseDateTest {
   }
 
   @Test
+  public void shouldConvertCaseInsensitiveStringToDate() {
+    // When:
+    final Date result = udf.parseDate("01-dec-2021", "dd-MMM-yyyy");
+
+    // Then:
+    assertThat(result.getTime(), is(1638316800000L));
+  }
+
+  @Test
   public void shouldThrowOnUnsupportedFields() {
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseTimeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseTimeTest.java
@@ -46,6 +46,15 @@ public class ParseTimeTest {
   }
 
   @Test
+  public void shouldConvertCaseInsensitiveStringToDate() {
+    // When:
+    final Time result = udf.parseTime("12:01:05 aM", "hh:mm:ss a");
+
+    // Then:
+    assertThat(result.getTime(), is(65000L));
+  }
+
+  @Test
   public void shouldThrowOnUnsupportedFields() {
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToDateTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToDateTest.java
@@ -45,6 +45,15 @@ public class StringToDateTest {
   }
 
   @Test
+  public void shouldConvertCaseInsensitiveStringToDate() {
+    // When:
+    final int result = udf.stringToDate("01-dec-2021", "dd-MMM-yyyy");
+
+    // Then:
+    assertThat(result, is(18962));
+  }
+
+  @Test
   public void shouldSupportEmbeddedChars() {
     // When:
     final Object result = udf.stringToDate("2021-12-01Fred", "yyyy-MM-dd'Fred'");

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/parse-date.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/parse-date.json
@@ -10,13 +10,15 @@
         {"topic": "test_topic", "key": "0", "value": "0,zero,2018-05-11Lit,yyyy-MM-dd'Lit'"},
         {"topic": "test_topic", "key": "1", "value": "1,zero,11/05/2019,dd/MM/yyyy"},
         {"topic": "test_topic", "key": "2", "value": "2,zero,01-Jan-2022,dd-MMM-yyyy"},
-        {"topic": "test_topic", "key": "3", "value": "3,yyy,01-01-1970,dd-MM-yyyy"}
+        {"topic": "test_topic", "key": "3", "value": "3,yyy,01-01-1970,dd-MM-yyyy"},
+        {"topic": "test_topic", "key": "4", "value": "4,yyy,01-JAN-2022,dd-MMM-yyyy"}
       ],
       "outputs": [
         {"topic": "TS", "key": "0", "value": "0,17662"},
         {"topic": "TS", "key": "1", "value": "1,18027"},
         {"topic": "TS", "key": "2", "value": "2,18993"},
-        {"topic": "TS", "key": "3", "value": "3,0"}
+        {"topic": "TS", "key": "3", "value": "3,0"},
+        {"topic": "TS", "key": "4", "value": "4,18993"}
       ]
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/parse-time.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/parse-time.json
@@ -9,12 +9,14 @@
       "inputs": [
         {"topic": "test_topic", "key": "0", "value": "0,zero,00:01:05Lit,HH:mm:ss'Lit'"},
         {"topic": "test_topic", "key": "1", "value": "1,zero,11/05/19,HH/mm/ss"},
-        {"topic": "test_topic", "key": "2", "value": "2,zero,01:00:00 PM,hh:mm:ss a"}
+        {"topic": "test_topic", "key": "2", "value": "2,zero,01:00:00 PM,hh:mm:ss a"},
+        {"topic": "test_topic", "key": "3", "value": "3,zero,01:00:00 Pm,hh:mm:ss a"}
       ],
       "outputs": [
         {"topic": "TS", "key": "0", "value": "0,65000"},
         {"topic": "TS", "key": "1", "value": "1,39919000"},
-        {"topic": "TS", "key": "2", "value": "2,46800000"}
+        {"topic": "TS", "key": "2", "value": "2,46800000"},
+        {"topic": "TS", "key": "3", "value": "3,46800000"}
       ]
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/stringtimestamp.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/stringtimestamp.json
@@ -12,11 +12,13 @@
       "inputs": [
         {"topic": "test_topic", "key": "0", "value": "0,zero,2018-05-11T21:58:33Z"},
         {"topic": "test_topic", "key": "0", "value": "0,zero,2019-05-11T21:58:33Z"},
-        {"topic": "test_topic", "key": "0", "value": "0,zero,2020-05-11T21:58:33Z"}
+        {"topic": "test_topic", "key": "0", "value": "0,zero,2020-05-11T21:58:33Z"},
+        {"topic": "test_topic", "key": "0", "value": "0,zero,2020-05-11T21:58:33z"}
       ],
       "outputs": [
         {"topic": "TS", "key": "0", "value": "0,1526075913000"},
         {"topic": "TS", "key": "0", "value": "0,1557611913000"},
+        {"topic": "TS", "key": "0", "value": "0,1589234313000"},
         {"topic": "TS", "key": "0", "value": "0,1589234313000"}
       ]
     },


### PR DESCRIPTION
fixes #7961

### Description 
This PR changes `PARSE_TIMESTAMP`, `PARSE_DATE` to parse case-insensitive strings.
As written in the [original issue](https://github.com/confluentinc/ksql/issues/7961) `PARSE_TIMESTAMP('29-JUN-21','dd-MMM-yy')` yields a null value, but will now result with the same value as of `PARSE_TIMESTAMP('29-Jun-21','dd-MMM-yy')`.

Affected functions - `PARSE_TIMESTAMP`, `PARSE_DATE` (and the deprecated functions - `STRINGTOTIMESTAMP`, `STRINGTODATE`)

### Testing done 
Wrote unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #7961")

