### PR TITLE
docs: cherry-pick: revert left/outer stream-stream join doc updates (DOCS-9600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 ### Bug Fixes
 
 * block out of order migrations in migrations tool ([#7693](https://github.com/confluentinc/ksql/pull/7693)) ([1d617d3](https://github.com/confluentinc/ksql/commit/1d617d38d2928b8ec39d48df8060d4f43649382d))
-* enable KAFKA-10847 bugfix when GRACE PERIOD is used on Joins ([#7739](https://github.com/confluentinc/ksql/pull/7739)) ([c1f5da6](https://github.com/confluentinc/ksql/commit/c1f5da627541b0500a4c4c6ebc439bcce899b426))
 ([#7678](https://github.com/confluentinc/ksql/pull/7678)) ([9bf9abf](https://github.com/confluentinc/ksql/commit/9bf9abf0d8093d2b53859abd5fe54a0d280a3cc7))
 * enable schema inference for timestamp/time/date ([#7737](https://github.com/confluentinc/ksql/pull/7737)) ([35b1cad](https://github.com/confluentinc/ksql/commit/35b1cadc08faea68ca0b76e6c08ac664a5122c0b))
 * enable time unit functions for interpreter ([#7709](https://github.com/confluentinc/ksql/pull/7709)) ([a26a297](https://github.com/confluentinc/ksql/commit/a26a297af55ad46c3f46efae78f470a33d0df251))

--- a/docs/developer-guide/joins/join-streams-and-tables.md
+++ b/docs/developer-guide/joins/join-streams-and-tables.md
@@ -158,22 +158,18 @@ the following table. In the table, each row represents a new incoming
 record. The following assumptions apply:
 
 -   All records have the same key.
+-   All records belong to a single join window.
 -   All records are processed in timestamp order.
--   The join window is 15 seconds, and the grace period is 5 seconds.
 
 When new input is received, the join is triggered under the conditions
 listed in the table. Input records with a NULL key or a NULL value are
 ignored and don't trigger the join.
 
-!!! important
-    If you don't specify a grace period, left/outer join results are emitted eagerly,
-    and the observed result might differ from the result shown below.
-
-| Timestamp | Left Stream | Right Stream | INNER JOIN                     | LEFT JOIN                      | OUTER JOIN                     |
+| Timestamp | Left Stream | Right Stream | INNER JOIN                     | LEFT JOIN                      | RIGHT JOIN                     |
 |-----------|-------------|--------------|--------------------------------|--------------------------------|--------------------------------|
 | 1         | null        |              |                                |                                |                                |
 | 2         |             | null         |                                |                                |                                |
-| 3         | A           |              |                                |                                |                                |
+| 3         | A           |              |                                | [A, null]                      | [A, null]                      |
 | 4         |             | a            | [A, a]                         | [A, a]                         | [A, a]                         |
 | 5         | B           |              | [B, a]                         | [B, a]                         | [B, a]                         |
 | 6         |             | b            | [A, b], [B, b]                 | [A, b], [B, b]                 | [A, b], [B, b]                 |
@@ -186,14 +182,6 @@ ignored and don't trigger the join.
 | 13        |             | null         |                                |                                |                                |
 | 14        |             | d            | [A, d], [B, d], [C, d]         | [A, d], [B, d], [C, d]         | [A, d], [B, d], [C, d]         |
 | 15        | D           |              | [D, a], [D, b], [D, c], [D, d] | [D, a], [D, b], [D, c], [D, d] | [D, a], [D, b], [D, c], [D, d] |
-| ...       |             |              |                                |                                |                                |
-| 40        | E           |              |                                |                                |                                |
-| ...       |             |              |                                |                                |                                |
-| 60        | F           |              |                                | [E,null]                       | [E,null]                       |
-| ...       |             |              |                                |                                |                                |
-| 80        |             | f            |                                | [F,null]                       | [F,null]                       |
-| ...       |             |              |                                |                                |                                |
-| 100       | G           |              |                                |                                | [null,f]                       |
 
 Stream-Table Joins
 ------------------


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/8030.