### PR TITLE
feat: create and write a query plan for source tables

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.analyzer.QueryAnalyzer;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Sink;
 import io.confluent.ksql.physical.PhysicalPlan;
@@ -72,7 +71,7 @@ class QueryEngine {
   PhysicalPlan buildPhysicalPlan(
       final LogicalPlanNode logicalPlanNode,
       final SessionConfig config,
-      final MutableMetaStore metaStore,
+      final MetaStore metaStore,
       final QueryId queryId
   ) {
 


### PR DESCRIPTION
### Description 
As part of the source table materialization feature, this PR creates a query plan for a source table command.
The query plan is not executed in this PR yet (a follow-up PR will include this). 

### Testing done 
I will add unit tests in `KsqlEngineTest` in the PR that adds the CST query execution.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

