### PR TITLE
test: add QTT for CREATE SOURCE STREAM

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/SourceNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/SourceNode.java
@@ -54,6 +54,7 @@ public final class SourceNode {
   private final Optional<String> valueFormat;
   private final Optional<Set<SerdeFeature>> keyFeatures;
   private final Optional<Set<SerdeFeature>> valueFeatures;
+  private final Optional<Boolean> isSource;
 
   public SourceNode(
       final String name,
@@ -62,7 +63,8 @@ public final class SourceNode {
       final Optional<KeyFormatNode> keyFormat,
       final Optional<String> valueFormat,
       final Optional<Set<SerdeFeature>> keyFeatures,
-      final Optional<Set<SerdeFeature>> valueFeatures
+      final Optional<Set<SerdeFeature>> valueFeatures,
+      final Optional<Boolean> isSource
   ) {
     this.name = Objects.requireNonNull(name, "name");
     this.type = Objects.requireNonNull(type, "type");
@@ -71,6 +73,7 @@ public final class SourceNode {
     this.valueFormat = Objects.requireNonNull(valueFormat, "valueFormat");
     this.keyFeatures = Objects.requireNonNull(keyFeatures, "keyFeatures");
     this.valueFeatures = Objects.requireNonNull(valueFeatures, "valueFeatures");
+    this.isSource = Objects.requireNonNull(isSource, "isSource");
 
     if (this.name.isEmpty()) {
       throw new InvalidFieldException("name", "missing or empty");
@@ -108,6 +111,10 @@ public final class SourceNode {
   @JsonInclude(Include.NON_EMPTY)
   public Optional<Set<SerdeFeature>> getValueFeatures() {
     return valueFeatures;
+  }
+
+  public Optional<Boolean> getIsSource() {
+    return isSource;
   }
 
   @SuppressWarnings("unchecked")
@@ -148,6 +155,11 @@ public final class SourceNode {
         .map(MetaStoreMatchers::hasValueSerdeFeatures)
         .orElse(null);
 
+    final Matcher<DataSource> isSourceMatcher = isSource
+        .map(Matchers::is)
+        .map(MetaStoreMatchers::isSourceMatches)
+        .orElse(null);
+
     final Matcher<DataSource>[] matchers = Stream.of(
         nameMatcher,
         typeMatcher,
@@ -155,7 +167,8 @@ public final class SourceNode {
         keyFmtMatcher,
         valueFmtMatcher,
         keyFeatsMatcher,
-        valFeatsMatcher
+        valFeatsMatcher,
+        isSourceMatcher
     ).filter(Objects::nonNull).toArray(Matcher[]::new);
 
     return allOf(matchers);
@@ -176,12 +189,14 @@ public final class SourceNode {
         && keyFormat.equals(that.keyFormat)
         && keyFeatures.equals(that.keyFeatures)
         && valueFormat.equals(that.valueFormat)
-        && valueFeatures.equals(that.valueFeatures);
+        && valueFeatures.equals(that.valueFeatures)
+        && isSource.equals(that.isSource);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, type, schema, keyFormat, valueFormat, keyFeatures, valueFeatures);
+    return Objects.hash(name, type, schema, keyFormat, valueFormat,
+        keyFeatures, valueFeatures, isSource);
   }
 
   private static Class<? extends DataSource> toType(final String type) {
@@ -230,6 +245,8 @@ public final class SourceNode {
       final Optional<Set<SerdeFeature>> valueFeatures = JsonParsingUtil
           .getOptional("valueFeatures", node, jp, new TypeReference<Set<SerdeFeature>>() {
           });
+      final Optional<Boolean> isSource = JsonParsingUtil
+          .getOptional("isSource", node, jp, Boolean.class);
 
       return new SourceNode(
           name,
@@ -238,7 +255,8 @@ public final class SourceNode {
           keyFormat,
           valueFormat,
           keyFeatures,
-          valueFeatures
+          valueFeatures,
+          isSource
       );
     }
   }
@@ -251,7 +269,8 @@ public final class SourceNode {
         Optional.of(KeyFormatNode.fromKeyFormat(dataSource.getKsqlTopic().getKeyFormat())),
         Optional.of(dataSource.getKsqlTopic().getValueFormat().getFormatInfo().getFormat()),
         Optional.of(dataSource.getKsqlTopic().getKeyFormat().getFeatures().all()),
-        Optional.of(dataSource.getKsqlTopic().getValueFormat().getFeatures().all())
+        Optional.of(dataSource.getKsqlTopic().getValueFormat().getFeatures().all()),
+        Optional.of(dataSource.isSource())
     );
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/matchers/MetaStoreMatchers.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/matchers/MetaStoreMatchers.java
@@ -114,4 +114,18 @@ public final class MetaStoreMatchers {
       }
     };
   }
+
+  public static Matcher<DataSource> isSourceMatches(
+      final Matcher<? super Boolean> matcher
+  ) {
+    return new FeatureMatcher<DataSource, Boolean>(
+        matcher,
+        "source type",
+        "isSource") {
+      @Override
+      protected Boolean featureValueOf(final DataSource actual) {
+        return actual.isSource();
+      }
+    };
+  }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/SourceNodeTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/SourceNodeTest.java
@@ -49,7 +49,8 @@ public class SourceNodeTest {
       Optional.of(KeyFormatNodeTest.INSTANCE),
       Optional.of("JSON"),
       Optional.of(ImmutableSet.of(SerdeFeature.UNWRAP_SINGLES)),
-      Optional.of(ImmutableSet.of(SerdeFeature.WRAP_SINGLES))
+      Optional.of(ImmutableSet.of(SerdeFeature.WRAP_SINGLES)),
+      Optional.empty()
   );
 
   private static final SourceNode INSTANCE_WITHOUT_SERDE_FEATURES = new SourceNode(
@@ -58,6 +59,7 @@ public class SourceNodeTest {
       Optional.of("ROWKEY INT KEY, NAME STRING"),
       Optional.of(KeyFormatNodeTest.INSTANCE),
       Optional.of("JSON"),
+      Optional.empty(),
       Optional.empty(),
       Optional.empty()
   );
@@ -69,7 +71,19 @@ public class SourceNodeTest {
       Optional.of(KeyFormatNodeTest.INSTANCE),
       Optional.of("JSON"),
       Optional.of(ImmutableSet.of()),
-      Optional.of(ImmutableSet.of())
+      Optional.of(ImmutableSet.of()),
+      Optional.empty()
+  );
+
+  private static final SourceNode SOURCE_STREAM_INSTANCE = new SourceNode(
+      "bob",
+      "stream",
+      Optional.of("ROWKEY INT KEY, NAME STRING"),
+      Optional.of(KeyFormatNodeTest.INSTANCE),
+      Optional.of("JSON"),
+      Optional.of(ImmutableSet.of()),
+      Optional.of(ImmutableSet.of()),
+      Optional.of(true)
   );
 
   @Test
@@ -85,6 +99,11 @@ public class SourceNodeTest {
   @Test
   public void shouldRoundTripWithEmptySerdeFeatures() {
     ModelTester.assertRoundTrip(INSTANCE_WITH_EMPTY_SERDE_FEATURES);
+  }
+
+  @Test
+  public void shouldRoundTripSourceStreamInstance() {
+    ModelTester.assertRoundTrip(SOURCE_STREAM_INSTANCE);
   }
 
   @Test
@@ -126,7 +145,8 @@ public class SourceNodeTest {
         )),
         Optional.of("DELIMITED"),
         Optional.of(ImmutableSet.of(SerdeFeature.UNWRAP_SINGLES)),
-        Optional.of(ImmutableSet.of(SerdeFeature.WRAP_SINGLES))
+        Optional.of(ImmutableSet.of(SerdeFeature.WRAP_SINGLES)),
+        Optional.of(false)
     )));
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/source-stream_-_create_source_stream/7.1.0_1629794097708/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/source-stream_-_create_source_stream/7.1.0_1629794097708/plan.json
@@ -1,0 +1,157 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE SOURCE STREAM INPUT (K STRING KEY, TEXT STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` STRING KEY, `TEXT` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : true
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `TEXT` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `TEXT` STRING"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "TEXT AS TEXT" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/source-stream_-_create_source_stream/7.1.0_1629794097708/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/source-stream_-_create_source_stream/7.1.0_1629794097708/spec.json
@@ -1,0 +1,114 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1629794097708,
+  "path" : "query-validation-tests/source-stream.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `TEXT` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `TEXT` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "create source stream",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "a1"
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "b1"
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : "B2"
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : "a1"
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : "b1"
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : "B2"
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');", "CREATE STREAM OUTPUT AS select * from INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `TEXT` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : true
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `TEXT` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/source-stream_-_create_source_stream/7.1.0_1629794097708/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/source-stream_-_create_source_stream/7.1.0_1629794097708/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
@@ -1,0 +1,37 @@
+{
+  "tests": [
+    {
+      "name": "create source stream",
+      "statements": [
+        "CREATE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS select * from INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": "a1"},
+        {"topic": "test_topic", "value": "b1"},
+        {"topic": "test_topic", "value": "B2"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": "a1"},
+        {"topic": "OUTPUT", "value": "b1"},
+        {"topic": "OUTPUT", "value": "B2"}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "INPUT",
+            "type": "stream",
+            "schema": "K STRING KEY, TEXT STRING",
+            "isSource": true
+          },
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "schema": "K STRING KEY, TEXT STRING",
+            "isSource": false
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
Adds `CREATE SOURCE STREAM` QTT and checks that the created sources are read-only.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

