### PR TITLE
fix: Lower session timeout for RQTT

### DIFF
--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/ThreadTestUtil.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/ThreadTestUtil.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableSet;
 import java.lang.Thread.State;
 import java.util.Arrays;
 import java.util.Collections;
@@ -112,7 +113,7 @@ public final class ThreadTestUtil {
     public void assertSameThreads() {
       // Give threads a chance to die...
       assertThatEventually(
-          () -> "Active thead-count is on the up: "
+          () -> "Active thread-count is on the up: "
               + "is there new ExecutorService that's not being shutdown somewhere?"
               + System.lineSeparator()
               + threadSnapshot(predicate).detailsOfNewThreads(this),
@@ -168,7 +169,11 @@ public final class ThreadTestUtil {
     }
 
     public ThreadFilterBuilder excludeJdkThreads() {
-      nameMatches(name -> !name.equals("executor-Heartbeat"));
+      nameMatches(name -> {
+        final ImmutableSet<String> jdkThreads =
+            ImmutableSet.of("executor-Heartbeat", "executor-Rebalance");
+        return !jdkThreads.contains(name);
+      });
       return this;
     }
   }


### PR DESCRIPTION
Apache Kafka increased the default session timeout to 30s in KIP-735:
https://cwiki.apache.org/confluence/display/KAFKA/KIP-735%3A+Increase+default+consumer+session+timeout

As a result, it's taking longer for integration tests to execute end-to-end, and we're running into flaky test timeouts.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

