### PR TITLE
fix: Removes config check to insert SPQ Processor

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -285,6 +285,13 @@ public class KsqlConfig extends AbstractConfig {
           + "functions, aggregations, or joins, but may include projections and filters.";
   public static final boolean KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT = false;
 
+  public static final String KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED
+      = "ksql.query.push.scalable.registry.installed";
+  public static final String KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED_DOC =
+      "Enables whether scalable push registry should be installed. This is a requirement of "
+          + "enabling scalable push queries using ksql.query.push.scalable.enabled.";
+  public static final boolean KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED_DEFAULT = false;
+
   public static final String KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY
       = "ksql.query.push.scalable.new.node.continuity";
   public static final String KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DOC =
@@ -922,6 +929,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PUSH_SCALABLE_ENABLED_DOC
+        )
+        .define(
+            KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED,
+            Type.BOOLEAN,
+            KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED_DOC
         )
         .define(
             KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ProcessingQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ProcessingQueue.java
@@ -30,7 +30,7 @@ import java.util.Deque;
  */
 public class ProcessingQueue {
 
-  static final int BLOCKING_QUEUE_CAPACITY = 100;
+  static final int BLOCKING_QUEUE_CAPACITY = 1000;
 
   private final Deque<TableRow> rowQueue;
   private final QueryId queryId;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -225,6 +225,9 @@ final class QueryExecutor {
       final Map<String, Object> streamsProperties,
       final KsqlConfig ksqlConfig
   ) {
+    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED)) {
+      return Optional.empty();
+    }
     final KStream<?, GenericRow> stream;
     final boolean isTable;
     if (result instanceof KTableHolder) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -225,9 +225,6 @@ final class QueryExecutor {
       final Map<String, Object> streamsProperties,
       final KsqlConfig ksqlConfig
   ) {
-    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED)) {
-      return Optional.empty();
-    }
     final KStream<?, GenericRow> stream;
     final boolean isTable;
     if (result instanceof KTableHolder) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -79,6 +79,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.junit.Before;
 import org.junit.Test;
@@ -177,6 +178,10 @@ public class QueryExecutorTest {
   @Mock
   private KStreamHolder<Struct> streamHolder;
   @Mock
+  private KTable<Struct, GenericRow> kTable;
+  @Mock
+  private KStream<Struct, GenericRow> kStream;
+  @Mock
   private SessionConfig config;
   @Mock
   private QueryMetadata.Listener queryListener;
@@ -198,6 +203,9 @@ public class QueryExecutorTest {
     when(kafkaStreamsBuilder.build(any(), any())).thenReturn(kafkaStreams);
     when(kafkaStreamsBuilder.buildNamedTopologyWrapper(any())).thenReturn(kafkaStreamsNamedTopologyWrapper);
     when(tableHolder.getMaterializationBuilder()).thenReturn(Optional.of(materializationBuilder));
+    when(tableHolder.getTable()).thenReturn(kTable);
+    when(kTable.toStream()).thenReturn(kStream);
+    when(streamHolder.getStream()).thenReturn(kstream);
     when(materializationBuilder.build()).thenReturn(materializationInfo);
     when(materializationInfo.getStateStoreSchema()).thenReturn(aggregationSchema);
     when(materializationInfo.stateStoreName()).thenReturn(STORE_NAME);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -79,7 +79,6 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.junit.Before;
 import org.junit.Test;
@@ -178,10 +177,6 @@ public class QueryExecutorTest {
   @Mock
   private KStreamHolder<Struct> streamHolder;
   @Mock
-  private KTable<Struct, GenericRow> kTable;
-  @Mock
-  private KStream<Struct, GenericRow> kStream;
-  @Mock
   private SessionConfig config;
   @Mock
   private QueryMetadata.Listener queryListener;
@@ -203,9 +198,6 @@ public class QueryExecutorTest {
     when(kafkaStreamsBuilder.build(any(), any())).thenReturn(kafkaStreams);
     when(kafkaStreamsBuilder.buildNamedTopologyWrapper(any())).thenReturn(kafkaStreamsNamedTopologyWrapper);
     when(tableHolder.getMaterializationBuilder()).thenReturn(Optional.of(materializationBuilder));
-    when(tableHolder.getTable()).thenReturn(kTable);
-    when(kTable.toStream()).thenReturn(kStream);
-    when(streamHolder.getStream()).thenReturn(kstream);
     when(materializationBuilder.build()).thenReturn(materializationInfo);
     when(materializationInfo.getStateStoreSchema()).thenReturn(aggregationSchema);
     when(materializationInfo.stateStoreName()).thenReturn(STORE_NAME);

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -100,6 +100,7 @@ public class RestQueryTranslationTest {
       .withProperty(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "set")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED, true)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .build();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -215,6 +215,7 @@ public class RestApiTest {
       .withProperty("sasl.mechanism", "PLAIN")
       .withProperty("sasl.jaas.config", SecureKafkaHelper.buildJaasConfig(NORMAL_USER))
       .withProperties(ClientTrustStore.trustStoreProps())
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED, true)
       .build();
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ScalablePushQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ScalablePushQueryFunctionalTest.java
@@ -98,6 +98,7 @@ public class ScalablePushQueryFunctionalTest {
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8088")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED, true)
       // Make rebalances happen quicker for the sake of the test
       .withProperty(KSQL_STREAMS_PREFIX + "max.poll.interval.ms", 5000)
@@ -112,6 +113,7 @@ public class ScalablePushQueryFunctionalTest {
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8089")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8089")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED, true)
       // Make rebalances happen quicker for the sake of the test
       .withProperty(KSQL_STREAMS_PREFIX + "max.poll.interval.ms", 5000)


### PR DESCRIPTION
### Description 
Replaces the check for `ksql.query.push.scalable.enabled` with `ksql.query.push.scalable.registry.installed` to insert the streams Processor for Scalable Push Queries. The idea behind this is that we want the user to be able to enable SPQs using the config `ksql.query.push.scalable.enabled` per request or in the CLI and control the registry installation separately.

Also, ups the ProcessingQueue limit to 1000 to allow for larger bursts.

### Testing done 
Verified it works as intended.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

