### PR TITLE
feat: block DROP...DELETE TOPIC for read-only sources

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
@@ -36,6 +36,7 @@ public final class DropSourceFactory {
     return create(
         statement.getName(),
         statement.getIfExists(),
+        statement.isDeleteTopic(),
         DataSourceType.KSTREAM
     );
   }
@@ -44,6 +45,7 @@ public final class DropSourceFactory {
     return create(
         statement.getName(),
         statement.getIfExists(),
+        statement.isDeleteTopic(),
         DataSourceType.KTABLE
     );
   }
@@ -51,6 +53,7 @@ public final class DropSourceFactory {
   private DropSourceCommand create(
       final SourceName sourceName,
       final boolean ifExists,
+      final boolean deleteTopic,
       final DataSourceType dataSourceType) {
     final DataSource dataSource = metaStore.getSource(sourceName);
     if (dataSource == null) {
@@ -63,6 +66,8 @@ public final class DropSourceFactory {
           dataSource.getDataSourceType() == DataSourceType.KSTREAM ? "STREAM" : "TABLE",
           dataSourceType == DataSourceType.KSTREAM ? "STREAM" : "TABLE"
       ));
+    } else if (dataSource.isSource() && deleteTopic) {
+      throw new KsqlException("Cannot delete topic for read-only source: " + sourceName.text());
     }
     return new DropSourceCommand(sourceName);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
@@ -97,6 +97,9 @@ public class TopicDeleteInjector implements Injector {
     final DataSource source = metastore.getSource(sourceName);
 
     if (source != null) {
+      if (source.isSource()) {
+        throw new KsqlException("Cannot delete topic for read-only source: " + sourceName.text());
+      }
       checkTopicRefs(source);
 
       deleteTopic(source);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceFactoryTest.java
@@ -149,4 +149,20 @@ public class DropSourceFactoryTest {
     // Then:
     assertThat(e.getMessage(), containsString("Cannot delete topic for read-only source: bob"));
   }
+
+  @Test
+  public void shouldFailDeleteTopicForSourceTable() {
+    // Given:
+    final DropTable dropTable = new DropTable(TABLE_NAME, false, true);
+    when(ksqlTable.isSource()).thenReturn(true);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> dropSourceFactory.create(dropTable)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Cannot delete topic for read-only source: tablename"));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceFactoryTest.java
@@ -133,4 +133,20 @@ public class DropSourceFactoryTest {
     // Then:
     assertThat(e.getMessage(), containsString("Incompatible data source type is TABLE"));
   }
+
+  @Test
+  public void shouldFailDeleteTopicForSourceStream() {
+    // Given:
+    final DropStream dropStream = new DropStream(SOME_NAME, false, true);
+    when(ksqlStream.isSource()).thenReturn(true);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> dropSourceFactory.create(dropStream)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("Cannot delete topic for read-only source: bob"));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
@@ -308,6 +308,22 @@ public class TopicDeleteInjectorTest {
     deleteInjector.inject(DROP_WITH_DELETE_TOPIC);
   }
 
+  @Test
+  public void shouldThrowOnDeleteTopicIfSourceIsReadOnly() {
+    // Given:
+    when(source.isSource()).thenReturn(true);
+
+    // When:
+    final Exception e = assertThrows(
+        RuntimeException.class,
+        () -> deleteInjector.inject(DROP_WITH_DELETE_TOPIC)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString("" +
+        "Cannot delete topic for read-only source: SOMETHING"));
+  }
+
   private static DataSource givenSource(final SourceName name, final String topicName) {
     final DataSource source = mock(DataSource.class);
     when(source.getName()).thenReturn(name);

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
@@ -55,6 +55,17 @@
         "type": "io.confluent.ksql.util.KsqlException",
         "message": "Cannot insert into read-only stream: INPUT"
       }
+    },
+    {
+      "name": "rejects DROP ... DELETE TOPIC statements for source streams",
+      "statements": [
+        "CREATE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "DROP STREAM INPUT DELETE TOPIC;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot delete topic for read-only source: INPUT"
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 
Throws an error if a user tries to DROP...DELETE TOPIC for read-only sources.

### Testing done 
Unit + QTT test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

