### PR TITLE
chore: reject TERMINATE commands on CST tables

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -178,7 +178,7 @@ public class KsqlEngineTest {
   @Test
   public void shouldCreateSourceTablesQueries() {
     // Given:
-    givenTopicsExist("s0_topic", "t1_topic");
+    givenTopicsExist("t1_topic");
 
     // When:
     final List<QueryMetadata> queries = KsqlEngineTestUtil.execute(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -130,7 +130,7 @@ public final class ValidatedCommandFactory {
 
     if (queryMetadata.getPersistentQueryType() == KsqlConstants.PersistentQueryType.CREATE_SOURCE) {
       throw new KsqlStatementException(
-          String.format("Cannot terminate query '%s' because is linked to a source table.",
+          String.format("Cannot terminate query '%s' because it is linked to a source table.",
               queryId.get()), statement.getStatementText());
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.rest.util.TerminateCluster;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -122,11 +123,18 @@ public final class ValidatedCommandFactory {
       return Command.of(statement);
     }
 
-    context.getPersistentQuery(queryId.get())
+    final PersistentQueryMetadata queryMetadata = context.getPersistentQuery(queryId.get())
         .orElseThrow(() -> new KsqlStatementException(
             "Unknown queryId: " + queryId.get(),
-            statement.getStatementText()))
-        .close();
+            statement.getStatementText()));
+
+    if (queryMetadata.getPersistentQueryType() == KsqlConstants.PersistentQueryType.CREATE_SOURCE) {
+      throw new KsqlStatementException(
+          String.format("Cannot terminate query '%s' because is linked to a source table.",
+              queryId.get()), statement.getStatementText());
+    }
+
+    queryMetadata.close();
     return Command.of(statement);
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
@@ -19,10 +19,12 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.engine.KsqlPlan;
@@ -41,6 +43,7 @@ import io.confluent.ksql.rest.util.TerminateCluster;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -99,6 +102,27 @@ public class ValidatedCommandFactoryTest {
 
     // Then:
     assertThat(command, is(Command.of(configuredStatement)));
+  }
+
+  @Test
+  public void shouldFailTerminateSourceTableQuery() {
+    // Given:
+    configuredStatement = configuredStatement("TERMINATE X", terminateQuery);
+    when(terminateQuery.getQueryId()).thenReturn(Optional.of(QUERY_ID));
+    when(executionContext.getPersistentQuery(QUERY_ID)).thenReturn(Optional.of(query1));
+    when(query1.getPersistentQueryType())
+        .thenReturn(KsqlConstants.PersistentQueryType.CREATE_SOURCE);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlStatementException.class,
+        () -> commandFactory.create(configuredStatement, executionContext)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Cannot terminate query 'FOO' because is linked to a source table"));
+    verify(query1, times(0)).close();
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
@@ -121,7 +121,7 @@ public class ValidatedCommandFactoryTest {
 
     // Then:
     assertThat(e.getMessage(), containsString(
-        "Cannot terminate query 'FOO' because is linked to a source table"));
+        "Cannot terminate query 'FOO' because it is linked to a source table"));
     verify(query1, times(0)).close();
   }
 


### PR DESCRIPTION
### Description 
This PR prevents to call `TERMINATE` on source table queries.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

