### PR TITLE
chore: Materialize only partition and offset information in V2 table source steps

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -157,6 +157,7 @@ public final class LogicalSchema {
 
   /**
    * Remove pseudo and key columns from the value schema, according to the pseudocolumn version
+   *
    * @param pseudoColumnVersion the version of pseudocolumns to evaluate against
    * @return the new schema with the columns removed
    */
@@ -198,7 +199,6 @@ public final class LogicalSchema {
    * {@code ROWOFFSET}.
    *
    * @param pseudoColumnVersion the version of pseudocolumns to evaluate against
-   *
    * @return the new schema with the columns removed
    */
   public LogicalSchema withPseudoColumnsToMaterialize(final int pseudoColumnVersion) {
@@ -371,9 +371,9 @@ public final class LogicalSchema {
     builder.addAll(keyColumns);
     builder.addAll(nonPseudoAndKeyCols);
 
-    //put all pseudocolumns which are not able to be accessed via processorContext after a join,
-    //and therefore require materialization, in a conditional block corresponding to their
-    //pseudocolumn version number
+    //put pseudocolumns which are not able to be accessed when getting value from an upstream
+    //state store, and therefore require materialization, in a conditional block corresponding to
+    //its pseudocolumn version number
     if (pseudoColumnVersion >= ROWPARTITION_ROWOFFSET_PSEUDOCOLUMN_VERSION) {
       builder.add(Column.of(ROWPARTITION_NAME, ROWPARTITION_TYPE, VALUE, valueIndex++));
       builder.add(Column.of(ROWOFFSET_NAME, ROWOFFSET_TYPE, VALUE, valueIndex++));

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -199,7 +199,7 @@ public final class LogicalSchema {
    * {@code ROWOFFSET}.
    *
    * @param pseudoColumnVersion the version of pseudocolumns to evaluate against
-   * @return the new schema with the columns removed
+   * @return the new schema with the columns added
    */
   public LogicalSchema withPseudoColumnsToMaterialize(final int pseudoColumnVersion) {
     return rebuildWithPseudoColumnsToMaterialize(pseudoColumnVersion);
@@ -371,9 +371,8 @@ public final class LogicalSchema {
     builder.addAll(keyColumns);
     builder.addAll(nonPseudoAndKeyCols);
 
-    //put pseudocolumns which are not able to be accessed when getting value from an upstream
-    //state store, and therefore require materialization, in a conditional block corresponding to
-    //its pseudocolumn version number
+    // add pseudocolumns which are not guaranteed to be accessible from downstream
+    // processor contexts to the schema for materialization in a state store
     if (pseudoColumnVersion >= ROWPARTITION_ROWOFFSET_PSEUDOCOLUMN_VERSION) {
       builder.add(Column.of(ROWPARTITION_NAME, ROWPARTITION_TYPE, VALUE, valueIndex++));
       builder.add(Column.of(ROWOFFSET_NAME, ROWOFFSET_TYPE, VALUE, valueIndex++));

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -192,6 +192,20 @@ public final class LogicalSchema {
   }
 
   /**
+   * Adds just the pseudocolumns that must be materialized as part of a join involving a table.
+   * As of pseudocolumn version {@code SystemColumns.ROWPARTITION_ROWOFFSET_PSEUDOCOLUMN_VERSION},
+   * there are only two pseudocolumns that fall under this definition: {@code ROWPARTITION} and
+   * {@code ROWOFFSET}.
+   *
+   * @param pseudoColumnVersion the version of pseudocolumns to evaluate against
+   *
+   * @return the new schema with the columns removed
+   */
+  public LogicalSchema withPseudoColumnsToMaterialize(final int pseudoColumnVersion) {
+    return rebuildWithPseudoColumnsToMaterialize(pseudoColumnVersion);
+  }
+
+  /**
    * @param columnName the column name to check
    * @return {@code true} if the column matches the name of any key column.
    */
@@ -332,6 +346,38 @@ public final class LogicalSchema {
 
     builder.addAll(keyColumns);
     builder.addAll(nonPseudoAndKeyCols);
+
+    return new LogicalSchema(builder.build());
+  }
+
+
+  /**
+   * Rebuilds schema with only certain pseudocolumns to materialize in an intermittent store
+   * @param pseudoColumnVersion indicates which set of pseudocolumns should be used
+   * @return the LogicalSchema created, with the corresponding pseudocolumns
+   */
+  private LogicalSchema rebuildWithPseudoColumnsToMaterialize(final int pseudoColumnVersion) {
+    final Map<Namespace, List<Column>> byNamespace = byNamespace();
+
+    final ImmutableList.Builder<Column> builder = ImmutableList.builder();
+
+    final List<Column> keyColumns = keyColumns(byNamespace);
+
+    final List<Column> nonPseudoAndKeyCols = nonPseudoAndKeyColsAsValueCols(
+        byNamespace, pseudoColumnVersion);
+
+    int valueIndex = nonPseudoAndKeyCols.size();
+
+    builder.addAll(keyColumns);
+    builder.addAll(nonPseudoAndKeyCols);
+
+    //put all pseudocolumns which are not able to be accessed via processorContext after a join,
+    //and therefore require materialization, in a conditional block corresponding to their
+    //pseudocolumn version number
+    if (pseudoColumnVersion >= ROWPARTITION_ROWOFFSET_PSEUDOCOLUMN_VERSION) {
+      builder.add(Column.of(ROWPARTITION_NAME, ROWPARTITION_TYPE, VALUE, valueIndex++));
+      builder.add(Column.of(ROWOFFSET_NAME, ROWOFFSET_TYPE, VALUE, valueIndex++));
+    }
 
     return new LogicalSchema(builder.build());
   }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
@@ -114,6 +114,10 @@ public final class SystemColumns {
     return systemColumnNames(CURRENT_PSEUDOCOLUMN_VERSION_NUMBER);
   }
 
+  public static Boolean mustBeMaterializedForTableJoins(ColumnName columnName) {
+    return PseudoColumns.MUST_BE_MATERIALIZED_FOR_TABLE_JOINS.contains(columnName);
+  }
+
   private static Set<ColumnName> buildColumns(final int pseudoColumnVersion) {
     return ImmutableSet.<ColumnName>builder()
         .addAll(pseudoColumnNames(pseudoColumnVersion))
@@ -144,6 +148,12 @@ public final class SystemColumns {
         ImmutableMap.of(
             0, VERSION_ZERO_NAMES,
             1, VERSION_ONE_NAMES
+        );
+
+    private static final Set<ColumnName> MUST_BE_MATERIALIZED_FOR_TABLE_JOINS =
+        ImmutableSet.of(
+            ROWPARTITION_NAME,
+            ROWOFFSET_NAME
         );
 
     private static Set<ColumnName> getPseudoColumnNamesByVersion(final int pseudoColumnVersion) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
@@ -114,7 +114,7 @@ public final class SystemColumns {
     return systemColumnNames(CURRENT_PSEUDOCOLUMN_VERSION_NUMBER);
   }
 
-  public static boolean mustBeMaterializedForTableJoins(ColumnName columnName) {
+  public static boolean mustBeMaterializedForTableJoins(final ColumnName columnName) {
     return PseudoColumns.MUST_BE_MATERIALIZED_FOR_TABLE_JOINS.contains(columnName);
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
@@ -114,7 +114,7 @@ public final class SystemColumns {
     return systemColumnNames(CURRENT_PSEUDOCOLUMN_VERSION_NUMBER);
   }
 
-  public static Boolean mustBeMaterializedForTableJoins(ColumnName columnName) {
+  public static boolean mustBeMaterializedForTableJoins(ColumnName columnName) {
     return PseudoColumns.MUST_BE_MATERIALIZED_FOR_TABLE_JOINS.contains(columnName);
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -151,7 +151,7 @@ final class SourceBuilder extends SourceBuilderBase {
       final String stateStoreName
   ) {
 
-    final PhysicalSchema physicalSchema = getPhysicalSchemaWithRelevantPseudoAndKeyCols(source);
+    final PhysicalSchema physicalSchema = getPhysicalSchemaWithPseudoColumnsToMaterialize(source);
 
     final QueryContext queryContext = addMaterializedContext(source);
 
@@ -187,7 +187,7 @@ final class SourceBuilder extends SourceBuilderBase {
       final String stateStoreName
   ) {
 
-    final PhysicalSchema physicalSchema = getPhysicalSchemaWithRelevantPseudoAndKeyCols(source);
+    final PhysicalSchema physicalSchema = getPhysicalSchemaWithPseudoColumnsToMaterialize(source);
 
     final QueryContext queryContext = addMaterializedContext(source);
 
@@ -213,7 +213,7 @@ final class SourceBuilder extends SourceBuilderBase {
     );
   }
 
-  private static PhysicalSchema getPhysicalSchemaWithRelevantPseudoAndKeyCols(
+  private static PhysicalSchema getPhysicalSchemaWithPseudoColumnsToMaterialize(
       final SourceStep<?> streamSource) {
 
     final boolean windowed = streamSource instanceof WindowedTableSource;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -354,7 +354,7 @@ final class SourceBuilder extends SourceBuilderBase {
           final int pseudoColumnsToShift = totalPseudoColumns - pseudoColumnsToAdd;
           final int numUserColumns = row.size() - totalPseudoColumns;
 
-          //create a list of pseudocolumns, in the order which they should be added
+          // collect pseudocolumn values, in the order in which they should be added
           final List<Object> pseudoCols = new ArrayList<>();
           if (pseudoColumnVersion >= SystemColumns.ROWTIME_PSEUDOCOLUMN_VERSION) {
             pseudoCols.add(processorContext.timestamp());

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -85,8 +85,8 @@ final class SourceBuilder extends SourceBuilderBase {
       final PlanInfo planInfo
   ) {
     final KTable<K, GenericRow> source = buildContext
-          .getStreamsBuilder()
-          .table(streamSource.getTopicName(), consumed);
+        .getStreamsBuilder()
+        .table(streamSource.getTopicName(), consumed);
 
     final boolean forceMaterialization = !planInfo.isRepartitionedInPlan(streamSource);
 
@@ -98,8 +98,8 @@ final class SourceBuilder extends SourceBuilderBase {
       // be enabled because we cannot require symmetric serialization between
       // producer and KSQL (see https://issues.apache.org/jira/browse/KAFKA-10179
       // and https://github.com/confluentinc/ksql/issues/5673 for more details)
-     maybeMaterialized = source.transformValues(
-         new AddPseudoColumnsToMaterialize<>(streamSource.getPseudoColumnVersion()), materialized);
+      maybeMaterialized = source.transformValues(
+          new AddPseudoColumnsToMaterialize<>(streamSource.getPseudoColumnVersion()), materialized);
     } else {
       // if we know this table source is repartitioned later in the topology,
       // we do not need to force a materialization at this source step since the
@@ -223,7 +223,7 @@ final class SourceBuilder extends SourceBuilderBase {
 
     final KeyFormat keyFormat = windowed
         ? KeyFormat.windowed(
-            formatInfo, serdeFeatures, ((WindowedTableSource) streamSource).getWindowInfo())
+        formatInfo, serdeFeatures, ((WindowedTableSource) streamSource).getWindowInfo())
         : KeyFormat.nonWindowed(formatInfo, serdeFeatures);
 
     final Formats format = of(keyFormat, streamSource.getFormats().getValueFormat());
@@ -355,12 +355,12 @@ final class SourceBuilder extends SourceBuilderBase {
           final int numUserColumns = row.size() - totalPseudoColumns;
 
           //create a list of pseudocolumns, in the order which they should be added
-          List<Object> pseudoCols = new ArrayList<>();
+          final List<Object> pseudoCols = new ArrayList<>();
           if (pseudoColumnVersion >= SystemColumns.ROWTIME_PSEUDOCOLUMN_VERSION) {
             pseudoCols.add(processorContext.timestamp());
           }
 
-          for (int i = numUserColumns; i < numUserColumns + pseudoColumnsToShift ; i++) {
+          for (int i = numUserColumns; i < numUserColumns + pseudoColumnsToShift; i++) {
             pseudoCols.add(row.get(i));
           }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -91,7 +91,7 @@ final class SourceBuilder extends SourceBuilderBase {
     final KTable<K, GenericRow> toPotentiallyMaterialize;
 
     if (forceMaterialization) {
-      // add this identity mapValues call to prevent the source-changelog
+      // materialize to prevent the source-changelog
       // optimization in kafka streams - we don't want this optimization to
       // be enabled because we cannot require symmetric serialization between
       // producer and KSQL (see https://issues.apache.org/jira/browse/KAFKA-10179

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -345,6 +345,10 @@ final class SourceBuilder extends SourceBuilderBase {
           final int pseudoColumnsToShift = totalPseudoColumns - pseudoColumnsToAdd;
           final int numUserColumns = row.size() - pseudoColumnsToShift;
 
+          //as we need to re-insert pseudocolumns after we've added timestamp, take the index we
+          //will add timestamp in, save the column that was occupying the index, then add timestamp.
+          //repeat this process until we reach end of the row, then append last saved column after
+          //loop is exited
           Object toShift = processorContext.timestamp();
 
           for (int i = numUserColumns; i < row.size(); i++) {

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -388,7 +388,7 @@ public class SourceBuilderTest {
     final GenericKey key = GenericKey.genericKey(1d, 2d);
 
     // When:
-    final GenericRow withKeyAndPseudoCols = applyAllTransformers(key, transformers);
+    final GenericRow withKeyAndPseudoCols = applyAllTransformers(key, transformers, row);
 
     // Then:
     assertThat(withKeyAndPseudoCols, equalTo(GenericRow.genericRow("baz", 123, A_ROWTIME, A_ROWPARTITION, A_ROWOFFSET, 1d, 2d)));
@@ -404,7 +404,7 @@ public class SourceBuilderTest {
     final GenericKey key = GenericKey.genericKey(null, 2d);
 
     // When:
-    final GenericRow withKeyAndPseudoCols = applyAllTransformers(key, transformers);
+    final GenericRow withKeyAndPseudoCols = applyAllTransformers(key, transformers, row);
 
     // Then:
     assertThat(withKeyAndPseudoCols, equalTo(GenericRow.genericRow("baz", 123, A_ROWTIME, A_ROWPARTITION, A_ROWOFFSET, null, 2d)));
@@ -420,7 +420,7 @@ public class SourceBuilderTest {
     final GenericKey key = GenericKey.genericKey(null, null);
 
     // When:
-    final GenericRow withKeyAndPseudoCols = applyAllTransformers(key, transformers);
+    final GenericRow withKeyAndPseudoCols = applyAllTransformers(key, transformers, row);
 
     // Then:
     assertThat(withKeyAndPseudoCols, equalTo(
@@ -447,7 +447,7 @@ public class SourceBuilderTest {
         getTransformersFromTableSource(tableSource);
 
     // When:
-    final GenericRow withKeyAndPseudoCols = applyAllTransformers(KEY, transformers);
+    final GenericRow withKeyAndPseudoCols = applyAllTransformers(KEY, transformers, row);
 
     // Then:
     assertThat(withKeyAndPseudoCols, equalTo(GenericRow.genericRow("baz", 123, A_ROWTIME, A_ROWPARTITION, A_ROWOFFSET, A_KEY)));
@@ -463,7 +463,7 @@ public class SourceBuilderTest {
     final GenericKey nullKey = GenericKey.genericKey((Object) null);
 
     // When:
-    final GenericRow withKeyAndPseudoCols = applyAllTransformers(nullKey, transformers);
+    final GenericRow withKeyAndPseudoCols = applyAllTransformers(nullKey, transformers, row);
 
     // Then:
     assertThat(withKeyAndPseudoCols, equalTo(GenericRow.genericRow("baz", 123, A_ROWTIME, A_ROWPARTITION, A_ROWOFFSET, null)));
@@ -611,9 +611,10 @@ public class SourceBuilderTest {
     return transformer;
   }
 
-  private GenericRow applyAllTransformers(
+  private static GenericRow applyAllTransformers(
       final GenericKey key,
-      final List<ValueTransformerWithKey<GenericKey, GenericRow, GenericRow>> transformerList
+      final List<ValueTransformerWithKey<GenericKey, GenericRow, GenericRow>> transformerList,
+      final GenericRow row
   ) {
     GenericRow last = row;
 
@@ -665,7 +666,7 @@ public class SourceBuilderTest {
   }
 
   private <K> void givenConsumed(final Consumed<K, GenericRow> consumed, final Serde<K> keySerde) {
-    when(consumedWindowed.withValueSerde(any())).thenReturn(consumedWindowed);
+    when(consumed.withValueSerde(any())).thenReturn(consumed);
     when(consumedFactory.create(keySerde, valueSerde)).thenReturn(consumed);
     when(consumed.withTimestampExtractor(any())).thenReturn(consumed);
     when(consumed.withOffsetResetPolicy(any())).thenReturn(consumed);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -229,7 +229,6 @@ public class SourceBuilderTest {
     when(materializationFactory.create(any(), any(), any()))
         .thenReturn((Materialized) materialized);
     when(valueFormatInfo.getFormat()).thenReturn(FormatFactory.AVRO.name());
-    when(consumedWindowed.withValueSerde(any())).thenReturn(consumedWindowed);
 
     planBuilder = new KSPlanBuilder(
         buildContext,
@@ -628,7 +627,6 @@ public class SourceBuilderTest {
   private void givenWindowedSourceTable() {
     when(buildContext.buildKeySerde(any(), any(), any(), any())).thenReturn(windowedKeySerde);
     givenConsumed(consumedWindowed, windowedKeySerde);
-    givenConsumed(consumedWindowed, windowedKeySerde);
     windowedTableSource = new WindowedTableSource(
         new ExecutionStepPropertiesV1(ctx),
         TOPIC_NAME,
@@ -667,6 +665,7 @@ public class SourceBuilderTest {
   }
 
   private <K> void givenConsumed(final Consumed<K, GenericRow> consumed, final Serde<K> keySerde) {
+    when(consumedWindowed.withValueSerde(any())).thenReturn(consumedWindowed);
     when(consumedFactory.create(keySerde, valueSerde)).thenReturn(consumed);
     when(consumed.withTimestampExtractor(any())).thenReturn(consumed);
     when(consumed.withOffsetResetPolicy(any())).thenReturn(consumed);


### PR DESCRIPTION
### Description 
As a result of https://github.com/confluentinc/ksql/pull/7990, we now materialize all key and pseudo columns in the value schema in order to allow for `ROWPARTITION` and `ROWOFFSET` in joins involving tables. This is wasteful as we are able to access timestamp and key columns after the materialization step, this PR adds just the partition and offset information without also storing the information we don't need.

Before:
```
   Sub-topology: 0
    Source: KSTREAM-SOURCE-0000000001 (topics: [t])
      --> KTABLE-SOURCE-0000000002
    Processor: KTABLE-SOURCE-0000000002 (stores: [])
      --> KTABLE-MAPVALUES-0000000003
      <-- KSTREAM-SOURCE-0000000001
    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
      --> KTABLE-TRANSFORMVALUES-0000000004
      <-- KTABLE-SOURCE-0000000002
    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
      --> Project
      <-- KTABLE-MAPVALUES-0000000003
    Processor: Project (stores: [])
      --> KTABLE-TOSTREAM-0000000006
      <-- KTABLE-TRANSFORMVALUES-0000000004
    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
      --> KSTREAM-SINK-0000000007
      <-- Project
    Sink: KSTREAM-SINK-0000000007 (topic: TT)
      <-- KTABLE-TOSTREAM-0000000006
```

After:
```
   Sub-topology: 0
    Source: KSTREAM-SOURCE-0000000001 (topics: [t])
      --> KTABLE-SOURCE-0000000002
    Processor: KTABLE-SOURCE-0000000002 (stores: [])
      --> KTABLE-TRANSFORMVALUES-0000000003
      <-- KSTREAM-SOURCE-0000000001
    Processor: KTABLE-TRANSFORMVALUES-0000000003 (stores: [])
      --> KTABLE-MAPVALUES-0000000004
      <-- KTABLE-SOURCE-0000000002
    Processor: KTABLE-MAPVALUES-0000000004 (stores: [KsqlTopic-Reduce])
      --> KTABLE-TRANSFORMVALUES-0000000005
      <-- KTABLE-TRANSFORMVALUES-0000000003
    Processor: KTABLE-TRANSFORMVALUES-0000000005 (stores: [])
      --> Project
      <-- KTABLE-MAPVALUES-0000000004
    Processor: Project (stores: [])
      --> KTABLE-TOSTREAM-0000000007
      <-- KTABLE-TRANSFORMVALUES-0000000005
    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])
      --> KSTREAM-SINK-0000000008
      <-- Project
    Sink: KSTREAM-SINK-0000000008 (topic: TT)
      <-- KTABLE-TOSTREAM-0000000007
```

### Testing done 
Changed unit tests to expect new behavior

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

