### PR TITLE
feat: add shared runtime config to QueryPlan

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -472,7 +472,7 @@ final class EngineExecutor {
         Optional.empty(),
         plans.physicalPlan.getPhysicalPlan(),
         plans.physicalPlan.getQueryId(),
-        config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
+        getApplicationId()
     );
 
     engineContext.createQueryValidator().validateQuery(
@@ -557,7 +557,7 @@ final class EngineExecutor {
           outputNode.getSinkName(),
           plans.physicalPlan.getPhysicalPlan(),
           plans.physicalPlan.getQueryId(),
-          config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
+          getApplicationId()
       );
 
       engineContext.createQueryValidator().validateQuery(
@@ -576,6 +576,12 @@ final class EngineExecutor {
     } catch (final Exception e) {
       throw new KsqlStatementException(e.getMessage(), statement.getStatementText(), e);
     }
+  }
+
+  private String getApplicationId() {
+    return config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
+        ? "appId"
+        : "";
   }
 
   private ExecutorPlans planQuery(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -825,7 +825,7 @@ final class EngineExecutor {
         queryPlan.getPhysicalPlan(),
         buildPlanSummary(queryPlan.getQueryId(), queryPlan.getPhysicalPlan()),
         persistentQueryType,
-        queryPlan.usesSharedRuntime()
+        queryPlan.getRuntimeId()
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -471,7 +471,8 @@ final class EngineExecutor {
         getSourceNames(outputNode),
         Optional.empty(),
         plans.physicalPlan.getPhysicalPlan(),
-        plans.physicalPlan.getQueryId()
+        plans.physicalPlan.getQueryId(),
+        config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
     );
 
     engineContext.createQueryValidator().validateQuery(
@@ -555,7 +556,8 @@ final class EngineExecutor {
           getSourceNames(outputNode),
           outputNode.getSinkName(),
           plans.physicalPlan.getPhysicalPlan(),
-          plans.physicalPlan.getQueryId()
+          plans.physicalPlan.getQueryId(),
+          config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
       );
 
       engineContext.createQueryValidator().validateQuery(
@@ -816,7 +818,8 @@ final class EngineExecutor {
         getSources(queryPlan),
         queryPlan.getPhysicalPlan(),
         buildPlanSummary(queryPlan.getQueryId(), queryPlan.getPhysicalPlan()),
-        persistentQueryType
+        persistentQueryType,
+        queryPlan.usesSharedRuntime()
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -578,10 +578,10 @@ final class EngineExecutor {
     }
   }
 
-  private String getApplicationId() {
+  private Optional<String> getApplicationId() {
     return config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
-        ? "appId"
-        : "";
+        ? Optional.of("appId")
+        : Optional.empty();
   }
 
   private ExecutorPlans planQuery(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -33,14 +33,14 @@ public final class QueryPlan  {
   private final Optional<SourceName> sink;
   private final ExecutionStep<?> physicalPlan;
   private final QueryId queryId;
-  private final Optional<String> usesSharedRuntime;
+  private final Optional<String> runtimeId;
 
   public QueryPlan(
       @JsonProperty(value = "sources", required = true) final Set<SourceName> sources,
       @JsonProperty(value = "sink") final Optional<SourceName> sink,
       @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
       @JsonProperty(value = "queryId", required = true) final QueryId queryId,
-      @JsonProperty(value = "sharedRuntimes") final Optional<String> usesSharedRuntime
+      @JsonProperty(value = "runtimeId") final Optional<String> runtimeId
   ) {
     this.sources = ImmutableSortedSet.copyOf(
         Comparator.comparing(Name::text),
@@ -49,7 +49,7 @@ public final class QueryPlan  {
     this.sink = Objects.requireNonNull(sink, "sink");
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
     this.queryId = Objects.requireNonNull(queryId, "queryId");
-    this.usesSharedRuntime = Objects.requireNonNull(usesSharedRuntime, "consumerGroupId");
+    this.runtimeId = Objects.requireNonNull(runtimeId, "consumerGroupId");
   }
 
   public Optional<SourceName> getSink() {
@@ -69,8 +69,8 @@ public final class QueryPlan  {
     return queryId;
   }
 
-  public Optional<String> usesSharedRuntime() {
-    return usesSharedRuntime;
+  public Optional<String> getRuntimeId() {
+    return runtimeId;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -33,12 +33,14 @@ public final class QueryPlan  {
   private final Optional<SourceName> sink;
   private final ExecutionStep<?> physicalPlan;
   private final QueryId queryId;
+  private final boolean usesSharedRuntime;
 
   public QueryPlan(
       @JsonProperty(value = "sources", required = true) final Set<SourceName> sources,
       @JsonProperty(value = "sink") final Optional<SourceName> sink,
       @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
-      @JsonProperty(value = "queryId", required = true) final QueryId queryId
+      @JsonProperty(value = "queryId", required = true) final QueryId queryId,
+      @JsonProperty(value = "sharedRuntimes") final boolean usesSharedRuntime
   ) {
     this.sources = ImmutableSortedSet.copyOf(
         Comparator.comparing(Name::text),
@@ -47,6 +49,7 @@ public final class QueryPlan  {
     this.sink = Objects.requireNonNull(sink, "sink");
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
     this.queryId = Objects.requireNonNull(queryId, "queryId");
+    this.usesSharedRuntime = usesSharedRuntime;
   }
 
   public Optional<SourceName> getSink() {
@@ -64,6 +67,10 @@ public final class QueryPlan  {
 
   public QueryId getQueryId() {
     return queryId;
+  }
+
+  public boolean usesSharedRuntime() {
+    return usesSharedRuntime;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -40,7 +40,7 @@ public final class QueryPlan  {
       @JsonProperty(value = "sink") final Optional<SourceName> sink,
       @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
       @JsonProperty(value = "queryId", required = true) final QueryId queryId,
-      @JsonProperty(value = "sharedRuntimes") final String usesSharedRuntime
+      @JsonProperty(value = "sharedRuntimes") final Optional<String> usesSharedRuntime
   ) {
     this.sources = ImmutableSortedSet.copyOf(
         Comparator.comparing(Name::text),
@@ -49,25 +49,7 @@ public final class QueryPlan  {
     this.sink = Objects.requireNonNull(sink, "sink");
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
     this.queryId = Objects.requireNonNull(queryId, "queryId");
-    this.usesSharedRuntime = usesSharedRuntime.equals("")
-        ? Optional.of(usesSharedRuntime)
-        : Optional.empty();
-  }
-
-  public QueryPlan(
-      @JsonProperty(value = "sources", required = true) final Set<SourceName> sources,
-      @JsonProperty(value = "sink") final Optional<SourceName> sink,
-      @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
-      @JsonProperty(value = "queryId", required = true) final QueryId queryId
-  ) {
-    this.sources = ImmutableSortedSet.copyOf(
-        Comparator.comparing(Name::text),
-        Objects.requireNonNull(sources, "sources")
-    );
-    this.sink = Objects.requireNonNull(sink, "sink");
-    this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
-    this.queryId = Objects.requireNonNull(queryId, "queryId");
-    this.usesSharedRuntime = Optional.empty();
+    this.usesSharedRuntime = Objects.requireNonNull(usesSharedRuntime, "consumerGroupId");
   }
 
   public Optional<SourceName> getSink() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -52,6 +52,22 @@ public final class QueryPlan  {
     this.usesSharedRuntime = usesSharedRuntime;
   }
 
+  public QueryPlan(
+      @JsonProperty(value = "sources", required = true) final Set<SourceName> sources,
+      @JsonProperty(value = "sink") final Optional<SourceName> sink,
+      @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
+      @JsonProperty(value = "queryId", required = true) final QueryId queryId
+  ) {
+    this.sources = ImmutableSortedSet.copyOf(
+        Comparator.comparing(Name::text),
+        Objects.requireNonNull(sources, "sources")
+    );
+    this.sink = Objects.requireNonNull(sink, "sink");
+    this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+    this.usesSharedRuntime = false;
+  }
+
   public Optional<SourceName> getSink() {
     return sink;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -33,14 +33,14 @@ public final class QueryPlan  {
   private final Optional<SourceName> sink;
   private final ExecutionStep<?> physicalPlan;
   private final QueryId queryId;
-  private final boolean usesSharedRuntime;
+  private final Optional<String> usesSharedRuntime;
 
   public QueryPlan(
       @JsonProperty(value = "sources", required = true) final Set<SourceName> sources,
       @JsonProperty(value = "sink") final Optional<SourceName> sink,
       @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
       @JsonProperty(value = "queryId", required = true) final QueryId queryId,
-      @JsonProperty(value = "sharedRuntimes") final boolean usesSharedRuntime
+      @JsonProperty(value = "sharedRuntimes") final String usesSharedRuntime
   ) {
     this.sources = ImmutableSortedSet.copyOf(
         Comparator.comparing(Name::text),
@@ -49,7 +49,9 @@ public final class QueryPlan  {
     this.sink = Objects.requireNonNull(sink, "sink");
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
     this.queryId = Objects.requireNonNull(queryId, "queryId");
-    this.usesSharedRuntime = usesSharedRuntime;
+    this.usesSharedRuntime = usesSharedRuntime.equals("")
+        ? Optional.of(usesSharedRuntime)
+        : Optional.empty();
   }
 
   public QueryPlan(
@@ -65,7 +67,7 @@ public final class QueryPlan  {
     this.sink = Objects.requireNonNull(sink, "sink");
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
     this.queryId = Objects.requireNonNull(queryId, "queryId");
-    this.usesSharedRuntime = false;
+    this.usesSharedRuntime = Optional.empty();
   }
 
   public Optional<SourceName> getSink() {
@@ -85,7 +87,7 @@ public final class QueryPlan  {
     return queryId;
   }
 
-  public boolean usesSharedRuntime() {
+  public Optional<String> usesSharedRuntime() {
     return usesSharedRuntime;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
@@ -96,7 +96,8 @@ public interface QueryRegistry {
       Set<DataSource> sources,
       ExecutionStep<?> physicalPlan,
       String planSummary,
-      KsqlConstants.PersistentQueryType persistentQueryType
+      KsqlConstants.PersistentQueryType persistentQueryType,
+      boolean usesSharedRuntimes
   );
   // CHECKSTYLE_RULES.ON: ParameterNumberCheck
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
@@ -97,7 +97,7 @@ public interface QueryRegistry {
       ExecutionStep<?> physicalPlan,
       String planSummary,
       KsqlConstants.PersistentQueryType persistentQueryType,
-      boolean usesSharedRuntimes
+      Optional<String> usesSharedRuntimes
   );
   // CHECKSTYLE_RULES.ON: ParameterNumberCheck
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -192,7 +192,7 @@ public class QueryRegistryImpl implements QueryRegistry {
       final ExecutionStep<?> physicalPlan,
       final String planSummary,
       final KsqlConstants.PersistentQueryType persistentQueryType,
-      final Optional<String> usesSharedRuntimes) {
+      final Optional<String> runtimeId) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     final QueryExecutor executor = executorFactory.create(
           config,
@@ -206,7 +206,7 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     final PersistentQueryMetadata query;
 
-    if (usesSharedRuntimes.isPresent()) {
+    if (runtimeId.isPresent()) {
       query = executor.buildPersistentQueryInSharedRuntime(
           ksqlConfig,
           persistentQueryType,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -192,7 +192,7 @@ public class QueryRegistryImpl implements QueryRegistry {
       final ExecutionStep<?> physicalPlan,
       final String planSummary,
       final KsqlConstants.PersistentQueryType persistentQueryType,
-      final boolean usesSharedRuntimes) {
+      final Optional<String> usesSharedRuntimes) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     final QueryExecutor executor = executorFactory.create(
           config,
@@ -206,7 +206,7 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     final PersistentQueryMetadata query;
 
-    if (usesSharedRuntimes) {
+    if (usesSharedRuntimes.isPresent()) {
       query = executor.buildPersistentQueryInSharedRuntime(
           ksqlConfig,
           persistentQueryType,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -191,7 +191,8 @@ public class QueryRegistryImpl implements QueryRegistry {
       final Set<DataSource> sources,
       final ExecutionStep<?> physicalPlan,
       final String planSummary,
-      final KsqlConstants.PersistentQueryType persistentQueryType) {
+      final KsqlConstants.PersistentQueryType persistentQueryType,
+      final boolean usesSharedRuntimes) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     final QueryExecutor executor = executorFactory.create(
           config,
@@ -205,7 +206,7 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     final PersistentQueryMetadata query;
 
-    if (ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+    if (usesSharedRuntimes) {
       query = executor.buildPersistentQueryInSharedRuntime(
           ksqlConfig,
           persistentQueryType,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryPlanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryPlanTest.java
@@ -58,12 +58,12 @@ public class QueryPlanTest {
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new QueryPlan(sources1, Optional.of(sink1), plan1, id1),
-            new QueryPlan(sources1, Optional.of(sink1), plan1, id1))
-        .addEqualityGroup(new QueryPlan(sources2, Optional.of(sink1), plan1, id1))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink2), plan1, id1))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan2, id1))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan1, id2))
+            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, true),
+            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, true))
+        .addEqualityGroup(new QueryPlan(sources2, Optional.of(sink1), plan1, id1, true))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink2), plan1, id1, true))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan2, id1, true))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan1, id2, true))
         .testEquals();
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryPlanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryPlanTest.java
@@ -58,12 +58,12 @@ public class QueryPlanTest {
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, true),
-            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, true))
-        .addEqualityGroup(new QueryPlan(sources2, Optional.of(sink1), plan1, id1, true))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink2), plan1, id1, true))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan2, id1, true))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan1, id2, true))
+            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, ""),
+            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, ""))
+        .addEqualityGroup(new QueryPlan(sources2, Optional.of(sink1), plan1, id1, ""))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink2), plan1, id1, ""))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan2, id1, ""))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan1, id2, ""))
         .testEquals();
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryPlanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/QueryPlanTest.java
@@ -58,12 +58,12 @@ public class QueryPlanTest {
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, ""),
-            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, ""))
-        .addEqualityGroup(new QueryPlan(sources2, Optional.of(sink1), plan1, id1, ""))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink2), plan1, id1, ""))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan2, id1, ""))
-        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan1, id2, ""))
+            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, Optional.empty()),
+            new QueryPlan(sources1, Optional.of(sink1), plan1, id1, Optional.empty()))
+        .addEqualityGroup(new QueryPlan(sources2, Optional.of(sink1), plan1, id1, Optional.empty()))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink2), plan1, id1, Optional.empty()))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan2, id1, Optional.empty()))
+        .addEqualityGroup(new QueryPlan(sources1, Optional.of(sink1), plan1, id2, Optional.empty()))
         .testEquals();
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -128,6 +128,15 @@ public class QueryRegistryImplTest {
   }
 
   @Test
+  public void shouldNotUseGlobalConfigIfQueryPlanOverrides() {
+    // Given:
+    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(!sharedRuntimes);
+    QueryMetadata query = givenCreate(registry, "q1", "source", Optional.of("sink"), CREATE_AS);
+
+    verify(listener1).onCreate(serviceContext, metaStore, query);
+  }
+
+  @Test
   public void shouldGetAllLiveQueriesSandbox() {
     // Given:
     givenCreate(registry, "q1", "source", Optional.of("sink"), CREATE_AS);
@@ -506,7 +515,6 @@ public class QueryRegistryImplTest {
       ).thenReturn(query);
     }
     when(config.getConfig(true)).thenReturn(ksqlConfig);
-    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(sharedRuntimes);
     registry.createOrReplacePersistentQuery(
         config,
         serviceContext,
@@ -519,7 +527,7 @@ public class QueryRegistryImplTest {
         mock(ExecutionStep.class),
         "plan-summary",
         persistentQueryType,
-        true
+        sharedRuntimes
     );
     return query;
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -518,7 +518,8 @@ public class QueryRegistryImplTest {
         ImmutableSet.of(toSource(source)),
         mock(ExecutionStep.class),
         "plan-summary",
-        persistentQueryType
+        persistentQueryType,
+        true
     );
     return query;
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -527,7 +527,7 @@ public class QueryRegistryImplTest {
         mock(ExecutionStep.class),
         "plan-summary",
         persistentQueryType,
-        sharedRuntimes
+        sharedRuntimes ? Optional.of("applicationId") : Optional.empty()
     );
     return query;
   }

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -287,7 +287,7 @@
         "queryId" : {
           "type" : "string"
         },
-        "consumerGroupId" : {
+        "runtimeId" : {
           "type" : "string"
         }
       },

--- a/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksqldb-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -286,6 +286,9 @@
         },
         "queryId" : {
           "type" : "string"
+        },
+        "consumerGroupId" : {
+          "type" : "string"
         }
       },
       "required" : [ "sources", "physicalPlan", "queryId" ]


### PR DESCRIPTION
Make it so the config value for shared runtimes are enabled is written into the cmd topic so it is specific to when each query was launched 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

