### PR TITLE
chore: resolve ambiguous method reference

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -109,7 +110,7 @@ public class KafkaTopicClientImplTest {
     topicConfigs.clear();
 
     when(adminClient.listTopics()).thenAnswer(listTopicResult());
-    when(adminClient.describeTopics(any(), any())).thenAnswer(describeTopicsResult());
+    when(adminClient.describeTopics(anyCollection(), any())).thenAnswer(describeTopicsResult());
     when(adminClient.createTopics(any(), any())).thenAnswer(createTopicsResult());
     when(adminClient.deleteTopics(any(Collection.class))).thenAnswer(deleteTopicsResult());
     when(adminClient.describeConfigs(any())).thenAnswer(describeConfigsResult());
@@ -193,7 +194,7 @@ public class KafkaTopicClientImplTest {
     // Given:
     givenTopicExists("topicName", 1, 2);
 
-    when(adminClient.describeTopics(any(), any()))
+    when(adminClient.describeTopics(anyCollection(), any()))
         .thenAnswer(describeTopicsResult()) // checks that topic exists
         .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh"))) // fails during validateProperties
         .thenAnswer(describeTopicsResult()); // succeeds the third time
@@ -202,7 +203,7 @@ public class KafkaTopicClientImplTest {
     kafkaTopicClient.createTopic("topicName", 1, (short) 2);
 
     // Then:
-    verify(adminClient, times(3)).describeTopics(any(), any());
+    verify(adminClient, times(3)).describeTopics(anyCollection(), any());
   }
 
   @Test
@@ -279,7 +280,7 @@ public class KafkaTopicClientImplTest {
     // Given:
     givenTopicExists("topicName", 1, 2);
 
-    when(adminClient.describeTopics(any(), any()))
+    when(adminClient.describeTopics(anyCollection(), any()))
         .thenAnswer(describeTopicsResult()) // checks that topic exists
         .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh"))) // fails during validateProperties
         .thenAnswer(describeTopicsResult()); // succeeds the third time
@@ -288,13 +289,13 @@ public class KafkaTopicClientImplTest {
     kafkaTopicClient.validateCreateTopic("topicName", 1, (short) 2);
 
     // Then:
-    verify(adminClient, times(3)).describeTopics(any(), any());
+    verify(adminClient, times(3)).describeTopics(anyCollection(), any());
   }
 
   @Test
   public void shouldThrowOnDescribeTopicsWhenRetriesExpire() {
     // Given:
-    when(adminClient.describeTopics(any(), any()))
+    when(adminClient.describeTopics(anyCollection(), any()))
         .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh")))
         .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh")))
         .thenAnswer(describeTopicsResult(new UnknownTopicOrPartitionException("meh")))
@@ -311,7 +312,7 @@ public class KafkaTopicClientImplTest {
   @Test
   public void shouldThrowOnDescribeOnTopicAuthorizationException() {
     // Given:
-    when(adminClient.describeTopics(any(), any()))
+    when(adminClient.describeTopics(anyCollection(), any()))
         .thenAnswer(describeTopicsResult(new TopicAuthorizationException("meh")));
 
     // When:
@@ -810,7 +811,7 @@ public class KafkaTopicClientImplTest {
     kafkaTopicClient.isTopicExists("foobar");
 
     // Then
-    verify(adminClient, times(1)).describeTopics(any(), any());
+    verify(adminClient, times(1)).describeTopics(anyCollection(), any());
   }
 
   @Test


### PR DESCRIPTION
In the jenkins job that builds ksql off the latest kafka, there were failures due to ambiguous method reference. In AK PR [#9769](https://github.com/apache/kafka/pull/9769), a new `DescribeTopics` method was added to `Admin.java`. This made our `KafkaClientTopicImpl` test fail because we mocked with `any()` in the `DescribeTopics` method call, which now map sto two methods -> `describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions)` and
`describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions)`

This PR specifies that we should be looking for a `Collection`. 

The test errors were:
`[2021-08-29T16:07:40.085Z] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project ksqldb-engine: Compilation failure: Compilation failure: 
[2021-08-29T16:07:40.085Z] [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java:[112,21] reference to describeTopics is ambiguous
[2021-08-29T16:07:40.085Z] [ERROR]   both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
[2021-08-29T16:07:40.085Z] [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java:[196,21] reference to describeTopics is ambiguous
[2021-08-29T16:07:40.086Z] [ERROR]   both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
[2021-08-29T16:07:40.086Z] [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java:[205,34] reference to describeTopics is ambiguous
[2021-08-29T16:07:40.086Z] [ERROR]   both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
[2021-08-29T16:07:40.086Z] [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java:[282,21] reference to describeTopics is ambiguous
[2021-08-29T16:07:40.086Z] [ERROR]   both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
[2021-08-29T16:07:40.086Z] [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java:[291,34] reference to describeTopics is ambiguous
[2021-08-29T16:07:40.086Z] [ERROR]   both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
[2021-08-29T16:07:40.086Z] [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java:[297,21] reference to describeTopics is ambiguous
[2021-08-29T16:07:40.086Z] [ERROR]   both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
[2021-08-29T16:07:40.086Z] [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java:[314,21] reference to describeTopics is ambiguous
[2021-08-29T16:07:40.086Z] [ERROR]   both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
[2021-08-29T16:07:40.086Z] [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java:[813,34] reference to describeTopics is ambiguous
[2021-08-29T16:07:40.086Z] [ERROR]   both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match`