### PR TITLE
test: add QTT tests for CST commands

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -504,20 +504,22 @@ public class TestExecutor implements Closeable {
             producedRecord.value(),
             producedRecord.timestamp());
 
-    final String sinkTopicName = testDriver.getSinkTopicName();
-    final TestOutputTopic<byte[], byte[]> sinkTopic = testDriver.getSinkTopic(sinkTopicName);
+    testDriver.getSinkTopicName().ifPresent(topicName -> {
+      final String sinkTopicName = topicName;
+      final TestOutputTopic<byte[], byte[]> sinkTopic = testDriver.getSinkTopic(sinkTopicName);
 
-    processRecordsForTopic(sinkTopic, sinkTopicName);
+      processRecordsForTopic(sinkTopic, sinkTopicName);
 
-    for (final Topic possibleSinkTopic : possibleSinkTopics) {
-      if (possibleSinkTopic.getName().equals(sinkTopicName)) {
-        continue;
+      for (final Topic possibleSinkTopic : possibleSinkTopics) {
+        if (possibleSinkTopic.getName().equals(sinkTopicName)) {
+          continue;
+        }
+        processRecordsForTopic(
+            testDriver.getSinkTopic(possibleSinkTopic.getName()),
+            possibleSinkTopic.getName()
+        );
       }
-      processRecordsForTopic(
-          testDriver.getSinkTopic(possibleSinkTopic.getName()),
-          possibleSinkTopic.getName()
-      );
-    }
+    });
   }
 
   private void processRecordsForTopic(

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -129,12 +129,12 @@ public final class TestExecutorUtil {
           })
           .collect(Collectors.toList());
 
-      // Sink may be Optional for source tables. Once source table query execution is supported,
-      // then we would need have a condition to not create a sink topic info
-      final Topic sinkTopic = buildSinkTopic(
-          ksqlEngine.getMetaStore().getSource(persistentQueryMetadata.getSinkName().get()),
-          stubKafkaService,
-          serviceContext.getSchemaRegistryClient());
+      final Optional<Topic> sinkTopic = persistentQueryMetadata.getSinkName()
+          .map(name -> buildSinkTopic(
+              ksqlEngine.getMetaStore().getSource(name),
+              stubKafkaService,
+              serviceContext.getSchemaRegistryClient()));
+
       testCase.setGeneratedTopologies(
           ImmutableList.of(persistentQueryMetadata.getTopologyDescription()));
       testCase.setGeneratedSchemas(persistentQueryMetadata.getQuerySchemas().getLoggerSchemaInfo());

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopologyTestDriverContainer.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopologyTestDriverContainer.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.util.Pair;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -33,13 +34,13 @@ public final class TopologyTestDriverContainer {
 
   private final TopologyTestDriver topologyTestDriver;
   private final Map<String, TestInputTopic<byte[], byte[]>> sourceTopics;
-  private final String sinkTopicName;
+  private final Optional<String> sinkTopicName;
   private final Map<String, TestOutputTopic<byte[], byte[]>> sinkTopics = new HashMap<>();
 
   public static TopologyTestDriverContainer of(
       final TopologyTestDriver topologyTestDriver,
       final List<Topic> sourceTopics,
-      final Topic sinkTopic
+      final Optional<Topic> sinkTopic
   ) {
     return new TopologyTestDriverContainer(
         topologyTestDriver,
@@ -51,7 +52,7 @@ public final class TopologyTestDriverContainer {
   private TopologyTestDriverContainer(
       final TopologyTestDriver topologyTestDriver,
       final List<Topic> sourceTopics,
-      final Topic sinkTopic
+      final Optional<Topic> sinkTopic
   ) {
     this.topologyTestDriver = requireNonNull(topologyTestDriver, "topologyTestDriver");
     requireNonNull(sourceTopics, "sourceTopics");
@@ -66,15 +67,16 @@ public final class TopologyTestDriverContainer {
             )
         )
         .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
-    sinkTopicName = requireNonNull(sinkTopic, "sinkTopic").getName();
-    sinkTopics.put(
-        sinkTopicName,
+
+    sinkTopicName = requireNonNull(sinkTopic, "sinkTopic").map(Topic::getName);
+    sinkTopicName.ifPresent(topicName -> sinkTopics.put(
+        topicName,
         topologyTestDriver.createOutputTopic(
-            sinkTopicName,
+            topicName,
             new ByteArrayDeserializer(),
             new ByteArrayDeserializer()
         )
-    );
+    ));
   }
 
   TopologyTestDriver getTopologyTestDriver() {
@@ -96,7 +98,7 @@ public final class TopologyTestDriverContainer {
     );
   }
 
-  public String getSinkTopicName() {
+  public Optional<String> getSinkTopicName() {
     return sinkTopicName;
   }
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -139,7 +139,6 @@ public class RestQueryTranslationTest {
 
   @After
   public void tearDown() {
-    REST_APP.closePersistentQueries();
     REST_APP.dropSourcesExcept();
     TEST_HARNESS.getKafkaCluster().deleteAllTopics(TestKsqlRestApp.getCommandTopicName());
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -141,7 +141,7 @@ public class TestExecutorTest {
     final TopologyTestDriverContainer container = TopologyTestDriverContainer.of(
         topologyTestDriver,
         ImmutableList.of(sourceTopic),
-        sinkTopic
+        Optional.of(sinkTopic)
     );
 
     when(topologyTestDriver.producedTopicNames()).thenReturn(ImmutableSet.of(SINK_TOPIC_NAME));

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
@@ -136,7 +136,7 @@ public class TestExecutorUtilTest {
     assertThat(topologyTestDriverContainer.getSourceTopicNames().size(), equalTo(1));
     assertThat(topologyTestDriverContainer.getSourceTopicNames().iterator().next(),
         equalTo("test_topic"));
-    assertThat(topologyTestDriverContainer.getSinkTopicName(), equalTo("S1"));
+    assertThat(topologyTestDriverContainer.getSinkTopicName(), equalTo(Optional.of("S1")));
     assertThat(topologyTestDriverContainer.getTopologyTestDriver(), notNullValue());
   }
 

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/source-table_-_create_source_table/7.1.0_1630345391687/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/source-table_-_create_source_table/7.1.0_1630345391687/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE SOURCE TABLE INPUT (K INTEGER PRIMARY KEY, TEXT STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='DELIMITED');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K` INTEGER KEY, `TEXT` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : true
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "physicalPlan" : {
+        "@type" : "tableSelectV1",
+        "properties" : {
+          "queryContext" : "Project"
+        },
+        "source" : {
+          "@type" : "tableSourceV1",
+          "properties" : {
+            "queryContext" : "KsqlTopic/Source"
+          },
+          "topicName" : "test_topic",
+          "formats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "DELIMITED"
+            }
+          },
+          "sourceSchema" : "`K` INTEGER KEY, `TEXT` STRING",
+          "forceChangelog" : true
+        },
+        "keyColumnNames" : [ "K" ],
+        "selectExpressions" : [ "TEXT AS TEXT" ],
+        "internalFormats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        }
+      },
+      "queryId" : "CST_INPUT_0"
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` INTEGER KEY, `TEXT` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "DELIMITED"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "tableSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "DELIMITED"
+              }
+            },
+            "sourceSchema" : "`K` INTEGER KEY, `TEXT` STRING",
+            "forceChangelog" : true
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "TEXT AS TEXT" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "DELIMITED"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_1"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/source-table_-_create_source_table/7.1.0_1630345391687/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/source-table_-_create_source_table/7.1.0_1630345391687/spec.json
@@ -1,0 +1,139 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630345391687,
+  "path" : "query-validation-tests/source-table.json",
+  "schemas" : {
+    "CTAS_OUTPUT_1.KsqlTopic.Source" : {
+      "schema" : "`K` INTEGER KEY, `TEXT` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CTAS_OUTPUT_1.OUTPUT" : {
+      "schema" : "`K` INTEGER KEY, `TEXT` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    },
+    "CTAS_OUTPUT_1.Project" : {
+      "schema" : "`K` INTEGER KEY, `TEXT` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "DELIMITED"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "create source table",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : "a1"
+    }, {
+      "topic" : "test_topic",
+      "key" : 2,
+      "value" : "a2"
+    }, {
+      "topic" : "test_topic",
+      "key" : 3,
+      "value" : "a3"
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : "a1"
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : "a2"
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : "a3"
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');", "CREATE TABLE OUTPUT AS SELECT * FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "TABLE",
+        "schema" : "`K` INTEGER KEY, `TEXT` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : true
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`K` INTEGER KEY, `TEXT` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "DELIMITED",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CST_INPUT_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_1-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "DELIMITED"
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/source-table_-_create_source_table/7.1.0_1630345391687/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/source-table_-_create_source_table/7.1.0_1630345391687/topology
@@ -1,0 +1,22 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Project
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-table.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-table.json
@@ -1,0 +1,71 @@
+{
+  "tests": [
+    {
+      "name": "create source table",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": "a1"},
+        {"topic": "test_topic", "key": 2, "value": "a2"},
+        {"topic": "test_topic", "key": 3, "value": "a3"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": "a1"},
+        {"topic": "OUTPUT", "key": 2, "value": "a2"},
+        {"topic": "OUTPUT", "key": 3, "value": "a3"}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "INPUT",
+            "type": "table",
+            "schema": "K INT PRIMARY KEY, TEXT STRING",
+            "isSource": true
+          },
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "schema": "K INT PRIMARY KEY, TEXT STRING",
+            "isSource": false
+          }
+        ]
+      }
+    },
+    {
+      "name": "rejects INSERT VALUES statements for source streams",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "INSERT INTO INPUT VALUES (1, 'b');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot insert values into read-only table: INPUT"
+      }
+    },
+    {
+      "name": "rejects INSERT INTO ... SELECT statements for source tables",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE SOURCE TABLE INPUT2 (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "INSERT INTO INPUT SELECT * FROM INPUT2;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "INSERT INTO can only be used to insert into a stream. INPUT is a table."
+      }
+    },
+    {
+      "name": "rejects DROP ... DELETE TOPIC statements for source tables",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "DROP TABLE INPUT DELETE TOPIC;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot delete topic for read-only source: INPUT"
+      }
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-cst-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-cst-materialized.json
@@ -1,0 +1,73 @@
+{
+  "comments": [
+    "Tests covering Pull queries of materialized using CST tables"
+  ],
+  "tests": [
+    {
+      "name": "select * against CST table",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 1, "value": "a1"},
+        {"topic": "test_topic", "timestamp": 12345, "key": 2, "value": "a2"},
+        {"topic": "test_topic", "timestamp": 12345, "key": 3, "value": "a3"}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER KEY, `TEXT` STRING"}},
+          {"row":{"columns":[1,"a1"]}},
+          {"row":{"columns":[2,"a2"]}},
+          {"row":{"columns":[3,"a3"]}}
+        ]}
+      ]
+    },
+    {
+      "name": "select * against CST table and filter by key",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "SELECT * FROM INPUT WHERE K=2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 1, "value": "a1"},
+        {"topic": "test_topic", "timestamp": 12345, "key": 2, "value": "a2"},
+        {"topic": "test_topic", "timestamp": 12345, "key": 3, "value": "a3"}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER KEY, `TEXT` STRING"}},
+          {"row":{"columns":[2,"a2"]}}
+        ]}
+      ]
+    },
+    {
+      "name": "select with projection table scan and key lookup",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "SELECT K, TEXT FROM INPUT;",
+        "SELECT K, TEXT FROM INPUT WHERE K=2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 1, "value": "a1"},
+        {"topic": "test_topic", "timestamp": 12345, "key": 2, "value": "a2"},
+        {"topic": "test_topic", "timestamp": 12345, "key": 3, "value": "a3"}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER KEY, `TEXT` STRING"}},
+          {"row":{"columns":[1,"a1"]}},
+          {"row":{"columns":[2,"a2"]}},
+          {"row":{"columns":[3,"a3"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER KEY, `TEXT` STRING"}},
+          {"row":{"columns":[2,"a2"]}}
+        ]}
+      ]
+    }
+  ]
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -418,26 +418,35 @@ public final class RestIntegrationTestUtil {
       final TestDataProvider dataProvider,
       final Optional<BasicCredentials> userCreds
   ) {
-    createSource(restApp, dataProvider, false, userCreds);
+    createSource(restApp, dataProvider, false,false, userCreds);
   }
 
   public static void createTable(
       final TestKsqlRestApp restApp,
       final TestDataProvider dataProvider
   ) {
-    createSource(restApp, dataProvider, true, Optional.empty());
+    createSource(restApp, dataProvider, false, true, Optional.empty());
+  }
+
+  public static void createTable(
+      final TestKsqlRestApp restApp,
+      final TestDataProvider dataProvider,
+      final boolean isSource
+  ) {
+    createSource(restApp, dataProvider, isSource,true, Optional.empty());
   }
 
   public static void createSource(
       final TestKsqlRestApp restApp,
       final TestDataProvider dataProvider,
+      final boolean isSource,
       final boolean table,
       final Optional<BasicCredentials> userCreds
   ) {
     makeKsqlRequest(
         restApp,
-        "CREATE " + (table ? "TABLE" : "STREAM") + " " + dataProvider.sourceName()
-            + " (" + dataProvider.ksqlSchemaString(table) + ") "
+        "CREATE " + (isSource ? "SOURCE " : "") + (table ? "TABLE" : "STREAM") + " "
+            + dataProvider.sourceName() + " (" + dataProvider.ksqlSchemaString(table) + ") "
             + "WITH (kafka_topic='" + dataProvider.topicName() + "', value_format='json');",
         userCreds
     );

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.rest.integration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.fail;
 
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
@@ -31,6 +33,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import io.confluent.ksql.util.UserDataProvider;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -47,8 +50,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class TerminateTransientQueryFunctionalTest {
 
   private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
+  private static final UserDataProvider USER_DATA_PROVIDER = new UserDataProvider();
+
   private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
   private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.sourceName();
+
+  private static final String USER_TOPIC = USER_DATA_PROVIDER.topicName();
+  private static final String USER_TABLE = USER_DATA_PROVIDER.sourceName();
+
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
   private static final TestKsqlRestApp REST_APP_0 = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
@@ -89,6 +98,31 @@ public class TerminateTransientQueryFunctionalTest {
   @AfterClass
   public static void tearDownClass() {
     service.shutdownNow();
+  }
+
+  @Test
+  public void shouldFailOnTerminateSourceTableQuery() {
+    // Given
+    TEST_HARNESS.ensureTopics(USER_TOPIC);
+    RestIntegrationTestUtil.createTable(REST_APP_0, USER_DATA_PROVIDER, true);
+    final String persistentQueryId = getPersistentQueryIds().stream()
+        .filter(n -> n.contains("CST_" + USER_TABLE))
+        .collect(Collectors.toList())
+        .get(0);
+
+    // When:
+    try {
+      RestIntegrationTestUtil.makeKsqlRequest(
+          REST_APP_0,
+          "terminate " + persistentQueryId + ";"
+      );
+
+      fail("CST queries cannot be terminated manually.");
+    } catch (final AssertionError e) {
+      // Then:
+      assertThat(e.getMessage(), containsString("Cannot terminate query " +
+          "'" + persistentQueryId + "' because it is linked to a source table."));
+    }
   }
 
   @Test
@@ -144,6 +178,12 @@ public class TerminateTransientQueryFunctionalTest {
   public List<String> getTransientQueryIds () {
     return showQueries().stream()
         .filter(q -> q.getId().toString().contains("transient"))
+        .map(q -> q.getId().toString())
+        .collect(Collectors.toList());
+  }
+
+  public List<String> getPersistentQueryIds () {
+    return showQueries().stream()
         .map(q -> q.getId().toString())
         .collect(Collectors.toList());
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
@@ -82,8 +82,9 @@ public class TerminateTransientQueryFunctionalTest {
       .around(REST_APP_1);
   @BeforeClass
   public static void setUpClass() {
-    TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
+    TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC, USER_TOPIC);
     RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
+    RestIntegrationTestUtil.createTable(REST_APP_0, USER_DATA_PROVIDER, true);
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP_0,
         "CREATE STREAM S AS SELECT * FROM " + PAGE_VIEW_STREAM + ";"
@@ -103,9 +104,8 @@ public class TerminateTransientQueryFunctionalTest {
   @Test
   public void shouldFailOnTerminateSourceTableQuery() {
     // Given
-    TEST_HARNESS.ensureTopics(USER_TOPIC);
-    RestIntegrationTestUtil.createTable(REST_APP_0, USER_DATA_PROVIDER, true);
-    final String persistentQueryId = getPersistentQueryIds().stream()
+    final String persistentQueryId = getPersistentQueryIds()
+        .stream()
         .filter(n -> n.contains("CST_" + USER_TABLE))
         .collect(Collectors.toList())
         .get(0);
@@ -184,6 +184,7 @@ public class TerminateTransientQueryFunctionalTest {
 
   public List<String> getPersistentQueryIds () {
     return showQueries().stream()
+        .filter(q -> !q.getId().toString().contains("transient"))
         .map(q -> q.getId().toString())
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
### Description 
Added QTT tests for source tables and RQTT to test pull queries on materialized CST tables. The PR also tests that TERMINATE cannot be executed on CST tables.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

