### PR TITLE
fix: add new types to udaf functions

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
@@ -72,7 +72,8 @@ public final class CollectListUdaf {
   }
 
   @UdafFactory(description = "collect values of a Timestamp field into a single Array")
-  public static TableUdaf<Timestamp, List<Timestamp>, List<Timestamp>> createCollectListTimestamp() {
+  public static TableUdaf<Timestamp, List<Timestamp>, List<Timestamp>>
+  createCollectListTimestamp() {
     return new Collect<>();
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
@@ -73,7 +73,7 @@ public final class CollectListUdaf {
 
   @UdafFactory(description = "collect values of a Timestamp field into a single Array")
   public static TableUdaf<Timestamp, List<Timestamp>, List<Timestamp>>
-  createCollectListTimestamp() {
+      createCollectListTimestamp() {
     return new Collect<>();
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
@@ -20,6 +20,10 @@ import io.confluent.ksql.function.udaf.TableUdaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
 import io.confluent.ksql.function.udaf.UdafFactory;
 import io.confluent.ksql.util.KsqlConstants;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.Configurable;
@@ -64,6 +68,26 @@ public final class CollectListUdaf {
 
   @UdafFactory(description = "collect values of a Boolean field into a single Array")
   public static TableUdaf<Boolean, List<Boolean>, List<Boolean>> createCollectListBool() {
+    return new Collect<>();
+  }
+
+  @UdafFactory(description = "collect values of a Timestamp field into a single Array")
+  public static TableUdaf<Timestamp, List<Timestamp>, List<Timestamp>> createCollectListTimestamp() {
+    return new Collect<>();
+  }
+
+  @UdafFactory(description = "collect values of a Time field into a single Array")
+  public static TableUdaf<Time, List<Time>, List<Time>> createCollectListTime() {
+    return new Collect<>();
+  }
+
+  @UdafFactory(description = "collect values of a Date field into a single Array")
+  public static TableUdaf<Date, List<Date>, List<Date>> createCollectListDate() {
+    return new Collect<>();
+  }
+
+  @UdafFactory(description = "collect values of a Bytes field into a single Array")
+  public static TableUdaf<ByteBuffer, List<ByteBuffer>, List<ByteBuffer>> createCollectListBytes() {
     return new Collect<>();
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectSetUdaf.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectSetUdaf.java
@@ -20,6 +20,10 @@ import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
 import io.confluent.ksql.function.udaf.UdafFactory;
 import io.confluent.ksql.util.KsqlConstants;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.Configurable;
@@ -62,6 +66,26 @@ public final class CollectSetUdaf {
 
   @UdafFactory(description = "collect distinct values of a Boolean field into a single Array")
   public static Udaf<Boolean, List<Boolean>, List<Boolean>> createCollectSetBool() {
+    return new Collect<>();
+  }
+
+  @UdafFactory(description = "collect distinct values of a Timestamp field into a single Array")
+  public static Udaf<Timestamp, List<Timestamp>, List<Timestamp>> createCollectSetTimestamp() {
+    return new Collect<>();
+  }
+
+  @UdafFactory(description = "collect distinct values of a Time field into a single Array")
+  public static Udaf<Time, List<Time>, List<Time>> createCollectSetTime() {
+    return new Collect<>();
+  }
+
+  @UdafFactory(description = "collect distinct values of a Date field into a single Array")
+  public static Udaf<Date, List<Date>, List<Date>> createCollectSetDate() {
+    return new Collect<>();
+  }
+
+  @UdafFactory(description = "collect distinct values of a Bytes field into a single Array")
+  public static Udaf<ByteBuffer, List<ByteBuffer>, List<ByteBuffer>> createCollectSetBytes() {
     return new Collect<>();
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/EarliestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/EarliestByOffset.java
@@ -17,10 +17,14 @@ package io.confluent.ksql.function.udaf.offset;
 
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.INTERMEDIATE_STRUCT_COMPARATOR;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_BOOLEAN;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_BYTES;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_DATE;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_DOUBLE;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_INTEGER;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_LONG;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_STRING;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_TIME;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_TIMESTAMP;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.VAL_FIELD;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -29,6 +33,10 @@ import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
 import io.confluent.ksql.function.udaf.UdafFactory;
 import io.confluent.ksql.util.KsqlConstants;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -184,6 +192,114 @@ public final class EarliestByOffset {
       final boolean ignoreNulls
   ) {
     return earliestN(STRUCT_STRING, earliestN, ignoreNulls);
+  }
+
+  @UdafFactory(description = "return the earliest value of a timestamp column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL TIMESTAMP>")
+  public static Udaf<Timestamp, Struct, Timestamp> earliestTimestamp() {
+    return earliestTimestamp(true);
+  }
+
+  @UdafFactory(description = "return the earliest value of a timestamp column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL TIMESTAMP>")
+  public static Udaf<Timestamp, Struct, Timestamp> earliestTimestamp(final boolean ignoreNulls) {
+    return earliest(STRUCT_TIMESTAMP, ignoreNulls);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a timestamp column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIMESTAMP>>")
+  public static Udaf<Timestamp, List<Struct>, List<Timestamp>> earliestTimestamps(final int earliestN) {
+    return earliestTimestamps(earliestN, true);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a timestamp column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIMESTAMP>>")
+  public static Udaf<Timestamp, List<Struct>, List<Timestamp>> earliestTimestamps(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_TIMESTAMP, earliestN, ignoreNulls);
+  }
+
+  @UdafFactory(description = "return the earliest value of a time column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL TIME>")
+  public static Udaf<Time, Struct, Time> earliestTime() {
+    return earliestTime(true);
+  }
+
+  @UdafFactory(description = "return the earliest value of a time column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL TIME>")
+  public static Udaf<Time, Struct, Time> earliestTime(final boolean ignoreNulls) {
+    return earliest(STRUCT_TIME, ignoreNulls);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a time column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIME>>")
+  public static Udaf<Time, List<Struct>, List<Time>> earliestTimes(final int earliestN) {
+    return earliestTimes(earliestN, true);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a time column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIME>>")
+  public static Udaf<Time, List<Struct>, List<Time>> earliestTimes(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_TIME, earliestN, ignoreNulls);
+  }
+
+  @UdafFactory(description = "return the earliest value of a date column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL DATE>")
+  public static Udaf<Date, Struct, Date> earliestDate() {
+    return earliestDate(true);
+  }
+
+  @UdafFactory(description = "return the earliest value of a date column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL DATE>")
+  public static Udaf<Date, Struct, Date> earliestDate(final boolean ignoreNulls) {
+    return earliest(STRUCT_DATE, ignoreNulls);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a date column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DATE>>")
+  public static Udaf<Date, List<Struct>, List<Date>> earliestDates(final int earliestN) {
+    return earliestDates(earliestN, true);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a date column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DATE>>")
+  public static Udaf<Date, List<Struct>, List<Date>> earliestDates(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_DATE, earliestN, ignoreNulls);
+  }
+
+  @UdafFactory(description = "return the earliest value of a bytes column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BYTES>")
+  public static Udaf<ByteBuffer, Struct, ByteBuffer> earliestBytes() {
+    return earliestBytes(true);
+  }
+
+  @UdafFactory(description = "return the earliest value of a bytes column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BYTES>")
+  public static Udaf<ByteBuffer, Struct, ByteBuffer> earliestBytes(final boolean ignoreNulls) {
+    return earliest(STRUCT_BYTES, ignoreNulls);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a bytes column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BYTES>>")
+  public static Udaf<ByteBuffer, List<Struct>, List<ByteBuffer>> earliestBytes(final int earliestN) {
+    return earliestBytes(earliestN, true);
+  }
+
+  @UdafFactory(description = "return the earliest N values of a bytes column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BYTES>>")
+  public static Udaf<ByteBuffer, List<Struct>, List<ByteBuffer>> earliestBytes(
+      final int earliestN,
+      final boolean ignoreNulls
+  ) {
+    return earliestN(STRUCT_BYTES, earliestN, ignoreNulls);
   }
 
   @VisibleForTesting

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/EarliestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/EarliestByOffset.java
@@ -208,7 +208,8 @@ public final class EarliestByOffset {
 
   @UdafFactory(description = "return the earliest N values of a timestamp column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIMESTAMP>>")
-  public static Udaf<Timestamp, List<Struct>, List<Timestamp>> earliestTimestamps(final int earliestN) {
+  public static Udaf<Timestamp, List<Struct>, List<Timestamp>> earliestTimestamps(
+      final int earliestN) {
     return earliestTimestamps(earliestN, true);
   }
 
@@ -289,7 +290,8 @@ public final class EarliestByOffset {
 
   @UdafFactory(description = "return the earliest N values of a bytes column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BYTES>>")
-  public static Udaf<ByteBuffer, List<Struct>, List<ByteBuffer>> earliestBytes(final int earliestN) {
+  public static Udaf<ByteBuffer, List<Struct>, List<ByteBuffer>> earliestBytes(
+      final int earliestN) {
     return earliestBytes(earliestN, true);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.function.udaf.offset;
 
+import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_DATE_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_TIMESTAMP_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_TIME_SCHEMA;
+
 import java.util.Comparator;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -48,6 +52,26 @@ final class KudafByOffsetUtils {
   static final Schema STRUCT_STRING = SchemaBuilder.struct().optional()
       .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
       .field(VAL_FIELD, Schema.OPTIONAL_STRING_SCHEMA)
+      .build();
+
+  static final Schema STRUCT_TIMESTAMP = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, OPTIONAL_TIMESTAMP_SCHEMA)
+      .build();
+
+  static final Schema STRUCT_TIME = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, OPTIONAL_TIME_SCHEMA)
+      .build();
+
+  static final Schema STRUCT_DATE = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, OPTIONAL_DATE_SCHEMA)
+      .build();
+
+  static final Schema STRUCT_BYTES = SchemaBuilder.struct().optional()
+      .field(SEQ_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
+      .field(VAL_FIELD, Schema.OPTIONAL_BYTES_SCHEMA)
       .build();
   
   static final Comparator<Struct> INTERMEDIATE_STRUCT_COMPARATOR = (struct1, struct2) -> {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
@@ -73,13 +73,13 @@ public final class LatestByOffset {
     return latest(STRUCT_INTEGER, ignoreNulls, getComparator(ignoreNulls));
   }
 
-  @UdafFactory(description = "return the latest N value of an integer column",
+  @UdafFactory(description = "return the latest N values of an integer column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL INT>>")
   public static Udaf<Integer, List<Struct>, List<Integer>> latestIntegers(final int latestN) {
     return latestIntegers(latestN, true);
   }
 
-  @UdafFactory(description = "return the latest N value of an integer column",
+  @UdafFactory(description = "return the latest N values of an integer column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL INT>>")
   public static Udaf<Integer, List<Struct>, List<Integer>> latestIntegers(
       final int latestN,
@@ -100,13 +100,13 @@ public final class LatestByOffset {
     return latest(STRUCT_LONG, ignoreNulls, getComparator(ignoreNulls));
   }
 
-  @UdafFactory(description = "return the latest N value of an big integer column",
+  @UdafFactory(description = "return the latest N values of an big integer column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BIGINT>>")
   public static Udaf<Long, List<Struct>, List<Long>> latestLongs(final int latestN) {
     return latestLongs(latestN, true);
   }
 
-  @UdafFactory(description = "return the latest N value of an big integer column",
+  @UdafFactory(description = "return the latest N values of an big integer column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BIGINT>>")
   public static Udaf<Long, List<Struct>, List<Long>> latestLongs(
       final int latestN,
@@ -154,13 +154,13 @@ public final class LatestByOffset {
     return latest(STRUCT_BOOLEAN, ignoreNulls, getComparator(ignoreNulls));
   }
 
-  @UdafFactory(description = "return the latest N value of a boolean column",
+  @UdafFactory(description = "return the latest N values of a boolean column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BOOLEAN>>")
   public static Udaf<Boolean, List<Struct>, List<Boolean>> latestBooleans(final int latestN) {
     return latestBooleans(latestN, true);
   }
 
-  @UdafFactory(description = "return the latest N value of a boolean column",
+  @UdafFactory(description = "return the latest N values of a boolean column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BOOLEAN>>")
   public static Udaf<Boolean, List<Struct>, List<Boolean>> latestBooleans(
       final int latestN,
@@ -181,13 +181,13 @@ public final class LatestByOffset {
     return latest(STRUCT_STRING, ignoreNulls, getComparator(ignoreNulls));
   }
 
-  @UdafFactory(description = "return the latest N value of a string column",
+  @UdafFactory(description = "return the latest N values of a string column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL STRING>>")
   public static Udaf<String, List<Struct>, List<String>> latestStrings(final int latestN) {
     return latestStrings(latestN, true);
   }
 
-  @UdafFactory(description = "return the latest N value of a string column",
+  @UdafFactory(description = "return the latest N values of a string column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL STRING>>")
   public static Udaf<String, List<Struct>, List<String>> latestStrings(
       final int latestN,
@@ -208,13 +208,13 @@ public final class LatestByOffset {
     return latest(STRUCT_TIMESTAMP, ignoreNulls, getComparator(ignoreNulls));
   }
 
-  @UdafFactory(description = "return the latest N value of a timestamp column",
+  @UdafFactory(description = "return the latest N values of a timestamp column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIMESTAMP>>")
   public static Udaf<Timestamp, List<Struct>, List<Timestamp>> latestTimestamps(final int latestN) {
     return latestTimestamps(latestN, true);
   }
 
-  @UdafFactory(description = "return the latest N value of a timestamp column",
+  @UdafFactory(description = "return the latest N values of a timestamp column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIMESTAMP>>")
   public static Udaf<Timestamp, List<Struct>, List<Timestamp>> latestTimestamps(
       final int latestN,
@@ -235,13 +235,13 @@ public final class LatestByOffset {
     return latest(STRUCT_DATE, ignoreNulls, getComparator(ignoreNulls));
   }
 
-  @UdafFactory(description = "return the latest N value of a date column",
+  @UdafFactory(description = "return the latest N values of a date column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DATE>>")
   public static Udaf<Date, List<Struct>, List<Date>> latestDates(final int latestN) {
     return latestDates(latestN, true);
   }
 
-  @UdafFactory(description = "return the latest N value of a date column",
+  @UdafFactory(description = "return the latest N values of a date column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DATE>>")
   public static Udaf<Date, List<Struct>, List<Date>> latestDates(
       final int latestN,
@@ -262,13 +262,13 @@ public final class LatestByOffset {
     return latest(STRUCT_TIME, ignoreNulls, getComparator(ignoreNulls));
   }
 
-  @UdafFactory(description = "return the latest N value of a time column",
+  @UdafFactory(description = "return the latest N values of a time column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIME>>")
   public static Udaf<Time, List<Struct>, List<Time>> latestTimes(final int latestN) {
     return latestTimes(latestN, true);
   }
 
-  @UdafFactory(description = "return the latest N value of a time column",
+  @UdafFactory(description = "return the latest N values of a time column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIME>>")
   public static Udaf<Time, List<Struct>, List<Time>> latestTimes(
       final int latestN,
@@ -289,13 +289,13 @@ public final class LatestByOffset {
     return latest(STRUCT_BYTES, ignoreNulls, getComparator(ignoreNulls));
   }
 
-  @UdafFactory(description = "return the latest N value of a bytes column",
+  @UdafFactory(description = "return the latest N values of a bytes column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BYTES>>")
   public static Udaf<ByteBuffer, List<Struct>, List<ByteBuffer>> latestBytes(final int latestN) {
     return latestBytes(latestN, true);
   }
 
-  @UdafFactory(description = "return the latest N value of a bytes column",
+  @UdafFactory(description = "return the latest N values of a bytes column",
       aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BYTES>>")
   public static Udaf<ByteBuffer, List<Struct>, List<ByteBuffer>> latestBytes(
       final int latestN,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
@@ -18,10 +18,14 @@ package io.confluent.ksql.function.udaf.offset;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.INTERMEDIATE_STRUCT_COMPARATOR;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.INTERMEDIATE_STRUCT_COMPARATOR_IGNORE_NULLS;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_BOOLEAN;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_BYTES;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_DATE;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_DOUBLE;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_INTEGER;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_LONG;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_STRING;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_TIME;
+import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.STRUCT_TIMESTAMP;
 import static io.confluent.ksql.function.udaf.offset.KudafByOffsetUtils.VAL_FIELD;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -30,6 +34,10 @@ import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
 import io.confluent.ksql.function.udaf.UdafFactory;
 import io.confluent.ksql.util.KsqlConstants;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -186,6 +194,114 @@ public final class LatestByOffset {
       final boolean ignoreNulls
   ) {
     return latestN(STRUCT_STRING, latestN, ignoreNulls, getComparator(ignoreNulls));
+  }
+
+  @UdafFactory(description = "return the latest value of a timestamp column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL TIMESTAMP>")
+  public static Udaf<Timestamp, Struct, Timestamp> latestTimestamp() {
+    return latestTimestamp(true);
+  }
+
+  @UdafFactory(description = "return the latest value of a timestamp column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL TIMESTAMP>")
+  public static Udaf<Timestamp, Struct, Timestamp> latestTimestamp(final boolean ignoreNulls) {
+    return latest(STRUCT_TIMESTAMP, ignoreNulls, getComparator(ignoreNulls));
+  }
+
+  @UdafFactory(description = "return the latest N value of a timestamp column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIMESTAMP>>")
+  public static Udaf<Timestamp, List<Struct>, List<Timestamp>> latestTimestamps(final int latestN) {
+    return latestTimestamps(latestN, true);
+  }
+
+  @UdafFactory(description = "return the latest N value of a timestamp column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIMESTAMP>>")
+  public static Udaf<Timestamp, List<Struct>, List<Timestamp>> latestTimestamps(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_TIMESTAMP, latestN, ignoreNulls, getComparator(ignoreNulls));
+  }
+
+  @UdafFactory(description = "return the latest value of a date column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL DATE>")
+  public static Udaf<Date, Struct, Date> latestDate() {
+    return latestDate(true);
+  }
+
+  @UdafFactory(description = "return the latest value of a date column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL DATE>")
+  public static Udaf<Date, Struct, Date> latestDate(final boolean ignoreNulls) {
+    return latest(STRUCT_DATE, ignoreNulls, getComparator(ignoreNulls));
+  }
+
+  @UdafFactory(description = "return the latest N value of a date column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DATE>>")
+  public static Udaf<Date, List<Struct>, List<Date>> latestDates(final int latestN) {
+    return latestDates(latestN, true);
+  }
+
+  @UdafFactory(description = "return the latest N value of a date column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL DATE>>")
+  public static Udaf<Date, List<Struct>, List<Date>> latestDates(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_DATE, latestN, ignoreNulls, getComparator(ignoreNulls));
+  }
+
+  @UdafFactory(description = "return the latest value of a time column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL TIME>")
+  public static Udaf<Time, Struct, Time> latestTime() {
+    return latestTime(true);
+  }
+
+  @UdafFactory(description = "return the latest value of a time column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL TIME>")
+  public static Udaf<Time, Struct, Time> latestTime(final boolean ignoreNulls) {
+    return latest(STRUCT_TIME, ignoreNulls, getComparator(ignoreNulls));
+  }
+
+  @UdafFactory(description = "return the latest N value of a time column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIME>>")
+  public static Udaf<Time, List<Struct>, List<Time>> latestTimes(final int latestN) {
+    return latestTimes(latestN, true);
+  }
+
+  @UdafFactory(description = "return the latest N value of a time column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL TIME>>")
+  public static Udaf<Time, List<Struct>, List<Time>> latestTimes(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_TIME, latestN, ignoreNulls, getComparator(ignoreNulls));
+  }
+
+  @UdafFactory(description = "return the latest value of a bytes column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BYTES>")
+  public static Udaf<ByteBuffer, Struct, ByteBuffer> latestBytes() {
+    return latestBytes(true);
+  }
+
+  @UdafFactory(description = "return the latest value of a bytes column",
+      aggregateSchema = "STRUCT<SEQ BIGINT, VAL BYTES>")
+  public static Udaf<ByteBuffer, Struct, ByteBuffer> latestBytes(final boolean ignoreNulls) {
+    return latest(STRUCT_BYTES, ignoreNulls, getComparator(ignoreNulls));
+  }
+
+  @UdafFactory(description = "return the latest N value of a bytes column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BYTES>>")
+  public static Udaf<ByteBuffer, List<Struct>, List<ByteBuffer>> latestBytes(final int latestN) {
+    return latestBytes(latestN, true);
+  }
+
+  @UdafFactory(description = "return the latest N value of a bytes column",
+      aggregateSchema = "ARRAY<STRUCT<SEQ BIGINT, VAL BYTES>>")
+  public static Udaf<ByteBuffer, List<Struct>, List<ByteBuffer>> latestBytes(
+      final int latestN,
+      final boolean ignoreNulls
+  ) {
+    return latestN(STRUCT_BYTES, latestN, ignoreNulls, getComparator(ignoreNulls));
   }
 
   @VisibleForTesting

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
@@ -24,6 +24,10 @@ import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.function.udaf.TableUdaf;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.List;
 import org.apache.kafka.common.Configurable;
 import org.junit.Test;
@@ -39,6 +43,50 @@ public class CollectListUdafTest {
       runningList = udaf.aggregate(i, runningList);
     }
     assertThat(runningList, contains(3, 4, 5, 3));
+  }
+
+  @Test
+  public void shouldCollectTimestamps() {
+    final TableUdaf<Timestamp, List<Timestamp>, List<Timestamp>> udaf = CollectListUdaf.createCollectListTimestamp();
+    final Timestamp[] values = new Timestamp[] {new Timestamp(1), new Timestamp(2)};
+    List<Timestamp> runningList = udaf.initialize();
+    for (final Timestamp i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, contains(new Timestamp(1), new Timestamp(2)));
+  }
+
+  @Test
+  public void shouldCollectTimes() {
+    final TableUdaf<Time, List<Time>, List<Time>> udaf = CollectListUdaf.createCollectListTime();
+    final Time[] values = new Time[] {new Time(1), new Time(2)};
+    List<Time> runningList = udaf.initialize();
+    for (final Time i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, contains(new Time(1), new Time(2)));
+  }
+
+  @Test
+  public void shouldCollectDates() {
+    final TableUdaf<Date, List<Date>, List<Date>> udaf = CollectListUdaf.createCollectListDate();
+    final Date[] values = new Date[] {new Date(1), new Date(2)};
+    List<Date> runningList = udaf.initialize();
+    for (final Date i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, contains(new Date(1), new Date(2)));
+  }
+
+  @Test
+  public void shouldCollectBytes() {
+    final TableUdaf<ByteBuffer, List<ByteBuffer>, List<ByteBuffer>> udaf = CollectListUdaf.createCollectListBytes();
+    final ByteBuffer[] values = new ByteBuffer[] {ByteBuffer.wrap(new byte[] {1}), ByteBuffer.wrap(new byte[] {2})};
+    List<ByteBuffer> runningList = udaf.initialize();
+    for (final ByteBuffer i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, contains(ByteBuffer.wrap(new byte[] {1}), ByteBuffer.wrap(new byte[] {2})));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectSetUdafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectSetUdafTest.java
@@ -23,6 +23,10 @@ import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.function.udaf.Udaf;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.List;
 import org.apache.kafka.common.Configurable;
 import org.junit.Test;
@@ -38,6 +42,50 @@ public class CollectSetUdafTest {
       runningList = udaf.aggregate(i, runningList);
     }
     assertThat(runningList, contains(3, 4, 5));
+  }
+
+  @Test
+  public void shouldCollectDistinctTimestamps() {
+    final Udaf<Timestamp, List<Timestamp>, List<Timestamp>> udaf = CollectSetUdaf.createCollectSetTimestamp();
+    final Timestamp[] values = new Timestamp[] {new Timestamp(1), new Timestamp(2)};
+    List<Timestamp> runningList = udaf.initialize();
+    for (final Timestamp i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, contains(new Timestamp(1), new Timestamp(2)));
+  }
+
+  @Test
+  public void shouldCollectDistinctTimes() {
+    final Udaf<Time, List<Time>, List<Time>> udaf = CollectSetUdaf.createCollectSetTime();
+    final Time[] values = new Time[] {new Time(1), new Time(2)};
+    List<Time> runningList = udaf.initialize();
+    for (final Time i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, contains(new Time(1), new Time(2)));
+  }
+
+  @Test
+  public void shouldCollectDistinctDates() {
+    final Udaf<Date, List<Date>, List<Date>> udaf = CollectSetUdaf.createCollectSetDate();
+    final Date[] values = new Date[] {new Date(1), new Date(2)};
+    List<Date> runningList = udaf.initialize();
+    for (final Date i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, contains(new Date(1), new Date(2)));
+  }
+
+  @Test
+  public void shouldCollectDistinctBytes() {
+    final Udaf<ByteBuffer, List<ByteBuffer>, List<ByteBuffer>> udaf = CollectSetUdaf.createCollectSetBytes();
+    final ByteBuffer[] values = new ByteBuffer[] {ByteBuffer.wrap(new byte[] {1}), ByteBuffer.wrap(new byte[] {2})};
+    List<ByteBuffer> runningList = udaf.initialize();
+    for (final ByteBuffer i : values) {
+      runningList = udaf.aggregate(i, runningList);
+    }
+    assertThat(runningList, contains(ByteBuffer.wrap(new byte[] {1}), ByteBuffer.wrap(new byte[] {2})));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_-_JSON/7.1.0_1630368512001/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_-_JSON/7.1.0_1630368512001/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, BYTES>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_-_JSON/7.1.0_1630368512001/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_-_JSON/7.1.0_1630368512001/spec.json
@@ -1,0 +1,155 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368512001,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, BYTES>, `KSQL_AGG_VARIABLE_0` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, BYTES>, `KSQL_INTERNAL_COL_2` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list bytes map - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : "YQ=="
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : "Yg=="
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ "YQ==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ "YQ==", "Yg==" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, bytes>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_-_JSON/7.1.0_1630368512001/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_-_JSON/7.1.0_1630368512001/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_table_-_JSON/7.1.0_1630368515862/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_table_-_JSON/7.1.0_1630368515862/plan.json
@@ -1,0 +1,215 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME STRING, VALUE MAP<STRING, BYTES>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+                  "forceChangelog" : true
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                }
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_table_-_JSON/7.1.0_1630368515862/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_table_-_JSON/7.1.0_1630368515862/spec.json
@@ -1,0 +1,186 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368515862,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, BYTES>, `KSQL_AGG_VARIABLE_0` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Prepare" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, BYTES>, `KSQL_INTERNAL_COL_2` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, BYTES>, `KSQL_INTERNAL_COL_2` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list bytes map table - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : "YQ=="
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : "Yg=="
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ "YQ==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ "Yg==" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, bytes>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_table_-_JSON/7.1.0_1630368515862/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_bytes_map_table_-_JSON/7.1.0_1630368515862/topology
@@ -1,0 +1,43 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-FILTER-0000000006 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- KTABLE-FILTER-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000009 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000010
+    Processor: KTABLE-AGGREGATE-0000000010 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000009
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000010
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000013
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000013 (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000014 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000013
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_JSON/7.1.0_1630368511768/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_JSON/7.1.0_1630368511768/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, DATE>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_JSON/7.1.0_1630368511768/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_JSON/7.1.0_1630368511768/spec.json
@@ -1,0 +1,173 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368511768,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_AGG_VARIABLE_0` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_INTERNAL_COL_2` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list date map - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20, 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_JSON/7.1.0_1630368511768/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_JSON/7.1.0_1630368511768/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368511850/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368511850/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, DATE>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368511850/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368511850/spec.json
@@ -1,0 +1,178 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368511850,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_AGG_VARIABLE_0` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_INTERNAL_COL_2` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list date map - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20, 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.type.Date KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.type.Date COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368511850/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368511850/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_JSON/7.1.0_1630368515513/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_JSON/7.1.0_1630368515513/plan.json
@@ -1,0 +1,215 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME STRING, VALUE MAP<STRING, DATE>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+                  "forceChangelog" : true
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                }
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_JSON/7.1.0_1630368515513/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_JSON/7.1.0_1630368515513/spec.json
@@ -1,0 +1,210 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368515513,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_AGG_VARIABLE_0` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Prepare" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_INTERNAL_COL_2` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_INTERNAL_COL_2` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list date map table - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_JSON/7.1.0_1630368515513/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_JSON/7.1.0_1630368515513/topology
@@ -1,0 +1,43 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-FILTER-0000000006 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- KTABLE-FILTER-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000009 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000010
+    Processor: KTABLE-AGGREGATE-0000000010 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000009
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000010
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000013
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000013 (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000014 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000013
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_PROTOBUF/7.1.0_1630368515678/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_PROTOBUF/7.1.0_1630368515678/plan.json
@@ -1,0 +1,215 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME STRING, VALUE MAP<STRING, DATE>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+                  "forceChangelog" : true
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                }
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_PROTOBUF/7.1.0_1630368515678/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_PROTOBUF/7.1.0_1630368515678/spec.json
@@ -1,0 +1,217 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368515678,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_AGG_VARIABLE_0` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Prepare" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_INTERNAL_COL_2` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_INTERNAL_COL_2` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list date map table - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.type.Date KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n"
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n"
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  google.type.Date KSQL_INTERNAL_COL_2 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.type.Date COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_PROTOBUF/7.1.0_1630368515678/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_date_map_table_-_PROTOBUF/7.1.0_1630368515678/topology
@@ -1,0 +1,43 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-FILTER-0000000006 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- KTABLE-FILTER-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000009 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000010
+    Processor: KTABLE-AGGREGATE-0000000010 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000009
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000010
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000013
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000013 (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000014 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000013
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_JSON/7.1.0_1630368511554/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_JSON/7.1.0_1630368511554/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, TIME>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_JSON/7.1.0_1630368511554/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_JSON/7.1.0_1630368511554/spec.json
@@ -1,0 +1,173 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368511554,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_AGG_VARIABLE_0` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_INTERNAL_COL_2` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list time map - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20, 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_JSON/7.1.0_1630368511554/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_JSON/7.1.0_1630368511554/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368511626/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368511626/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, TIME>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368511626/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368511626/spec.json
@@ -1,0 +1,178 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368511626,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_AGG_VARIABLE_0` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_INTERNAL_COL_2` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list time map - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20, 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.type.TimeOfDay KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.type.TimeOfDay COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368511626/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368511626/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_JSON/7.1.0_1630368515150/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_JSON/7.1.0_1630368515150/plan.json
@@ -1,0 +1,215 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME STRING, VALUE MAP<STRING, TIME>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+                  "forceChangelog" : true
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                }
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_JSON/7.1.0_1630368515150/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_JSON/7.1.0_1630368515150/spec.json
@@ -1,0 +1,210 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368515150,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_AGG_VARIABLE_0` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Prepare" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_INTERNAL_COL_2` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_INTERNAL_COL_2` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list time map table - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_JSON/7.1.0_1630368515150/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_JSON/7.1.0_1630368515150/topology
@@ -1,0 +1,43 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-FILTER-0000000006 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- KTABLE-FILTER-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000009 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000010
+    Processor: KTABLE-AGGREGATE-0000000010 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000009
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000010
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000013
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000013 (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000014 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000013
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_PROTOBUF/7.1.0_1630368515326/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_PROTOBUF/7.1.0_1630368515326/plan.json
@@ -1,0 +1,215 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME STRING, VALUE MAP<STRING, TIME>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+                  "forceChangelog" : true
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                }
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_PROTOBUF/7.1.0_1630368515326/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_PROTOBUF/7.1.0_1630368515326/spec.json
@@ -1,0 +1,217 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368515326,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_AGG_VARIABLE_0` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Prepare" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_INTERNAL_COL_2` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_INTERNAL_COL_2` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list time map table - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.type.TimeOfDay KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n"
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n"
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  google.type.TimeOfDay KSQL_INTERNAL_COL_2 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.type.TimeOfDay COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_PROTOBUF/7.1.0_1630368515326/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_time_map_table_-_PROTOBUF/7.1.0_1630368515326/topology
@@ -1,0 +1,43 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-FILTER-0000000006 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- KTABLE-FILTER-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000009 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000010
+    Processor: KTABLE-AGGREGATE-0000000010 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000009
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000010
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000013
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000013 (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000014 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000013
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368511264/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368511264/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, TIMESTAMP>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368511264/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368511264/spec.json
@@ -1,0 +1,173 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368511264,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_AGG_VARIABLE_0` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_INTERNAL_COL_2` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list timestamp map - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20, 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368511264/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368511264/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368511384/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368511384/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, TIMESTAMP>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368511384/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368511384/spec.json
@@ -1,0 +1,178 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368511384,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_AGG_VARIABLE_0` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_INTERNAL_COL_2` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list timestamp map - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20, 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.protobuf.Timestamp KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.protobuf.Timestamp COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368511384/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368511384/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_JSON/7.1.0_1630368514803/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_JSON/7.1.0_1630368514803/plan.json
@@ -1,0 +1,215 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME STRING, VALUE MAP<STRING, TIMESTAMP>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+                  "forceChangelog" : true
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "JSON"
+                  }
+                }
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_JSON/7.1.0_1630368514803/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_JSON/7.1.0_1630368514803/spec.json
@@ -1,0 +1,210 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368514803,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_AGG_VARIABLE_0` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Prepare" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_INTERNAL_COL_2` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_INTERNAL_COL_2` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list timestamp map table - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_JSON/7.1.0_1630368514803/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_JSON/7.1.0_1630368514803/topology
@@ -1,0 +1,43 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-FILTER-0000000006 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- KTABLE-FILTER-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000009 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000010
+    Processor: KTABLE-AGGREGATE-0000000010 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000009
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000010
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000013
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000013 (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000014 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000013
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_PROTOBUF/7.1.0_1630368514960/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_PROTOBUF/7.1.0_1630368514960/plan.json
@@ -1,0 +1,215 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME STRING, VALUE MAP<STRING, TIMESTAMP>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_LIST(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "tableAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "tableGroupByV2",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "tableSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "tableSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+                  "forceChangelog" : true
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ],
+                "internalFormats" : {
+                  "keyFormat" : {
+                    "format" : "KAFKA"
+                  },
+                  "valueFormat" : {
+                    "format" : "PROTOBUF"
+                  }
+                }
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              },
+              "groupByExpressions" : [ "ID" ]
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_LIST(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_PROTOBUF/7.1.0_1630368514960/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_PROTOBUF/7.1.0_1630368514960/spec.json
@@ -1,0 +1,217 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368514960,
+  "path" : "query-validation-tests/collect-list.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_AGG_VARIABLE_0` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Prepare" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_INTERNAL_COL_2` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_INTERNAL_COL_2` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list timestamp map table - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 30,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 30 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.protobuf.Timestamp KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n"
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-KsqlTopic-Reduce-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n"
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-GroupBy-repartition",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  google.protobuf.Timestamp KSQL_INTERNAL_COL_2 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.protobuf.Timestamp COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_PROTOBUF/7.1.0_1630368514960/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-list_-_collect_list_timestamp_map_table_-_PROTOBUF/7.1.0_1630368514960/topology
@@ -1,0 +1,43 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000001 (topics: [test_topic])
+      --> KTABLE-SOURCE-0000000002
+    Processor: KTABLE-SOURCE-0000000002 (stores: [])
+      --> KTABLE-MAPVALUES-0000000003
+      <-- KSTREAM-SOURCE-0000000001
+    Processor: KTABLE-MAPVALUES-0000000003 (stores: [KsqlTopic-Reduce])
+      --> KTABLE-TRANSFORMVALUES-0000000004
+      <-- KTABLE-SOURCE-0000000002
+    Processor: KTABLE-TRANSFORMVALUES-0000000004 (stores: [])
+      --> Aggregate-Prepare
+      <-- KTABLE-MAPVALUES-0000000003
+    Processor: Aggregate-Prepare (stores: [])
+      --> KTABLE-FILTER-0000000006
+      <-- KTABLE-TRANSFORMVALUES-0000000004
+    Processor: KTABLE-FILTER-0000000006 (stores: [])
+      --> Aggregate-GroupBy
+      <-- Aggregate-Prepare
+    Processor: Aggregate-GroupBy (stores: [])
+      --> KSTREAM-SINK-0000000008
+      <-- KTABLE-FILTER-0000000006
+    Sink: KSTREAM-SINK-0000000008 (topic: Aggregate-GroupBy-repartition)
+      <-- Aggregate-GroupBy
+
+  Sub-topology: 1
+    Source: KSTREAM-SOURCE-0000000009 (topics: [Aggregate-GroupBy-repartition])
+      --> KTABLE-AGGREGATE-0000000010
+    Processor: KTABLE-AGGREGATE-0000000010 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- KSTREAM-SOURCE-0000000009
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KTABLE-AGGREGATE-0000000010
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000013
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000013 (stores: [])
+      --> KSTREAM-SINK-0000000014
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000014 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000013
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_bytes_map_-_JSON/7.1.0_1630368518406/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_bytes_map_-_JSON/7.1.0_1630368518406/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, BYTES>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_SET(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_SET(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_bytes_map_-_JSON/7.1.0_1630368518406/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_bytes_map_-_JSON/7.1.0_1630368518406/spec.json
@@ -1,0 +1,170 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368518406,
+  "path" : "query-validation-tests/collect-set.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, BYTES>, `KSQL_AGG_VARIABLE_0` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, BYTES>, `KSQL_INTERNAL_COL_2` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list bytes map - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : "YQ=="
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : "Yg=="
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : "Yg=="
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ "YQ==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ "YQ==", "Yg==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ "YQ==", "Yg==" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, bytes>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<BYTES>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, BYTES>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_bytes_map_-_JSON/7.1.0_1630368518406/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_bytes_map_-_JSON/7.1.0_1630368518406/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_JSON/7.1.0_1630368518205/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_JSON/7.1.0_1630368518205/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, DATE>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_SET(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_SET(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_JSON/7.1.0_1630368518205/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_JSON/7.1.0_1630368518205/spec.json
@@ -1,0 +1,173 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368518205,
+  "path" : "query-validation-tests/collect-set.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_AGG_VARIABLE_0` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_INTERNAL_COL_2` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list date map - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_JSON/7.1.0_1630368518205/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_JSON/7.1.0_1630368518205/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368518316/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368518316/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, DATE>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_SET(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_SET(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368518316/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368518316/spec.json
@@ -1,0 +1,178 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368518316,
+  "path" : "query-validation-tests/collect-set.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_AGG_VARIABLE_0` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, DATE>, `KSQL_INTERNAL_COL_2` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list date map - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.type.Date KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.Date value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/date.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.type.Date COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368518316/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_date_map_-_PROTOBUF/7.1.0_1630368518316/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_JSON/7.1.0_1630368518012/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_JSON/7.1.0_1630368518012/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, TIME>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_SET(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_SET(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_JSON/7.1.0_1630368518012/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_JSON/7.1.0_1630368518012/spec.json
@@ -1,0 +1,173 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368518012,
+  "path" : "query-validation-tests/collect-set.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_AGG_VARIABLE_0` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_INTERNAL_COL_2` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list time map - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_JSON/7.1.0_1630368518012/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_JSON/7.1.0_1630368518012/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368518117/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368518117/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, TIME>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_SET(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_SET(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368518117/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368518117/spec.json
@@ -1,0 +1,178 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368518117,
+  "path" : "query-validation-tests/collect-set.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_AGG_VARIABLE_0` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIME>, `KSQL_INTERNAL_COL_2` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list time map - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.type.TimeOfDay KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.type.TimeOfDay value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/type/timeofday.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.type.TimeOfDay COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368518117/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_time_map_-_PROTOBUF/7.1.0_1630368518117/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368517819/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368517819/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, TIMESTAMP>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_SET(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_SET(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368517819/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368517819/spec.json
@@ -1,0 +1,173 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368517819,
+  "path" : "query-validation-tests/collect-set.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_AGG_VARIABLE_0` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_INTERNAL_COL_2` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list timestamp map - JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368517819/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_JSON/7.1.0_1630368517819/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368517923/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368517923/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE MAP<STRING, TIMESTAMP>) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='PROTOBUF');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  COLLECT_SET(TEST.VALUE['key1']) COLLECTED\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "PROTOBUF"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "VALUE['key1'] AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "PROTOBUF"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "COLLECT_SET(KSQL_INTERNAL_COL_2)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS COLLECTED" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "PROTOBUF"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          }
+        },
+        "topicName" : "S2"
+      },
+      "queryId" : "CTAS_S2_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368517923/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368517923/spec.json
@@ -1,0 +1,178 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368517923,
+  "path" : "query-validation-tests/collect-set.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_AGG_VARIABLE_0` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` MAP<STRING, TIMESTAMP>, `KSQL_INTERNAL_COL_2` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "collect_list timestamp map - PROTOBUF",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 10,
+          "key2" : 15
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 25
+        }
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "name" : "zero",
+        "value" : {
+          "key1" : 20,
+          "key2" : 35
+        }
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "COLLECTED" : [ 10, 20 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='PROTOBUF');", "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `COLLECTED` ARRAY<TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` MAP<STRING, TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  int64 ID = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n  repeated google.protobuf.Timestamp KSQL_AGG_VARIABLE_0 = 3;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n"
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  string NAME = 1;\n  repeated ConnectDefault2Entry VALUE = 2;\n\n  message ConnectDefault2Entry {\n    string key = 1;\n    google.protobuf.Timestamp value = 2;\n  }\n}\n"
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF"
+          },
+          "partitions" : 4,
+          "valueSchema" : "syntax = \"proto3\";\n\nimport \"google/protobuf/timestamp.proto\";\n\nmessage ConnectDefault1 {\n  repeated google.protobuf.Timestamp COLLECTED = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368517923/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/collect-set_-_collect_list_timestamp_map_-_PROTOBUF/7.1.0_1630368517923/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/7.1.0_1630368526794/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/7.1.0_1630368526794/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING, F5 TIMESTAMP, F6 TIME, F7 DATE, F8 BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  EARLIEST_BY_OFFSET(INPUT.F0) L0,\n  EARLIEST_BY_OFFSET(INPUT.F1) L1,\n  EARLIEST_BY_OFFSET(INPUT.F2) L2,\n  EARLIEST_BY_OFFSET(INPUT.F3) L3,\n  EARLIEST_BY_OFFSET(INPUT.F4) L4,\n  EARLIEST_BY_OFFSET(INPUT.F5) L5,\n  EARLIEST_BY_OFFSET(INPUT.F6) L6,\n  EARLIEST_BY_OFFSET(INPUT.F7) L7,\n  EARLIEST_BY_OFFSET(INPUT.F8) L8\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING, `L5` TIMESTAMP, `L6` TIME, `L7` DATE, `L8` BYTES",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "F1 AS F1", "F2 AS F2", "F3 AS F3", "F4 AS F4", "F5 AS F5", "F6 AS F6", "F7 AS F7", "F8 AS F8" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8" ],
+            "aggregationFunctions" : [ "EARLIEST_BY_OFFSET(F0)", "EARLIEST_BY_OFFSET(F1)", "EARLIEST_BY_OFFSET(F2)", "EARLIEST_BY_OFFSET(F3)", "EARLIEST_BY_OFFSET(F4)", "EARLIEST_BY_OFFSET(F5)", "EARLIEST_BY_OFFSET(F6)", "EARLIEST_BY_OFFSET(F7)", "EARLIEST_BY_OFFSET(F8)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0", "KSQL_AGG_VARIABLE_1 AS L1", "KSQL_AGG_VARIABLE_2 AS L2", "KSQL_AGG_VARIABLE_3 AS L3", "KSQL_AGG_VARIABLE_4 AS L4", "KSQL_AGG_VARIABLE_5 AS L5", "KSQL_AGG_VARIABLE_6 AS L6", "KSQL_AGG_VARIABLE_7 AS L7", "KSQL_AGG_VARIABLE_8 AS L8" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/7.1.0_1630368526794/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/7.1.0_1630368526794/spec.json
@@ -1,0 +1,237 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368526794,
+  "path" : "query-validation-tests/earliest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING, `L5` TIMESTAMP, `L6` TIME, `L7` DATE, `L8` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>, `KSQL_AGG_VARIABLE_1` STRUCT<`SEQ` BIGINT, `VAL` BIGINT>, `KSQL_AGG_VARIABLE_2` STRUCT<`SEQ` BIGINT, `VAL` DOUBLE>, `KSQL_AGG_VARIABLE_3` STRUCT<`SEQ` BIGINT, `VAL` BOOLEAN>, `KSQL_AGG_VARIABLE_4` STRUCT<`SEQ` BIGINT, `VAL` STRING>, `KSQL_AGG_VARIABLE_5` STRUCT<`SEQ` BIGINT, `VAL` TIMESTAMP>, `KSQL_AGG_VARIABLE_6` STRUCT<`SEQ` BIGINT, `VAL` TIME>, `KSQL_AGG_VARIABLE_7` STRUCT<`SEQ` BIGINT, `VAL` DATE>, `KSQL_AGG_VARIABLE_8` STRUCT<`SEQ` BIGINT, `VAL` BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING, `L5` TIMESTAMP, `L6` TIME, `L7` DATE, `L8` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "earliest by offset",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12,
+        "F1" : 1000,
+        "F2" : 1.23,
+        "F3" : true,
+        "F4" : "foo",
+        "F5" : 12,
+        "F6" : 123,
+        "F7" : 1234,
+        "F8" : "YQ=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "F0" : 12,
+        "F1" : 1000,
+        "F2" : 1.23,
+        "F3" : true,
+        "F4" : "foo",
+        "F5" : 12,
+        "F6" : 123,
+        "F7" : 1234,
+        "F8" : "YQ=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 21,
+        "F1" : 2000,
+        "F2" : 2.23,
+        "F3" : false,
+        "F4" : "foo",
+        "F5" : 34,
+        "F6" : 234,
+        "F7" : 2345,
+        "F8" : "Yg=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "F0" : 21,
+        "F1" : 2000,
+        "F2" : 2.23,
+        "F3" : false,
+        "F4" : "foo",
+        "F5" : 34,
+        "F6" : 234,
+        "F7" : 2345,
+        "F8" : "Yg=="
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo",
+        "L5" : 12,
+        "L6" : 123,
+        "L7" : 1234,
+        "L8" : "YQ=="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo",
+        "L5" : 12,
+        "L6" : 123,
+        "L7" : 1234,
+        "L8" : "YQ=="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo",
+        "L5" : 12,
+        "L6" : 123,
+        "L7" : 1234,
+        "L8" : "YQ=="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo",
+        "L5" : 12,
+        "L6" : 123,
+        "L7" : 1234,
+        "L8" : "YQ=="
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING, F5 TIMESTAMP, F6 TIME, F7 DATE, F8 BYTES) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0, EARLIEST_BY_OFFSET(F1) AS L1, EARLIEST_BY_OFFSET(F2) AS L2, EARLIEST_BY_OFFSET(F3) AS L3, EARLIEST_BY_OFFSET(F4) AS L4, EARLIEST_BY_OFFSET(F5) AS L5, EARLIEST_BY_OFFSET(F6) AS L6, EARLIEST_BY_OFFSET(F7) AS L7, EARLIEST_BY_OFFSET(F8) AS L8 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING, `L5` TIMESTAMP, `L6` TIME, `L7` DATE, `L8` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/7.1.0_1630368526794/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/earliest-offset-udaf_-_earliest_by_offset/7.1.0_1630368526794/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset/7.1.0_1630368619417/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset/7.1.0_1630368619417/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, F0 INTEGER, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING, F5 TIMESTAMP, F6 TIME, F7 DATE, F8 BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE OUTPUT AS SELECT\n  INPUT.ID ID,\n  LATEST_BY_OFFSET(INPUT.F0) L0,\n  LATEST_BY_OFFSET(INPUT.F1) L1,\n  LATEST_BY_OFFSET(INPUT.F2) L2,\n  LATEST_BY_OFFSET(INPUT.F3) L3,\n  LATEST_BY_OFFSET(INPUT.F4) L4,\n  LATEST_BY_OFFSET(INPUT.F5) L5,\n  LATEST_BY_OFFSET(INPUT.F6) L6,\n  LATEST_BY_OFFSET(INPUT.F7) L7,\n  LATEST_BY_OFFSET(INPUT.F8) L8\nFROM INPUT INPUT\nGROUP BY INPUT.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING, `L5` TIMESTAMP, `L6` TIME, `L7` DATE, `L8` BYTES",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA"
+                    },
+                    "valueFormat" : {
+                      "format" : "JSON"
+                    }
+                  },
+                  "sourceSchema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES"
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectExpressions" : [ "ID AS ID", "F0 AS F0", "F1 AS F1", "F2 AS F2", "F3 AS F3", "F4 AS F4", "F5 AS F5", "F6 AS F6", "F7 AS F7", "F8 AS F8" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "F0", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8" ],
+            "aggregationFunctions" : [ "LATEST_BY_OFFSET(F0)", "LATEST_BY_OFFSET(F1)", "LATEST_BY_OFFSET(F2)", "LATEST_BY_OFFSET(F3)", "LATEST_BY_OFFSET(F4)", "LATEST_BY_OFFSET(F5)", "LATEST_BY_OFFSET(F6)", "LATEST_BY_OFFSET(F7)", "LATEST_BY_OFFSET(F8)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS L0", "KSQL_AGG_VARIABLE_1 AS L1", "KSQL_AGG_VARIABLE_2 AS L2", "KSQL_AGG_VARIABLE_3 AS L3", "KSQL_AGG_VARIABLE_4 AS L4", "KSQL_AGG_VARIABLE_5 AS L5", "KSQL_AGG_VARIABLE_6 AS L6", "KSQL_AGG_VARIABLE_7 AS L7", "KSQL_AGG_VARIABLE_8 AS L8" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA"
+            },
+            "valueFormat" : {
+              "format" : "JSON"
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CTAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.query.push.scalable.enabled" : "false",
+    "ksql.query.push.scalable.interpreter.enabled" : "true",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "false",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "false",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "100",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.query.push.scalable.new.node.continuity" : "false",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset/7.1.0_1630368619417/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset/7.1.0_1630368619417/spec.json
@@ -1,0 +1,237 @@
+{
+  "version" : "7.1.0",
+  "timestamp" : 1630368619417,
+  "path" : "query-validation-tests/latest-offset-udaf.json",
+  "schemas" : {
+    "CTAS_OUTPUT_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING, `L5` TIMESTAMP, `L6` TIME, `L7` DATE, `L8` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES, `KSQL_AGG_VARIABLE_0` STRUCT<`SEQ` BIGINT, `VAL` INTEGER>, `KSQL_AGG_VARIABLE_1` STRUCT<`SEQ` BIGINT, `VAL` BIGINT>, `KSQL_AGG_VARIABLE_2` STRUCT<`SEQ` BIGINT, `VAL` DOUBLE>, `KSQL_AGG_VARIABLE_3` STRUCT<`SEQ` BIGINT, `VAL` BOOLEAN>, `KSQL_AGG_VARIABLE_4` STRUCT<`SEQ` BIGINT, `VAL` STRING>, `KSQL_AGG_VARIABLE_5` STRUCT<`SEQ` BIGINT, `VAL` TIMESTAMP>, `KSQL_AGG_VARIABLE_6` STRUCT<`SEQ` BIGINT, `VAL` TIME>, `KSQL_AGG_VARIABLE_7` STRUCT<`SEQ` BIGINT, `VAL` DATE>, `KSQL_AGG_VARIABLE_8` STRUCT<`SEQ` BIGINT, `VAL` BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CTAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING, `L5` TIMESTAMP, `L6` TIME, `L7` DATE, `L8` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "latest by offset",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 12,
+        "F1" : 1000,
+        "F2" : 1.23,
+        "F3" : true,
+        "F4" : "foo",
+        "F5" : 12,
+        "F6" : 123,
+        "F7" : 1234,
+        "F8" : "YQ=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "F0" : 12,
+        "F1" : 1000,
+        "F2" : 1.23,
+        "F3" : true,
+        "F4" : "foo",
+        "F5" : 12,
+        "F6" : 123,
+        "F7" : 1234,
+        "F8" : "YQ=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "F0" : 21,
+        "F1" : 2000,
+        "F2" : 2.23,
+        "F3" : false,
+        "F4" : "bar",
+        "F5" : 34,
+        "F6" : 234,
+        "F7" : 2345,
+        "F8" : "Yg=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 1,
+      "value" : {
+        "F0" : 21,
+        "F1" : 2000,
+        "F2" : 2.23,
+        "F3" : false,
+        "F4" : "bar",
+        "F5" : 34,
+        "F6" : 234,
+        "F7" : 2345,
+        "F8" : "Yg=="
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo",
+        "L5" : 12,
+        "L6" : 123,
+        "L7" : 1234,
+        "L8" : "YQ=="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "L0" : 12,
+        "L1" : 1000,
+        "L2" : 1.23,
+        "L3" : true,
+        "L4" : "foo",
+        "L5" : 12,
+        "L6" : 123,
+        "L7" : 1234,
+        "L8" : "YQ=="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 0,
+      "value" : {
+        "L0" : 21,
+        "L1" : 2000,
+        "L2" : 2.23,
+        "L3" : false,
+        "L4" : "bar",
+        "L5" : 34,
+        "L6" : 234,
+        "L7" : 2345,
+        "L8" : "Yg=="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "L0" : 21,
+        "L1" : 2000,
+        "L2" : 2.23,
+        "L3" : false,
+        "L4" : "bar",
+        "L5" : 34,
+        "L6" : 234,
+        "L7" : 2345,
+        "L8" : "Yg=="
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "keySerdeFeatures" : [ ],
+      "valueSerdeFeatures" : [ ],
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING, F5 TIMESTAMP, F6 TIME, F7 DATE, F8 BYTES) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0, LATEST_BY_OFFSET(F1) AS L1, LATEST_BY_OFFSET(F2) AS L2, LATEST_BY_OFFSET(F3) AS L3, LATEST_BY_OFFSET(F4) AS L4, LATEST_BY_OFFSET(F5) AS L5, LATEST_BY_OFFSET(F6) AS L6, LATEST_BY_OFFSET(F7) AS L7, LATEST_BY_OFFSET(F8) AS L8 FROM INPUT GROUP BY ID;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `F0` INTEGER, `F1` BIGINT, `F2` DOUBLE, `F3` BOOLEAN, `F4` STRING, `F5` TIMESTAMP, `F6` TIME, `F7` DATE, `F8` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `L0` INTEGER, `L1` BIGINT, `L2` DOUBLE, `L3` BOOLEAN, `L4` STRING, `L5` TIMESTAMP, `L6` TIME, `L7` DATE, `L8` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset/7.1.0_1630368619417/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/latest-offset-udaf_-_latest_by_offset/7.1.0_1630368619417/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: OUTPUT)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-list.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-list.json
@@ -109,6 +109,76 @@
       ]
     },
     {
+      "name": "collect_list timestamp map",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":30, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20,30]}}
+      ]
+    },
+    {
+      "name": "collect_list time map",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":30, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20,30]}}
+      ]
+    },
+    {
+      "name": "collect_list date map",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":30, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20,30]}}
+      ]
+    },
+    {
+      "name": "collect_list bytes map",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, bytes>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":"YQ=="}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":"Yg=="}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":["YQ=="]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":["YQ==","Yg=="]}}
+      ]
+    },
+    {
       "name": "collect_list int table",
       "format": ["AVRO", "JSON", "PROTOBUF"],
       "statements": [
@@ -217,6 +287,83 @@
         {"topic": "S2", "key": 0,"value": {"COLLECTED":[false]}},
         {"topic": "S2", "key": 0,"value": {"COLLECTED":[]}},
         {"topic": "S2", "key": 0,"value": {"COLLECTED":[true]}}
+      ]
+    },
+    {
+      "name": "collect_list timestamp map table",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":30, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[30]}}
+      ]
+    },
+    {
+      "name": "collect_list time map table",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":30, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[30]}}
+      ]
+    },
+    {
+      "name": "collect_list date map table",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":30, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[30]}}
+      ]
+    },
+    {
+      "name": "collect_list bytes map table",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT PRIMARY KEY, NAME varchar, VALUE map<varchar, bytes>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":"YQ=="}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":"Yg=="}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":["YQ=="]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":["Yg=="]}}
       ]
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-set.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/collect-set.json
@@ -109,6 +109,78 @@
       ]
     },
     {
+      "name": "collect_list timestamp map",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, timestamp>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}}
+      ]
+    },
+    {
+      "name": "collect_list time map",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, time>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}}
+      ]
+    },
+    {
+      "name": "collect_list date map",
+      "format": ["JSON", "PROTOBUF"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, date>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":10, "key2":15}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":25}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":20, "key2":35}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":[10,20]}}
+      ]
+    },
+    {
+      "name": "collect_list bytes map",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, bytes>) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE S2 as SELECT ID, collect_set(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":"YQ=="}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":"Yg=="}}},
+        {"topic": "test_topic", "key": 0, "value": {"name": "zero", "value": {"key1":"Yg=="}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":["YQ=="]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":["YQ==","Yg=="]}},
+        {"topic": "S2", "key": 0, "value": {"COLLECTED":["YQ==","Yg=="]}}
+      ]
+    },
+    {
       "name": "collect_set with limit of 1",
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, VALUE integer) WITH (kafka_topic='test_topic',value_format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/earliest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/earliest-offset-udaf.json
@@ -7,20 +7,20 @@
     {
       "name": "earliest by offset",
       "statements": [
-        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0, EARLIEST_BY_OFFSET(F1) AS L1, EARLIEST_BY_OFFSET(F2) AS L2, EARLIEST_BY_OFFSET(F3) AS L3, EARLIEST_BY_OFFSET(F4) AS L4 FROM INPUT GROUP BY ID;"
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING, F5 TIMESTAMP, F6 TIME, F7 DATE, F8 BYTES) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EARLIEST_BY_OFFSET(F0) AS L0, EARLIEST_BY_OFFSET(F1) AS L1, EARLIEST_BY_OFFSET(F2) AS L2, EARLIEST_BY_OFFSET(F3) AS L3, EARLIEST_BY_OFFSET(F4) AS L4, EARLIEST_BY_OFFSET(F5) AS L5, EARLIEST_BY_OFFSET(F6) AS L6, EARLIEST_BY_OFFSET(F7) AS L7, EARLIEST_BY_OFFSET(F8) AS L8 FROM INPUT GROUP BY ID;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
-        {"topic": "test_topic", "key": 1, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
-        {"topic": "test_topic", "key": 0, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}},
-        {"topic": "test_topic", "key": 1, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}}
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo", "F5": 12, "F6": 123, "F7": 1234, "F8": "YQ=="}},
+        {"topic": "test_topic", "key": 1, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo", "F5": 12, "F6": 123, "F7": 1234, "F8": "YQ=="}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "foo", "F5": 34, "F6": 234, "F7": 2345, "F8": "Yg=="}},
+        {"topic": "test_topic", "key": 1, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "foo", "F5": 34, "F6": 234, "F7": 2345, "F8": "Yg=="}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
-        {"topic": "OUTPUT", "key": 1, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
-        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
-        {"topic": "OUTPUT", "key": 1, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}}
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo", "L5": 12, "L6": 123, "L7": 1234, "L8": "YQ=="}},
+        {"topic": "OUTPUT", "key": 1, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo", "L5": 12, "L6": 123, "L7": 1234, "L8": "YQ=="}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo", "L5": 12, "L6": 123, "L7": 1234, "L8": "YQ=="}},
+        {"topic": "OUTPUT", "key": 1, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo", "L5": 12, "L6": 123, "L7": 1234, "L8": "YQ=="}}
       ]
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/latest-offset-udaf.json
@@ -6,20 +6,20 @@
     {
       "name": "latest by offset",
       "statements": [
-        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0, LATEST_BY_OFFSET(F1) AS L1, LATEST_BY_OFFSET(F2) AS L2, LATEST_BY_OFFSET(F3) AS L3, LATEST_BY_OFFSET(F4) AS L4 FROM INPUT GROUP BY ID;"
+        "CREATE STREAM INPUT (ID BIGINT KEY, F0 INT, F1 BIGINT, F2 DOUBLE, F3 BOOLEAN, F4 STRING, F5 TIMESTAMP, F6 TIME, F7 DATE, F8 BYTES) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, LATEST_BY_OFFSET(F0) AS L0, LATEST_BY_OFFSET(F1) AS L1, LATEST_BY_OFFSET(F2) AS L2, LATEST_BY_OFFSET(F3) AS L3, LATEST_BY_OFFSET(F4) AS L4, LATEST_BY_OFFSET(F5) AS L5, LATEST_BY_OFFSET(F6) AS L6, LATEST_BY_OFFSET(F7) AS L7, LATEST_BY_OFFSET(F8) AS L8 FROM INPUT GROUP BY ID;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
-        {"topic": "test_topic", "key": 1, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo"}},
-        {"topic": "test_topic", "key": 0, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}},
-        {"topic": "test_topic", "key": 1, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar"}}
+        {"topic": "test_topic", "key": 0, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo", "F5": 12, "F6": 123, "F7": 1234, "F8": "YQ=="}},
+        {"topic": "test_topic", "key": 1, "value": {"F0": 12, "F1": 1000, "F2": 1.23, "F3": true, "F4": "foo", "F5": 12, "F6": 123, "F7": 1234, "F8": "YQ=="}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar", "F5": 34, "F6": 234, "F7": 2345, "F8": "Yg=="}},
+        {"topic": "test_topic", "key": 1, "value": {"F0": 21, "F1": 2000, "F2": 2.23, "F3": false, "F4": "bar", "F5": 34, "F6": 234, "F7": 2345, "F8": "Yg=="}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
-        {"topic": "OUTPUT", "key": 1, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo"}},
-        {"topic": "OUTPUT", "key": 0, "value": {"L0": 21, "L1": 2000, "L2": 2.23, "L3": false, "L4": "bar"}},
-        {"topic": "OUTPUT", "key": 1, "value": {"L0": 21, "L1": 2000, "L2": 2.23, "L3": false, "L4": "bar"}}
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo", "L5": 12, "L6": 123, "L7": 1234, "L8": "YQ=="}},
+        {"topic": "OUTPUT", "key": 1, "value": {"L0": 12, "L1": 1000, "L2": 1.23, "L3": true, "L4": "foo", "L5": 12, "L6": 123, "L7": 1234, "L8": "YQ=="}},
+        {"topic": "OUTPUT", "key": 0, "value": {"L0": 21, "L1": 2000, "L2": 2.23, "L3": false, "L4": "bar", "L5": 34, "L6": 234, "L7": 2345, "L8": "Yg=="}},
+        {"topic": "OUTPUT", "key": 1, "value": {"L0": 21, "L1": 2000, "L2": 2.23, "L3": false, "L4": "bar", "L5": 34, "L6": 234, "L7": 2345, "L8": "Yg=="}}
       ]
     },
     {


### PR DESCRIPTION
### Description 
Adds support for timestamp, time, date and bytes to collect_list, collect_set, latest_by_offset and earliest_by_offset.

Fixes #7787

### Testing done 
unit/qtt

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

