### PR TITLE
feat: add feature flag to disable source table materialization

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -33,6 +33,7 @@ public final class ImmutableProperties {
       .add(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG)
       .add(KsqlConfig.KSQL_HIDDEN_TOPICS_CONFIG)
       .add(KsqlConfig.KSQL_READONLY_TOPICS_CONFIG)
+      .add(KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED)
       .addAll(KsqlConfig.SSL_CONFIG_NAMES)
       .build();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -411,10 +411,11 @@ public class KsqlConfig extends AbstractConfig {
       "ksql.source.table.materialization.enabled";
   private static final Boolean KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DEFAULT = true;
   private static final String KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DOC =
-      "Feature flag that enables table materialization on source tables. "
-          + "A source table is created with the CREATE SOURCE TABLE syntax. "
-          + "Default is true. If false, CREATE SOURCE TABLE will not be materialized, "
-          + "thus not able to run pull queries on them.";
+      "Feature flag that enables table materialization on source tables. Default is true. "
+          + "If false, CREATE SOURCE [TABLE|STREAM] statements will be rejected. "
+          + "Current CREATE SOURCE TABLE statements found in the KSQL command topic will "
+          + "not be materialized and pull queries won't be allowed on them. However, current "
+          + "CREATE SOURCE [TABLE|STREAM] statements will continue being read-only.";
 
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
   public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -407,6 +407,15 @@ public class KsqlConfig extends AbstractConfig {
       "Feature flag for ROWPARTITION and ROWOFFSET pseudocolumns. If enabled, new queries will be"
           + "built with ROWPARTITION and ROWOFFSET pseudocolumns. If off, they will not be.";
 
+  public static final String KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED =
+      "ksql.source.table.materialization.enabled";
+  private static final Boolean KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DEFAULT = true;
+  private static final String KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DOC =
+      "Feature flag that enables table materialization on source tables. "
+          + "A source table is created with the CREATE SOURCE TABLE syntax. "
+          + "Default is true. If false, CREATE SOURCE TABLE will not be materialized, "
+          + "thus not able to run pull queries on them.";
+
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
   public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
@@ -1046,6 +1055,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_SHARED_RUNTIME_ENABLED_DEFAULT,
             Importance.MEDIUM,
             KSQL_SHARED_RUNTIME_ENABLED_DOC
+        )
+        .define(
+            KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED,
+            Type.BOOLEAN,
+            KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DEFAULT,
+            Importance.LOW,
+            KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DOC
         )
         .withClientSslSupport();
 


### PR DESCRIPTION
### Description 
Adds a feature flag disable source table materialization. The config to disable is:
```
ksql.source.table.materialization.enabled=true
```

The  config can only be disabled from the `ksql-server.properties`. This config cannot be set on the CLI or other clients to avoid ksql clients users to enable it without notice of the ksql server admin (like Cloud users).

When the config is disabled, KSQL will not accept new CST commands. However, current CST commands found in the command topic will be executed but with no materialization and pull query support. I left the behavior this way to prevent crashing the KSQL on startup if this config is disabled and there were CST commands already running. CST tables will still be read-only, though.

### Testing done 
I didn't add tests because there's still a PR pending where to add them - https://github.com/confluentinc/ksql/pull/8079
I tested manually.

Note that the below message does not show what property is required to set. I left it this way as the feature flag should be an internal flag to disable the feature and users, especially cloud users, should not know what the property to enable it is.
```
ksql> create source table t1(id int primary key, name string) with (kafka_topic='t1', value_format='json', partitions=1);
Cannot execute command because source table materialization is disabled.

ksql> set 'ksql.source.table.materialization.enabled'='true';
Cannot override property 'ksql.source.table.materialization.enabled'
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

