### PR TITLE
test: add logging to shouldStreamInserts in case it times out again

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -50,9 +50,12 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ApiTest extends BaseApiTest {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ApiTest.class);
   protected static final List<JsonObject> DEFAULT_INSERT_ROWS = generateInsertRows();
 
   @Test
@@ -483,7 +486,7 @@ public class ApiTest extends BaseApiTest {
   @Test
   @CoreApiTest
   public void shouldStreamInserts() throws Exception {
-
+    LOG.info("Starting shouldStreamInserts");
     // Given
     JsonObject params = new JsonObject().put("target", "test-stream");
 
@@ -518,7 +521,9 @@ public class ApiTest extends BaseApiTest {
     });
 
     // Wait for the response to complete
+    LOG.info("Awaiting response from inserts");
     HttpResponse<Void> response = fut.get();
+    LOG.info("Got response from inserts");
 
     // Then
 
@@ -535,12 +540,15 @@ public class ApiTest extends BaseApiTest {
 
     // Make sure all inserts made it to the server
     TestInsertsSubscriber insertsSubscriber = testEndpoints.getInsertsSubscriber();
+    LOG.info("Checking all rows inserted");
     assertThatEventually(insertsSubscriber::getRowsInserted, is(rows));
+    LOG.info("Checking got completion marker");
     assertThatEventually(insertsSubscriber::isCompleted, is(true));
 
     // Ensure we received at least some of the response before all the request body was written
     // Yay HTTP2!
     assertThat(readStream.getLastSentTime() > writeStream.getFirstReceivedTime(), is(true));
+    LOG.info("ShouldStreamInserts complete");
   }
 
   @Test


### PR DESCRIPTION
### Description 
This test very rarely flakes out, but when it does it just "times out". I'd like to know which part is timing out.

### Testing done 
N/A logging only

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

