### PR TITLE
chore: mock describeTopics w/ explicit type to resolve ambiguous ref

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -202,6 +202,7 @@ public class HealthCheckAgentTest {
     assertThat(response.getIsHealthy(), is(true));
   }
 
+  // isolate suppressed calls to their own methods
   @SuppressWarnings("unchecked")
   private void givenDescribeTopicsReturns(final DescribeTopicsResult topicsResult) {
     when(adminClient.describeTopics(any(Collection.class), any())).thenReturn(topicsResult);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
 import java.net.URI;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.kafka.clients.admin.Admin;
@@ -97,7 +98,7 @@ public class HealthCheckAgentTest {
     when(serviceContext.getAdminClient()).thenReturn(adminClient);
 
     final DescribeTopicsResult topicsResult = mock(DescribeTopicsResult.class);
-    when(adminClient.describeTopics(any(), any())).thenReturn(topicsResult);
+    givenDescribeTopicsReturns(topicsResult);
     when(topicsResult.all()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.RUNNING);
 
@@ -139,7 +140,7 @@ public class HealthCheckAgentTest {
   @Test
   public void shouldReturnUnhealthyIfKafkaCheckFails() {
     // Given:
-    doThrow(KafkaResponseGetFailedException.class).when(adminClient).describeTopics(any(), any());
+    givenDescribeTopicsThrows(KafkaResponseGetFailedException.class);
 
     // When:
     final HealthCheckResponse response = healthCheckAgent.checkHealth();
@@ -165,7 +166,7 @@ public class HealthCheckAgentTest {
   @Test
   public void shouldReturnHealthyIfKafkaCheckFailsWithAuthorizationException() {
     // Given:
-    doThrow(KsqlTopicAuthorizationException.class).when(adminClient).describeTopics(any(), any());
+    givenDescribeTopicsThrows(KsqlTopicAuthorizationException.class);
 
     // When:
     final HealthCheckResponse response = healthCheckAgent.checkHealth();
@@ -178,7 +179,7 @@ public class HealthCheckAgentTest {
   @Test
   public void shouldReturnHealthyIfKafkaCheckFailsWithUnknownTopicOrPartitionExceptionAsRootCause() {
     // Given:
-    when(adminClient.describeTopics(any(), any())).thenThrow(new RuntimeException(new UnknownTopicOrPartitionException()));
+    givenDescribeTopicsThrows(new RuntimeException(new UnknownTopicOrPartitionException()));
 
     // When:
     final HealthCheckResponse response = healthCheckAgent.checkHealth();
@@ -191,7 +192,7 @@ public class HealthCheckAgentTest {
   @Test
   public void shouldReturnHealthyIfKafkaCheckFailsWithUnknownTopicOrPartitionException() {
     // Given:
-    when(adminClient.describeTopics(any(), any())).thenThrow(new UnknownTopicOrPartitionException());
+    givenDescribeTopicsThrows(new UnknownTopicOrPartitionException());
 
     // When:
     final HealthCheckResponse response = healthCheckAgent.checkHealth();
@@ -199,5 +200,20 @@ public class HealthCheckAgentTest {
     // Then:
     assertThat(response.getDetails().get(KAFKA_CHECK_NAME).getIsHealthy(), is(true));
     assertThat(response.getIsHealthy(), is(true));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenDescribeTopicsReturns(final DescribeTopicsResult topicsResult) {
+    when(adminClient.describeTopics(any(Collection.class), any())).thenReturn(topicsResult);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenDescribeTopicsThrows(final Class<? extends Throwable> clazz) {
+    doThrow(clazz).when(adminClient).describeTopics(any(Collection.class), any());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenDescribeTopicsThrows(final Throwable t) {
+    doThrow(t).when(adminClient).describeTopics(any(Collection.class), any());
   }
 }


### PR DESCRIPTION
### Description 
Should fix this upstream build failure:
```
09:22:14  [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java:[100,21] reference to describeTopics is ambiguous
09:22:14    both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
09:22:14  [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java:[142,69] reference to describeTopics is ambiguous
09:22:14    both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
09:22:14  [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java:[168,69] reference to describeTopics is ambiguous
09:22:14    both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
09:22:14  [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java:[181,21] reference to describeTopics is ambiguous
09:22:14    both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match
09:22:14  [ERROR] /home/jenkins/workspace/apache-kafka-to-ksql-test_trunk/ksql-master/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java:[194,21] reference to describeTopics is ambiguous
09:22:14    both method describeTopics(java.util.Collection<java.lang.String>,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin and method describeTopics(org.apache.kafka.common.TopicCollection,org.apache.kafka.clients.admin.DescribeTopicsOptions) in org.apache.kafka.clients.admin.Admin match

```
