### PR TITLE
fix: Enables ALPN for internal requests when http2 and tls are in use

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 public final class InternalKsqlClientFactory {
 
@@ -89,11 +88,11 @@ public final class InternalKsqlClientFactory {
     };
   }
 
-  private static HttpClientOptions createClientOptions(boolean tls) {
+  private static HttpClientOptions createClientOptions(final boolean tls) {
     return new HttpClientOptions().setMaxPoolSize(100);
   }
 
-  private static HttpClientOptions createClientOptionsHttp2(boolean tls) {
+  private static HttpClientOptions createClientOptionsHttp2(final boolean tls) {
     return new HttpClientOptions().setHttp2MaxPoolSize(100).setProtocolVersion(HttpVersion.HTTP_2)
         .setUseAlpn(tls);
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
@@ -60,9 +60,9 @@ public final class InternalKsqlClientFactory {
 
   private static Function<Boolean, HttpClientOptions> httpOptionsFactory(
       final Map<String, String> clientProps, final boolean verifyHost,
-      final Supplier<HttpClientOptions> optionsSupplier) {
+      final Function<Boolean, HttpClientOptions> clientOptions) {
     return (tls) -> {
-      final HttpClientOptions httpClientOptions = optionsSupplier.get();
+      final HttpClientOptions httpClientOptions = clientOptions.apply(tls);
       if (!tls) {
         return httpClientOptions;
       }
@@ -89,11 +89,12 @@ public final class InternalKsqlClientFactory {
     };
   }
 
-  private static HttpClientOptions createClientOptions() {
+  private static HttpClientOptions createClientOptions(boolean tls) {
     return new HttpClientOptions().setMaxPoolSize(100);
   }
 
-  private static HttpClientOptions createClientOptionsHttp2() {
-    return new HttpClientOptions().setHttp2MaxPoolSize(100).setProtocolVersion(HttpVersion.HTTP_2);
+  private static HttpClientOptions createClientOptionsHttp2(boolean tls) {
+    return new HttpClientOptions().setHttp2MaxPoolSize(100).setProtocolVersion(HttpVersion.HTTP_2)
+        .setUseAlpn(tls);
   }
 }


### PR DESCRIPTION
### Description 
Vertx throws an error when http2 and tls are enabled, but the ALPN option isn't set on the options:
https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java#L548

This sets the option when tls is used for http2, internal requests.

### Testing done 
Tested using http2 and tls.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

