### PR TITLE
feat: update storage utilization metrics to start when app is initialized

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -67,20 +67,9 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
 
   @Override
   public void configure(final Map<String, ?> map) {
-    final String dir;
-    if (map.containsKey(StreamsConfig.STATE_DIR_CONFIG)) {
-      dir = map.get(StreamsConfig.STATE_DIR_CONFIG).toString();
-    } else {
-      dir =  StreamsConfig
-        .configDef()
-        .defaultValues()
-        .get(StreamsConfig.STATE_DIR_CONFIG)
-        .toString();
-    }
-    configureShared(new File(dir), this.metricRegistry);
   }
 
-  private static void configureShared(final File baseDir, final Metrics metricRegistry) {
+  public static void configureShared(final File baseDir, final Metrics metricRegistry) {
     if (registeredNodeMetrics.getAndSet(true)) {
       return;
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -41,9 +41,12 @@ import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
-import org.apache.kafka.streams.StreamsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StorageUtilizationMetricsReporter implements MetricsReporter {
+  private static final Logger LOGGER
+      = LoggerFactory.getLogger(StorageUtilizationMetricsReporter.class);
   private static final String METRIC_GROUP = "ksqldb_utilization";
 
   private final Map<String, Map<String, TaskStorageMetric>> metricsSeen;
@@ -73,6 +76,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     if (registeredNodeMetrics.getAndSet(true)) {
       return;
     }
+    LOGGER.info("Adding node level storage usage gauges");
     final MetricName nodeAvailable =
         metricRegistry.metricName("node_storage_free_bytes", METRIC_GROUP);
     final MetricName nodeTotal =
@@ -158,6 +162,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
       final String taskId,
       final String queryId
   ) {
+    LOGGER.debug("Updating disk usage metrics");
     // if we haven't seen a task for this query yet
     if (!metricsSeen.containsKey(queryId)) {
       metricRegistry.addMetric(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -60,7 +60,7 @@ public class StorageUtilizationMetricsReporterTest {
     final File f = new File("/tmp/storage-test/");
     f.getParentFile().mkdirs();
     f.createNewFile();
-    listener.configure(ImmutableMap.of("state.dir", "/tmp/storage-test/"));
+    listener.configureShared(f, metrics);
   }
 
   @After

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
 import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.internal.PullQueryExecutorMetrics;
+import io.confluent.ksql.internal.StorageUtilizationMetricsReporter;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogServerUtils;
@@ -699,6 +700,13 @@ public final class KsqlRestApplication implements Executable {
 
     final SpecificQueryIdGenerator specificQueryIdGenerator =
         new SpecificQueryIdGenerator();
+    
+    final String stateDir = ksqlConfig.getKsqlStreamConfigProps().getOrDefault(
+      StreamsConfig.STATE_DIR_CONFIG,
+      StreamsConfig.configDef().defaultValues().get(StreamsConfig.STATE_DIR_CONFIG))
+      .toString();
+
+    StorageUtilizationMetricsReporter.configureShared(new File(stateDir), MetricCollectors.getMetrics());
 
     final KsqlEngine ksqlEngine = new KsqlEngine(
         serviceContext,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -702,11 +702,14 @@ public final class KsqlRestApplication implements Executable {
         new SpecificQueryIdGenerator();
     
     final String stateDir = ksqlConfig.getKsqlStreamConfigProps().getOrDefault(
-      StreamsConfig.STATE_DIR_CONFIG,
-      StreamsConfig.configDef().defaultValues().get(StreamsConfig.STATE_DIR_CONFIG))
-      .toString();
+          StreamsConfig.STATE_DIR_CONFIG,
+          StreamsConfig.configDef().defaultValues().get(StreamsConfig.STATE_DIR_CONFIG))
+          .toString();
 
-    StorageUtilizationMetricsReporter.configureShared(new File(stateDir), MetricCollectors.getMetrics());
+    StorageUtilizationMetricsReporter.configureShared(
+      new File(stateDir), 
+            MetricCollectors.getMetrics()
+    );
 
     final KsqlEngine ksqlEngine = new KsqlEngine(
         serviceContext,


### PR DESCRIPTION
### Description 
per https://confluentinc.atlassian.net/browse/KCI-938, make storage utilization per node metrics initialized when the app starts up. this means that even if the app has no queries, we'll still be getting metrics at the node level. previously, we'd only see node level metrics after we created a query

### Testing done 
kept existing unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

