### PR TITLE
chore: do not reset offset on source tables

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/statement/Injectors.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/statement/Injectors.java
@@ -33,7 +33,8 @@ public enum Injectors implements BiFunction<KsqlExecutionContext, ServiceContext
       new DefaultSchemaInjector(
           new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient())),
       new TopicCreateInjector(ec, sc),
-      new SchemaRegisterInjector(ec, sc)
+      new SchemaRegisterInjector(ec, sc),
+      new PropertiesInjector()
   )),
 
   DEFAULT((ec, sc) -> InjectorChain.of(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/statement/PropertiesInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/statement/PropertiesInjector.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.statement;
+
+import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.CreateTable;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PropertiesInjector implements Injector {
+  private <T extends Statement> boolean isSourceTable(final ConfiguredStatement<T> statement) {
+    return statement.getStatement() instanceof CreateTable
+        && ((CreateTable) statement.getStatement()).isSource();
+  }
+
+  @Override
+  public <T extends Statement> ConfiguredStatement<T> inject(
+      final ConfiguredStatement<T> statement
+  ) {
+    if (!isSourceTable(statement)) {
+      return statement;
+    }
+
+    return ConfiguredStatement.of(
+      KsqlParser.PreparedStatement.of(statement.getStatementText(), statement.getStatement()),
+      forSourceTable(statement.getSessionConfig())
+    );
+  }
+
+  public SessionConfig forSourceTable(final SessionConfig sessionConfig) {
+    final KsqlConfig systemConfig = sessionConfig.getConfig(false);
+    final Map<String, Object> overrides = new HashMap<>(sessionConfig.getOverrides());
+
+    // Source tables must be materialized from the earliest offset. This config makes sure to
+    // override system or a user overridden auto.offset.reset config.
+    overrides.put("auto.offset.reset", "earliest");
+
+    return SessionConfig.of(systemConfig, overrides);
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/statement/PropertiesInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/statement/PropertiesInjectorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.statement;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.parser.tree.CreateTable;
+import io.confluent.ksql.util.KsqlConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PropertiesInjectorTest {
+  @Mock
+  private CreateTable createTable;
+  @Mock
+  private ConfiguredStatement<CreateTable> createTableStatement;
+  @Mock
+  private SessionConfig sessionConfig;
+
+  private PropertiesInjector propertiesInjector;
+
+  @Before
+  public void setup() {
+    propertiesInjector = new PropertiesInjector();
+    when(createTableStatement.getStatement()).thenReturn(createTable);
+    when(createTableStatement.getStatementText()).thenReturn("SQL");
+    when(createTableStatement.getSessionConfig()).thenReturn(sessionConfig);
+  }
+
+  @Test
+  public void shouldSetOffsetResetToEarliestIfNotPresent() {
+    // Given:
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of());
+    when(createTable.isSource()).thenReturn(true);
+    when(sessionConfig.getConfig(false)).thenReturn(config);
+    when(sessionConfig.getOverrides()).thenReturn(ImmutableMap.of());
+
+    // When:
+    final ConfiguredStatement<CreateTable> newStatement =
+        propertiesInjector.inject(createTableStatement);
+
+    // Then:
+    assertThat(newStatement.getStatement(), is(createTableStatement.getStatement()));
+    assertThat(newStatement.getStatementText(), is(createTableStatement.getStatementText()));
+    assertThat(newStatement.getSessionConfig().getConfig(false), is(config));
+    assertThat(newStatement.getSessionConfig().getOverrides(),
+        is(ImmutableMap.of("auto.offset.reset", "earliest")));
+  }
+
+  @Test
+  public void shouldSetOffsetResetToEarliestIfOverridden() {
+    // Given:
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of());
+    when(createTable.isSource()).thenReturn(true);
+    when(sessionConfig.getConfig(false)).thenReturn(config);
+    when(sessionConfig.getOverrides()).thenReturn(ImmutableMap.of("auto.offset.reset", "latest"));
+
+    // When:
+    final ConfiguredStatement<CreateTable> newStatement =
+        propertiesInjector.inject(createTableStatement);
+
+    // Then:
+    assertThat(newStatement.getStatement(), is(createTableStatement.getStatement()));
+    assertThat(newStatement.getStatementText(), is(createTableStatement.getStatementText()));
+    assertThat(newStatement.getSessionConfig().getConfig(false), is(config));
+    assertThat(newStatement.getSessionConfig().getOverrides(),
+        is(ImmutableMap.of("auto.offset.reset", "earliest")));
+  }
+
+  @Test
+  public void shouldSetOffsetResetToEarliestDifferentSystemConfigIsPresent() {
+    // Given:
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of("auto.offset.reset", "latest"));
+    when(createTable.isSource()).thenReturn(true);
+    when(sessionConfig.getConfig(false)).thenReturn(config);
+    when(sessionConfig.getOverrides()).thenReturn(ImmutableMap.of());
+
+    // When:
+    final ConfiguredStatement<CreateTable> newStatement =
+        propertiesInjector.inject(createTableStatement);
+
+    // Then:
+    assertThat(newStatement.getStatement(), is(createTableStatement.getStatement()));
+    assertThat(newStatement.getStatementText(), is(createTableStatement.getStatementText()));
+    assertThat(newStatement.getSessionConfig().getConfig(false), is(config));
+    assertThat(newStatement.getSessionConfig().getOverrides(),
+        is(ImmutableMap.of("auto.offset.reset", "earliest")));
+  }
+
+  @Test
+  public void shouldNotSetOffsetResetOnNoSourceTables() {
+    // Given:
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of());
+    when(createTable.isSource()).thenReturn(false);
+    when(sessionConfig.getConfig(false)).thenReturn(config);
+    when(sessionConfig.getOverrides()).thenReturn(ImmutableMap.of());
+
+    // When:
+    final ConfiguredStatement<CreateTable> newStatement =
+        propertiesInjector.inject(createTableStatement);
+
+    // Then:
+    assertThat(newStatement.getStatement(), is(createTableStatement.getStatement()));
+    assertThat(newStatement.getStatementText(), is(createTableStatement.getStatementText()));
+    assertThat(newStatement.getSessionConfig().getConfig(false), is(config));
+    assertThat(newStatement.getSessionConfig().getOverrides(), is(ImmutableMap.of()));
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-cst-materialized.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-cst-materialized.json
@@ -68,6 +68,28 @@
           {"row":{"columns":[2,"a2"]}}
         ]}
       ]
+    },
+    {
+      "name": "should not override offset on CST commands",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "SELECT * FROM INPUT WHERE K=2;"
+      ],
+      "properties": {
+        "auto.offset.reset" : "latest"
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 1, "value": "a1"},
+        {"topic": "test_topic", "timestamp": 12345, "key": 2, "value": "a2"},
+        {"topic": "test_topic", "timestamp": 12345, "key": 3, "value": "a3"}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`K` INTEGER KEY, `TEXT` STRING"}},
+          {"row":{"columns":[2,"a2"]}}
+        ]}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 
This PR makes sure that users do not override the `auto.offset.reset` config when creating a new source table. I found this problem while testing. If I user sets `auto.offset.reste=latest` and then create a source table, the internal query will populate the state materialization from the latest changes of the topic. 

This PR always sets `auto.offset.reset` to `earliest`, so the table starts materialization from the beginning of the topic.

### Testing done 
Added unit tests and verified manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

