### PR TITLE
chore: Move build alerts to quality-oncall

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,7 @@
 #!/usr/bin/env groovy
 
-def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksql-alerts' : '#ksqldb-warn'
-
 dockerfile {
-    slackChannel = channel
+    slackChannel = '#ksqldb-quality-oncall'
     upstreamProjects = 'confluentinc/schema-registry'
     extraDeployArgs = '-Ddocker.skip=true'
     dockerPush = false


### PR DESCRIPTION
Consolidates the alerting for failed builds into the ksqldb-quality-oncall channel.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

