### PR TITLE
chore: raise the limit on number of builds to keep

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,5 +11,7 @@ dockerfile {
     dockerImageClean = false
     downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins"]
     nanoVersion = true
+    maxBuildsToKeep = 999
+    maxDaysToKeep = 90
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ dockerfile {
     dockerImageClean = false
     downStreamRepos = ["confluent-security-plugins", "confluent-cloud-plugins"]
     nanoVersion = true
-    maxBuildsToKeep = 999
+    maxBuildsToKeep = 99
     maxDaysToKeep = 90
 }
 


### PR DESCRIPTION
We want to keep builds for three months to support investigations,
but have been hampered by the default value of maxBuildsToKeep (15).

I just raised it arbitrarily to 99. I also made the default retention time
of 90 days explicit in the Jenkinsfile.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

