### PR TITLE
chore: Rename Scalable Push Query to be push query v2

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -278,34 +278,37 @@ public class KsqlConfig extends AbstractConfig {
           + " much faster for short-lived queries.";
   public static final boolean KSQL_QUERY_PULL_INTERPRETER_ENABLED_DEFAULT = true;
 
-  public static final String KSQL_QUERY_PUSH_SCALABLE_ENABLED
-      = "ksql.query.push.scalable.enabled";
-  public static final String KSQL_QUERY_PUSH_SCALABLE_ENABLED_DOC =
-      "Enables whether scalable push queries are enabled. Scalable push queries require no window "
-          + "functions, aggregations, or joins, but may include projections and filters.";
-  public static final boolean KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT = false;
+  public static final String KSQL_QUERY_PUSH_V2_ENABLED
+      = "ksql.query.push.v2.enabled";
+  public static final String KSQL_QUERY_PUSH_V2_ENABLED_DOC =
+      "Enables whether v2 push queries are enabled. The scalable form of push queries require no"
+          + " window functions, aggregations, or joins, but may include projections and filters. If"
+          + " they cannot be utilized, the streams application version will automatically be used"
+          + " instead.";
+  public static final boolean KSQL_QUERY_PUSH_V2_ENABLED_DEFAULT = false;
 
-  public static final String KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED
-      = "ksql.query.push.scalable.registry.installed";
-  public static final String KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED_DOC =
-      "Enables whether scalable push registry should be installed. This is a requirement of "
-          + "enabling scalable push queries using ksql.query.push.scalable.enabled.";
-  public static final boolean KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED_DEFAULT = false;
+  public static final String KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED
+      = "ksql.query.push.v2.registry.installed";
+  public static final String KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED_DOC =
+      "Enables whether v2 push registry should be installed. This is a requirement of "
+          + "enabling scalable push queries using ksql.query.push.v2.enabled.";
+  public static final boolean KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED_DEFAULT = false;
 
-  public static final String KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY
-      = "ksql.query.push.scalable.new.node.continuity";
-  public static final String KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DOC =
-      "Whether new node continuity is enforced for scalable push queries. This means that it's an "
-          + "error for an existing query to miss data processed on a newly added node";
-  public static final boolean KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DEFAULT = false;
+  public static final String KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY
+      = "ksql.query.push.v2.new.node.continuity";
+  public static final String KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY_DOC =
+      "Whether new node continuity is enforced for the scalable form of push queries. "
+          + "This means that it's an error for an existing query to miss data processed on a newly "
+          + "added node";
+  public static final boolean KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY_DEFAULT = false;
 
-  public static final String KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED
-      = "ksql.query.push.scalable.interpreter.enabled";
-  public static final String KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED_DOC =
+  public static final String KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED
+      = "ksql.query.push.v2.interpreter.enabled";
+  public static final String KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED_DOC =
       "Enables whether we use the interpreter for expression evaluation for scalable push queries, "
           + "or the default code generator. They should produce the same results, but may have "
           + "different performance characteristics.";
-  public static final boolean KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED_DEFAULT = true;
+  public static final boolean KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED_DEFAULT = true;
 
   public static final String KSQL_STRING_CASE_CONFIG_TOGGLE = "ksql.cast.strings.preserve.nulls";
   public static final String KSQL_STRING_CASE_CONFIG_TOGGLE_DOC =
@@ -934,32 +937,32 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PULL_INTERPRETER_ENABLED_DOC
         )
         .define(
-            KSQL_QUERY_PUSH_SCALABLE_ENABLED,
+            KSQL_QUERY_PUSH_V2_ENABLED,
             Type.BOOLEAN,
-            KSQL_QUERY_PUSH_SCALABLE_ENABLED_DEFAULT,
+            KSQL_QUERY_PUSH_V2_ENABLED_DEFAULT,
             Importance.LOW,
-            KSQL_QUERY_PUSH_SCALABLE_ENABLED_DOC
+            KSQL_QUERY_PUSH_V2_ENABLED_DOC
         )
         .define(
-            KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED,
+            KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED,
             Type.BOOLEAN,
-            KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED_DEFAULT,
+            KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED_DEFAULT,
             Importance.LOW,
-            KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED_DOC
+            KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED_DOC
         )
         .define(
-            KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY,
+            KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY,
             Type.BOOLEAN,
-            KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DEFAULT,
+            KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY_DEFAULT,
             Importance.LOW,
-            KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY_DOC
+            KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY_DOC
         )
         .define(
-            KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED,
+            KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED,
             Type.BOOLEAN,
-            KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED_DEFAULT,
+            KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED_DEFAULT,
             Importance.LOW,
-            KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED_DOC
+            KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED_DOC
         )
         .define(
             KSQL_ERROR_CLASSIFIER_REGEX_PREFIX,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -225,7 +225,7 @@ final class QueryExecutor {
       final Map<String, Object> streamsProperties,
       final KsqlConfig ksqlConfig
   ) {
-    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED)) {
+    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED)) {
       return Optional.empty();
     }
     final KStream<?, GenericRow> stream;
@@ -239,7 +239,7 @@ final class QueryExecutor {
     }
     final Optional<ScalablePushRegistry> registry = ScalablePushRegistry.create(schema,
         allPersistentQueries, isTable, windowed, streamsProperties,
-        ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_NEW_NODE_CONTINUITY));
+        ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY));
     registry.ifPresent(r -> stream.process(registry.get()));
     return registry;
   }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -102,8 +102,8 @@ public class RestQueryTranslationTest {
       .withProperty(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "set")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED, true)
-      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED, true)
-      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED, true)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .build();
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigPlannerOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigPlannerOptions.java
@@ -40,9 +40,9 @@ public class PushQueryConfigPlannerOptions implements QueryPlannerOptions {
 
   @Override
   public boolean getInterpreterEnabled() {
-    if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED)) {
-      return (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED);
+    if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED)) {
+      return (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED);
     }
-    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_INTERPRETER_ENABLED);
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ScalablePushUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ScalablePushUtil.java
@@ -45,7 +45,7 @@ public final class ScalablePushUtil {
       final KsqlConfig ksqlConfig,
       final Map<String, Object> overrides
   ) {
-    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED)) {
+    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED)) {
       return false;
     }
     if (! (statement instanceof Query)) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -215,8 +215,8 @@ public class RestApiTest {
       .withProperty("sasl.mechanism", "PLAIN")
       .withProperty("sasl.jaas.config", SecureKafkaHelper.buildJaasConfig(NORMAL_USER))
       .withProperties(ClientTrustStore.trustStoreProps())
-      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED, true)
-      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED, true)
       .build();
 
   @ClassRule

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ScalablePushQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/ScalablePushQueryFunctionalTest.java
@@ -98,8 +98,8 @@ public class ScalablePushQueryFunctionalTest {
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8088")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
-      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED, true)
-      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED, true)
       // Make rebalances happen quicker for the sake of the test
       .withProperty(KSQL_STREAMS_PREFIX + "max.poll.interval.ms", 5000)
       .withProperty(KSQL_STREAMS_PREFIX + "session.timeout.ms", 10000)
@@ -113,8 +113,8 @@ public class ScalablePushQueryFunctionalTest {
       .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8089")
       .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8089")
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS, true)
-      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_REGISTRY_INSTALLED, true)
-      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_SCALABLE_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED, true)
+      .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED, true)
       // Make rebalances happen quicker for the sake of the test
       .withProperty(KSQL_STREAMS_PREFIX + "max.poll.interval.ms", 5000)
       .withProperty(KSQL_STREAMS_PREFIX + "session.timeout.ms", 10000)


### PR DESCRIPTION
### Description 
Changes the config names of scalable push queries to be push queries v2. The idea is that this uses a more efficient methodology if possible and falls back to the conventional method if not, so it's really an updated version of push queries.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

