### PR TITLE
fix: allow insert into table using HTTP/2 endpoint and Java API

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.api.client;
 import static io.confluent.ksql.api.client.util.ClientTestUtil.awaitLatch;
 import static io.confluent.ksql.api.client.util.ClientTestUtil.subscribeAndWait;
 import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_REQUEST;
+import static io.confluent.ksql.rest.Errors.ERROR_CODE_BAD_STATEMENT;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -595,7 +596,7 @@ public class ClientTest extends BaseApiTest {
   @Test
   public void shouldHandleErrorResponseFromInsertInto() {
     // Given
-    KsqlApiException exception = new KsqlApiException("Cannot insert into a table", ERROR_CODE_BAD_REQUEST);
+    KsqlApiException exception = new KsqlApiException("Invalid target name", ERROR_CODE_BAD_STATEMENT);
     testEndpoints.setCreateInsertsSubscriberException(exception);
 
     // When
@@ -607,7 +608,7 @@ public class ClientTest extends BaseApiTest {
     // Then
     assertThat(e.getCause(), instanceOf(KsqlClientException.class));
     assertThat(e.getCause().getMessage(), containsString("Received 400 response from server"));
-    assertThat(e.getCause().getMessage(), containsString("Cannot insert into a table"));
+    assertThat(e.getCause().getMessage(), containsString("Invalid target name"));
   }
 
   @Test
@@ -671,7 +672,7 @@ public class ClientTest extends BaseApiTest {
   @Test
   public void shouldHandleErrorResponseFromStreamInserts() {
     // Given
-    KsqlApiException exception = new KsqlApiException("Cannot insert into a table", ERROR_CODE_BAD_REQUEST);
+    KsqlApiException exception = new KsqlApiException("Invalid target name", ERROR_CODE_BAD_STATEMENT);
     testEndpoints.setCreateInsertsSubscriberException(exception);
 
     // When
@@ -683,7 +684,7 @@ public class ClientTest extends BaseApiTest {
     // Then
     assertThat(e.getCause(), instanceOf(KsqlClientException.class));
     assertThat(e.getCause().getMessage(), containsString("Received 400 response from server"));
-    assertThat(e.getCause().getMessage(), containsString("Cannot insert into a table"));
+    assertThat(e.getCause().getMessage(), containsString("Invalid target name"));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -133,7 +133,7 @@ public final class IntegrationTestHarness extends ExternalResource {
   /**
    * Ensure topics with the given {@code topicNames} exist.
    *
-   * <p>Topics will be creates, if they do not already exist, with a single partition and replica.
+   * <p>Topics will be created, if they do not already exist, with a single partition and replica.
    *
    * @param topicNames the names of the topics to create.
    */
@@ -144,7 +144,7 @@ public final class IntegrationTestHarness extends ExternalResource {
   /**
    * Ensure topics with the given {@code topicNames} exist.
    *
-   * <p>Topics will be creates, if they do not already exist, with the specified
+   * <p>Topics will be created, if they do not already exist, with the specified
    * {@code partitionCount}.
    *
    * @param topicNames the names of the topics to create.

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -514,7 +514,8 @@ public class ApiIntegrationTest {
         .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then: request fails because stream name is invalid
-    shouldRejectInsertRequest(target, row, "Cannot insert values into an unknown stream: " + target);
+    shouldRejectInsertRequest(target, row,
+        "Cannot insert values into an unknown stream/table: " + target);
   }
 
   @Test
@@ -533,7 +534,8 @@ public class ApiIntegrationTest {
         .put("COMPLEX", COMPLEX_FIELD_VALUE);
 
     // Then: request fails because stream name is invalid
-    shouldRejectInsertRequest(target, row, "Cannot insert values into an unknown stream: `" + TEST_STREAM.toLowerCase() + "`");
+    shouldRejectInsertRequest(target, row,
+        "Cannot insert values into an unknown stream/table: `" + TEST_STREAM.toLowerCase() + "`");
   }
 
   @Test


### PR DESCRIPTION
## Description

Inserting into tables using CLI is permitted but using Java API is not. Allow it in Java API to make the behavior consistent.

Fixes https://github.com/confluentinc/ksql/issues/7948

## Changes
* Remove checks for table insertion in `ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/InsertsStreamEndpoint.java`.
* Remove two unit tests in `ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java` as they use `testEndpoint` and doesn't actually test anything in production endpoint.
* Add 4 test in integration test. All other changes in Integration test comes from Intellij auto formatting
  * Insert and Pull from table -> Exception
  * Insert and Push query from table -> Success
  * Insert and Pull from CTAS table -> Nothing returns
  * Insert to topic and Pull from CTAS table -> Success
