### PR TITLE
feat: disable stream pull queries by default

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -282,7 +282,7 @@ public class KsqlConfig extends AbstractConfig {
       = "ksql.query.pull.stream.enabled";
   public static final String KSQL_QUERY_STREAM_PULL_QUERY_ENABLED_DOC =
       "Config to enable pull queries on streams";
-  public static final boolean KSQL_QUERY_STREAM_PULL_QUERY_ENABLED_DEFAULT = true;
+  public static final boolean KSQL_QUERY_STREAM_PULL_QUERY_ENABLED_DEFAULT = false;
 
   public static final String KSQL_QUERY_PULL_RANGE_SCAN_ENABLED
       = "ksql.query.pull.range.scan.enabled";

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -336,8 +336,13 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       final ConfiguredStatement<Query> statementOrig,
       final boolean excludeTombstones
   ) {
+    final boolean streamPullQueriesEnabled =
+        statementOrig
+            .getSessionConfig()
+            .getConfig(true)
+            .getBoolean(KsqlConfig.KSQL_QUERY_STREAM_PULL_QUERY_ENABLED);
 
-    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_STREAM_PULL_QUERY_ENABLED)) {
+    if (!streamPullQueriesEnabled) {
       throw new KsqlStatementException(
           "Pull queries on streams are disabled. To create a push query on the stream,"
               + " add EMIT CHANGES to the end. To enable pull queries on streams, set"

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-streams.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-streams.json
@@ -5,6 +5,9 @@
   "tests": [
     {
       "name": "empty response on empty stream",
+      "properties": {
+        "ksql.query.pull.stream.enabled": true
+      },
       "statements": [
         "CREATE STREAM S1 (MYKEY INT KEY, MYVALUE INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT * FROM S1;"
@@ -15,6 +18,18 @@
           {"header":{"schema":"`MYKEY` INTEGER, `MYVALUE` INTEGER"}}
         ]}
       ]
+    },
+    {
+      "name": "disabled by default",
+      "statements": [
+        "CREATE STREAM S1 (MYKEY INT KEY, MYVALUE INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT * FROM S1;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Pull queries on streams are disabled. To create a push query on the stream, add EMIT CHANGES to the end. To enable pull queries on streams, set the ksql.query.pull.stream.enabled config to 'true'.",
+        "status": 400
+      }
     },
     {
       "name": "error on GROUP BY",
@@ -79,6 +94,9 @@
     },
     {
       "name": "correct results",
+      "properties": {
+        "ksql.query.pull.stream.enabled": true
+      },
       "statements": [
         "CREATE STREAM S1 (MYKEY INT KEY, MYVALUE INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "SELECT * FROM S1;",


### PR DESCRIPTION
Since stream pull queries are only implemented for the HTTP/1 REST endpoint, they will be disabled by default.

The config is overridable on a per-query basis, though, in case people want to use the feature in a preview state.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

