### PR TITLE
feat: add methods and classes to execute low level HTTP requests in the ksqldb-api-client

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -812,12 +812,12 @@ Map<String, Object> variables = client.getVariables();
 Execute Direct HTTP Requests<a name="direct-http-requests"></a>
 ---------------------------------------------------------------
 
-Sometimes it is necessary to execute requests directly against the ksqlDB server for reasons including, 
+Sometimes, you need to execute requests directly against the ksqlDB server for reasons including, 
 but not limited to, accessing features in ksqlDB REST API that are not available in the API client,
 or deserializing responses into different classes that are more native to your application.
 
-For this, the Client now adds an `HttpRequest` and `HttpResponse` interface that can be used to send 
-direct requests. 
+For this purpose, the Client now adds an `HttpRequest` and `HttpResponse` interface that you can 
+use for sending direct requests. 
 
 ### Example Usage ###
 Call the `/info` endpoint in ksqlDB with: 
@@ -857,7 +857,8 @@ HttpResponse response = client.buildRequest("POST", "/ksql")
 assert response.status() == 200;
 ```
 
-The `send()` method will add authentication headers as specified in [ClientOptions](api/io/confluent/ksql/api/client/ClientOptions.html).
+The `send()` method adds authentication headers as specified in 
+[ClientOptions](api/io/confluent/ksql/api/client/ClientOptions.html).
 
 Tutorial Examples<a name="tutorial-examples"></a>
 -------------------------------------------------

--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -34,6 +34,7 @@ Use the Java client to:
 - [Get metadata about the ksqlDB cluster](#server-info)
 - [Manage, list and describe connectors](#connector-operations)
 - [Define variables for substitution](#variable-substitution)
+- [Execute Direct HTTP Requests](#direct-http-requests)
 
 Get started below or skip to the end for full-fledged [examples](#tutorial-examples).
 
@@ -807,6 +808,56 @@ Get all variables:
 ```java
 Map<String, Object> variables = client.getVariables();
 ```
+
+Execute Direct HTTP Requests<a name="direct-http-requests"></a>
+---------------------------------------------------------------
+
+Sometimes it is necessary to execute requests directly against the ksqlDB server for reasons including, 
+but not limited to, accessing features in ksqlDB REST API that are not available in the API client,
+or deserializing responses into different classes that are more native to your application.
+
+For this, the Client now adds an `HttpRequest` and `HttpResponse` interface that can be used to send 
+direct requests. 
+
+### Example Usage ###
+Call the `/info` endpoint in ksqlDB with: 
+```java
+HttpResponse response = client.buildRequest("GET", "/info")
+    .send()
+    .get();
+
+// check status with
+assert response.status() == 200;
+
+// parse body (a byte[]) with:
+parseIntoJson(response.body())
+
+// or use the helper method to read body into a map:
+Map<String, Map<String, Object>> info = response.bodyAsMap();
+```
+
+Add query properties variables: 
+```java
+HttpResponse response = client.buildRequest("POST", "/ksql")
+    .payload("ksql", "CREATE STREAM FOO AS CONCAT(A, `wow;`) FROM `BAR`;")
+    .propertiesKey("streamsProperties")
+    .property("auto.offset.reset", "earliest")
+    .send()
+    .get();
+assert response.status() == 200;
+```
+
+Or build the entire payload manually: 
+```java
+HttpResponse response = client.buildRequest("POST", "/ksql")
+    .payload("ksql", "CREATE STREAM FOO AS CONCAT(A, `wow;`) FROM `BAR`;")
+    .payload("streamsProperties", Collections.singletonMap("auto.offset.reset", "earliest"))
+    .send()
+    .get();
+assert response.status() == 200;
+```
+
+The `send()` method will add authentication headers as specified in [ClientOptions](api/io/confluent/ksql/api/client/ClientOptions.html).
 
 Tutorial Examples<a name="tutorial-examples"></a>
 -------------------------------------------------

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -379,6 +379,15 @@ public interface Client extends Closeable {
     HttpRequest properties(Map<String, Object> properties);
 
     /**
+     * Set the key to be used for properties map in the request. If not set, all properties are
+     * keyed to a <strong>"properties"</strong> when sent in the request body. This is useful
+     * as certain endpoints (for example, the /ksql endpoint) in ksqlDB's API look for
+     * properties in a top-level "streamProperties" object, whereas others look for this
+     * in this top-level "properties" object.
+     */
+    HttpRequest propertiesKey(String propertiesKey);
+
+    /**
      * @return a non-null payload map constructed so far for this request.
      */
     Map<String, Object> payload();
@@ -387,6 +396,11 @@ public interface Client extends Closeable {
      * @return a non-null properties map constructed so far for this request.
      */
     Map<String, Object> properties();
+
+    /**
+     * @return the key the properties are associated with in the final request payload.
+     */
+    String propertiesKey();
 
     /**
      * @return the URL path for this request.
@@ -408,8 +422,9 @@ public interface Client extends Closeable {
      *   client.request("POST", "/some/path")
      *     .payload("k1", "v1").
      *     .payload(singletonMap("k2", "v2"))
-     *     .property("p1", "v2")
+     *     .property("p1", "v1")
      *     .properties(singletonMap("p2", "v2"))
+     *     .propertiesKey("streamProperties")
      *     .send().get();
      * </pre>
      *
@@ -418,7 +433,7 @@ public interface Client extends Closeable {
      * <pre>
      *   {
      *     "k1": "v1",
-     *     "properties": {
+     *     "streamProperties": {
      *       "p1": "v1",
      *       "p2": "v2"
      *     }, sessionVariables: {

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.api.client;
 
-import io.confluent.ksql.api.client.impl.ClientImpl;
 import io.confluent.ksql.api.client.exception.KsqlClientException;
+import io.confluent.ksql.api.client.impl.ClientImpl;
 import io.vertx.core.Vertx;
 import java.io.Closeable;
 import java.util.List;
@@ -291,7 +291,7 @@ public interface Client extends Closeable {
    * @param path   a non-null URL path
    *
    * @return a future that completes with a {@link HttpResponse} if the http request completes
-   * or throws an exception for low level network errors
+   *         or throws an exception for low level network errors
    */
   HttpRequest buildRequest(String method, String path);
 
@@ -360,6 +360,11 @@ public interface Client extends Closeable {
     HttpRequest payload(Map<String, Object> payload);
 
     /**
+     * @return a non-null payload map constructed so far for this request.
+     */
+    Map<String, Object> payload();
+
+    /**
      * Set a property. If an entry already exists with this key, it is
      * replaced.
      *
@@ -368,6 +373,11 @@ public interface Client extends Closeable {
      * @return this instance of {@link HttpRequest}
      */
     HttpRequest property(String key, Object value);
+
+    /**
+     * @return a non-null properties map constructed so far for this request.
+     */
+    Map<String, Object> properties();
 
     /**
      * Add all properties from the given map. If an entry already exists with this key, it is
@@ -386,16 +396,6 @@ public interface Client extends Closeable {
      * in this top-level "properties" object.
      */
     HttpRequest propertiesKey(String propertiesKey);
-
-    /**
-     * @return a non-null payload map constructed so far for this request.
-     */
-    Map<String, Object> payload();
-
-    /**
-     * @return a non-null properties map constructed so far for this request.
-     */
-    Map<String, Object> properties();
 
     /**
      * @return the key the properties are associated with in the final request payload.
@@ -428,7 +428,7 @@ public interface Client extends Closeable {
      *     .send().get();
      * </pre>
      *
-     * will create the following request body:
+     * <p>will create the following request body:
      *
      * <pre>
      *   {
@@ -443,7 +443,7 @@ public interface Client extends Closeable {
      * </pre>
      *
      * @return a future that completes once the server response is received and parsed into
-     * a {@link HttpResponse} or with an exception if the request failed to complete.
+     *         an {@link HttpResponse} or with an exception if the request failed to complete.
      */
     CompletableFuture<HttpResponse> send();
   }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -331,6 +331,11 @@ public interface Client extends Closeable {
     return new ClientImpl(clientOptions, vertx);
   }
 
+  /**
+   * Construct and return an {@link HttpRequest}.
+   *
+   * @return an instance of {@link HttpRequest}.
+   */
   static HttpRequest buildRequest() {
     return new HttpRequestImpl();
   }
@@ -339,6 +344,7 @@ public interface Client extends Closeable {
 
     /**
      * Execute an HTTP GET request.
+     *
      * @return this instance of {@link HttpRequest}
      */
     default HttpRequest get() {
@@ -347,6 +353,7 @@ public interface Client extends Closeable {
 
     /**
      * Execute an HTTP POST request
+     *
      * @return this instance of {@link HttpRequest}
      */
     default HttpRequest post() {
@@ -355,6 +362,7 @@ public interface Client extends Closeable {
 
     /**
      * Execute an HTTP PUT request
+     *
      * @return this instance of {@link HttpRequest}
      */
     default HttpRequest put() {
@@ -363,6 +371,7 @@ public interface Client extends Closeable {
 
     /**
      * Execute an HTTP DELETE request
+     *
      * @return this instance of {@link HttpRequest}
      */
     default HttpRequest delete() {
@@ -390,15 +399,15 @@ public interface Client extends Closeable {
      * Add a key and value in the payload map. If an entry already exists with this key, it is
      * replaced.
      *
-     * @param key a String key
+     * @param key   a String key
      * @param value the value
      * @return this instance of {@link HttpRequest}
      */
     HttpRequest payload(String key, Object value);
 
     /**
-     * Add all entries from the input map into the payload map. If any of the entries already
-     * exist, it is replaced with the new one.
+     * Add all entries from the input map into the payload map. If any of the entries already exist,
+     * it is replaced with the new one.
      *
      * @param payload a non-null input map
      * @return this instance of {@link HttpRequest}
@@ -425,10 +434,24 @@ public interface Client extends Closeable {
 
   interface HttpResponse {
 
+    /**
+     * @return the status code of the HTTP response.
+     */
     int status();
 
+    /**
+     * @return response payload as a byte array.
+     */
     byte[] payloadAsBytes();
 
+    /**
+     * Parse and return JSON response as a {@link Map}.
+     *
+     * @param <T> the type of the values in the returned map.
+     * @return the parsed response
+     * @throws io.confluent.ksql.api.client.exception.KsqlClientException if response could not be
+     *                                                                    parsed.
+     */
     <T> Map<String, T> payloadAsMap();
   }
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.api.client;
 
 import io.confluent.ksql.api.client.impl.ClientImpl;
-import io.confluent.ksql.api.client.impl.HttpRequestImpl;
+import io.confluent.ksql.api.client.exception.KsqlClientException;
 import io.vertx.core.Vertx;
 import java.io.Closeable;
 import java.util.List;
@@ -283,7 +283,8 @@ public interface Client extends Closeable {
   CompletableFuture<ConnectorDescription> describeConnector(String connectorName);
 
   /**
-   * Make an HTTP request to ksqldb server and return its reponse.
+   * A factory to construct {@link HttpRequest} objects. Instances of {@link HttpRequest} are
+   * used to make direct HTTP requests to ksqlDB server's REST API.
    *
    * @param method the http verb (for example, "get", "put"). the input is case-sensitive and may
    *               not be null.
@@ -292,7 +293,7 @@ public interface Client extends Closeable {
    * @return a future that completes with a {@link HttpResponse} if the http request completes
    * or throws an exception for low level network errors
    */
-  HttpRequest request(String method, String path);
+  HttpRequest buildRequest(String method, String path);
 
   /**
    * Define a session variable which can be referenced in sql commands by wrapping the variable name
@@ -333,6 +334,10 @@ public interface Client extends Closeable {
     return new ClientImpl(clientOptions, vertx);
   }
 
+  /**
+   * Instances of {@link HttpRequest} are used to make direct HTTP requests
+   * to ksqlDB server's REST API.
+   */
   interface HttpRequest {
 
     /**
@@ -445,8 +450,7 @@ public interface Client extends Closeable {
      *
      * @param <T> the type of the values in the returned map.
      * @return the parsed response
-     * @throws io.confluent.ksql.api.client.exception.KsqlClientException if response could not be
-     *                                                                    parsed.
+     * @throws KsqlClientException if response could not be parsed.
      */
     <T> Map<String, T> bodyAsMap();
   }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -457,11 +457,11 @@ public class ClientImpl implements Client {
   }
 
   @Override
-  public HttpRequest request(String method, String path) {
+  public HttpRequest buildRequest(final String method, final String path) {
     return new HttpRequestImpl(method, path, this);
   }
 
-  CompletableFuture<HttpResponse> send(HttpRequest request) {
+  CompletableFuture<HttpResponse> send(final HttpRequest request) {
     final CompletableFuture<HttpResponse> cf = new CompletableFuture<>();
 
     Map<String, Object> payload = request.payload();

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -461,23 +461,23 @@ public class ClientImpl implements Client {
     return new HttpRequestImpl(method, path, this);
   }
 
-  CompletableFuture<HttpResponse> send(final HttpRequest request) {
+  CompletableFuture<HttpResponse> send(
+      final HttpMethod method,
+      final String path,
+      final Map<String, Object> payload
+  ) {
     final CompletableFuture<HttpResponse> cf = new CompletableFuture<>();
 
-    Map<String, Object> payload = request.payload();
-    // include properties
-    payload.put("properties", request.properties());
-    // include session variables
-    payload.put("sessionVariables", sessionVariables);
-    JsonObject jsonPayload = new JsonObject(payload);
+    JsonObject jsonPayload = new JsonObject(payload)
+        .put("sessionVariables", sessionVariables);
 
     makeRequest(
-        request.path(),
+        path,
         jsonPayload.toBuffer(),
         cf,
         response -> handleResponse(response, cf),
         true,
-        HttpMethod.valueOf(request.method().toUpperCase(Locale.ROOT))
+        method
     );
 
     return cf;

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -456,14 +456,18 @@ public class ClientImpl implements Client {
     );
   }
 
-  public CompletableFuture<HttpResponse> sendRequest(HttpRequest request) {
-    Objects.requireNonNull(request);
-    Objects.requireNonNull(request.method(), "HTTP method may not be null.");
-    Objects.requireNonNull(request.path(), "Illegal request for HTTP request to null path.");
+  @Override
+  public HttpRequest request(String method, String path) {
+    return new HttpRequestImpl(method, path, this);
+  }
+
+  CompletableFuture<HttpResponse> send(HttpRequest request) {
     final CompletableFuture<HttpResponse> cf = new CompletableFuture<>();
 
     Map<String, Object> payload = request.payload();
-    // include session varibles specified in client object
+    // include properties
+    payload.put("properties", request.properties());
+    // include session variables
     payload.put("sessionVariables", sessionVariables);
     JsonObject jsonPayload = new JsonObject(payload);
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -56,7 +56,6 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -468,7 +467,7 @@ public class ClientImpl implements Client {
   ) {
     final CompletableFuture<HttpResponse> cf = new CompletableFuture<>();
 
-    JsonObject jsonPayload = new JsonObject(payload)
+    final JsonObject jsonPayload = new JsonObject(payload)
         .put("sessionVariables", sessionVariables);
 
     makeRequest(

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
@@ -31,6 +31,7 @@ public class HttpRequestImpl implements HttpRequest {
   private final String path;
   private final HttpMethod method;
   private final Client client;
+  private String propertiesKey = "properties";
 
   public HttpRequestImpl(String method, String path, Client client) {
     this.path = Objects.requireNonNull(path, "Path may not be null");
@@ -87,13 +88,31 @@ public class HttpRequestImpl implements HttpRequest {
   @Override
   public HttpRequest properties(final Map<String, Object> properties) {
     Objects.requireNonNull(properties, "Properties map may not be null");
-    this.properties.forEach(this::property);
+    properties.forEach(this::property);
     return this;
   }
 
   @Override
+  public HttpRequest propertiesKey(String propertiesKey) {
+    this.propertiesKey = propertiesKey;
+    return this;
+  }
+
+  public String propertiesKey() {
+    return propertiesKey;
+  }
+
+
+  Map<String, Object> buildPayload() {
+    Map<String, Object> payload = payload();
+    // include properties
+    payload.put(propertiesKey(), properties());
+    return payload;
+  }
+
+  @Override
   public CompletableFuture<HttpResponse> send() {
-    return ((ClientImpl) client).send(this);
+    return ((ClientImpl) client).send(method, path, buildPayload());
   }
 
   @Override

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
@@ -33,7 +33,7 @@ public class HttpRequestImpl implements HttpRequest {
   private final Client client;
   private String propertiesKey = "properties";
 
-  public HttpRequestImpl(String method, String path, Client client) {
+  public HttpRequestImpl(final String method, final String path, final Client client) {
     this.path = Objects.requireNonNull(path, "Path may not be null");
     this.method = HttpMethod.valueOf(
         Objects.requireNonNull(method, "HTTP method may not be null")
@@ -64,15 +64,22 @@ public class HttpRequestImpl implements HttpRequest {
   }
 
   @Override
+  public HttpRequest payload(final String key, final Object value) {
+    Objects.requireNonNull(key, "Payload key may not be null");
+    Objects.requireNonNull(value, "Payload value may not be null");
+    payloadAsMap.put(key, value);
+    return this;
+  }
+
+  @Override
   public Map<String, Object> properties() {
     return new HashMap<>(properties);
   }
 
   @Override
-  public HttpRequest payload(final String key, final Object value) {
-    Objects.requireNonNull(key, "Payload key may not be null");
-    Objects.requireNonNull(value, "Payload value may not be null");
-    payloadAsMap.put(key, value);
+  public HttpRequest properties(final Map<String, Object> properties) {
+    Objects.requireNonNull(properties, "Properties map may not be null");
+    properties.forEach(this::property);
     return this;
   }
 
@@ -86,14 +93,7 @@ public class HttpRequestImpl implements HttpRequest {
   }
 
   @Override
-  public HttpRequest properties(final Map<String, Object> properties) {
-    Objects.requireNonNull(properties, "Properties map may not be null");
-    properties.forEach(this::property);
-    return this;
-  }
-
-  @Override
-  public HttpRequest propertiesKey(String propertiesKey) {
+  public HttpRequest propertiesKey(final String propertiesKey) {
     this.propertiesKey = propertiesKey;
     return this;
   }
@@ -102,9 +102,8 @@ public class HttpRequestImpl implements HttpRequest {
     return propertiesKey;
   }
 
-
   Map<String, Object> buildPayload() {
-    Map<String, Object> payload = payload();
+    final Map<String, Object> payload = payload();
     // include properties
     payload.put(propertiesKey(), properties());
     return payload;
@@ -123,7 +122,7 @@ public class HttpRequestImpl implements HttpRequest {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    HttpRequestImpl that = (HttpRequestImpl) o;
+    final HttpRequestImpl that = (HttpRequestImpl) o;
 
     return Objects.equals(payloadAsMap, that.payloadAsMap)
         && Objects.equals(properties, that.properties)

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
@@ -15,11 +15,11 @@
 
 package io.confluent.ksql.api.client.impl;
 
+import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.Client.HttpRequest;
 import io.confluent.ksql.api.client.Client.HttpResponse;
 import io.vertx.core.http.HttpMethod;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -30,18 +30,14 @@ public class HttpRequestImpl implements HttpRequest {
   private final Map<String, Object> properties = new HashMap<>();
   private final String path;
   private final HttpMethod method;
-  private final ClientImpl client;
+  private final Client client;
 
-  public HttpRequestImpl(String method, String path) {
-    this(method, path, null);
-  }
-
-  public HttpRequestImpl(String method, String path, ClientImpl client) {
-    Objects.requireNonNull(path, "Path may not be null");
-    Objects.requireNonNull(method, "HTTP method may not be null");
-    this.path = path;
-    this.method = HttpMethod.valueOf(method.toUpperCase(Locale.ROOT));
-    this.client = client;
+  public HttpRequestImpl(String method, String path, Client client) {
+    this.path = Objects.requireNonNull(path, "Path may not be null");
+    this.method = HttpMethod.valueOf(
+        Objects.requireNonNull(method, "HTTP method may not be null")
+    );
+    this.client = Objects.requireNonNull(client, "Client may not be null");
   }
 
   @Override
@@ -60,9 +56,9 @@ public class HttpRequestImpl implements HttpRequest {
   }
 
   @Override
-  public HttpRequest payload(Map<String, Object> payload) {
+  public HttpRequest payload(final Map<String, Object> payload) {
     Objects.requireNonNull(payload, "Payload may not be null");
-    payloadAsMap.putAll(Objects.requireNonNull(payload));
+    payload.forEach(this::payload);
     return this;
   }
 
@@ -72,7 +68,7 @@ public class HttpRequestImpl implements HttpRequest {
   }
 
   @Override
-  public HttpRequest payload(String key, Object value) {
+  public HttpRequest payload(final String key, final Object value) {
     Objects.requireNonNull(key, "Payload key may not be null");
     Objects.requireNonNull(value, "Payload value may not be null");
     payloadAsMap.put(key, value);
@@ -80,7 +76,7 @@ public class HttpRequestImpl implements HttpRequest {
   }
 
   @Override
-  public HttpRequest property(String key, Object value) {
+  public HttpRequest property(final String key, final Object value) {
     Objects.requireNonNull(key, "Property key may not be null");
     Objects.requireNonNull(value, "Property value may not be null");
 
@@ -89,19 +85,19 @@ public class HttpRequestImpl implements HttpRequest {
   }
 
   @Override
-  public HttpRequest properties(Map<String, Object> properties) {
+  public HttpRequest properties(final Map<String, Object> properties) {
     Objects.requireNonNull(properties, "Properties map may not be null");
-    this.properties.putAll(properties);
+    this.properties.forEach(this::property);
     return this;
   }
 
   @Override
   public CompletableFuture<HttpResponse> send() {
-    return client.send(this);
+    return ((ClientImpl) client).send(this);
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.client.impl;
+
+import io.confluent.ksql.api.client.Client.HttpRequest;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+public class HttpRequestImpl implements HttpRequest {
+
+  private final Map<String, Object> payloadAsMap = new HashMap<>();
+  private String path;
+  private String method;
+
+  @Override
+  public String path() {
+    return this.path;
+  }
+
+  @Override
+  public String method() {
+    return this.method;
+  }
+
+  @Override
+  public Map<String, Object> payload() {
+    return new HashMap<>(payloadAsMap);
+  }
+
+  @Override
+  public HttpRequest path(String path) {
+    Objects.requireNonNull(path, "path may not be null");
+    this.path = path;
+    return this;
+  }
+
+  @Override
+  public HttpRequest payload(Map<String, Object> payload) {
+    Objects.requireNonNull(payload, "payload may not be null");
+    payloadAsMap.putAll(Objects.requireNonNull(payload));
+    return this;
+  }
+
+  @Override
+  public HttpRequest payload(String key, Object value) {
+    Objects.requireNonNull(key, "key may not be null");
+    Objects.requireNonNull(value, "value may not be null");
+    payloadAsMap.put(key, value);
+    return this;
+  }
+
+  @Override
+  public HttpRequest method(String method) {
+    Objects.requireNonNull(method, "HTTP method may not be null");
+    this.method = method;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HttpRequestImpl that = (HttpRequestImpl) o;
+
+    return Objects.equals(payloadAsMap, that.payloadAsMap)
+        && Objects.equals(path, that.path)
+        && (Objects.equals(method, that.method) || (method != null && method.equalsIgnoreCase(that.method)));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        payloadAsMap,
+        path,
+        method != null ? method.toUpperCase(Locale.ROOT) : null
+    );
+  }
+}

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpRequestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -37,7 +37,7 @@ public class HttpRequestImpl implements HttpRequest {
   }
 
   public HttpRequestImpl(String method, String path, ClientImpl client) {
-    Objects.requireNonNull(path, "path may not be null");
+    Objects.requireNonNull(path, "Path may not be null");
     Objects.requireNonNull(method, "HTTP method may not be null");
     this.path = path;
     this.method = HttpMethod.valueOf(method.toUpperCase(Locale.ROOT));
@@ -61,7 +61,7 @@ public class HttpRequestImpl implements HttpRequest {
 
   @Override
   public HttpRequest payload(Map<String, Object> payload) {
-    Objects.requireNonNull(payload, "payload may not be null");
+    Objects.requireNonNull(payload, "Payload may not be null");
     payloadAsMap.putAll(Objects.requireNonNull(payload));
     return this;
   }
@@ -73,16 +73,16 @@ public class HttpRequestImpl implements HttpRequest {
 
   @Override
   public HttpRequest payload(String key, Object value) {
-    Objects.requireNonNull(key, "key may not be null");
-    Objects.requireNonNull(value, "value may not be null");
+    Objects.requireNonNull(key, "Payload key may not be null");
+    Objects.requireNonNull(value, "Payload value may not be null");
     payloadAsMap.put(key, value);
     return this;
   }
 
   @Override
   public HttpRequest property(String key, Object value) {
-    Objects.requireNonNull(key, "property key may not be null");
-    Objects.requireNonNull(value, "property value may not be null");
+    Objects.requireNonNull(key, "Property key may not be null");
+    Objects.requireNonNull(value, "Property value may not be null");
 
     properties.put(key, value);
     return this;
@@ -90,7 +90,7 @@ public class HttpRequestImpl implements HttpRequest {
 
   @Override
   public HttpRequest properties(Map<String, Object> properties) {
-    Objects.requireNonNull(properties, "properties may not be null");
+    Objects.requireNonNull(properties, "Properties map may not be null");
     this.properties.putAll(properties);
     return this;
   }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpResponseImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpResponseImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.client.impl;
+
+import io.confluent.ksql.api.client.Client.HttpResponse;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import java.util.Collections;
+import java.util.Map;
+
+public class HttpResponseImpl implements HttpResponse {
+
+  private final int status;
+  private final byte[] payload;
+
+  public HttpResponseImpl(int status, byte[] payload) {
+    this.status = status;
+    this.payload = payload;
+  }
+
+  @Override
+  public int status() {
+    return status;
+  }
+
+  @Override
+  public byte[] payloadAsBytes() {
+    return payload;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> Map<String, T> payloadAsMap() {
+    if (payload == null) {
+      return Collections.emptyMap();
+    }
+    JsonObject object = new JsonObject(Buffer.buffer(payload));
+    return (Map<String, T>) object.getMap();
+  }
+
+}

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpResponseImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpResponseImpl.java
@@ -26,11 +26,11 @@ import java.util.Map;
 public class HttpResponseImpl implements HttpResponse {
 
   private final int status;
-  private final byte[] payloadBytes;
+  private final byte[] body;
 
-  public HttpResponseImpl(int status, byte[] payloadBytes) {
+  public HttpResponseImpl(int status, byte[] body) {
     this.status = status;
-    this.payloadBytes = payloadBytes;
+    this.body = body;
   }
 
   @Override
@@ -39,22 +39,21 @@ public class HttpResponseImpl implements HttpResponse {
   }
 
   @Override
-  public byte[] payloadAsBytes() {
-    return payloadBytes;
+  public byte[] body() {
+    return body;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T> Map<String, T> payloadAsMap() {
-    if (payloadBytes == null) {
+  public <T> Map<String, T> bodyAsMap() {
+    if (body == null) {
       return Collections.emptyMap();
     }
     try {
-      JsonObject object = new JsonObject(Buffer.buffer(payloadBytes));
+      JsonObject object = new JsonObject(Buffer.buffer(body));
       return (Map<String, T>) object.getMap();
     } catch (DecodeException e) {
-      throw new KsqlClientException("could not decode response: " + new String(payloadBytes));
+      throw new KsqlClientException("could not decode response: " + new String(body));
     }
   }
-
 }

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpResponseImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/HttpResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -28,7 +28,7 @@ public class HttpResponseImpl implements HttpResponse {
   private final int status;
   private final byte[] body;
 
-  public HttpResponseImpl(int status, byte[] body) {
+  public HttpResponseImpl(final int status, final byte[] body) {
     this.status = status;
     this.body = body;
   }
@@ -53,7 +53,7 @@ public class HttpResponseImpl implements HttpResponse {
       JsonObject object = new JsonObject(Buffer.buffer(body));
       return (Map<String, T>) object.getMap();
     } catch (DecodeException e) {
-      throw new KsqlClientException("could not decode response: " + new String(body));
+      throw new KsqlClientException("Could not decode response: " + new String(body));
     }
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
@@ -15,7 +15,9 @@
 
 package io.confluent.ksql.api.client.impl;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.testing.EqualsTester;
@@ -24,8 +26,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class HttpRequestImplTest {
 
   @Mock
@@ -53,6 +58,24 @@ public class HttpRequestImplTest {
   }
 
   @Test
+  public void testDefaultPropertiesKey() {
+    HttpRequestImpl request = new HttpRequestImpl("GET", "/path", client);
+    request.property("a", 1);
+    assertEquals(singletonMap("a", 1), request.buildPayload().get("properties"));
+  }
+
+  @Test
+  public void testOverridePopertiesKeyValue() {
+    HttpRequestImpl request = new HttpRequestImpl("GET", "/path", client);
+    request.property("a", 1);
+    assertFalse(request.buildPayload().containsKey("hello"));
+    assertEquals(singletonMap("a", 1), request.buildPayload().get("properties"));
+    // override
+    request.propertiesKey("hello");
+    assertEquals(singletonMap("a", 1), request.buildPayload().get("hello"));
+  }
+
+  @Test
   public void nullPayloadKeysShouldNotBeAllowed() {
     assertThrows(
         NullPointerException.class,
@@ -72,9 +95,9 @@ public class HttpRequestImplTest {
   public void testSetAndUpdatePayload() {
     HttpRequestImpl request = new HttpRequestImpl("GET", "/", client);
     request.payload("hello", "world");
-    assertEquals(Collections.singletonMap("hello", "world"), request.payload());
+    assertEquals(singletonMap("hello", "world"), request.payload());
     request.payload("hello", "again");
-    assertEquals(Collections.singletonMap("hello", "again"), request.payload());
+    assertEquals(singletonMap("hello", "again"), request.payload());
     request.payload("ob", "one");
     request.payload("ken", "ob");
     assertEquals(3, request.payload().size());
@@ -104,9 +127,9 @@ public class HttpRequestImplTest {
   public void testSetAndUpdateProperties() {
     HttpRequestImpl request = new HttpRequestImpl("GET", "/", client);
     request.property("hello", "world");
-    assertEquals(Collections.singletonMap("hello", "world"), request.properties());
+    assertEquals(singletonMap("hello", "world"), request.properties());
     request.property("hello", "again");
-    assertEquals(Collections.singletonMap("hello", "again"), request.properties());
+    assertEquals(singletonMap("hello", "again"), request.properties());
     request.property("ob", "one");
     request.property("ken", "ob");
     assertEquals(3, request.properties().size());

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
@@ -1,59 +1,71 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.api.client.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.testing.EqualsTester;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 
 public class HttpRequestImplTest {
 
-  private HttpRequestImpl request;
-
-  @Before
-  public void setup() {
-    request = new HttpRequestImpl();
+  @Test
+  public void testSetMethodAndPath() {
+    HttpRequestImpl request = new HttpRequestImpl("GET", "/");
+    assertEquals("GET", request.method());
+    assertEquals("/", request.path());
   }
 
   @Test
-  public void testSetAndUpdateMethod() {
-    // set a value for method
-    request.method("get");
-    assertEquals("get", request.method());
-
-    // updating it should reflect new value
-    request.method("post");
-    assertEquals("post", request.method());
-
-    new EqualsTester()
-        .addEqualityGroup(new HttpRequestImpl())
-        .addEqualityGroup(request, new HttpRequestImpl().post())
-        .addEqualityGroup(new HttpRequestImpl().method("delete"), new HttpRequestImpl().delete())
-        .addEqualityGroup(new HttpRequestImpl().method("put"), new HttpRequestImpl().put())
-        .addEqualityGroup(new HttpRequestImpl().method("get"), new HttpRequestImpl().get())
-        .testEquals();
-  }
-
-  @Test(expected = NullPointerException.class)
   public void nullMethodsShouldNotBeAllowedTest() {
-    request.method(null);
+    assertThrows(
+        NullPointerException.class, () -> new HttpRequestImpl(null, "/")
+    );
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
+  public void nullPathsShouldNotBeAllowedTest() {
+    assertThrows(
+        NullPointerException.class, () -> new HttpRequestImpl("GET", null)
+    );
+  }
+
+  @Test
   public void nullPayloadKeysShouldNotBeAllowed() {
-    request.payload(null, "");
+    assertThrows(
+        NullPointerException.class,
+        () -> new HttpRequestImpl("GET", "/").payload(null, "")
+    );
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void nullPayloadValuesShouldNotBeAllowed() {
-    request.payload("abc", null);
+    assertThrows(
+        NullPointerException.class,
+        () -> new HttpRequestImpl("GET", "/").payload("", null)
+    );
   }
 
   @Test
   public void testSetAndUpdatePayload() {
+    HttpRequestImpl request = new HttpRequestImpl("GET", "/");
     request.payload("hello", "world");
     assertEquals(Collections.singletonMap("hello", "world"), request.payload());
     request.payload("hello", "again");
@@ -68,31 +80,54 @@ public class HttpRequestImplTest {
     Map<String, Object> payload = new HashMap<>();
     payload.put("ob", "two");
     payload.put("three", "three");
-    request.payload(payload);
+    request.payload(payload).payload("four", 4);
     assertEquals("two", request.payload().get("ob"));
     assertEquals("three", request.payload().get("three"));
+    assertEquals(4, request.payload().get("four"));
 
     new EqualsTester()
         .addEqualityGroup(request)
-        .addEqualityGroup(new HttpRequestImpl())
+        .addEqualityGroup(request())
         .addEqualityGroup(
-            new HttpRequestImpl().payload("one", "one").payload("two", "two"),
-            new HttpRequestImpl().payload("two", "two").payload("one", "one")
-        ).addEqualityGroup(new HttpRequestImpl().payload("one", "one"))
+            request().payload("one", "one").payload("two", "two"),
+            request().payload("two", "two").payload("one", "one")
+        ).addEqualityGroup(request().payload("one", "one"))
         .testEquals();
   }
 
   @Test
-  public void testSetAndUpdatePath() {
-    request.path("/a/b/c");
-    assertEquals("/a/b/c", request.path());
+  public void testSetAndUpdateProperties() {
+    HttpRequestImpl request = new HttpRequestImpl("GET", "/");
+    request.property("hello", "world");
+    assertEquals(Collections.singletonMap("hello", "world"), request.properties());
+    request.property("hello", "again");
+    assertEquals(Collections.singletonMap("hello", "again"), request.properties());
+    request.property("ob", "one");
+    request.property("ken", "ob");
+    assertEquals(3, request.properties().size());
+    assertEquals("one", request.properties().get("ob"));
+    assertEquals("ob", request.properties().get("ken"));
+    assertEquals("again", request.properties().get("hello"));
 
-    request.path("/x/y/z");
-    assertEquals("/x/y/z", request.path());
+    Map<String, Object> props = new HashMap<>();
+    props.put("ob", "two");
+    props.put("three", "three");
+    request.properties(props).property("four", 4);
+    assertEquals("two", request.properties().get("ob"));
+    assertEquals("three", request.properties().get("three"));
+    assertEquals(4, request.properties().get("four"));
 
     new EqualsTester()
-        .addEqualityGroup(request, new HttpRequestImpl().path("/x/y/z"))
-        .addEqualityGroup(new HttpRequestImpl())
+        .addEqualityGroup(request)
+        .addEqualityGroup(request())
+        .addEqualityGroup(
+            request().property("one", "one").property("two", "two"),
+            request().property("two", "two").property("one", "one")
+        ).addEqualityGroup(request().property("one", "one"))
         .testEquals();
+  }
+
+  HttpRequestImpl request() {
+    return new HttpRequestImpl("GET", "/");
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
@@ -19,16 +19,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.api.client.Client;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
+import org.mockito.Mock;
 
 public class HttpRequestImplTest {
 
+  @Mock
+  private Client client;
+
   @Test
   public void testSetMethodAndPath() {
-    HttpRequestImpl request = new HttpRequestImpl("GET", "/");
+    HttpRequestImpl request = request();
     assertEquals("GET", request.method());
     assertEquals("/", request.path());
   }
@@ -36,14 +41,14 @@ public class HttpRequestImplTest {
   @Test
   public void nullMethodsShouldNotBeAllowedTest() {
     assertThrows(
-        NullPointerException.class, () -> new HttpRequestImpl(null, "/")
+        NullPointerException.class, () -> new HttpRequestImpl(null, "/", client)
     );
   }
 
   @Test
   public void nullPathsShouldNotBeAllowedTest() {
     assertThrows(
-        NullPointerException.class, () -> new HttpRequestImpl("GET", null)
+        NullPointerException.class, () -> new HttpRequestImpl("GET", null, client)
     );
   }
 
@@ -51,7 +56,7 @@ public class HttpRequestImplTest {
   public void nullPayloadKeysShouldNotBeAllowed() {
     assertThrows(
         NullPointerException.class,
-        () -> new HttpRequestImpl("GET", "/").payload(null, "")
+        () -> new HttpRequestImpl("GET", "/", client).payload(null, "")
     );
   }
 
@@ -59,13 +64,13 @@ public class HttpRequestImplTest {
   public void nullPayloadValuesShouldNotBeAllowed() {
     assertThrows(
         NullPointerException.class,
-        () -> new HttpRequestImpl("GET", "/").payload("", null)
+        () -> new HttpRequestImpl("GET", "/", client).payload("", null)
     );
   }
 
   @Test
   public void testSetAndUpdatePayload() {
-    HttpRequestImpl request = new HttpRequestImpl("GET", "/");
+    HttpRequestImpl request = new HttpRequestImpl("GET", "/", client);
     request.payload("hello", "world");
     assertEquals(Collections.singletonMap("hello", "world"), request.payload());
     request.payload("hello", "again");
@@ -97,7 +102,7 @@ public class HttpRequestImplTest {
 
   @Test
   public void testSetAndUpdateProperties() {
-    HttpRequestImpl request = new HttpRequestImpl("GET", "/");
+    HttpRequestImpl request = new HttpRequestImpl("GET", "/", client);
     request.property("hello", "world");
     assertEquals(Collections.singletonMap("hello", "world"), request.properties());
     request.property("hello", "again");
@@ -128,6 +133,6 @@ public class HttpRequestImplTest {
   }
 
   HttpRequestImpl request() {
-    return new HttpRequestImpl("GET", "/");
+    return new HttpRequestImpl("GET", "/", client);
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpRequestImplTest.java
@@ -1,0 +1,98 @@
+package io.confluent.ksql.api.client.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HttpRequestImplTest {
+
+  private HttpRequestImpl request;
+
+  @Before
+  public void setup() {
+    request = new HttpRequestImpl();
+  }
+
+  @Test
+  public void testSetAndUpdateMethod() {
+    // set a value for method
+    request.method("get");
+    assertEquals("get", request.method());
+
+    // updating it should reflect new value
+    request.method("post");
+    assertEquals("post", request.method());
+
+    new EqualsTester()
+        .addEqualityGroup(new HttpRequestImpl())
+        .addEqualityGroup(request, new HttpRequestImpl().post())
+        .addEqualityGroup(new HttpRequestImpl().method("delete"), new HttpRequestImpl().delete())
+        .addEqualityGroup(new HttpRequestImpl().method("put"), new HttpRequestImpl().put())
+        .addEqualityGroup(new HttpRequestImpl().method("get"), new HttpRequestImpl().get())
+        .testEquals();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullMethodsShouldNotBeAllowedTest() {
+    request.method(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullPayloadKeysShouldNotBeAllowed() {
+    request.payload(null, "");
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullPayloadValuesShouldNotBeAllowed() {
+    request.payload("abc", null);
+  }
+
+  @Test
+  public void testSetAndUpdatePayload() {
+    request.payload("hello", "world");
+    assertEquals(Collections.singletonMap("hello", "world"), request.payload());
+    request.payload("hello", "again");
+    assertEquals(Collections.singletonMap("hello", "again"), request.payload());
+    request.payload("ob", "one");
+    request.payload("ken", "ob");
+    assertEquals(3, request.payload().size());
+    assertEquals("one", request.payload().get("ob"));
+    assertEquals("ob", request.payload().get("ken"));
+    assertEquals("again", request.payload().get("hello"));
+
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("ob", "two");
+    payload.put("three", "three");
+    request.payload(payload);
+    assertEquals("two", request.payload().get("ob"));
+    assertEquals("three", request.payload().get("three"));
+
+    new EqualsTester()
+        .addEqualityGroup(request)
+        .addEqualityGroup(new HttpRequestImpl())
+        .addEqualityGroup(
+            new HttpRequestImpl().payload("one", "one").payload("two", "two"),
+            new HttpRequestImpl().payload("two", "two").payload("one", "one")
+        ).addEqualityGroup(new HttpRequestImpl().payload("one", "one"))
+        .testEquals();
+  }
+
+  @Test
+  public void testSetAndUpdatePath() {
+    request.path("/a/b/c");
+    assertEquals("/a/b/c", request.path());
+
+    request.path("/x/y/z");
+    assertEquals("/x/y/z", request.path());
+
+    new EqualsTester()
+        .addEqualityGroup(request, new HttpRequestImpl().path("/x/y/z"))
+        .addEqualityGroup(new HttpRequestImpl())
+        .testEquals();
+  }
+}

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpResponseImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/HttpResponseImplTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.client.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import io.confluent.ksql.api.client.exception.KsqlClientException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.junit.Test;
+
+public class HttpResponseImplTest {
+
+  @Test
+  public void testResponseHandlesNullBody() {
+    HttpResponseImpl response = new HttpResponseImpl(200, null);
+    assertNull(response.body());
+    assertThat(response.status(), is(200));
+    assertThat(response.bodyAsMap(), is(Collections.emptyMap()));
+  }
+
+  @Test
+  public void testDeserializeJson() {
+    HttpResponseImpl response = new HttpResponseImpl(200,
+        "{'a': 10}".replace('\'', '"').getBytes(StandardCharsets.UTF_8)
+    );
+    assertNotNull(response.body());
+    assertThat(response.status(), is(200));
+    assertThat(response.bodyAsMap().get("a"), is(10));
+  }
+
+  @Test
+  public void shouldConvertDeserializationErrorIntoKsqlExceptionsTest() {
+    // response that cannot be deserialized into a map
+    HttpResponseImpl response = new HttpResponseImpl(200,
+        "hello world".getBytes(StandardCharsets.UTF_8)
+    );
+
+    assertThat(
+        assertThrows(KsqlClientException.class, response::bodyAsMap).getMessage(),
+        is("Could not decode response: hello world")
+    );
+  }
+
+}

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -912,43 +912,6 @@ public class ClientIntegrationTest {
   }
 
   @Test
-  public void shouldExecuteExplainStatements() throws Exception {
-    // Given
-    final String streamName = TEST_STREAM + "_COPY";
-    final String csas = "create stream " + streamName + " as select * from " + TEST_STREAM + " emit changes;";
-
-    final int numInitialStreams = 3;
-    final int numInitialQueries = 1;
-    verifyNumStreams(numInitialStreams);
-    verifyNumQueries(numInitialQueries);
-
-    // When: create stream, start persistent query
-    final ExecuteStatementResult csasResult = client.executeStatement(csas).get();
-
-    // Then
-    verifyNumStreams(numInitialStreams + 1);
-    verifyNumQueries(numInitialQueries + 1);
-    assertThat(csasResult.queryId(), is(Optional.of(findQueryIdForSink(streamName))));
-
-    // When: terminate persistent query
-    final String queryId = csasResult.queryId().get();
-    final ExecuteStatementResult terminateResult =
-        client.executeStatement("terminate " + queryId + ";").get();
-
-    // Then
-    verifyNumQueries(numInitialQueries);
-    assertThat(terminateResult.queryId(), is(Optional.empty()));
-
-    // When: drop stream
-    final ExecuteStatementResult dropStreamResult =
-        client.executeStatement("drop stream " + streamName + ";").get();
-
-    // Then
-    verifyNumStreams(numInitialStreams);
-    assertThat(dropStreamResult.queryId(), is(Optional.empty()));
-  }
-
-  @Test
   public void shouldExecutePlainHttpRequests() throws Exception {
     HttpResponse response = client.sendRequest(Client.buildRequest().get().path("/info")).get();
     assertEquals(200, response.status());

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -912,7 +912,7 @@ public class ClientIntegrationTest {
 
   @Test
   public void shouldExecutePlainHttpRequests() throws Exception {
-    HttpResponse response = client.request("GET", "/info").send().get();
+    HttpResponse response = client.buildRequest("GET", "/info").send().get();
     assertThat(response.status(), is(200));
     Map<String, Map<String, Object>> info = response.bodyAsMap();
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -913,25 +912,17 @@ public class ClientIntegrationTest {
 
   @Test
   public void shouldExecutePlainHttpRequests() throws Exception {
-    HttpResponse response = client.sendRequest(Client.buildRequest().get().path("/info")).get();
-    assertEquals(200, response.status());
-    Map<String, Map<String, Object>> info = response.payloadAsMap();
+    HttpResponse response = client.request("GET", "/info").send().get();
+    assertThat(response.status(), is(200));
+    Map<String, Map<String, Object>> info = response.bodyAsMap();
 
-    // Given:
-    final String expectedClusterId = REST_APP.getServiceContext().getAdminClient().describeCluster().clusterId().get();
-
-    // When:
     final ServerInfo serverInfo = client.serverInfo().get();
+    Map<String, Object> innerMap = info.get("KsqlServerInfo");
 
-    // Then:
-    assertThat(serverInfo.getServerVersion(), is(AppInfo.getVersion()));
-    assertThat(serverInfo.getKsqlServiceId(), is("default_"));
-    assertThat(serverInfo.getKafkaClusterId(), is(expectedClusterId));
-
-    assertThat(info.get("KsqlServerInfo").get("version"), is(serverInfo.getServerVersion()));
-    assertThat(info.get("KsqlServerInfo").get("ksqlServiceId"), is(serverInfo.getKsqlServiceId()));
-    assertThat(info.get("KsqlServerInfo").get("kafkaClusterId"), is(serverInfo.getKafkaClusterId()));
-    assertThat(info.get("KsqlServerInfo").get("serverStatus"), is("RUNNING"));
+    assertThat(innerMap.get("version"), is(serverInfo.getServerVersion()));
+    assertThat(innerMap.get("ksqlServiceId"), is(serverInfo.getKsqlServiceId()));
+    assertThat(innerMap.get("kafkaClusterId"), is(serverInfo.getKafkaClusterId()));
+    assertThat(innerMap.get("serverStatus"), is("RUNNING"));
   }
 
   @Test


### PR DESCRIPTION
### Description 
This PR adds methods and classes that allow users to directly execute HTTP requests against ksqldb's REST server. The API client today uses a number of "high level" classes. With an 'escape hatch' as implemented in this PR, users do not need to wait for all the REST APIs, request and response objects to be implemented as java objects and classes in the api-client. 

This PR resolves one of the issues described in #8042.

### Testing done 
Unit and integration tests (and tests against a local docker container).

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

