### PR TITLE
fix: fix spq bandwidth throttling on http2 

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -49,7 +49,8 @@ public final class KsqlConstants {
 
   public enum KsqlQueryType {
     PERSISTENT,
-    PUSH
+    PUSH,
+    PULL
   }
 
   public enum PersistentQueryType {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -110,6 +110,11 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
                 queryPublisher.getColumnTypes());
             routingContext.response().endHandler(v -> {
               queryPublisher.close();
+              metricsCallbackHolder.reportMetrics(
+                  routingContext.response().getStatusCode(),
+                  routingContext.request().bytesRead(),
+                  routingContext.response().bytesWritten(),
+                  startTimeNanos);
             });
           } else {
             final PushQueryHolder query = connectionQueryManager

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
@@ -83,7 +83,8 @@ public class SlidingWindowRateLimiter {
   }
 
   @VisibleForTesting
-  protected synchronized void allow(final KsqlQueryType ksqlQueryType, final long timestamp) throws KsqlException {
+  protected synchronized void allow(final KsqlQueryType ksqlQueryType, final long timestamp)
+      throws KsqlException {
     checkArgument(timestamp >= 0,
             "Timestamp can't be negative.");
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.rest.util.ConcurrencyLimiter.Decrementer;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KeyValue;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -109,7 +110,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
 
     PullQueryExecutionUtil.checkRateLimit(rateLimiter);
     final Decrementer decrementer = concurrencyLimiter.increment();
-    pullBandRateLimiter.allow();
+    pullBandRateLimiter.allow(KsqlQueryType.PULL);
 
     PullQueryResult result = null;
     try {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KeyValue;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.PushQueryMetadata;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
@@ -146,7 +147,7 @@ final class PushQueryPublisher implements Flow.Publisher<Collection<StreamedRow>
               query.getSessionConfig().getConfig(false),
               query.getSessionConfig().getOverrides());
 
-      scalablePushBandRateLimiter.allow();
+      scalablePushBandRateLimiter.allow(KsqlQueryType.PUSH);
 
       final ImmutableAnalysis analysis =
           ksqlEngine.analyzeQueryWithNoOutputTopic(query.getStatement(), query.getStatementText());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -65,6 +65,7 @@ import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
@@ -494,7 +495,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
       PullQueryExecutionUtil.checkRateLimit(rateLimiter);
       decrementer = concurrencyLimiter.increment();
     }
-    pullBandRateLimiter.allow();
+    pullBandRateLimiter.allow(KsqlQueryType.PULL);
 
     final Optional<Decrementer> optionalDecrementer = Optional.ofNullable(decrementer);
 
@@ -548,7 +549,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
     final PushQueryConfigPlannerOptions plannerOptions =
         new PushQueryConfigPlannerOptions(ksqlConfig, configOverrides);
 
-    scalablePushBandRateLimiter.allow();
+    scalablePushBandRateLimiter.allow(KsqlQueryType.PUSH);
 
     final ScalablePushQueryMetadata query = ksqlEngine
         .executeScalablePushQuery(analysis, serviceContext, configured, pushRouting, routingOptions,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/PullBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/PullBandwidthThrottleIntegrationTest.java
@@ -96,7 +96,7 @@ public class PullBandwidthThrottleIntegrationTest {
             .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
             .around(TEST_HARNESS)
             .around(REST_APP);
-    private static final String RATE_LIMIT_MESSAGE = "Host is at bandwidth rate limit for queries.";
+    private static final String RATE_LIMIT_MESSAGE = "Host is at bandwidth rate limit for pull queries.";
 
     @BeforeClass
     public static void setUpClass() {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.api.integration;
 
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
-import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER2;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_DEFAULT_KEY_FORMAT_CONFIG;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG;
@@ -36,12 +35,9 @@ import io.confluent.ksql.rest.client.StreamPublisher;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.integration.QueryStreamSubscriber;
 import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.serde.FormatFactory;
-import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
-import io.confluent.ksql.test.util.secure.ClientTrustStore;
-import io.confluent.ksql.test.util.secure.Credentials;
-import io.confluent.ksql.test.util.secure.SecureKafkaHelper;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PageViewDataProvider;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -55,37 +51,30 @@ import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
 @Category({IntegrationTest.class})
 public class ScalablePushBandwidthThrottleIntegrationTest {
-  private static final String RATE_LIMIT_MESSAGE = "Host is at bandwidth rate limit for queries.";
+  private static final String RATE_LIMIT_MESSAGE = "Host is at bandwidth rate limit for push queries.";
   private static final PageViewDataProvider TEST_DATA_PROVIDER = new PageViewDataProvider();
   private static final String TEST_TOPIC = TEST_DATA_PROVIDER.topicName();
   private static final String TEST_STREAM = TEST_DATA_PROVIDER.sourceName();
 
   private static final String AGG_TABLE = "AGG_TABLE";
-  private static final Credentials NORMAL_USER = VALID_USER2;
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
-  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.builder()
-      .withKafkaCluster(
-          EmbeddedSingleNodeKafkaCluster.newBuilder()
-              .withoutPlainListeners()
-              .withSaslSslListeners()
-      ).build();
+
 
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
-      .withProperty("security.protocol", "SASL_SSL")
-      .withProperty("sasl.mechanism", "PLAIN")
-      .withProperty("sasl.jaas.config", SecureKafkaHelper.buildJaasConfig(NORMAL_USER))
-      .withProperties(ClientTrustStore.trustStoreProps())
+      .withEnabledKsqlClient()
+      .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
+      .withProperty(KsqlRestConfig.ADVERTISED_LISTENER_CONFIG, "http://localhost:8088")
       .withProperty(KSQL_QUERY_PUSH_V2_ENABLED , true)
       .withProperty(KSQL_QUERY_PUSH_V2_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG , 1)
       .withProperty("auto.offset.reset", "latest")
@@ -97,36 +86,29 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
   @ClassRule
   public static final RuleChain CHAIN = RuleChain
       .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
-      .around(TEST_HARNESS)
-      .around(REST_APP);
+      .around(TEST_HARNESS);
+
+  @Rule
+  public final RuleChain CHAIN_TEST = RuleChain
+      .outerRule(REST_APP);
 
   private Vertx vertx;
   private KsqlRestClient restClient;
   private StreamPublisher<StreamedRow> publisher;
   private QueryStreamSubscriber subscriber;
 
-  @BeforeClass
-  public static void setUpClass() {
-    TEST_HARNESS.ensureTopics(TEST_TOPIC);
-
-    TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, FormatFactory.JSON, FormatFactory.JSON);
-
-    RestIntegrationTestUtil.createStream(REST_APP, TEST_DATA_PROVIDER);
-
-    makeKsqlRequest("CREATE TABLE " + AGG_TABLE + " AS "
-        + "SELECT PAGEID, LATEST_BY_OFFSET(USERID) AS USERID FROM " + TEST_STREAM + " GROUP BY PAGEID;"
-    );
-  }
-
-  @AfterClass
-  public static void classTearDown() {
-    REST_APP.getPersistentQueries().forEach(str -> makeKsqlRequest("TERMINATE " + str + ";"));
-  }
-
   @Before
   public void setUp() {
     vertx = Vertx.vertx();
     restClient = REST_APP.buildKsqlClient();
+
+    TEST_HARNESS.ensureTopics(TEST_TOPIC);
+    TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, FormatFactory.JSON, FormatFactory.JSON);
+
+    RestIntegrationTestUtil.createStream(REST_APP, TEST_DATA_PROVIDER);
+    makeKsqlRequest("CREATE TABLE " + AGG_TABLE + " AS "
+        + "SELECT PAGEID, LATEST_BY_OFFSET(USERID) AS USERID FROM " + TEST_STREAM + " GROUP BY PAGEID;"
+    );
   }
 
   @After
@@ -135,6 +117,8 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
       vertx.close();
     }
     REST_APP.getServiceContext().close();
+    REST_APP.closePersistentQueries();
+    REST_APP.dropSourcesExcept();
   }
 
   @SuppressFBWarnings({"DLS_DEAD_LOCAL_STORE"})
@@ -152,7 +136,6 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
           ImmutableMap.of("auto.offset.reset", "latest"),
           header, complete );
       TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, FormatFactory.JSON, FormatFactory.JSON);
-      System.out.println(i);
     }
 
     // scalable push query should fail on 11th try since it exceeds 1MB bandwidth limit
@@ -181,20 +164,17 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
           ImmutableMap.of("auto.offset.reset", "latest"),
           header, complete );
       TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, FormatFactory.JSON, FormatFactory.JSON);
-      System.out.println(i);
     }
 
     // scalable push query should fail on 11th try since it exceeds 1MB bandwidth limit
     try {
-      makeQueryRequest(sql,
+      makeQueryRequestAsync(sql,
           ImmutableMap.of("auto.offset.reset", "latest"));
       throw new AssertionError("New scalable push query should have exceeded bandwidth limit ");
     } catch (KsqlException e) {
       assertThat(e.getMessage(), is(RATE_LIMIT_MESSAGE));
     }
   }
-
-
 
   private static String createDataSize(int msgSize) {
     StringBuilder sb = new StringBuilder(msgSize);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
@@ -68,8 +68,6 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
   private static final String AGG_TABLE = "AGG_TABLE";
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
 
-
-
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withEnabledKsqlClient()

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/SlidingWindowRateLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/SlidingWindowRateLimiterTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
+import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +14,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SlidingWindowRateLimiterTest {
     private SlidingWindowRateLimiter limiter;
-    private static String RATE_LIMIT_MESSAGE = "Host is at bandwidth rate limit for queries.";
+    private static String RATE_LIMIT_MESSAGE = "Host is at bandwidth rate limit for pull queries.";
     private static String TEST_SHOULD_NOT_FAIL = "This test should not throw an exception";
 
     @Before
@@ -25,7 +26,7 @@ public class SlidingWindowRateLimiterTest {
     public void bigInitialResponse() {
         Throwable exception = assertThrows(KsqlException.class, () -> {
             limiter.add(0L, 1148576L);
-            limiter.allow(1000L);
+            limiter.allow(KsqlQueryType.PULL, 1000L);
         });
         assertEquals(RATE_LIMIT_MESSAGE, exception.getMessage());
     }
@@ -35,7 +36,7 @@ public class SlidingWindowRateLimiterTest {
         try {
             for (long i = 0L; i < 30L; i += 1L) {
                 limiter.add(i * 500L, 100000L);
-                limiter.allow(i * 500L + 1L);
+                limiter.allow(KsqlQueryType.PULL, i * 500L + 1L);
             }
         } catch (Exception e) {
             fail(TEST_SHOULD_NOT_FAIL);
@@ -47,7 +48,7 @@ public class SlidingWindowRateLimiterTest {
         Throwable exception = assertThrows(KsqlException.class, () -> {
             for (long i = 0L; i < 11L; i += 1L) {
                 limiter.add(i * 400L, 100000L);
-                limiter.allow(i * 400L + 1L);
+                limiter.allow(KsqlQueryType.PULL, i * 400L + 1L);
             }
         });
 
@@ -59,14 +60,14 @@ public class SlidingWindowRateLimiterTest {
         try {
             for (long i = 0L; i < 5L; i += 1L) {
                 limiter.add(i * 500L, i * 100000L);
-                limiter.allow(i * 500L + 1L);
+                limiter.allow(KsqlQueryType.PULL, i * 500L + 1L);
             }
         } catch (Exception e) {
             fail(TEST_SHOULD_NOT_FAIL);
         }
 
         try {
-            limiter.allow(3499L);
+            limiter.allow(KsqlQueryType.PULL, 3499L);
             limiter.add(3500L, 80000L);
         } catch (Exception e) {
             fail(TEST_SHOULD_NOT_FAIL);
@@ -75,7 +76,7 @@ public class SlidingWindowRateLimiterTest {
         Throwable exception = assertThrows(KsqlException.class, () -> {
             for (long i = 10L; i < 18L; i += 1L) {
                 limiter.add(i * 600L, 140000L);
-                limiter.allow(i * 600L + 1L);
+                limiter.allow(KsqlQueryType.PULL,i * 600L + 1L);
             }
         });
 

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -204,7 +204,7 @@ public final class KsqlRestClient implements Closeable {
       final Map<String, ?> properties
   ) {
     KsqlTarget targetHttp2 = targetHttp2();
-    if (properties != null) {
+    if (!properties.isEmpty()) {
       targetHttp2 = targetHttp2.properties(properties);
     }
     return targetHttp2.postQueryRequestStreamedAsync(ksql, properties);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.ServerMetadata;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpVersion;
 import java.io.Closeable;
 import java.net.URI;
 import java.net.URL;
@@ -70,7 +71,8 @@ public final class KsqlRestClient implements Closeable {
         clientProps,
         creds,
         (cprops, credz, lprops) -> new KsqlClient(cprops, credz, lprops,
-            new HttpClientOptions(), Optional.empty())
+            new HttpClientOptions(), Optional.of(
+                new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2)))
     );
   }
 
@@ -195,6 +197,19 @@ public final class KsqlRestClient implements Closeable {
     return target.postQueryRequestStreamed(ksql, Optional.ofNullable(commandSeqNum));
   }
 
+  @VisibleForTesting
+  public CompletableFuture<RestResponse<StreamPublisher<StreamedRow>>>
+      makeQueryRequestStreamedAsync(
+      final String ksql,
+      final Map<String, ?> properties
+  ) {
+    KsqlTarget targetHttp2 = targetHttp2();
+    if (properties != null) {
+      targetHttp2 = targetHttp2.properties(properties);
+    }
+    return targetHttp2.postQueryRequestStreamedAsync(ksql, properties);
+  }
+
   public RestResponse<List<StreamedRow>> makeQueryRequest(final String ksql,
       final Long commandSeqNum) {
     return makeQueryRequest(ksql, commandSeqNum, null, Collections.emptyMap());
@@ -239,6 +254,10 @@ public final class KsqlRestClient implements Closeable {
 
   private KsqlTarget target() {
     return client.target(getServerAddress());
+  }
+
+  private KsqlTarget targetHttp2() {
+    return client.targetHttp2(getServerAddress());
   }
 
   private static List<URI> parseServerAddresses(final String serverAddresses) {


### PR DESCRIPTION
### Description 
Scalable push query bandwidth on the http2 endpoint is now tracked and is throttled just like the http1 endpoint. Bandwidth limit error messages also now specify whether it was pull or push bandwidth that was exceeded. 

### Testing done 
Added integration test and updated unit/integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

