### PR TITLE
fix: Allow multiple EXTRACTJSONFIELD invocations on different paths (#8122)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractString.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractString.java
@@ -37,7 +37,8 @@ public class JsonExtractString {
 
   private static final ObjectReader OBJECT_READER = UdfJsonMapper.INSTANCE.get().reader();
 
-  private List<String> tokens = null;
+  private String latestPath = null;
+  private List<String> latestTokens = null;
 
   @Udf
   public String extract(
@@ -48,13 +49,15 @@ public class JsonExtractString {
       return null;
     }
 
-    if (tokens == null) {
+
+    if (latestPath == null || !latestPath.equals(path)) {
       final JsonPathTokenizer tokenizer = new JsonPathTokenizer(path);
-      tokens = ImmutableList.copyOf(tokenizer);
+      latestTokens = ImmutableList.copyOf(tokenizer);
+      latestPath = path;
     }
 
     JsonNode currentNode = parseJsonDoc(input);
-    for (final String token : tokens) {
+    for (final String token : latestTokens) {
       if (currentNode instanceof ArrayNode) {
         try {
           final int index = Integer.parseInt(token);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudfTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudfTest.java
@@ -105,4 +105,13 @@ public class JsonExtractStringKudfTest {
         .parallel()
         .forEach(idx -> shouldExtractJsonField());
   }
+
+  @Test
+  public void shouldParseCorrectlyDifferentPathsOnSameInstance() {
+    final String thing1 = udf.extract(JSON_DOC, "$.thing1");
+    assertThat(thing1, is("{\"thing2\":\"hello\"}"));
+
+    final String array = udf.extract(JSON_DOC, "$.array.1");
+    assertThat(array, is("102"));
+  }
 }


### PR DESCRIPTION
### Description 
Allows the `extract` function to be invoked on the same instance multiple times with different `path` variables.

### Testing done 
A unit test has been added and the steps that reproduce the bug validated.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

