### PR TITLE
feat: Add metrics and limiters for stream pull queries for HTTP1 endpoint

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullPhysicalPlan.java
@@ -164,7 +164,8 @@ public class PullPhysicalPlan {
     // Could be one or more keys
     KEY_LOOKUP,
     RANGE_SCAN,
-    TABLE_SCAN
+    TABLE_SCAN,
+    UNKNOWN
   }
 
   /**
@@ -173,7 +174,9 @@ public class PullPhysicalPlan {
    */
   public enum PullSourceType {
     NON_WINDOWED,
-    WINDOWED
+    WINDOWED,
+    NON_WINDOWED_STREAM,
+    WINDOWED_STREAM
   }
 
   /**

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullQueryResult.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullQueryResult.java
@@ -131,10 +131,19 @@ public class PullQueryResult {
     return routingNodeType;
   }
 
+  /**
+   * @return Number of rows returned to user
+   */
   public long getTotalRowsReturned() {
     return pullQueryQueue.getTotalRowsQueued();
   }
 
+  /**
+   * Number of rows read from the underlying data store. This does not need to match
+   * the number of rows returned to the user as rows can get filtered out based on the
+   * WHERE clause conditions.
+   * @return Number of rows read from the data store
+   */
   public long getTotalRowsProcessed() {
     return rowsProcessedSupplier.get();
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
@@ -27,6 +27,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * A queue of rows for transient queries.
@@ -42,6 +43,7 @@ public class TransientQueryQueue implements BlockingRowQueue {
   private LimitHandler limitHandler;
   private CompletionHandler completionHandler;
   private Runnable queuedCallback;
+  private AtomicLong totalRowsQueued = new AtomicLong(0);
 
   public TransientQueryQueue(final OptionalInt limit) {
     this(limit, BLOCKING_QUEUE_CAPACITY, 100);
@@ -118,6 +120,7 @@ public class TransientQueryQueue implements BlockingRowQueue {
       while (!closed) {
         if (rowQueue.offer(row, offerTimeoutMs, TimeUnit.MILLISECONDS)) {
           onQueued();
+          totalRowsQueued.incrementAndGet();
           break;
         }
       }
@@ -178,5 +181,8 @@ public class TransientQueryQueue implements BlockingRowQueue {
 
   private boolean passedLimit() {
     return remaining != null && remaining.get() <= 0;
+  }
+  public long getTotalRowsQueued() {
+    return totalRowsQueued.get();
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
@@ -182,6 +182,7 @@ public class TransientQueryQueue implements BlockingRowQueue {
   private boolean passedLimit() {
     return remaining != null && remaining.get() <= 0;
   }
+
   public long getTotalRowsQueued() {
     return totalRowsQueued.get();
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
@@ -194,4 +194,15 @@ public class TransientQueryQueueTest {
     queue.drainTo(entries);
     return entries;
   }
+
+  @Test
+  public void shouldCountTotalRowsQueued() {
+    // When:
+    queue.acceptRow(KEY_ONE, VAL_ONE);
+
+    // Then:
+    assertThat(queue.getTotalRowsQueued(), is(1L));
+    queue.acceptRow(KEY_TWO, VAL_TWO);
+    assertThat(queue.getTotalRowsQueued(), is(2L));
+  }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,7 @@ class QueryStreamWriter implements StreamingOutput {
   private volatile boolean complete;
   private volatile boolean connectionClosed;
   private boolean closed;
+  private AtomicLong totalRowsQueued = new AtomicLong(0);
 
   QueryStreamWriter(
       final PushQueryMetadata queryMetadata,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +55,6 @@ class QueryStreamWriter implements StreamingOutput {
   private volatile boolean complete;
   private volatile boolean connectionClosed;
   private boolean closed;
-  private AtomicLong totalRowsQueued = new AtomicLong(0);
 
   QueryStreamWriter(
       final PushQueryMetadata queryMetadata,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -385,8 +385,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
           final AtomicReference<Optional<Decrementer>> optionalDecrementer =
               new AtomicReference<>(null);
           metricsCallbackHolder.setCallback(
-              pullMetricsInitializer.initializeStreamMetricsCallback(analysis, resultForMetrics,
-                                                             optionalDecrementer));
+              pullMetricsInitializer.initializeStreamMetricsCallback(
+                  analysis, resultForMetrics, optionalDecrementer));
 
           final SessionConfig sessionConfig = SessionConfig.of(ksqlConfig, configProperties);
           final ConfiguredStatement<Query> configured = ConfiguredStatement

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -362,7 +362,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
           final AtomicReference<PullQueryResult> resultForMetrics = new AtomicReference<>(null);
           metricsCallbackHolder.setCallback(
               pullMetricsInitializer.initializeTableMetricsCallback(resultForMetrics));
-//          metricsCallbackHolder.setCallback(initializeTablePullMetricsCallback(resultForMetrics));
 
           final SessionConfig sessionConfig = SessionConfig.of(ksqlConfig, configProperties);
           final ConfiguredStatement<Query> configured = ConfiguredStatement
@@ -388,8 +387,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
           metricsCallbackHolder.setCallback(
               pullMetricsInitializer.initializeStreamMetricsCallback(analysis, resultForMetrics,
                                                              optionalDecrementer));
-//          metricsCallbackHolder.setCallback(initializeStreamPullMetricsCallback(analysis,
-//              resultForMetrics, optionalDecrementer));
 
           final SessionConfig sessionConfig = SessionConfig.of(ksqlConfig, configProperties);
           final ConfiguredStatement<Query> configured = ConfiguredStatement
@@ -561,7 +558,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
     // Apply the same rate, bandwidth and concurrency limits as with table pull queries
     PullQueryExecutionUtil.checkRateLimit(rateLimiter);
     final Decrementer decrementer = concurrencyLimiter.increment();
-    pullBandRateLimiter.allow();
+    pullBandRateLimiter.allow(KsqlQueryType.PULL);
     optionalDecrementer.set(Optional.ofNullable(decrementer));
 
     final StreamPullQueryMetadata streamPullQueryMetadata = ksqlEngine
@@ -685,7 +682,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
                   final TransientQueryQueue rowQueue = (TransientQueryQueue)
                       m.getTransientQueryMetadata().getRowQueue();
                   // The rows read from the underlying data source equal the rows read by the user
-                  // since the WHERE condition is pushed to the data source and the plan is pipelined
+                  // since the WHERE condition is pushed to the data source
                   metrics.recordRowsReturned(rowQueue.getTotalRowsQueued(), sourceType, planType,
                                              routingNodeType);
                   metrics.recordRowsProcessed(rowQueue.getTotalRowsQueued(), sourceType, planType,
@@ -697,7 +694,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
       return metricsCallback;
     }
 
-    private void recordErrorMetrics(long responseBytes, long startTimeNanos) {
+    private void recordErrorMetrics(final long responseBytes, final long startTimeNanos) {
       pullQueryMetrics.ifPresent(metrics -> {
         metrics.recordResponseSizeForError(responseBytes);
         metrics.recordLatencyForError(startTimeNanos);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.physical.pull.PullPhysicalPlan.RoutingNodeType;
 import io.confluent.ksql.physical.pull.PullQueryResult;
 import io.confluent.ksql.physical.scalablepush.PushRouting;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
+import io.confluent.ksql.query.TransientQueryQueue;
 import io.confluent.ksql.rest.ApiJsonMapper;
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
@@ -85,6 +86,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -340,46 +343,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final DataSource dataSource = analysis.getFrom().getDataSource();
       final DataSource.DataSourceType dataSourceType = dataSource.getDataSourceType();
 
-      // First thing, set the metrics callback so that it gets called, even if we hit an error
-      final AtomicReference<PullQueryResult> resultForMetrics = new AtomicReference<>(null);
-      final MetricsCallback metricsCallback =
-          (statusCode, requestBytes, responseBytes, startTimeNanos) ->
-              pullQueryMetrics.ifPresent(metrics -> {
-                metrics.recordStatusCode(statusCode);
-                metrics.recordRequestSize(requestBytes);
-                final PullQueryResult r = resultForMetrics.get();
-                if (r == null) {
-                  metrics.recordResponseSizeForError(responseBytes);
-                  metrics.recordLatencyForError(startTimeNanos);
-                  metrics.recordZeroRowsReturnedForError();
-                  metrics.recordZeroRowsProcessedForError();
-                } else {
-                  final PullSourceType sourceType = r.getSourceType();
-                  final PullPhysicalPlanType planType = r.getPlanType();
-                  final RoutingNodeType routingNodeType = r.getRoutingNodeType();
-                  metrics.recordResponseSize(
-                      responseBytes,
-                      sourceType,
-                      planType,
-                      routingNodeType
-                  );
-                  metrics.recordLatency(
-                      startTimeNanos,
-                      sourceType,
-                      planType,
-                      routingNodeType
-                  );
-                  metrics.recordRowsReturned(
-                      r.getTotalRowsReturned(),
-                      sourceType, planType, routingNodeType);
-                  metrics.recordRowsProcessed(
-                      r.getTotalRowsProcessed(),
-                      sourceType, planType, routingNodeType);
-                }
-                pullBandRateLimiter.add(responseBytes);
-              });
-      metricsCallbackHolder.setCallback(metricsCallback);
-
       if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG)) {
         throw new KsqlStatementException(
             "Pull queries are disabled."
@@ -391,11 +354,20 @@ public class StreamedQueryResource implements KsqlConfigurable {
             statement.getStatementText());
       }
 
+      final PullMetricsInitializer pullMetricsInitializer = new PullMetricsInitializer(
+          pullQueryMetrics, pullBandRateLimiter);
       switch (dataSourceType) {
         case KTABLE: {
+          // First thing, set the metrics callback so that it gets called, even if we hit an error
+          final AtomicReference<PullQueryResult> resultForMetrics = new AtomicReference<>(null);
+          metricsCallbackHolder.setCallback(
+              pullMetricsInitializer.initializeTableMetricsCallback(resultForMetrics));
+//          metricsCallbackHolder.setCallback(initializeTablePullMetricsCallback(resultForMetrics));
+
           final SessionConfig sessionConfig = SessionConfig.of(ksqlConfig, configProperties);
           final ConfiguredStatement<Query> configured = ConfiguredStatement
               .of(statement, sessionConfig);
+
           return handleTablePullQuery(
               analysis,
               securityContext.getServiceContext(),
@@ -408,8 +380,18 @@ public class StreamedQueryResource implements KsqlConfigurable {
           );
         }
         case KSTREAM: {
-          final SessionConfig sessionConfig = SessionConfig.of(ksqlConfig, configProperties);
+          // First thing, set the metrics callback so that it gets called, even if we hit an error
+          final AtomicReference<StreamPullQueryMetadata> resultForMetrics =
+              new AtomicReference<>(null);
+          final AtomicReference<Optional<Decrementer>> optionalDecrementer =
+              new AtomicReference<>(null);
+          metricsCallbackHolder.setCallback(
+              pullMetricsInitializer.initializeStreamMetricsCallback(analysis, resultForMetrics,
+                                                             optionalDecrementer));
+//          metricsCallbackHolder.setCallback(initializeStreamPullMetricsCallback(analysis,
+//              resultForMetrics, optionalDecrementer));
 
+          final SessionConfig sessionConfig = SessionConfig.of(ksqlConfig, configProperties);
           final ConfiguredStatement<Query> configured = ConfiguredStatement
               .of(statement, sessionConfig);
 
@@ -417,7 +399,9 @@ public class StreamedQueryResource implements KsqlConfigurable {
               analysis,
               securityContext.getServiceContext(),
               configured,
-              connectionClosedFuture
+              connectionClosedFuture,
+              resultForMetrics,
+              optionalDecrementer
           );
         }
         default:
@@ -570,7 +554,15 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final ImmutableAnalysis analysis,
       final ServiceContext serviceContext,
       final ConfiguredStatement<Query> configured,
-      final CompletableFuture<Void> connectionClosedFuture) {
+      final CompletableFuture<Void> connectionClosedFuture,
+      final AtomicReference<StreamPullQueryMetadata> resultForMetrics,
+      final AtomicReference<Optional<Decrementer>> optionalDecrementer) {
+
+    // Apply the same rate, bandwidth and concurrency limits as with table pull queries
+    PullQueryExecutionUtil.checkRateLimit(rateLimiter);
+    final Decrementer decrementer = concurrencyLimiter.increment();
+    pullBandRateLimiter.allow();
+    optionalDecrementer.set(Optional.ofNullable(decrementer));
 
     final StreamPullQueryMetadata streamPullQueryMetadata = ksqlEngine
         .createStreamPullQuery(
@@ -579,6 +571,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
             configured,
             false
         );
+    resultForMetrics.set(streamPullQueryMetadata);
     localCommands.ifPresent(lc -> lc.write(streamPullQueryMetadata.getTransientQueryMetadata()));
 
     final QueryStreamWriter queryStreamWriter = new QueryStreamWriter(
@@ -590,6 +583,128 @@ public class StreamedQueryResource implements KsqlConfigurable {
     );
 
     return EndpointResponse.ok(queryStreamWriter);
+  }
+
+  private static final class PullMetricsInitializer {
+
+    private final Optional<PullQueryExecutorMetrics> pullQueryMetrics;
+    private final SlidingWindowRateLimiter pullBandRateLimiter;
+
+    private PullMetricsInitializer(
+        final Optional<PullQueryExecutorMetrics> pullQueryMetrics,
+        final SlidingWindowRateLimiter pullBandRateLimiter) {
+
+      this.pullQueryMetrics = Objects.requireNonNull(pullQueryMetrics, "pullQueryMetrics");
+      this.pullBandRateLimiter = Objects.requireNonNull(pullBandRateLimiter, "pullBandRateLimiter");
+    }
+
+    private MetricsCallback initializeTableMetricsCallback(
+        final AtomicReference<PullQueryResult> resultForMetrics) {
+
+      final MetricsCallback metricsCallback =
+          (statusCode, requestBytes, responseBytes, startTimeNanos) ->
+              pullQueryMetrics.ifPresent(metrics -> {
+                metrics.recordStatusCode(statusCode);
+                metrics.recordRequestSize(requestBytes);
+
+                final PullQueryResult r = resultForMetrics.get();
+                if (r == null) {
+                  recordErrorMetrics(responseBytes, startTimeNanos);
+                } else {
+                  final PullSourceType sourceType = r.getSourceType();
+                  final PullPhysicalPlanType planType = r.getPlanType();
+                  final RoutingNodeType routingNodeType = RoutingNodeType.SOURCE_NODE;
+                  metrics.recordResponseSize(
+                      responseBytes,
+                      sourceType,
+                      planType,
+                      routingNodeType
+                  );
+                  metrics.recordLatency(
+                      startTimeNanos,
+                      sourceType,
+                      planType,
+                      routingNodeType
+                  );
+                  metrics.recordRowsReturned(
+                      r.getTotalRowsReturned(),
+                      sourceType, planType, routingNodeType);
+                  metrics.recordRowsProcessed(
+                      r.getTotalRowsProcessed(),
+                      sourceType, planType, routingNodeType);
+                }
+                pullBandRateLimiter.add(responseBytes);
+              });
+
+      return metricsCallback;
+    }
+
+    private MetricsCallback initializeStreamMetricsCallback(
+        final ImmutableAnalysis analysis,
+        final AtomicReference<StreamPullQueryMetadata> resultForMetrics,
+        final AtomicReference<Optional<Decrementer>> optionalDecrementer) {
+
+      final MetricsCallback metricsCallback =
+          (statusCode, requestBytes, responseBytes, startTimeNanos) ->
+              pullQueryMetrics.ifPresent(metrics -> {
+                metrics.recordStatusCode(statusCode);
+                metrics.recordRequestSize(requestBytes);
+
+                final StreamPullQueryMetadata m = resultForMetrics.get();
+                final KafkaStreams.State state = m == null ? null : m.getTransientQueryMetadata()
+                    .getKafkaStreams().state();
+
+                if (m == null || state == null
+                    || state.equals(State.ERROR)
+                    || state.equals(State.PENDING_ERROR)) {
+                  recordErrorMetrics(responseBytes, startTimeNanos);
+                  optionalDecrementer.get().ifPresent(Decrementer::decrementAtMostOnce);
+                } else {
+                  final boolean isWindowed = analysis
+                      .getFrom()
+                      .getDataSource()
+                      .getKsqlTopic()
+                      .getKeyFormat().isWindowed();
+                  final PullSourceType sourceType = isWindowed
+                      ? PullSourceType.WINDOWED_STREAM : PullSourceType.NON_WINDOWED_STREAM;
+                  // There is no WHERE clause constraint information in the persistent logical plan
+                  final PullPhysicalPlanType planType = PullPhysicalPlanType.UNKNOWN;
+                  final RoutingNodeType routingNodeType = RoutingNodeType.SOURCE_NODE;
+                  metrics.recordResponseSize(
+                      responseBytes,
+                      sourceType,
+                      planType,
+                      routingNodeType
+                  );
+                  metrics.recordLatency(
+                      startTimeNanos,
+                      sourceType,
+                      planType,
+                      routingNodeType
+                  );
+                  final TransientQueryQueue rowQueue = (TransientQueryQueue)
+                      m.getTransientQueryMetadata().getRowQueue();
+                  // The rows read from the underlying data source equal the rows read by the user
+                  // since the WHERE condition is pushed to the data source and the plan is pipelined
+                  metrics.recordRowsReturned(rowQueue.getTotalRowsQueued(), sourceType, planType,
+                                             routingNodeType);
+                  metrics.recordRowsProcessed(rowQueue.getTotalRowsQueued(), sourceType, planType,
+                                              routingNodeType);
+                }
+                pullBandRateLimiter.add(responseBytes);
+              });
+
+      return metricsCallback;
+    }
+
+    private void recordErrorMetrics(long responseBytes, long startTimeNanos) {
+      pullQueryMetrics.ifPresent(metrics -> {
+        metrics.recordResponseSizeForError(responseBytes);
+        metrics.recordLatencyForError(startTimeNanos);
+        metrics.recordZeroRowsReturnedForError();
+        metrics.recordZeroRowsProcessedForError();
+      });
+    }
   }
 
   private EndpointResponse handlePushQuery(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -383,7 +383,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
           final AtomicReference<Decrementer> refDecrementer = new AtomicReference<>(null);
           metricsCallbackHolder.setCallback(
               initializeStreamMetricsCallback(
-                  pullQueryMetrics, pullBandRateLimiter, analysis, resultForMetrics, refDecrementer));
+                  pullQueryMetrics, pullBandRateLimiter, analysis, resultForMetrics,
+                  refDecrementer));
 
           final SessionConfig sessionConfig = SessionConfig.of(ksqlConfig, configProperties);
           final ConfiguredStatement<Query> configured = ConfiguredStatement

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -137,7 +137,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final RateLimiter rateLimiter,
       final ConcurrencyLimiter concurrencyLimiter,
       final SlidingWindowRateLimiter pullBandRateLimiter,
-      final  SlidingWindowRateLimiter scalablePushBandRateLimiter,
+      final SlidingWindowRateLimiter scalablePushBandRateLimiter,
       final HARouting routing,
       final PushRouting pushRouting,
       final Optional<LocalCommands> localCommands
@@ -655,7 +655,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
                     || state.equals(State.ERROR)
                     || state.equals(State.PENDING_ERROR)) {
                   recordErrorMetrics(responseBytes, startTimeNanos);
-                  optionalDecrementer.get().ifPresent(Decrementer::decrementAtMostOnce);
                 } else {
                   final boolean isWindowed = analysis
                       .getFrom()
@@ -689,6 +688,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
                                               routingNodeType);
                 }
                 pullBandRateLimiter.add(responseBytes);
+                // Decrement on happy or exception path
+                optionalDecrementer.get().ifPresent(Decrementer::decrementAtMostOnce);
               });
 
       return metricsCallback;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -380,10 +380,10 @@ public class StreamedQueryResource implements KsqlConfigurable {
           // First thing, set the metrics callback so that it gets called, even if we hit an error
           final AtomicReference<StreamPullQueryMetadata> resultForMetrics =
               new AtomicReference<>(null);
-          final AtomicReference<Decrementer> decrementer = new AtomicReference<>(null);
+          final AtomicReference<Decrementer> refDecrementer = new AtomicReference<>(null);
           metricsCallbackHolder.setCallback(
               initializeStreamMetricsCallback(
-                  pullQueryMetrics, pullBandRateLimiter, analysis, resultForMetrics, decrementer));
+                  pullQueryMetrics, pullBandRateLimiter, analysis, resultForMetrics, refDecrementer));
 
           final SessionConfig sessionConfig = SessionConfig.of(ksqlConfig, configProperties);
           final ConfiguredStatement<Query> configured = ConfiguredStatement
@@ -395,7 +395,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
               configured,
               connectionClosedFuture,
               resultForMetrics,
-              decrementer
+              refDecrementer
           );
         }
         default:
@@ -550,12 +550,12 @@ public class StreamedQueryResource implements KsqlConfigurable {
       final ConfiguredStatement<Query> configured,
       final CompletableFuture<Void> connectionClosedFuture,
       final AtomicReference<StreamPullQueryMetadata> resultForMetrics,
-      final AtomicReference<Decrementer> decrementer) {
+      final AtomicReference<Decrementer> refDecrementer) {
 
     // Apply the same rate, bandwidth and concurrency limits as with table pull queries
     PullQueryExecutionUtil.checkRateLimit(rateLimiter);
     pullBandRateLimiter.allow(KsqlQueryType.PULL);
-    decrementer.set(concurrencyLimiter.increment());
+    refDecrementer.set(concurrencyLimiter.increment());
 
     final StreamPullQueryMetadata streamPullQueryMetadata = ksqlEngine
         .createStreamPullQuery(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryMetricsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryMetricsFunctionalTest.java
@@ -248,14 +248,6 @@ public class PullQueryMetricsFunctionalTest {
         "SELECT * from " + PAGE_VIEW_STREAM + " WHERE PAGEID='" + A_STREAM_KEY + "';",
         Optional.empty());
 
-    for (MetricName metric: TestMetricsReporter.METRICS.keySet()) {
-      if (metric.name().startsWith("pull-query")) {
-        if ((Double)TestMetricsReporter.METRICS.get(metric).metricValue() > 0) {
-          System.out.println(metric + " , " + (Double)TestMetricsReporter.METRICS.get(metric).metricValue());
-        }
-      }
-    }
-
     // Then:
     assertThat(recordsReturnedTableMetric.metricValue(), is(1.0));
     assertThat((Double)latencyTableMetric.metricValue(), greaterThan(1.0));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryMetricsFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryMetricsFunctionalTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatFactory;
+import io.confluent.ksql.serde.SerdeFeatures;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PageViewDataProvider;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.Timeout;
+
+public class PullQueryMetricsFunctionalTest {
+
+  private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
+  private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
+  private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.sourceName();
+  private static final Format KEY_FORMAT = FormatFactory.KAFKA;
+  private static final Format VALUE_FORMAT = FormatFactory.JSON;
+  private static final String AGG_TABLE = "AGG_TABLE";
+  private static final String AN_AGG_KEY = "USER_1";
+  private static final String A_STREAM_KEY = "PAGE_1";
+
+  private static final PhysicalSchema AGGREGATE_SCHEMA = PhysicalSchema.from(
+      LogicalSchema.builder()
+          .keyColumn(ColumnName.of("USERID"), SqlTypes.STRING)
+          .valueColumn(ColumnName.of("COUNT"), SqlTypes.BIGINT)
+          .build(),
+      SerdeFeatures.of(),
+      SerdeFeatures.of()
+  );
+
+  private static final ImmutableMap<String, String> TABLE_TAGS = ImmutableMap.of(
+      "ksql_service_id", "default_",
+      "query_source", "non_windowed",
+      "query_plan_type", "key_lookup",
+      "query_routing_type", "source_node"
+  );
+
+  private static final ImmutableMap<String, String> STREAMS_TAGS = ImmutableMap.of(
+      "ksql_service_id", "default_",
+      "query_source", "non_windowed_stream",
+      "query_plan_type", "unknown",
+      "query_routing_type", "source_node"
+  );
+
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+
+  private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty(KsqlConfig.METRIC_REPORTER_CLASSES_CONFIG, TestMetricsReporter.class.getName())
+      .withProperty(KsqlConfig.KSQL_QUERY_STREAM_PULL_QUERY_ENABLED, true)
+      .build();
+
+  @ClassRule
+  public static final RuleChain CHAIN = RuleChain.outerRule(TEST_HARNESS).around(REST_APP);
+
+  @Rule
+  public final Timeout timeout = Timeout.seconds(60);
+
+  @BeforeClass
+  public static void setUpClass() {
+    TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
+
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, FormatFactory.KAFKA, FormatFactory.JSON);
+
+    RestIntegrationTestUtil.createStream(REST_APP, PAGE_VIEWS_PROVIDER);
+
+    RestIntegrationTestUtil.makeKsqlRequest(REST_APP, "CREATE TABLE " + AGG_TABLE + " AS "
+        + "SELECT USERID, COUNT(1) AS COUNT FROM " + PAGE_VIEW_STREAM + " GROUP BY USERID;"
+    );
+
+    waitForTableRows();
+  }
+
+  @Before
+  public void setUp() {
+  }
+
+  @After
+  public void tearDown() {
+  }
+
+  @AfterClass
+  public static void classTearDown() {
+  }
+
+  public static class TestMetricsReporter implements MetricsReporter {
+    static final ConcurrentHashMap<MetricName, KafkaMetric> METRICS = new ConcurrentHashMap<>();
+
+    @Override
+    public void init(final List<KafkaMetric> metrics) {
+      for (final KafkaMetric metric : metrics) {
+        METRICS.put(metric.metricName(), metric);
+      }
+    }
+
+    @Override
+    public void metricChange(final KafkaMetric metric) {
+      METRICS.put(metric.metricName(), metric);
+    }
+
+    @Override
+    public void metricRemoval(final KafkaMetric metric) {
+      METRICS.remove(metric.metricName());
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+    }
+  }
+
+  @Test
+  public void shouldVerifyMetrics() {
+
+    // Given:
+    final MetricName recordsReturnedTable = new MetricName(
+        "pull-query-requests-rows-returned-total",
+        "_confluent-ksql-pull-query",
+        "Number of rows returned - non_windowed-key_lookup-source_node",
+        TABLE_TAGS
+    );
+    final KafkaMetric recordsReturnedTableMetric = TestMetricsReporter.METRICS.get(recordsReturnedTable);
+
+    final MetricName latencyTable = new MetricName(
+        "pull-query-requests-detailed-latency-min",
+        "_confluent-ksql-pull-query",
+        "Min time for a pull query request - non_windowed-key_lookup-source_node",
+        TABLE_TAGS
+    );
+    final KafkaMetric latencyTableMetric = TestMetricsReporter.METRICS.get(latencyTable);
+
+    final MetricName responseSizeTable = new MetricName(
+        "pull-query-requests-detailed-response-size",
+        "_confluent-ksql-pull-query",
+        "Size in bytes of pull query response - non_windowed-key_lookup-source_node",
+        TABLE_TAGS
+    );
+    final KafkaMetric responseSizeTableMetric = TestMetricsReporter.METRICS.get(responseSizeTable);
+
+    final MetricName totalRequestsTable = new MetricName(
+        "pull-query-requests-detailed-total",
+        "_confluent-ksql-pull-query",
+        "Total number of pull query request - non_windowed-key_lookup-source_node",
+        TABLE_TAGS
+    );
+    final KafkaMetric totalRequestsTableMetric = TestMetricsReporter.METRICS.get(totalRequestsTable);
+
+    final MetricName requestDistributionTable = new MetricName(
+        "pull-query-requests-detailed-distribution-90",
+        "_confluent-ksql-pull-query",
+        "Latency distribution - non_windowed-key_lookup-source_node",
+        TABLE_TAGS
+    );
+    final KafkaMetric requestDistributionTableMetric = TestMetricsReporter.METRICS.get(requestDistributionTable);
+
+
+    final MetricName recordsReturnedStream = new MetricName(
+        "pull-query-requests-rows-returned-total",
+        "_confluent-ksql-pull-query",
+        "Number of rows returned - non_windowed_stream-unknown-source_node",
+        STREAMS_TAGS
+    );
+    final KafkaMetric recordsReturnedStreamMetric = TestMetricsReporter.METRICS.get(recordsReturnedStream);
+
+    final MetricName latencyStream = new MetricName(
+        "pull-query-requests-detailed-latency-min",
+        "_confluent-ksql-pull-query",
+        "Min time for a pull query request - non_windowed_stream-unknown-source_node",
+        STREAMS_TAGS
+    );
+    final KafkaMetric latencyStreamMetric = TestMetricsReporter.METRICS.get(latencyStream);
+
+    final MetricName responseSizeStream = new MetricName(
+        "pull-query-requests-detailed-response-size",
+        "_confluent-ksql-pull-query",
+        "Size in bytes of pull query response - non_windowed_stream-unknown-source_node",
+        STREAMS_TAGS
+    );
+    final KafkaMetric responseSizeStreamMetric = TestMetricsReporter.METRICS.get(responseSizeStream);
+
+    final MetricName totalRequestsStream = new MetricName(
+        "pull-query-requests-detailed-total",
+        "_confluent-ksql-pull-query",
+        "Total number of pull query request - non_windowed_stream-unknown-source_node",
+        STREAMS_TAGS
+    );
+    final KafkaMetric totalRequestsStreamMetric = TestMetricsReporter.METRICS.get(totalRequestsStream);
+
+    final MetricName requestDistributionStream = new MetricName(
+        "pull-query-requests-detailed-distribution-90",
+        "_confluent-ksql-pull-query",
+        "Latency distribution - non_windowed_stream-unknown-source_node",
+        TABLE_TAGS
+    );
+    final KafkaMetric requestDistributionStreamMetric = TestMetricsReporter.METRICS.get(requestDistributionStream);
+
+    // When:
+    RestIntegrationTestUtil.makeQueryRequest(
+        REST_APP,
+        "SELECT COUNT, USERID from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';",
+        Optional.empty());
+
+    RestIntegrationTestUtil.makeQueryRequest(
+        REST_APP,
+        "SELECT * from " + PAGE_VIEW_STREAM + " WHERE PAGEID='" + A_STREAM_KEY + "';",
+        Optional.empty());
+
+    for (MetricName metric: TestMetricsReporter.METRICS.keySet()) {
+      if (metric.name().startsWith("pull-query")) {
+        if ((Double)TestMetricsReporter.METRICS.get(metric).metricValue() > 0) {
+          System.out.println(metric + " , " + (Double)TestMetricsReporter.METRICS.get(metric).metricValue());
+        }
+      }
+    }
+
+    // Then:
+    assertThat(recordsReturnedTableMetric.metricValue(), is(1.0));
+    assertThat((Double)latencyTableMetric.metricValue(), greaterThan(1.0));
+    assertThat((Double)responseSizeTableMetric.metricValue(), greaterThan(1.0));
+    assertThat(totalRequestsTableMetric.metricValue(), is(1.0));
+    assertThat((Double)requestDistributionTableMetric.metricValue(), greaterThan(1.0));
+
+    assertThat(recordsReturnedStreamMetric.metricValue(), is(1.0));
+    assertThat((Double)latencyStreamMetric.metricValue(), greaterThan(1.0));
+    assertThat((Double)responseSizeStreamMetric.metricValue(), greaterThan(1.0));
+    assertThat(totalRequestsStreamMetric.metricValue(), is(1.0));
+    assertThat((Double)requestDistributionStreamMetric.metricValue(), greaterThan(1.0));
+  }
+
+  private static void waitForTableRows() {
+    TEST_HARNESS.verifyAvailableUniqueRows(
+        AGG_TABLE,
+        5,
+        KEY_FORMAT,
+        VALUE_FORMAT,
+        AGGREGATE_SCHEMA
+    );
+  }
+
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -131,9 +131,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -450,6 +450,7 @@ public class StreamedQueryResourceTest {
         .thenReturn(streamPullQueryMetadata);
     when(streamPullQueryMetadata.getTransientQueryMetadata()).thenReturn(transientQueryMetadata);
     when(transientQueryMetadata.getLogicalSchema()).thenReturn(schema);
+    when(streamPullQueryMetadata.getEndOffsets()).thenReturn(new ImmutableMap.Builder<TopicPartition, Long>().build());
 
     // When:
     testResource.streamQuery(


### PR DESCRIPTION
### Description 
Add metrics and limiters (rate, bandwidth, concurrency) for stream pull queries. The limiters are counting both table and stream pull queries in the same limit. For example, if we allow 100 concurrent queries it must hold: table-pull + stream-pull <= 100

### Testing done 
Added new junit tests for metrics. Did manual tests for limiters. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

