### PR TITLE
fix: CREATE OR REPLACE TABLE on an existing query fails while initializing kafka streams

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -143,7 +143,9 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
         serviceContext,
         ksqlPlan.getConfig()
     ).execute(ksqlPlan.getPlan());
-    result.getQuery().ifPresent(query -> query.getKafkaStreams().close());
+
+    // Having a streams running in a sandboxed environment is not necessary
+    result.getQuery().map(QueryMetadata::getKafkaStreams).ifPresent(streams -> streams.close());
     return result;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -333,8 +333,13 @@ public class QueryRegistryImpl implements QueryRegistry {
       unregisterQuery(oldQuery);
     }
 
-    // Initialize the query before it's exposed to other threads via the map/sets.
-    persistentQuery.initialize();
+    // If the old query was sandboxed, then the stop() won't stop the streams and will cause
+    // the initialize() to fail because the stream is still running. Let's initialize the
+    // query only when it is a new query or the old query is not sandboxed.
+    if (oldQuery == null || !sandbox) {
+      // Initialize the query before it's exposed to other threads via the map/sets.
+      persistentQuery.initialize();
+    }
     persistentQueries.put(queryId, persistentQuery);
     switch (persistentQuery.getPersistentQueryType()) {
       case CREATE_SOURCE:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -58,8 +58,6 @@ import org.mockito.Mockito;
 
 @RunWith(Parameterized.class)
 public class QueryRegistryImplTest {
-  private static final SourceName SINK = SourceName.of("source");
-
   @Mock
   private SessionConfig config;
   @Mock


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/8104

The issue in https://github.com/confluentinc/ksql/issues/8104 was caused by a `persistentQuery.initialize()` call in the `QueryRegistryImpl` class because it was attempting to initialize a new kafka streams with a state directory that was used by the old kafka streams. This old kafka streams is not stopped because it is run in a sandboxed environment, however, the state store is never unlinked from this old kafka streams, so the new query fails linking to it.

The fix is just to avoid initializing the new query in a sandboxed environment. 

This issue started happening since ksqldB 0.17.0

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

