### PR TITLE
fix: Ensures background timer completes for scalable push queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushRouting.java
@@ -594,6 +594,7 @@ public class PushRouting implements AutoCloseable {
   public static class PushConnectionsHandle {
     private final Map<KsqlNode, RoutingResult> results = new ConcurrentHashMap<>();
     private final CompletableFuture<Void> errorCallback;
+    private volatile boolean closed = false;
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP")
     public PushConnectionsHandle() {
@@ -619,6 +620,7 @@ public class PushRouting implements AutoCloseable {
     }
 
     public void close() {
+      closed = true;
       for (RoutingResult result : results.values()) {
         result.close();
       }
@@ -636,7 +638,7 @@ public class PushRouting implements AutoCloseable {
     }
 
     public boolean isClosed() {
-      return errorCallback.isDone();
+      return closed || errorCallback.isDone();
     }
 
     public void onException(final Consumer<Throwable> consumer) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushRoutingTest.java
@@ -139,7 +139,7 @@ public class PushRoutingTest {
     CompletableFuture<PushConnectionsHandle> future =
         routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
             outputSchema, transientQueryQueue);
-    future.get();
+    final PushConnectionsHandle handle = future.get();
     context.runOnContext(v -> {
       localPublisher.accept(LOCAL_ROW1);
       localPublisher.accept(LOCAL_ROW2);
@@ -157,6 +157,7 @@ public class PushRoutingTest {
       }
       rows.add(kv.value().values());
     }
+    handle.close();
     assertThat(rows.contains(LOCAL_ROW1), is(true));
     assertThat(rows.contains(LOCAL_ROW2), is(true));
     assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
@@ -179,7 +180,7 @@ public class PushRoutingTest {
     CompletableFuture<PushConnectionsHandle> future =
         routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
             outputSchema, transientQueryQueue);
-    future.get();
+    final PushConnectionsHandle handle = future.get();
     context.runOnContext(v -> {
       localPublisher.accept(LOCAL_ROW1);
       localPublisher.accept(LOCAL_ROW2);
@@ -210,6 +211,7 @@ public class PushRoutingTest {
       }
       rows.add(kv.value().values());
     }
+    handle.close();
     assertThat(rows.contains(LOCAL_ROW1), is(true));
     assertThat(rows.contains(LOCAL_ROW2), is(true));
     assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
@@ -256,6 +258,7 @@ public class PushRoutingTest {
       Thread.sleep(100);
       continue;
     }
+    handle.close();
 
     // Then:
     assertThat(rows.contains(LOCAL_ROW1), is(true));
@@ -304,6 +307,7 @@ public class PushRoutingTest {
       Thread.sleep(100);
       continue;
     }
+    handle.close();
 
     // Then:
     assertThat(rows.contains(LOCAL_ROW1), is(true));
@@ -342,6 +346,7 @@ public class PushRoutingTest {
       Thread.sleep(100);
       continue;
     }
+    handle.close();
 
     // Then:
     assertThat(exception.get().getMessage(), containsString("Random error"));
@@ -360,7 +365,7 @@ public class PushRoutingTest {
     CompletableFuture<PushConnectionsHandle> future =
         routing.handlePushQuery(serviceContext, pushPhysicalPlan, statement, pushRoutingOptions,
             outputSchema, transientQueryQueue);
-    future.get();
+    final PushConnectionsHandle handle = future.get();
     context.runOnContext(v -> {
       localPublisher.accept(LOCAL_ROW1);
       localPublisher.accept(LOCAL_ROW2);
@@ -377,6 +382,7 @@ public class PushRoutingTest {
       }
       rows.add(kv.value().values());
     }
+    handle.close();
     assertThat(rows.contains(LOCAL_ROW1), is(true));
     assertThat(rows.contains(LOCAL_ROW2), is(true));
   }
@@ -463,6 +469,7 @@ public class PushRoutingTest {
       }
       rows.add(kv.value().values());
     }
+    handle.close();
     assertThat(rows.get(0), is(LOCAL_ROW1));
     assertThat(handle.getError().getMessage(), containsString("Hit limit of request queue"));
   }
@@ -497,6 +504,7 @@ public class PushRoutingTest {
       }
       rows.add(kv.value().values());
     }
+    handle.close();
     assertThat(rows.contains(REMOTE_ROW1.getRow().get().getColumns()), is(true));
     assertThat(handle.getError().getMessage(), containsString("Hit limit of request queue"));
   }


### PR DESCRIPTION
### Description 
The Vertx timer which is used to ensure connections with other nodes in the cluster correctly checks if the handle has been closed, but the condition for isClosed only considered if there was an error, not if it had been manually closed as when the connection is closed.

### Testing done 
Called it in unit tests and manually verified.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

