### PR TITLE
fix: Allow variable to have = character in value

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/parser/VariableParser.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/parser/VariableParser.java
@@ -34,7 +34,7 @@ public final class VariableParser {
 
     final ImmutableMap.Builder<String, String> variables = ImmutableMap.builder();
     for (String pair : definedVars) {
-      final String[] parts = pair.split("=");
+      final String[] parts = pair.split("=", 2);
       if (parts.length != 2) {
         throw new IllegalArgumentException("Failed to parse argument " + pair
             + ": variables must be defined using '=' (i.e. var=val).");


### PR DESCRIPTION
### Description 
Currently, if defining variable with `-d VAR=123`, it will fail when there is more than one '=' character, e.g. `-d VAR={"test":"123=456"}`

### Testing done 
TODO

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

