### PR TITLE
refactor: rename QueryExecutor to QueryBuilder

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -88,8 +88,11 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyStreamsBuilder;
 
+/**
+ * A builder for creating queries metadata.
+ */
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
-final class QueryExecutor {
+final class QueryBuilder {
 
   private static final String KSQL_THREAD_EXCEPTION_UNCAUGHT_LOGGER
       = "ksql.logger.thread.exception.uncaught";
@@ -104,7 +107,7 @@ final class QueryExecutor {
   private final List<SharedKafkaStreamsRuntime> streams;
   private final boolean real;
 
-  QueryExecutor(
+  QueryBuilder(
       final SessionConfig config,
       final ProcessingLogContext processingLogContext,
       final ServiceContext serviceContext,
@@ -131,7 +134,7 @@ final class QueryExecutor {
   }
 
   @VisibleForTesting
-  QueryExecutor(
+  QueryBuilder(
       final SessionConfig config,
       final ProcessingLogContext processingLogContext,
       final ServiceContext serviceContext,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -90,7 +90,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class QueryExecutorTest {
+public class QueryBuilderTest {
 
   private static final String STATEMENT_TEXT = "KSQL STATEMENT";
   private static final QueryId QUERY_ID = new QueryId("queryid");
@@ -183,7 +183,7 @@ public class QueryExecutorTest {
   @Captor
   private ArgumentCaptor<Map<String, Object>> propertyCaptor;
 
-  private QueryExecutor queryBuilder;
+  private QueryBuilder queryBuilder;
   private final Stacker stacker = new Stacker();
   private List<SharedKafkaStreamsRuntime> sharedKafkaStreamsRuntimes;
 
@@ -219,7 +219,7 @@ public class QueryExecutorTest {
     when(kstream.filter(any())).thenReturn(kstream);
     sharedKafkaStreamsRuntimes = new ArrayList<>();
 
-    queryBuilder = new QueryExecutor(
+    queryBuilder = new QueryBuilder(
         config,
         processingLogContext,
         serviceContext,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryError.Type;
-import io.confluent.ksql.query.QueryRegistryImpl.QueryExecutorFactory;
+import io.confluent.ksql.query.QueryRegistryImpl.QueryBuilderFactory;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
@@ -73,9 +73,9 @@ public class QueryRegistryImplTest {
   @Mock
   private QueryEventListener sandboxListener;
   @Mock
-  private QueryExecutor executor;
+  private QueryBuilder queryBuilder;
   @Mock
-  private QueryExecutorFactory executorFactory;
+  private QueryBuilderFactory executorFactory;
   @Mock
   private ServiceContext serviceContext;
   @Mock
@@ -104,7 +104,7 @@ public class QueryRegistryImplTest {
   @Before
   public void setup() {
     rule.strictness(Strictness.WARN);
-    when(executorFactory.create(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(executor);
+    when(executorFactory.create(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(queryBuilder);
     when(listener1.createSandbox()).thenReturn(Optional.of(sandboxListener));
     when(listener2.createSandbox()).thenReturn(Optional.empty());
     registry = new QueryRegistryImpl(ImmutableList.of(listener1, listener2), executorFactory);
@@ -471,10 +471,10 @@ public class QueryRegistryImplTest {
   ) {
     givenCreate(registry, id, "source", Optional.of("sink1"), CREATE_AS);
     if (!sharedRuntimes) {
-      verify(executor).buildPersistentQueryInDedicatedRuntime(
+      verify(queryBuilder).buildPersistentQueryInDedicatedRuntime(
           any(), any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any(), any());
     } else {
-      verify(executor).buildPersistentQueryInSharedRuntime(
+      verify(queryBuilder).buildPersistentQueryInSharedRuntime(
           any(), any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any());
     }
     return queryListenerCaptor.getValue();
@@ -506,11 +506,11 @@ public class QueryRegistryImplTest {
     when(query.getSourceNames()).thenReturn(ImmutableSet.of(SourceName.of(source)));
     when(query.getPersistentQueryType()).thenReturn(persistentQueryType);
     if (sharedRuntimes) {
-      when(executor.buildPersistentQueryInSharedRuntime(
+      when(queryBuilder.buildPersistentQueryInSharedRuntime(
           any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
       ).thenReturn(query);
     } else {
-      when(executor.buildPersistentQueryInDedicatedRuntime(
+      when(queryBuilder.buildPersistentQueryInDedicatedRuntime(
           any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
       ).thenReturn(query);
     }
@@ -539,7 +539,7 @@ public class QueryRegistryImplTest {
     final QueryId queryId = new QueryId(id);
     final TransientQueryMetadata query = mock(TransientQueryMetadata.class);
     when(query.getQueryId()).thenReturn(queryId);
-    when(executor.buildTransientQuery(
+    when(queryBuilder.buildTransientQuery(
         any(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any(), any())
     ).thenReturn(query);
     registry.createTransientQuery(


### PR DESCRIPTION
### Description 
For so long, I've been getting confused about the real job of the `QueryExecutor`. The class does not executes anything, but only builds transient and persistent queries metadata. So why not refactoring to avoid more confusion?

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

