### PR TITLE
feat: add stream pull queries to websocket endpoint

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -314,12 +314,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     }
   }
 
-  /**
-   * Unlike the other queries, stream pull queries are split into create and wait because the three
-   * API endpoints all need to do different stuff before, in the middle of, and after these two
-   * phases. One of them actually needs to wait on the pull query in a callback after starting the
-   * query, so splitting it into two method calls was the most practical choice.
-   */
   public StreamPullQueryMetadata createStreamPullQuery(
       final ServiceContext serviceContext,
       final ImmutableAnalysis analysis,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
@@ -133,6 +133,7 @@ final class PushQueryPublisher implements Flow.Publisher<Collection<StreamedRow>
       this.queryMetadata = requireNonNull(queryMetadata, "queryMetadata");
 
       queryMetadata.setLimitHandler(this::setDone);
+      queryMetadata.setCompletionHandler(this::setDone);
       queryMetadata.setUncaughtExceptionHandler(
           e -> {
             setError(e);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -22,7 +22,6 @@ import static io.netty.handler.codec.http.websocketx.WebSocketCloseStatus.TRY_AG
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
-import io.confluent.ksql.analyzer.PullQueryValidator;
 import io.confluent.ksql.api.server.SlidingWindowRateLimiter;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.engine.KsqlEngine;
@@ -44,6 +43,7 @@ import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.LocalCommands;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
+import io.confluent.ksql.rest.server.resources.streaming.PushQueryPublisher.PushQuerySubscription;
 import io.confluent.ksql.rest.util.CommandStoreUtil;
 import io.confluent.ksql.rest.util.ConcurrencyLimiter;
 import io.confluent.ksql.rest.util.ScalablePushUtil;
@@ -52,6 +52,7 @@ import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlStatementException;
+import io.confluent.ksql.util.StreamPullQueryMetadata;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
@@ -297,11 +298,30 @@ public class WSQueryEndpoint {
           return;
         }
         case KSTREAM: {
-          throw new KsqlStatementException(
-              "Pull queries are not supported on streams."
-                  + PullQueryValidator.PULL_QUERY_SYNTAX_HELP,
-              statement.getStatementText()
+          final StreamPullQueryMetadata queryMetadata =
+              ksqlEngine.createStreamPullQuery(
+                  info.securityContext.getServiceContext(),
+                  analysis,
+                  configured,
+                  true
+              );
+
+          localCommands.ifPresent(lc -> lc.write(queryMetadata.getTransientQueryMetadata()));
+
+          final PushQuerySubscription subscription =
+              new PushQuerySubscription(exec,
+                  streamSubscriber,
+                  queryMetadata.getTransientQueryMetadata()
+              );
+
+          log.info(
+              "Running query {}",
+              queryMetadata.getTransientQueryMetadata().getQueryId().toString()
           );
+          queryMetadata.getTransientQueryMetadata().start();
+
+          streamSubscriber.onSubscribe(subscription);
+          return;
         }
         default:
           throw new KsqlStatementException(


### PR DESCRIPTION
Finishing out the stream pull query implementation cycle, this adds support
to the websocket endpoint, building on the HTTP/1 and HTTP/2 endpoints.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

