### PR TITLE
chore: normalize output help text

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/cmd/Output.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/cmd/Output.java
@@ -27,8 +27,7 @@ final class Output implements CliSpecificCommand {
   private static final String HELP = "output:" + System.lineSeparator()
       + "\tView the current output format." + System.lineSeparator()
       + System.lineSeparator()
-      + "output <format>;" + System.lineSeparator()
-      + System.lineSeparator()
+      + "output <format>:" + System.lineSeparator()
       + "\tSet the output format to <format> (valid formats: " + OutputFormat.VALID_FORMATS + ")"
       + System.lineSeparator()
       + System.lineSeparator()


### PR DESCRIPTION
### Description 
Normalizes the help text of the `output` command in the CLI so that it better matches the formatting of the other commands.

### Testing done 
N/A; simply a change to help output.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

