### PR TITLE
chore: add an scm block to the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <scm>
+        <connection>scm:git:git://github.com/confluentinc/ksql.git</connection>
+        <developerConnection>scm:git:git@github.com:confluentinc/ksql.git</developerConnection>
+        <url>https://github.com/confluentinc/ksql</url>
+        <tag>HEAD</tag>
+    </scm>
+  
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>


### PR DESCRIPTION
Adds an scm block to ksql pom.xml. The release build tooling relies on this block