### PR TITLE
fix: Always dec. concurrency counter, even hitting rate limits

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullQueryResult.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullQueryResult.java
@@ -29,8 +29,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PullQueryResult {
+  private static final Logger LOG = LoggerFactory.getLogger(PullQueryResult.class);
 
   private final LogicalSchema schema;
   private final PullQueryQueuePopulator populator;
@@ -87,16 +90,26 @@ public class PullQueryResult {
   public void start() {
     Preconditions.checkState(!started, "Should only start once");
     started = true;
-    final CompletableFuture<Void> f = populator.run();
-    f.exceptionally(t -> {
+    try {
+      final CompletableFuture<Void> f = populator.run();
+      f.exceptionally(t -> {
+        future.completeExceptionally(t);
+        return null;
+      });
+      f.thenAccept(future::complete);
+    } catch (final Throwable t) {
       future.completeExceptionally(t);
-      return null;
-    });
-    f.thenAccept(future::complete);
+      throw t;
+    }
   }
 
   public void stop() {
-    pullQueryQueue.close();
+    try {
+      pullQueryQueue.close();
+    } catch (final Throwable t) {
+      LOG.error("Error closing pull query queue", t);
+    }
+    future.complete(null);
   }
 
   public void onException(final Consumer<Throwable> consumer) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullQueryResult.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/PullQueryResult.java
@@ -101,6 +101,11 @@ public class PullQueryResult {
       future.completeExceptionally(t);
       throw t;
     }
+    // Register the error metric
+    onException(t ->
+        pullQueryMetrics.ifPresent(metrics ->
+            metrics.recordErrorRate(1, sourceType, planType, routingNodeType))
+    );
   }
 
   public void stop() {
@@ -114,8 +119,6 @@ public class PullQueryResult {
 
   public void onException(final Consumer<Throwable> consumer) {
     future.exceptionally(t -> {
-      pullQueryMetrics.ifPresent(metrics ->
-          metrics.recordErrorRate(1, sourceType, planType, routingNodeType));
       consumer.accept(t);
       return null;
     });

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
@@ -25,6 +25,8 @@ import io.confluent.ksql.util.Pair;
 import java.util.LinkedList;
 import java.util.Queue;
 import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * SlidingWindowRateLimiter keeps a log of timestamps and the size for each response returned by
@@ -38,6 +40,7 @@ import org.apache.kafka.common.utils.Time;
 
 public class SlidingWindowRateLimiter {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SlidingWindowRateLimiter.class);
   private static long NUM_BYTES_IN_ONE_MEGABYTE = 1 * 1024 * 1024;
 
   /**
@@ -93,6 +96,7 @@ public class SlidingWindowRateLimiter {
       this.numBytesInWindow -= responseSizesLog.poll().right;
     }
     if (this.numBytesInWindow > throttleLimit) {
+      LOG.warn("Hit bandwidth rate limit of " + throttleLimit + " with use of " + numBytesInWindow);
       throw new KsqlApiException("Host is at bandwidth rate limit for "
           + ksqlQueryType.toString().toLowerCase() + " queries.",
           ERROR_CODE_BAD_REQUEST);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
@@ -96,7 +96,8 @@ public class SlidingWindowRateLimiter {
       this.numBytesInWindow -= responseSizesLog.poll().right;
     }
     if (this.numBytesInWindow > throttleLimit) {
-      LOG.warn("Hit bandwidth rate limit of " + throttleLimit + " with use of " + numBytesInWindow);
+      LOG.warn("Hit bandwidth rate limit of " + throttleLimit + "MB with use of "
+          + numBytesInWindow + "MB");
       throw new KsqlApiException("Host is at bandwidth rate limit for "
           + ksqlQueryType.toString().toLowerCase() + " queries.",
           ERROR_CODE_BAD_REQUEST);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -317,13 +317,10 @@ public class StreamedQueryResource implements KsqlConfigurable {
             statement.getClass().getName()));
       }
     } catch (final TopicAuthorizationException e) {
-      log.error("Cannot access Kafka topic", e);
       return errorHandler.accessDeniedFromKafkaResponse(e);
-    } catch (final KsqlStatementException e) {
-      log.error("Cannot execute statement", e);
+    } catch (final KsqlStatementException e) {;
       return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
     } catch (final KsqlException e) {
-      log.error("Error executing pull query", e);
       return errorHandler.generateResponse(e, Errors.badRequest(e));
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -318,7 +318,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
       }
     } catch (final TopicAuthorizationException e) {
       return errorHandler.accessDeniedFromKafkaResponse(e);
-    } catch (final KsqlStatementException e) {;
+    } catch (final KsqlStatementException e) {
       return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
     } catch (final KsqlException e) {
       return errorHandler.generateResponse(e, Errors.badRequest(e));


### PR DESCRIPTION
### Description 
When the bandwidth rate limit is hit, it never decrements the concurrency counter.  This change ensures it always does.

### Testing done 
Ran tests and verified manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

