### PR TITLE
fix: stream pull query internal overrides shouldn't clash with query configs

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -67,6 +67,7 @@ import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
 import java.io.Closeable;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -336,18 +337,17 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     }
 
     // Stream pull query overrides.
-    final ConfiguredStatement<Query> statement = statementOrig.withConfigOverrides(
-        ImmutableMap.<String, Object>builder()
-            .putAll(statementOrig.getSessionConfig().getOverrides())
-            // Starting from earliest is semantically necessary.
-            .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-            // Using a single thread keeps these queries as lightweight as possible, since we are
-            // not counting them against the transient query limit.
-            .put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
-            // There's no point in EOS, since this query only produces side effects.
-            .put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE)
-            .build()
-    );
+    final Map<String, Object> overrides =
+        new HashMap<>(statementOrig.getSessionConfig().getOverrides());
+    // Starting from earliest is semantically necessary.
+    overrides.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    // Using a single thread keeps these queries as lightweight as possible, since we are
+    // not counting them against the transient query limit.
+    overrides.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1);
+    // There's no point in EOS, since this query only produces side effects.
+    overrides.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE);
+
+    final ConfiguredStatement<Query> statement = statementOrig.withConfigOverrides(overrides);
     final ImmutableMap<TopicPartition, Long> endOffsets =
         getQueryInputEndOffsets(analysis, serviceContext.getAdminClient());
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -503,7 +503,7 @@ public class RestApiTest {
     final KsqlRequest request =
         new KsqlRequest(
             "SELECT USERID, PAGEID, VIEWTIME from " + PAGE_VIEW_STREAM + ";",
-            ImmutableMap.of("auto.offset.reset", "lastest"), // should get ignored
+            ImmutableMap.of("auto.offset.reset", "latest"), // should get ignored
             ImmutableMap.of(),
             null
         );


### PR DESCRIPTION
Previously, if you `SET 'auto.offset.reset'='earliest'` or `'latest'`, the query would fail
with an exception. This patch fixes that and simply overrides the configs as desired.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

