### PR TITLE
chore: fix for bug where QueryAnalyzers weren't being constructed with session configs

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -601,12 +601,15 @@ final class EngineExecutor {
         query,
         sink,
         metaStore,
-        ksqlConfig.cloneWithPropertyOverwrite(statement.getSessionConfig().getOverrides())
+        ksqlConfig,
+        statement.getSessionConfig()
     );
+
     final LogicalPlanNode logicalPlan = new LogicalPlanNode(
         statement.getStatementText(),
         Optional.of(outputNode)
     );
+
     final QueryId queryId = QueryIdUtil.buildId(
         statement.getStatement(),
         engineContext,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -602,7 +602,7 @@ final class EngineExecutor {
         sink,
         metaStore,
         ksqlConfig,
-        statement.getSessionConfig()
+        statement.getSessionConfig().getConfig(true)
     );
 
     final LogicalPlanNode logicalPlan = new LogicalPlanNode(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -601,7 +601,7 @@ final class EngineExecutor {
         query,
         sink,
         metaStore,
-        ksqlConfig
+        ksqlConfig.cloneWithPropertyOverwrite(statement.getSessionConfig().getOverrides())
     );
     final LogicalPlanNode logicalPlan = new LogicalPlanNode(
         statement.getStatementText(),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.analyzer.QueryAnalyzer;
 import io.confluent.ksql.analyzer.RewrittenAnalysis;
+import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.execution.streams.RoutingOptions;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.internal.KsqlEngineMetrics;
@@ -546,9 +547,10 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
    */
   public ImmutableAnalysis analyzeQueryWithNoOutputTopic(
       final Query query,
-      final String queryText) {
+      final String queryText,
+      final Map<String, Object> configOverrides) {
 
-    final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(getMetaStore(), "", ksqlConfig);
+    final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(getMetaStore(), "", ksqlConfig.cloneWithPropertyOverwrite(configOverrides));
     final Analysis analysis;
     try {
       analysis = queryAnalyzer.analyze(query, Optional.empty());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.analyzer.QueryAnalyzer;
 import io.confluent.ksql.analyzer.RewrittenAnalysis;
-import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.execution.streams.RoutingOptions;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.internal.KsqlEngineMetrics;
@@ -550,7 +549,12 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
       final String queryText,
       final Map<String, Object> configOverrides) {
 
-    final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(getMetaStore(), "", ksqlConfig.cloneWithPropertyOverwrite(configOverrides));
+    final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(
+        getMetaStore(),
+        "",
+        ksqlConfig.cloneWithPropertyOverwrite(configOverrides)
+    );
+
     final Analysis analysis;
     try {
       analysis = queryAnalyzer.analyze(query, Optional.empty());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
@@ -56,12 +56,13 @@ class QueryEngine {
       final Query query,
       final Optional<Sink> sink,
       final MetaStore metaStore,
-      final KsqlConfig config
+      final KsqlConfig config,
+      final SessionConfig sessionConfig
   ) {
     final String outputPrefix = config.getString(KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG);
 
     final QueryAnalyzer queryAnalyzer =
-        new QueryAnalyzer(metaStore, outputPrefix, config);
+        new QueryAnalyzer(metaStore, outputPrefix, config.cloneWithPropertyOverwrite(sessionConfig.getOverrides()));
 
     final Analysis analysis = queryAnalyzer.analyze(query, sink);
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
@@ -62,7 +62,10 @@ class QueryEngine {
     final String outputPrefix = config.getString(KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG);
 
     final QueryAnalyzer queryAnalyzer =
-        new QueryAnalyzer(metaStore, outputPrefix, config.cloneWithPropertyOverwrite(sessionConfig.getOverrides()));
+        new QueryAnalyzer(metaStore,
+            outputPrefix,
+            config.cloneWithPropertyOverwrite(sessionConfig.getOverrides())
+        );
 
     final Analysis analysis = queryAnalyzer.analyze(query, sink);
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
@@ -57,14 +57,14 @@ class QueryEngine {
       final Optional<Sink> sink,
       final MetaStore metaStore,
       final KsqlConfig config,
-      final SessionConfig sessionConfig
+      final KsqlConfig configWithOverrides
   ) {
     final String outputPrefix = config.getString(KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG);
 
     final QueryAnalyzer queryAnalyzer =
         new QueryAnalyzer(metaStore,
             outputPrefix,
-            config.cloneWithPropertyOverwrite(sessionConfig.getOverrides())
+            configWithOverrides
         );
 
     final Analysis analysis = queryAnalyzer.analyze(query, sink);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -138,7 +138,8 @@ public class QueryEndpoint {
 
     if (statement.getStatement().isPullQuery()) {
       final ImmutableAnalysis analysis = ksqlEngine
-          .analyzeQueryWithNoOutputTopic(statement.getStatement(), statement.getStatementText(), properties);
+          .analyzeQueryWithNoOutputTopic(
+              statement.getStatement(), statement.getStatementText(), properties);
       final DataSource dataSource = analysis.getFrom().getDataSource();
       final DataSource.DataSourceType dataSourceType = dataSource.getDataSourceType();
       switch (dataSourceType) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -138,7 +138,7 @@ public class QueryEndpoint {
 
     if (statement.getStatement().isPullQuery()) {
       final ImmutableAnalysis analysis = ksqlEngine
-          .analyzeQueryWithNoOutputTopic(statement.getStatement(), statement.getStatementText());
+          .analyzeQueryWithNoOutputTopic(statement.getStatement(), statement.getStatementText(), properties);
       final DataSource dataSource = analysis.getFrom().getDataSource();
       final DataSource.DataSourceType dataSourceType = dataSource.getDataSourceType();
       switch (dataSourceType) {
@@ -169,7 +169,11 @@ public class QueryEndpoint {
     } else if (ScalablePushUtil.isScalablePushQuery(statement.getStatement(), ksqlEngine,
         ksqlConfig, properties)) {
       final ImmutableAnalysis analysis = ksqlEngine
-          .analyzeQueryWithNoOutputTopic(statement.getStatement(), statement.getStatementText());
+          .analyzeQueryWithNoOutputTopic(
+              statement.getStatement(),
+              statement.getStatementText(),
+              statement.getSessionConfig().getOverrides()
+          );
       return createScalablePushQueryPublisher(
           analysis,
           context,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -173,7 +173,7 @@ public class QueryEndpoint {
           .analyzeQueryWithNoOutputTopic(
               statement.getStatement(),
               statement.getStatementText(),
-              statement.getSessionConfig().getOverrides()
+              properties
           );
       return createScalablePushQueryPublisher(
           analysis,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -340,7 +340,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
     if (statement.getStatement().isPullQuery()) {
       final ImmutableAnalysis analysis = ksqlEngine
           .analyzeQueryWithNoOutputTopic(
-              statement.getStatement(), statement.getStatementText(), request.getConfigOverrides());
+              statement.getStatement(), statement.getStatementText(), configProperties);
       final DataSource dataSource = analysis.getFrom().getDataSource();
       final DataSource.DataSourceType dataSourceType = dataSource.getDataSourceType();
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -339,7 +339,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
 
     if (statement.getStatement().isPullQuery()) {
       final ImmutableAnalysis analysis = ksqlEngine
-          .analyzeQueryWithNoOutputTopic(statement.getStatement(), statement.getStatementText());
+          .analyzeQueryWithNoOutputTopic(statement.getStatement(), statement.getStatementText(), request.getConfigOverrides());
       final DataSource dataSource = analysis.getFrom().getDataSource();
       final DataSource.DataSourceType dataSourceType = dataSource.getDataSourceType();
 
@@ -410,7 +410,11 @@ public class StreamedQueryResource implements KsqlConfigurable {
             configProperties)) {
 
       final ImmutableAnalysis analysis = ksqlEngine
-          .analyzeQueryWithNoOutputTopic(statement.getStatement(), statement.getStatementText());
+          .analyzeQueryWithNoOutputTopic(
+              statement.getStatement(),
+              statement.getStatementText(),
+              request.getConfigOverrides()
+          );
 
       QueryLogger.info("Scalable push query created", statement.getStatementText());
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -414,7 +414,7 @@ public class StreamedQueryResource implements KsqlConfigurable {
           .analyzeQueryWithNoOutputTopic(
               statement.getStatement(),
               statement.getStatementText(),
-              request.getConfigOverrides()
+              configProperties
           );
 
       QueryLogger.info("Scalable push query created", statement.getStatementText());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -339,7 +339,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
 
     if (statement.getStatement().isPullQuery()) {
       final ImmutableAnalysis analysis = ksqlEngine
-          .analyzeQueryWithNoOutputTopic(statement.getStatement(), statement.getStatementText(), request.getConfigOverrides());
+          .analyzeQueryWithNoOutputTopic(
+              statement.getStatement(), statement.getStatementText(), request.getConfigOverrides());
       final DataSource dataSource = analysis.getFrom().getDataSource();
       final DataSource.DataSourceType dataSourceType = dataSource.getDataSourceType();
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -275,7 +275,11 @@ public class WSQueryEndpoint {
     if (query.isPullQuery()) {
 
       final ImmutableAnalysis analysis = ksqlEngine
-          .analyzeQueryWithNoOutputTopic(configured.getStatement(), configured.getStatementText());
+          .analyzeQueryWithNoOutputTopic(
+              configured.getStatement(),
+              configured.getStatementText(),
+              configured.getSessionConfig().getOverrides()
+          );
       final DataSource dataSource = analysis.getFrom().getDataSource();
       final DataSource.DataSourceType dataSourceType = dataSource.getDataSourceType();
 
@@ -333,7 +337,11 @@ public class WSQueryEndpoint {
         statement.getStatement(), ksqlEngine, ksqlConfig, clientLocalProperties)) {
 
       final ImmutableAnalysis analysis = ksqlEngine
-          .analyzeQueryWithNoOutputTopic(configured.getStatement(), configured.getStatementText());
+          .analyzeQueryWithNoOutputTopic(
+              configured.getStatement(),
+              configured.getStatementText(),
+              configured.getSessionConfig().getOverrides()
+          );
 
       PushQueryPublisher.createScalablePushQueryPublisher(
           ksqlEngine,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -267,7 +267,7 @@ public class StreamedQueryResourceTest {
     when(errorsHandler.accessDeniedFromKafkaResponse(any(Exception.class))).thenReturn(AUTHORIZATION_ERROR_RESPONSE);
     when(errorsHandler.generateResponse(exception.capture(), any()))
         .thenReturn(EndpointResponse.failed(500));
-    when(mockKsqlEngine.analyzeQueryWithNoOutputTopic(any(), any())).thenReturn(mockAnalysis);
+    when(mockKsqlEngine.analyzeQueryWithNoOutputTopic(any(), any(), any())).thenReturn(mockAnalysis);
     when(mockAnalysis.getFrom()).thenReturn(mockAliasedDataSource);
     when(mockAliasedDataSource.getDataSource()).thenReturn(mockDataSource);
     when(mockDataSource.getDataSourceType()).thenReturn(DataSourceType.KSTREAM);


### PR DESCRIPTION
### Description 
To add a feature flag for [KLIP-50](https://github.com/confluentinc/ksql/blob/master/design-proposals/klip-50-partition-and-offset-in-ksqldb.md) in https://github.com/confluentinc/ksql/pull/8120, a `KsqlConfig` had to be available in every location where a decision had to be made about which psuedo column version to use. For certain queries that require session config overrides, these were being ignored, as only the engine config was being provided. This PR fixes that.

### Testing done 
None. I think this is acceptable because this will be removed when the flag is removed, and other tests should fail if this fix is undone. If there is smart test coverage to be done here, I'm open to adding it.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

