### PR TITLE
refactor: Refactor ConnectFormatSchemaTranslator to take translator object instead of lamda function so that the translator can take in config to decide how to transform field names

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/KudafByOffsetUtils.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.function.udaf.offset;
 
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_DATE_SCHEMA;
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_TIMESTAMP_SCHEMA;
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_TIME_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_DATE_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_TIMESTAMP_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_TIME_SCHEMA;
 
 import java.util.Comparator;
 import org.apache.kafka.connect.data.Schema;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.schema.ksql.inference;
 
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_DATE_SCHEMA;
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_TIMESTAMP_SCHEMA;
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_TIME_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_DATE_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_TIMESTAMP_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_TIME_SCHEMA;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
@@ -57,7 +57,7 @@ public abstract class ConnectFormat implements Format {
     return new ConnectFormatSchemaTranslator(
         this,
         formatProperties,
-        ConnectSchemaUtil::toKsqlSchema
+        new ConnectKsqlSchemaTranslator()
     );
   }
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslator.java
@@ -32,7 +32,6 @@ import io.confluent.ksql.serde.SerdeUtils;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Field;
@@ -43,16 +42,16 @@ class ConnectFormatSchemaTranslator implements SchemaTranslator {
 
   private final ConnectFormat format;
   private final ConnectSchemaTranslator connectSrTranslator;
-  private final Function<Schema, Schema> connectKsqlTranslator;
+  private final ConnectKsqlSchemaTranslator connectKsqlTranslator;
 
   ConnectFormatSchemaTranslator(
       final ConnectFormat format,
       final Map<String, String> formatProps,
-      final Function<Schema, Schema> connectKsqlTranslator
+      final ConnectKsqlSchemaTranslator connectKsqlSchemaTranslator
   ) {
     this.format = requireNonNull(format, "format");
     this.connectSrTranslator = requireNonNull(format.getConnectSchemaTranslator(formatProps));
-    this.connectKsqlTranslator = requireNonNull(connectKsqlTranslator, "toKsqlTransformer");
+    this.connectKsqlTranslator = requireNonNull(connectKsqlSchemaTranslator);
   }
 
   @Override
@@ -83,7 +82,7 @@ class ConnectFormatSchemaTranslator implements SchemaTranslator {
           + "=false' in the WITH clause properties.");
     }
 
-    final Schema rowSchema = connectKsqlTranslator.apply(connectSchema);
+    final Schema rowSchema = connectKsqlTranslator.toKsqlSchema(connectSchema);
 
     return rowSchema.fields().stream()
         .map(ConnectFormatSchemaTranslator::toColumn)

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectFormatSchemaTranslatorTest.java
@@ -54,7 +54,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class ConnectFormatSchemaTranslatorTest {
 
   @Mock
-  private Function<Schema, Schema> connectKsqlTranslator;
+  private ConnectKsqlSchemaTranslator connectKsqlTranslator;
   @Mock
   private ParsedSchema parsedSchema;
   @Mock
@@ -72,7 +72,7 @@ public class ConnectFormatSchemaTranslatorTest {
 
   @Before
   public void setUp() {
-    when(connectKsqlTranslator.apply(any())).thenReturn(transformedSchema);
+    when(connectKsqlTranslator.toKsqlSchema(any())).thenReturn(transformedSchema);
     when(connectSchema.type()).thenReturn(Type.STRUCT);
 
     when(format.getConnectSchemaTranslator(any())).thenReturn(innerTranslator);
@@ -93,7 +93,7 @@ public class ConnectFormatSchemaTranslatorTest {
     translator.toColumns(parsedSchema, SerdeFeatures.of(), false);
 
     // Then:
-    verify(connectKsqlTranslator).apply(connectSchema);
+    verify(connectKsqlTranslator).toKsqlSchema(connectSchema);
   }
 
   @Test
@@ -157,7 +157,7 @@ public class ConnectFormatSchemaTranslatorTest {
     translator.toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), false);
 
     // Then:
-    verify(connectKsqlTranslator).apply(SchemaBuilder.struct()
+    verify(connectKsqlTranslator).toKsqlSchema(SchemaBuilder.struct()
         .field("ROWVAL", connectSchema)
         .build());
   }
@@ -171,7 +171,7 @@ public class ConnectFormatSchemaTranslatorTest {
     translator.toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), true);
 
     // Then:
-    verify(connectKsqlTranslator).apply(SchemaBuilder.struct()
+    verify(connectKsqlTranslator).toKsqlSchema(SchemaBuilder.struct()
         .field("ROWKEY", connectSchema)
         .build());
   }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectKsqlSchemaTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectKsqlSchemaTranslatorTest.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.serde.connect;
 
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_DATE_SCHEMA;
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_TIMESTAMP_SCHEMA;
-import static io.confluent.ksql.serde.connect.ConnectSchemaUtil.OPTIONAL_TIME_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_DATE_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_TIMESTAMP_SCHEMA;
+import static io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator.OPTIONAL_TIME_SCHEMA;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -31,7 +31,7 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.junit.Test;
 
 
-public class ConnectSchemaUtilTest {
+public class ConnectKsqlSchemaTranslatorTest {
 
   @Test
   public void shouldTranslatePrimitives() {
@@ -45,7 +45,7 @@ public class ConnectSchemaUtilTest {
         .field("bytesField", Schema.BYTES_SCHEMA)
         .build();
 
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
+    final Schema ksqlSchema = new ConnectKsqlSchemaTranslator().toKsqlSchema(connectSchema);
     assertThat(ksqlSchema.schema().type(), equalTo(Schema.Type.STRUCT));
     assertThat(ksqlSchema.fields().size(), equalTo(connectSchema.fields().size()));
     for (int i = 0; i < ksqlSchema.fields().size(); i++) {
@@ -69,7 +69,7 @@ public class ConnectSchemaUtilTest {
         .field("mapField", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA))
         .build();
 
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
+    final Schema ksqlSchema = new ConnectKsqlSchemaTranslator().toKsqlSchema(connectSchema);
     assertThat(ksqlSchema.field("MAPFIELD"), notNullValue());
     final Schema mapSchema = ksqlSchema.field("MAPFIELD").schema();
     assertThat(mapSchema.type(), equalTo(Schema.Type.MAP));
@@ -90,7 +90,7 @@ public class ConnectSchemaUtilTest {
                     .build()))
         .build();
 
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
+    final Schema ksqlSchema = new ConnectKsqlSchemaTranslator().toKsqlSchema(connectSchema);
     assertThat(ksqlSchema.field("MAPFIELD"), notNullValue());
     final Schema mapSchema = ksqlSchema.field("MAPFIELD").schema();
     assertThat(mapSchema.type(), equalTo(Schema.Type.MAP));
@@ -109,7 +109,7 @@ public class ConnectSchemaUtilTest {
         .field("arrayField", SchemaBuilder.array(Schema.INT32_SCHEMA))
         .build();
 
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
+    final Schema ksqlSchema = new ConnectKsqlSchemaTranslator().toKsqlSchema(connectSchema);
     assertThat(ksqlSchema.field("ARRAYFIELD"), notNullValue());
     final Schema arraySchema = ksqlSchema.field("ARRAYFIELD").schema();
     assertThat(arraySchema.type(), equalTo(Schema.Type.ARRAY));
@@ -129,7 +129,7 @@ public class ConnectSchemaUtilTest {
                     .build()))
         .build();
 
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
+    final Schema ksqlSchema = new ConnectKsqlSchemaTranslator().toKsqlSchema(connectSchema);
     assertThat(ksqlSchema.field("ARRAYFIELD"), notNullValue());
     final Schema arraySchema = ksqlSchema.field("ARRAYFIELD").schema();
     assertThat(arraySchema.type(), equalTo(Schema.Type.ARRAY));
@@ -150,7 +150,7 @@ public class ConnectSchemaUtilTest {
         .field("structField", connectInnerSchema)
         .build();
 
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
+    final Schema ksqlSchema = new ConnectKsqlSchemaTranslator().toKsqlSchema(connectSchema);
     assertThat(ksqlSchema.field("STRUCTFIELD"), notNullValue());
     final Schema innerSchema = ksqlSchema.field("STRUCTFIELD").schema();
     assertThat(innerSchema.fields().size(), equalTo(connectInnerSchema.fields().size()));
@@ -172,7 +172,7 @@ public class ConnectSchemaUtilTest {
         .field("mapfield", SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.INT32_SCHEMA))
         .build();
 
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
+    final Schema ksqlSchema = new ConnectKsqlSchemaTranslator().toKsqlSchema(connectSchema);
 
     assertThat(ksqlSchema.field("MAPFIELD"), notNullValue());
     final Schema mapSchema = ksqlSchema.field("MAPFIELD").schema();
@@ -190,7 +190,7 @@ public class ConnectSchemaUtilTest {
         .field("timestampfield", Timestamp.SCHEMA)
         .build();
 
-    final Schema ksqlSchema = ConnectSchemaUtil.toKsqlSchema(connectSchema);
+    final Schema ksqlSchema = new ConnectKsqlSchemaTranslator().toKsqlSchema(connectSchema);
 
     assertThat(ksqlSchema.field("TIMEFIELD").schema(), equalTo(OPTIONAL_TIME_SCHEMA));
     assertThat(ksqlSchema.field("DATEFIELD").schema(), equalTo(OPTIONAL_DATE_SCHEMA));

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.databind.ser.std.DateSerializer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.serde.SerdeUtils;
-import io.confluent.ksql.serde.connect.ConnectSchemaUtil;
+import io.confluent.ksql.serde.connect.ConnectKsqlSchemaTranslator;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
@@ -103,9 +103,9 @@ public class KsqlJsonDeserializerTest {
           .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA)
           .optional()
           .build())
-      .field(TIMEFIELD, ConnectSchemaUtil.OPTIONAL_TIME_SCHEMA)
-      .field(DATEFIELD, ConnectSchemaUtil.OPTIONAL_DATE_SCHEMA)
-      .field(TIMESTAMPFIELD, ConnectSchemaUtil.OPTIONAL_TIMESTAMP_SCHEMA)
+      .field(TIMEFIELD, ConnectKsqlSchemaTranslator.OPTIONAL_TIME_SCHEMA)
+      .field(DATEFIELD, ConnectKsqlSchemaTranslator.OPTIONAL_DATE_SCHEMA)
+      .field(TIMESTAMPFIELD, ConnectKsqlSchemaTranslator.OPTIONAL_TIMESTAMP_SCHEMA)
       .field(BYTESFIELD, Schema.OPTIONAL_BYTES_SCHEMA)
       .build();
 


### PR DESCRIPTION
Current `ConnectFormatSchemaTranslator` take a Function to translate `Schema` to ksql `Schema`. In the function, it always uppercase the field names. This PR refactor the param type from Function to Class so that we can pass in config to control how field names should be translated.

Actual config and translation fix will be following PRs