### PR TITLE
chore: log a warning message when known IF NOT EXISTS bug is found

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommandsCompactor.java
@@ -24,16 +24,21 @@ import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.CommandId.Type;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Util for compacting the restore commands
  */
 public final class RestoreCommandsCompactor {
+  private static final Logger LOG = LoggerFactory.getLogger(RestoreCommandsCompactor.class);
 
   private RestoreCommandsCompactor() {
   }
@@ -54,11 +59,17 @@ public final class RestoreCommandsCompactor {
     final Map<SourceName, QueryId> latestCreateAsWithId = new HashMap<>();
     CompactedNode current = null;
 
+    // This is a temporary list that helps to detect invalid CREATE_AS statements with
+    // IF NOT EXISTS in the restore process.
+    // Know bug https://github.com/confluentinc/ksql/issues/8173
+    final Set<SourceName> createAsIfNotExistsBugDetection = new HashSet<>();
+
     for (final QueuedCommand cmd : restoreCommands) {
       // Whenever a new command is processed, we check if a previous command with
       // the same queryID exists - in which case, we mark that command as "shouldSkip"
       // and it will not be included in the output
-      current = CompactedNode.maybeAppend(current, cmd, latestNodeWithId, latestCreateAsWithId);
+      current = CompactedNode.maybeAppend(current, cmd,
+          latestNodeWithId, latestCreateAsWithId, createAsIfNotExistsBugDetection);
     }
 
     final List<QueuedCommand> compacted = new LinkedList<>();
@@ -83,7 +94,8 @@ public final class RestoreCommandsCompactor {
         final CompactedNode prev,
         final QueuedCommand queued,
         final Map<QueryId, CompactedNode> latestNodeWithId,
-        final Map<SourceName, QueryId> latestCreateAsWithId
+        final Map<SourceName, QueryId> latestCreateAsWithId,
+        final Set<SourceName> createAsIfNotExistsBugDetection
     ) {
       final Command command = queued.getAndDeserializeCommand(
           InternalTopicSerdes.deserializer(Command.class)
@@ -112,6 +124,10 @@ public final class RestoreCommandsCompactor {
               final QueryId queryId = latestCreateAsWithId.get(sourceName);
               if (queryId != null) {
                 markShouldSkip(queryId, latestNodeWithId);
+
+                // If a DROP statement was found, then we can safely ignore the previous
+                // CREATE_AS with IF NOT EXISTS statement (if exists in the set).
+                createAsIfNotExistsBugDetection.remove(sourceName);
               }
             }));
 
@@ -127,10 +143,33 @@ public final class RestoreCommandsCompactor {
 
       // keep track of the latest query ID for the new CREATE_AS source
       ddlCommand.ifPresent(ddl ->
-          getCreateSourceName(ddl).ifPresent(sourceName ->
-              latestCreateAsWithId.put(sourceName, queryId)));
+          getCreateSourceName(ddl).ifPresent(sourceName -> {
+            // Only CREATE statements are executed at this point
+            final CreateSourceCommand createCommand = (CreateSourceCommand) ddl;
+            if (!createCommand.isOrReplace() && isCreateIfNotExists(command)) {
+              // This condition is hit only for create statements with queries. If the CREATE_AS
+              // does not have OR REPLACE clause, but has an IF NOT EXISTS clause, then we are
+              // hitting a known bug that wrote IF NOT EXISTS statements to the command topic.
+              // See https://github.com/confluentinc/ksql/issues/8173
+              if (createAsIfNotExistsBugDetection.contains(sourceName)) {
+                LOG.warn("A known bug is found while restoring the command topic. The restoring "
+                    + "process will continue, but the query of the affected stream or table won't "
+                    + "be executed until https://github.com/confluentinc/ksql/issues/8173 "
+                    + "is fixed. Invalid statement is: " + command.getStatement());
+              }
+            }
+
+            createAsIfNotExistsBugDetection.add(sourceName);
+            latestCreateAsWithId.put(sourceName, queryId);
+          }));
 
       return node;
+    }
+
+    private static boolean isCreateIfNotExists(final Command command) {
+      final String statement = command.getStatement().toUpperCase();
+      return statement.startsWith("CREATE STREAM IF NOT EXISTS")
+          || statement.startsWith("CREATE TABLE IF NOT EXISTS");
     }
 
     private static Optional<SourceName> getCreateSourceName(final DdlCommand ddlCommand) {


### PR DESCRIPTION
### Description 
This PR only logs a warning message when restoring the command topic if the https://github.com/confluentinc/ksql/issues/8173 bug is hit.



### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

