### PR TITLE
chore: fix pull and push query v2 to properly ignore ROWOFFSET/ROWPARTITION

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -157,13 +157,46 @@ public final class LogicalSchema {
     return withPseudoAndKeyColsInValue(windowed, CURRENT_PSEUDOCOLUMN_VERSION_NUMBER);
   }
 
+  /**
+   * Copies pseudo and key columns to the value schema with the current pseudocolumn version number
+   *
+   * <p>Similar to the above implementation, but determines the version to use by looking at the
+   * config
+   *
+   * @param windowed indicates that the source is windowed
+   * @param ksqlConfig the config to utilize for finding the version number
+   * @return the new schema.
+   */
   public LogicalSchema withPseudoAndKeyColsInValue(
       final boolean windowed,
       final KsqlConfig ksqlConfig
   ) {
     return withPseudoAndKeyColsInValue(
         windowed,
-        SystemColumns.getPseudoColumnVersionFromConfig(ksqlConfig)
+        ksqlConfig,
+        false
+    );
+  }
+
+  /**
+   * Copies pseudo and key columns to the value schema with the current pseudocolumn version number
+   *
+   * <p>Similar to the above implementation, but determines the version to use by looking at the
+   * config and whether or not the calling context is a pull or scalable push query.
+   *
+   * @param windowed indicates that the source is windowed
+   * @param ksqlConfig the config to utilize for finding the version number
+   * @param forPullOrScalablePushQuery whether this is a pull or scalable push query schema
+   * @return the new schema.
+   */
+  public LogicalSchema withPseudoAndKeyColsInValue(
+      final boolean windowed,
+      final KsqlConfig ksqlConfig,
+      final boolean forPullOrScalablePushQuery
+  ) {
+    return withPseudoAndKeyColsInValue(
+        windowed,
+        SystemColumns.getPseudoColumnVersionFromConfig(ksqlConfig, forPullOrScalablePushQuery)
     );
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
@@ -163,7 +163,15 @@ public final class SystemColumns {
   }
 
   public static int getPseudoColumnVersionFromConfig(final KsqlConfig ksqlConfig) {
+    return getPseudoColumnVersionFromConfig(ksqlConfig, false);
+  }
+
+  public static int getPseudoColumnVersionFromConfig(
+      final KsqlConfig ksqlConfig,
+      final boolean forPullOrScalablePushQuery
+  ) {
     return ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED)
+        && !forPullOrScalablePushQuery
         ? CURRENT_PSEUDOCOLUMN_VERSION_NUMBER
         : LEGACY_PSEUDOCOLUMN_VERSION_NUMBER;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryLogicalPlanUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryLogicalPlanUtil.java
@@ -38,7 +38,7 @@ final class QueryLogicalPlanUtil {
     if (!addAdditionalColumnsToIntermediateSchema) {
       return schema;
     } else {
-      return schema.withPseudoAndKeyColsInValue(isWindowed, ksqlConfig);
+      return schema.withPseudoAndKeyColsInValue(isWindowed, ksqlConfig, true);
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryProjectNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryProjectNode.java
@@ -100,7 +100,7 @@ public class QueryProjectNode extends ProjectNode {
     this.addAdditionalColumnsToIntermediateSchema = shouldAddAdditionalColumnsInSchema();
     this.outputSchema = buildOutputSchema(metaStore);
     this.intermediateSchema = QueryLogicalPlanUtil.buildIntermediateSchema(
-          source.getSchema(),
+          source.getSchema().withoutPseudoAndKeyColsInValue(),
           addAdditionalColumnsToIntermediateSchema,
           isWindowed,
           ksqlConfig

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryProjectNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/QueryProjectNodeTest.java
@@ -160,6 +160,7 @@ public class QueryProjectNodeTest {
     // Given:
     selects = ImmutableList.of(new SingleColumn(COL0_REF, Optional.of(ALIAS)));
     when(keyFormat.isWindowed()).thenReturn(false);
+    when(analysis.getSelectColumnNames()).thenReturn(ImmutableSet.of(ALIAS));
 
     // When:
     final QueryProjectNode projectNode = new QueryProjectNode(
@@ -175,7 +176,8 @@ public class QueryProjectNodeTest {
     );
 
     // Then:
-    assertThat(INPUT_SCHEMA, is(projectNode.getIntermediateSchema()));
+    assertThat(INPUT_SCHEMA.withoutPseudoAndKeyColsInValue(),
+        is(projectNode.getIntermediateSchema()));
   }
 
   @Test
@@ -183,6 +185,7 @@ public class QueryProjectNodeTest {
     // Given:
     selects = ImmutableList.of(new SingleColumn(K_REF, Optional.of(K)));
     when(keyFormat.isWindowed()).thenReturn(false);
+    when(analysis.getSelectColumnNames()).thenReturn(ImmutableSet.of(K));
 
     // When:
     final QueryProjectNode projectNode = new QueryProjectNode(
@@ -219,6 +222,8 @@ public class QueryProjectNodeTest {
         .add(new SingleColumn(windowstartRef, Optional.of(SystemColumns.WINDOWSTART_NAME)))
         .add((new SingleColumn(windowendRef, Optional.of(SystemColumns.WINDOWEND_NAME))))
         .add((new SingleColumn(K_REF, Optional.of(K)))).build();
+    when(analysis.getSelectColumnNames()).thenReturn(
+        ImmutableSet.of(SystemColumns.WINDOWSTART_NAME, SystemColumns.WINDOWEND_NAME, K));
 
     // When:
     final QueryProjectNode projectNode = new QueryProjectNode(
@@ -257,6 +262,8 @@ public class QueryProjectNodeTest {
         .add(new SingleColumn(windowstartRef, Optional.of(SystemColumns.WINDOWSTART_NAME)))
         .add((new SingleColumn(windowendRef, Optional.of(SystemColumns.WINDOWEND_NAME))))
         .add((new SingleColumn(COL0_REF, Optional.of(COL0)))).build();
+    when(analysis.getSelectColumnNames()).thenReturn(
+        ImmutableSet.of(SystemColumns.WINDOWSTART_NAME, SystemColumns.WINDOWEND_NAME, COL0));
 
     // When:
     final QueryProjectNode projectNode = new QueryProjectNode(

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -108,6 +108,7 @@ public class RestQueryTranslationTest {
       .withProperty(KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED, true)
       .withProperty(KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED, true)
+      .withProperty(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED, true)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .build();
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderBase.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderBase.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.PlanInfo;
 import io.confluent.ksql.execution.plan.SourceStep;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import java.util.Collection;
 import java.util.function.Function;
@@ -91,11 +92,14 @@ abstract class SourceBuilderBase {
         planInfo
     );
 
+    final LogicalSchema stateStoreSchema = source.getSourceSchema()
+        .withPseudoColumnsToMaterialize(source.getPseudoColumnVersion());
+
     return KTableHolder.materialized(
         ktable,
         buildSchema(source, false),
         ExecutionKeyFactory.unwindowed(buildContext),
-        MaterializationInfo.builder(stateStoreName, physicalSchema.logicalSchema())
+        MaterializationInfo.builder(stateStoreName, stateStoreSchema)
     );
   }
 


### PR DESCRIPTION
### Description 
Ensures that we don't provide the new pseudo column version (and therefore ROWOFFSET and ROWPARTITION) to pull queries or scalable push queries yet since they don't (and in the case of pull queries won't) support it.

Also, stores the right state store schema in `MaterializationInfo` since this breaks when comparing to the actual rows (which have the new cols) without this change.

### Testing done 
Ran RQTT tests and unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

