### PR TITLE
fix: allow more time for consumer group cleanup

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/ExecutorUtil.java
@@ -82,11 +82,20 @@ public final class ExecutorUtil {
       final Predicate<Throwable> shouldRetry,
       final Supplier<Duration> retryBackOff
   ) throws Exception {
+    return executeWithRetries(executable, shouldRetry, (retry) -> retryBackOff.get(), NUM_RETRIES);
+  }
+
+  public static <T> T executeWithRetries(
+      final Callable<T> executable,
+      final Predicate<Throwable> shouldRetry,
+      final java.util.function.Function<Integer, Duration> retryBackOff,
+      final int numRetries
+  ) throws Exception {
     Exception lastException = null;
-    for (int retries = 0; retries < NUM_RETRIES; ++retries) {
+    for (int retries = 0; retries < numRetries; ++retries) {
       try {
         if (retries != 0) {
-          Thread.sleep(retryBackOff.get().toMillis());
+          Thread.sleep(retryBackOff.apply(retries).toMillis());
         }
         return executable.call();
       } catch (final Exception e) {


### PR DESCRIPTION
During local testing, I've noticed that consumer group cleanup for my transient queries 
is frequently timing out and leaving defunct groups lying around. This patch increases the amount
of time to wait for the group to become empty.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

