### PR TITLE
test: fix race condition in PushPhysicalPlanTest

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import org.reactivestreams.Subscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.concurrent.impl.FutureConvertersImpl.P;
 
 /**
  * Represents a physical plan for a scalable push query. The execution of the plan is done async

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlan.java
@@ -26,8 +26,11 @@ import io.confluent.ksql.util.VertxUtils;
 import io.vertx.core.Context;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import org.reactivestreams.Subscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.concurrent.impl.FutureConvertersImpl.P;
 
 /**
  * Represents a physical plan for a scalable push query. The execution of the plan is done async
@@ -71,7 +74,13 @@ public class PushPhysicalPlan {
   }
 
   public BufferedPublisher<List<?>> execute() {
+    return subscribeAndExecute(Optional.empty());
+  }
+
+  // for testing only
+  BufferedPublisher<List<?>> subscribeAndExecute(final Optional<Subscriber<List<?>>> subscriber) {
     final Publisher publisher = new Publisher(context);
+    subscriber.ifPresent(publisher::subscribe);
     context.runOnContext(v -> open(publisher));
     return publisher;
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/PushPhysicalPlanTest.java
@@ -12,12 +12,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.physical.common.operators.AbstractPhysicalOperator;
 import io.confluent.ksql.physical.scalablepush.operators.PushDataSourceOperator;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.reactive.BufferedPublisher;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -71,9 +71,8 @@ public class PushPhysicalPlanTest {
     doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
     when(pushDataSourceOperator.droppedRows()).thenReturn(false);
 
-    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
     final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
-    publisher.subscribe(subscriber);
+    pushPhysicalPlan.subscribeAndExecute(Optional.of(subscriber));
 
     context.owner().setPeriodic(50, timerId -> {
       if (runnableCaptor.getValue() == null) {
@@ -99,9 +98,8 @@ public class PushPhysicalPlanTest {
     doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
     when(pushDataSourceOperator.droppedRows()).thenReturn(false, false, true);
 
-    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
     final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
-    publisher.subscribe(subscriber);
+    pushPhysicalPlan.subscribeAndExecute(Optional.of(subscriber));
 
     context.owner().setPeriodic(50, timerId -> {
       if (runnableCaptor.getValue() == null) {
@@ -132,9 +130,8 @@ public class PushPhysicalPlanTest {
     doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
     when(pushDataSourceOperator.hasError()).thenReturn(false, false, true);
 
-    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
     final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
-    publisher.subscribe(subscriber);
+    pushPhysicalPlan.subscribeAndExecute(Optional.of(subscriber));
 
     context.owner().setPeriodic(50, timerId -> {
       if (runnableCaptor.getValue() == null) {
@@ -165,9 +162,8 @@ public class PushPhysicalPlanTest {
     doNothing().when(pushDataSourceOperator).setNewRowCallback(runnableCaptor.capture());
     doThrow(new RuntimeException("Error on open")).when(root).open();
 
-    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
     final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
-    publisher.subscribe(subscriber);
+    pushPhysicalPlan.subscribeAndExecute(Optional.of(subscriber));
 
     while (subscriber.getError() == null) {
       Thread.sleep(100);
@@ -183,9 +179,8 @@ public class PushPhysicalPlanTest {
     when(pushDataSourceOperator.droppedRows()).thenReturn(false);
     doThrow(new RuntimeException("Error on next")).when(root).next();
 
-    final BufferedPublisher<List<?>> publisher = pushPhysicalPlan.execute();
     final TestSubscriber<List<?>> subscriber = new TestSubscriber<>();
-    publisher.subscribe(subscriber);
+    pushPhysicalPlan.subscribeAndExecute(Optional.of(subscriber));
 
     while (subscriber.getError() == null) {
       Thread.sleep(100);


### PR DESCRIPTION
### Description 
Observed a failing test run with error: `Cannot subscribe to failed publisher.`

The reason is a race condition because the subscriber subscribes to the publisher after the publisher background thread is started. This PR changes the order to register the subscriber before we start the publisher thread.

### Testing done 
Using a breakpoint on the old `publisher.subscribe()` line allows to 100% reproduce the race. Thus no additional testing is needed as we call `publisher.subscribe()` earlier now (and setting a breakpoint at the new line verifies that the issue is resolved).

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

