### PR TITLE
chore: disable CREATE OR REPLACE on source streams and tables

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -71,7 +71,7 @@ public class CommandFactories implements DdlCommandFactory {
         new DropSourceFactory(metaStore),
         new RegisterTypeFactory(metaStore),
         new DropTypeFactory(metaStore),
-        new AlterSourceFactory()
+        new AlterSourceFactory(metaStore)
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -214,9 +214,10 @@ public final class CreateSourceFactory {
 
       if (createSource.isSource() || (existingSource != null && existingSource.isSource())) {
         throw new KsqlException(
-            String.format("Cannot add %s '%s': CREATE OR REPLACE is not supported on "
-                    + "source streams or tables.",
-                createSourceType, createSource.getName().text()));
+            String.format("Cannot add %s '%s': CREATE OR REPLACE is not supported on source %s.",
+                createSourceType,
+                createSource.getName().text(),
+                createSourceType + "s"));
       }
     }
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/AlterSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/AlterSourceFactoryTest.java
@@ -15,20 +15,30 @@
 
 package io.confluent.ksql.ddl.commands;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.execution.ddl.commands.AlterSourceCommand;
 import io.confluent.ksql.execution.expression.tree.Type;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.metastore.model.KsqlStream;
+import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.AlterOption;
 import io.confluent.ksql.parser.tree.AlterSource;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Arrays;
 import java.util.List;
+
+import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,12 +48,25 @@ public class AlterSourceFactoryTest {
   private static final List<AlterOption> NEW_COLUMNS = Arrays.asList(
       new AlterOption("FOO", new Type(SqlTypes.STRING)));
 
+  @Mock
+  private MetaStore metaStore;
+  @Mock
+  KsqlStream ksqlStream;
+  @Mock
+  KsqlTable ksqlTable;
+
   private AlterSourceFactory alterSourceFactory;
 
   @Before
   @SuppressWarnings("unchecked")
   public void before() {
-    alterSourceFactory = new AlterSourceFactory();
+    when(ksqlStream.isSource()).thenReturn(false);
+    when(ksqlTable.isSource()).thenReturn(false);
+
+    when(metaStore.getSource(STREAM_NAME)).thenReturn(ksqlStream);
+    when(metaStore.getSource(TABLE_NAME)).thenReturn(ksqlTable);
+
+    alterSourceFactory = new AlterSourceFactory(metaStore);
   }
 
   @Test
@@ -72,5 +95,39 @@ public class AlterSourceFactoryTest {
     assertEquals(result.getKsqlType(), DataSourceType.KTABLE.getKsqlType());
     assertEquals(result.getSourceName(), TABLE_NAME);
     assertEquals(result.getNewColumns().size(), 1);
+  }
+
+  @Test
+  public void shouldThrowInAlterOnSourceStream() {
+    // Given:
+    final AlterSource alterSource = new AlterSource(STREAM_NAME, DataSourceType.KSTREAM, NEW_COLUMNS);
+    when(ksqlStream.isSource()).thenReturn(true);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class, () -> alterSourceFactory.create(alterSource));
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString(
+            "Cannot alter stream 'streamname': ALTER operations are not supported on "
+                + "source streams."));
+  }
+
+  @Test
+  public void shouldThrowInAlterOnSourceTable() {
+    // Given:
+    final AlterSource alterSource = new AlterSource(TABLE_NAME, DataSourceType.KTABLE, NEW_COLUMNS);
+    when(ksqlTable.isSource()).thenReturn(true);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class, () -> alterSourceFactory.create(alterSource));
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString(
+            "Cannot alter table 'tablename': ALTER operations are not supported on "
+                + "source tables."));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -1156,7 +1156,7 @@ public class CreateSourceFactoryTest {
     assertThat(e.getMessage(),
         containsString(
             "Cannot add stream 'bob': CREATE OR REPLACE is not supported on "
-                + "source streams or tables."));
+                + "source streams."));
   }
 
   @Test
@@ -1182,7 +1182,7 @@ public class CreateSourceFactoryTest {
     assertThat(e.getMessage(),
         containsString(
             "Cannot add stream 'existingStreamName': CREATE OR REPLACE is not supported on "
-                + "source streams or tables."));
+                + "source streams."));
   }
 
   @Test
@@ -1203,7 +1203,7 @@ public class CreateSourceFactoryTest {
     assertThat(e.getMessage(),
         containsString(
             "Cannot add table 'table_bob': CREATE OR REPLACE is not supported on "
-                + "source streams or tables."));
+                + "source tables."));
   }
 
   @Test
@@ -1231,7 +1231,7 @@ public class CreateSourceFactoryTest {
     assertThat(e.getMessage(),
         containsString(
             "Cannot add table 'existingTableName': CREATE OR REPLACE is not supported on "
-                + "source streams or tables."));
+                + "source tables."));
   }
 
   private void givenProperty(final String name, final Literal value) {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
@@ -66,6 +66,28 @@
         "type": "io.confluent.ksql.util.KsqlException",
         "message": "Cannot delete topic for read-only source: INPUT"
       }
+    },
+    {
+      "name": "rejects CREATE OR REPLACE SOURCE ... statements for source streams",
+      "statements": [
+        "CREATE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE OR REPLACE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams or tables."
+      }
+    },
+    {
+      "name": "rejects CREATE OR REPLACE ... statements for source streams",
+      "statements": [
+        "CREATE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE OR REPLACE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams or tables."
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
@@ -74,7 +74,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams or tables."
+        "message": "Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams."
       }
     },
     {
@@ -85,7 +85,29 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams or tables."
+        "message": "Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams."
+      }
+    },
+    {
+      "name": "rejects CREATE OR REPLACE SOURCE ... statements on existing non-source streams",
+      "statements": [
+        "CREATE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE OR REPLACE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams."
+      }
+    },
+    {
+      "name": "rejects ALTER ... statements on existing source streams",
+      "statements": [
+        "CREATE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "ALTER STREAM INPUT ADD COLUMN newCol INT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot alter stream 'INPUT': ALTER operations are not supported on source streams."
       }
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-stream.json
@@ -68,9 +68,8 @@
       }
     },
     {
-      "name": "rejects CREATE OR REPLACE SOURCE ... statements for source streams",
+      "name": "rejects CREATE OR REPLACE SOURCE ... statements",
       "statements": [
-        "CREATE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
         "CREATE OR REPLACE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"
       ],
       "expectedException": {
@@ -79,7 +78,7 @@
       }
     },
     {
-      "name": "rejects CREATE OR REPLACE ... statements for source streams",
+      "name": "rejects CREATE OR REPLACE ... statements on existing source streams",
       "statements": [
         "CREATE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
         "CREATE OR REPLACE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-table.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-table.json
@@ -66,6 +66,28 @@
         "type": "io.confluent.ksql.util.KsqlException",
         "message": "Cannot delete topic for read-only source: INPUT"
       }
+    },
+    {
+      "name": "rejects CREATE OR REPLACE SOURCE ... statements for source tables",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE OR REPLACE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot add table 'INPUT': CREATE OR REPLACE is not supported on source streams or tables."
+      }
+    },
+    {
+      "name": "rejects CREATE OR REPLACE ... statements for source tables",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE OR REPLACE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot add table 'INPUT': CREATE OR REPLACE is not supported on source streams or tables."
+      }
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-table.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-table.json
@@ -74,7 +74,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Cannot add table 'INPUT': CREATE OR REPLACE is not supported on source streams or tables."
+        "message": "Cannot add table 'INPUT': CREATE OR REPLACE is not supported on source tables."
       }
     },
     {
@@ -85,7 +85,29 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Cannot add table 'INPUT': CREATE OR REPLACE is not supported on source streams or tables."
+        "message": "Cannot add table 'INPUT': CREATE OR REPLACE is not supported on source tables."
+      }
+    },
+    {
+      "name": "rejects CREATE OR REPLACE SOURCE ... statements on existing non-source tables",
+      "statements": [
+        "CREATE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE OR REPLACE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot add table 'INPUT': CREATE OR REPLACE is not supported on source tables."
+      }
+    },
+    {
+      "name": "rejects ALTER ... statements on existing source streams",
+      "statements": [
+        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "ALTER TABLE INPUT ADD COLUMN newCol INT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Cannot alter table 'INPUT': ALTER operations are not supported on source tables."
       }
     }
   ]

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-table.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/source-table.json
@@ -68,9 +68,8 @@
       }
     },
     {
-      "name": "rejects CREATE OR REPLACE SOURCE ... statements for source tables",
+      "name": "rejects CREATE OR REPLACE SOURCE ... statements",
       "statements": [
-        "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
         "CREATE OR REPLACE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"
       ],
       "expectedException": {
@@ -79,7 +78,7 @@
       }
     },
     {
-      "name": "rejects CREATE OR REPLACE ... statements for source tables",
+      "name": "rejects CREATE OR REPLACE ... statements on existing source tables",
       "statements": [
         "CREATE SOURCE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
         "CREATE OR REPLACE TABLE INPUT (K INT PRIMARY KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');"


### PR DESCRIPTION
### Description 
Disables the use of CREATE OR REPLACE on streams and tables to prevent the issue in https://github.com/confluentinc/ksql/issues/8197. This PR is created to continue with the 0.22 release. 

Examples for Streams:
```
ksql> CREATE OR REPLACE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');
Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams or tables.

ksql> CREATE OR REPLACE SOURCE STREAM INPUT (K STRING KEY, text STRING) WITH (kafka_topic='test_topic', value_format='DELIMITED');
Cannot add stream 'INPUT': CREATE OR REPLACE is not supported on source streams or tables.
```

Examples for Tables:
```
ksql> create or replace source table t1(id int primary key, name string) with (kafka_topic='t1', value_format='json', partitions=1);
Cannot add table 'T1': CREATE OR REPLACE is not supported on source streams or tables.

ksql> create or replace  table t1(id int primary key, name string) with (kafka_topic='t1', value_format='json', partitions=1);
Cannot add table 'T1': CREATE OR REPLACE is not supported on source streams or tables.
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

