### PR TITLE
chore: Assume default push queries are latest for SPQ

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ScalablePushUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ScalablePushUtil.java
@@ -105,9 +105,12 @@ public final class ScalablePushUtil {
         KsqlConfig.KSQL_STREAMS_PREFIX + STREAMS_AUTO_OFFSET_RESET_CONFIG)) {
       return LATEST_VALUE.equals(
           overrides.get(KsqlConfig.KSQL_STREAMS_PREFIX + STREAMS_AUTO_OFFSET_RESET_CONFIG));
-    } else {
+    } else if (ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG).isPresent()) {
       return LATEST_VALUE.equals(
           ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG).orElse(null));
+    } else {
+      // Implicitly assume latest since this is the default for push queries in ksqlDB.
+      return true;
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ScalablePushUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ScalablePushUtil.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.OutputRefinement;
@@ -29,11 +28,10 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 public final class ScalablePushUtil {
 
-  @VisibleForTesting
-  static String STREAMS_AUTO_OFFSET_RESET_CONFIG = "auto.offset.reset";
   private static String LATEST_VALUE = "latest";
 
   private ScalablePushUtil() {
@@ -99,15 +97,16 @@ public final class ScalablePushUtil {
       final KsqlConfig ksqlConfig,
       final Map<String, Object> overrides
   ) {
-    if (overrides.containsKey(STREAMS_AUTO_OFFSET_RESET_CONFIG)) {
-      return LATEST_VALUE.equals(overrides.get(STREAMS_AUTO_OFFSET_RESET_CONFIG));
+    if (overrides.containsKey(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)) {
+      return LATEST_VALUE.equals(overrides.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
     } else if (overrides.containsKey(
-        KsqlConfig.KSQL_STREAMS_PREFIX + STREAMS_AUTO_OFFSET_RESET_CONFIG)) {
+        KsqlConfig.KSQL_STREAMS_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)) {
       return LATEST_VALUE.equals(
-          overrides.get(KsqlConfig.KSQL_STREAMS_PREFIX + STREAMS_AUTO_OFFSET_RESET_CONFIG));
-    } else if (ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG).isPresent()) {
+          overrides.get(KsqlConfig.KSQL_STREAMS_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+    } else if (ksqlConfig.getKsqlStreamConfigProp(
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).isPresent()) {
       return LATEST_VALUE.equals(
-          ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG).orElse(null));
+          ksqlConfig.getKsqlStreamConfigProp(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).orElse(null));
     } else {
       // Implicitly assume latest since this is the default for push queries in ksqlDB.
       return true;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ScalablePushUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ScalablePushUtilTest.java
@@ -169,9 +169,35 @@ public class ScalablePushUtilTest {
 
 
   @Test
-  public void isScalablePushQuery_false_noLatest() {
+  public void isScalablePushQuery_true_noLatest() {
     // When:
     expectIsSQP();
+
+    // Then:
+    assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
+        ImmutableMap.of()),
+        equalTo(true));
+  }
+
+  @Test
+  public void isScalablePushQuery_true_configLatest() {
+    // When:
+    expectIsSQP();
+    when(ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG))
+        .thenReturn(Optional.of("latest"));
+
+    // Then:
+    assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
+        ImmutableMap.of()),
+        equalTo(true));
+  }
+
+  @Test
+  public void isScalablePushQuery_false_configNotLatest() {
+    // When:
+    expectIsSQP();
+    when(ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG))
+        .thenReturn(Optional.of("earliest"));
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ScalablePushUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/ScalablePushUtilTest.java
@@ -1,6 +1,5 @@
 package io.confluent.ksql.rest.util;
 
-import static io.confluent.ksql.rest.util.ScalablePushUtil.STREAMS_AUTO_OFFSET_RESET_CONFIG;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
@@ -25,6 +24,7 @@ import io.confluent.ksql.serde.RefinementInfo;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -61,7 +61,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(true));
   }
 
@@ -73,7 +73,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 
@@ -85,7 +85,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest",
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest",
             KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED, true)),
         equalTo(true));
   }
@@ -100,7 +100,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 
@@ -113,7 +113,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 
@@ -125,7 +125,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 
@@ -139,7 +139,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 
@@ -151,7 +151,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 
@@ -163,7 +163,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 
@@ -183,7 +183,7 @@ public class ScalablePushUtilTest {
   public void isScalablePushQuery_true_configLatest() {
     // When:
     expectIsSQP();
-    when(ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG))
+    when(ksqlConfig.getKsqlStreamConfigProp(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
         .thenReturn(Optional.of("latest"));
 
     // Then:
@@ -196,7 +196,7 @@ public class ScalablePushUtilTest {
   public void isScalablePushQuery_false_configNotLatest() {
     // When:
     expectIsSQP();
-    when(ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG))
+    when(ksqlConfig.getKsqlStreamConfigProp(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
         .thenReturn(Optional.of("earliest"));
 
     // Then:
@@ -209,7 +209,7 @@ public class ScalablePushUtilTest {
   public void isScalablePushQuery_true_latestConfig() {
     // When:
     expectIsSQP();
-    when(ksqlConfig.getKsqlStreamConfigProp(STREAMS_AUTO_OFFSET_RESET_CONFIG))
+    when(ksqlConfig.getKsqlStreamConfigProp(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
         .thenReturn(Optional.of("latest"));
 
     // Then:
@@ -226,7 +226,7 @@ public class ScalablePushUtilTest {
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
         ImmutableMap.of(
-            KsqlConfig.KSQL_STREAMS_PREFIX + STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+            KsqlConfig.KSQL_STREAMS_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(true));
   }
 
@@ -239,7 +239,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 
@@ -252,7 +252,7 @@ public class ScalablePushUtilTest {
 
     // Then:
     assertThat(ScalablePushUtil.isScalablePushQuery(query, ksqlEngine, ksqlConfig,
-        ImmutableMap.of(STREAMS_AUTO_OFFSET_RESET_CONFIG, "latest")),
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")),
         equalTo(false));
   }
 }


### PR DESCRIPTION
### Description 
Assume that if no latest config is set, `auto.offset.reset` is "latest" for SPQ, which is the default for push queries in ksqlDB.

### Testing done 
Unit testing and manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

