### PR TITLE
fix: ClassCastException when dropping sources with 2+ insert queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -258,12 +258,12 @@ final class EngineContext {
               + "You need to terminate them before dropping %s.",
           sourceName.text(),
           sourceQueries.stream()
-              .sorted()
               .map(QueryId::toString)
+              .sorted()
               .collect(Collectors.joining(", ")),
           sinkQueries.stream()
-              .sorted()
               .map(QueryId::toString)
+              .sorted()
               .collect(Collectors.joining(", ")),
           sourceName.text()
       ));


### PR DESCRIPTION
### Description 
Fixes #8129 

`QueryId` does not implement `Comparable`, so calls made to `Stream<QueryId>.sorted()` threw errors. This is a quick fix to get around that.

### Testing done 
Updated unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

