### PR TITLE
fix: close command runner when command topic is deleted

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -378,6 +378,8 @@ public class CommandRunner implements Closeable {
 
     clusterTerminator.terminateCluster(deleteTopicList);
     LOG.info("The KSQL server was terminated.");
+    closeEarly();
+    LOG.debug("The KSQL command runner was closed.");
   }
 
   private List<QueuedCommand> checkForIncompatibleCommands(final List<QueuedCommand> commands) {


### PR DESCRIPTION
### Description 
We were seeing some command topics go into a `degraded` state after a cluster was terminated because the command runner deleted the command topic but doesn't close itself. This has the command runner `close` right after seeing a `terminate` command so we don't get spurious alerts.

### Testing done 
unit test and manual test.

manual test:
created ksql cluster, rolled to this image
issued a terminate command
`
curl -X "POST" "endpoint/ksql/terminate" \
     -H "Content-Type: application/vnd.ksql.v1+json; charset=utf-8" \
     -d $'{
}' -v --http2 -H "Authorization: Basic $AUTH"
`
saw the following in datadog:
![image](https://user-images.githubusercontent.com/51764475/135528228-cce506cd-618f-440b-8132-892b15fecc2f.png)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

