### PR TITLE
chore: disallow new queries on sources with user columns named the same as new pseudocolumns

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -224,10 +224,7 @@ public final class LogicalSchema {
 
   public LogicalSchema withoutPseudoAndKeyColsInValue(final KsqlConfig ksqlConfig) {
     return withoutPseudoAndKeyColsInValue(
-        ksqlConfig.getBoolean(KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED)
-        ? CURRENT_PSEUDOCOLUMN_VERSION_NUMBER
-        : LEGACY_PSEUDOCOLUMN_VERSION_NUMBER
-    );
+        SystemColumns.getPseudoColumnVersionFromConfig(ksqlConfig));
   }
 
   /**

--- a/ksqldb-functional-tests/src/test/resources/sql-tests/query-upgrades/rowpartition-rowoffset.sql
+++ b/ksqldb-functional-tests/src/test/resources/sql-tests/query-upgrades/rowpartition-rowoffset.sql
@@ -33,3 +33,29 @@ ASSERT VALUES b (id, col1) VALUES (1, 0);
 SET 'ksql.rowpartition.rowoffset.enabled' = 'true';
 
 CREATE OR REPLACE TABLE b AS SELECT id, col1 FROM a WHERE col1 > ROWOFFSET EMIT CHANGES;
+
+----------------------------------------------------------------------------------------------------
+--@test: should fail on querying stream with user columns named the same as new pseudocolumns
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: You cannot query a stream or table that has user columns with the same name as new pseudocolumns.
+----------------------------------------------------------------------------------------------------
+SET 'ksql.rowpartition.rowoffset.enabled' = 'false';
+
+CREATE STREAM a (id INT KEY, ROWOFFSET STRING) WITH (kafka_topic='a', value_format='JSON');
+
+SET 'ksql.rowpartition.rowoffset.enabled' = 'true';
+
+CREATE STREAM b AS SELECT ROWOFFSET AS ro FROM a;
+
+----------------------------------------------------------------------------------------------------
+--@test: should fail on querying stream with user columns named and typed the same as new pseudocolumns
+--@expected.error: io.confluent.ksql.util.KsqlException
+--@expected.message: You cannot query a stream or table that has user columns with the same name as new pseudocolumns.
+----------------------------------------------------------------------------------------------------
+SET 'ksql.rowpartition.rowoffset.enabled' = 'false';
+
+CREATE STREAM a (id INT KEY, ROWPARTITION BIGINT) WITH (kafka_topic='a', value_format='JSON');
+
+SET 'ksql.rowpartition.rowoffset.enabled' = 'true';
+
+CREATE STREAM b AS SELECT ROWOFFSET AS ro FROM a;


### PR DESCRIPTION
### Description 
As part of [KLIP-50](https://github.com/confluentinc/ksql/blob/master/design-proposals/klip-50-partition-and-offset-in-ksqldb.md), we want to ensure that users who have old queries with names conflicting with new pseudocolumns (in this case, `ROWPARTITION` or `ROWOFFSET` are disallowed from doing this, and get an informative error message. This PR does that.

### Testing done 
SQL testing tool tests validating the new behavior

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

