### PR TITLE
fix: don't register stream pull queries as push

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -313,7 +313,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     try {
       final TransientQueryMetadata query = EngineExecutor
           .create(primaryContext, serviceContext, statement.getSessionConfig())
-          .executeTransientQuery(statement, excludeTombstones, Optional.empty());
+          .executeTransientQuery(statement, excludeTombstones);
       return query;
     } catch (final KsqlStatementException e) {
       throw e;
@@ -361,7 +361,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
     final TransientQueryMetadata transientQueryMetadata = EngineExecutor
         .create(primaryContext, serviceContext, statement.getSessionConfig())
-        .executeTransientQuery(statement, excludeTombstones, Optional.of(endOffsets));
+        .executeStreamPullQuery(statement, excludeTombstones, endOffsets);
 
     QueryLogger.info(
         "Streaming stream pull query results '{}'",

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -171,7 +171,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
         engineContext,
         serviceContext,
         statement.getSessionConfig()
-    ).executeTransientQuery(statement, excludeTombstones, Optional.empty());
+    ).executeTransientQuery(statement, excludeTombstones);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
@@ -77,8 +77,29 @@ public interface QueryRegistry {
       LogicalSchema schema,
       OptionalInt limit,
       Optional<WindowInfo> windowInfo,
+      boolean excludeTombstones
+  );
+  // CHECKSTYLE_RULES.ON: ParameterNumberCheck
+
+  /**
+   * Create a transient query
+   */
+  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
+  TransientQueryMetadata createStreamPullQuery(
+      SessionConfig config,
+      ServiceContext serviceContext,
+      ProcessingLogContext processingLogContext,
+      MetaStore metaStore,
+      String statementText,
+      QueryId queryId,
+      Set<SourceName> sources,
+      ExecutionStep<?> physicalPlan,
+      String planSummary,
+      LogicalSchema schema,
+      OptionalInt limit,
+      Optional<WindowInfo> windowInfo,
       boolean excludeTombstones,
-      Optional<ImmutableMap<TopicPartition, Long>> endOffsets
+      ImmutableMap<TopicPartition, Long> endOffsets
   );
   // CHECKSTYLE_RULES.ON: ParameterNumberCheck
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -225,6 +225,7 @@ public class QueryRegistryImpl implements QueryRegistry {
     query.initialize();
     // We don't register it as a transient query, so it won't show up in `show queries;`,
     // nor will it count against the push query limit.
+    notifyCreate(serviceContext, metaStore, query);
     return query;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -372,6 +372,10 @@ public class QueryMetadataImpl implements QueryMetadata {
     }
   }
 
+  public boolean isInitialized() {
+    return initialized;
+  }
+
   public static class TimeBoundedQueue {
     private final Duration duration;
     private final Queue<QueryError> queue;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -539,6 +539,7 @@ public class QueryRegistryImplTest {
     when(queryBuilder.buildTransientQuery(
         any(), any(), any(), any(), any(), any(), any(), any(), anyBoolean(), any(), any(), any())
     ).thenReturn(query);
+    when(query.isInitialized()).thenReturn(true);
     registry.createTransientQuery(
         config,
         serviceContext,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -552,8 +552,7 @@ public class QueryRegistryImplTest {
         mock(LogicalSchema.class),
         OptionalInt.of(123),
         Optional.empty(),
-        false,
-        Optional.empty()
+        false
     );
     return query;
   }


### PR DESCRIPTION
Previously, stream pull queries would be included in the `show queries;` output,
but they would be listed as "push" queries. Also, they would be counted against
the push query concurrency limit. Both of those behaviors are unintended
consequences of the implementation details (that stream pull queries are
currently specialized transient push queries).

This patch fixes the situation by simply not registering stream pull queries.
I will file a separate issue to register them properly, as pull queries, so they
will be listed appropriately and not count against the push query limit.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

