### PR TITLE
fix: Always dec. concurrency counter, even hitting rate limits (#8165)

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -245,11 +245,10 @@ public class QueryEndpoint {
     try {
       PullQueryExecutionUtil.checkRateLimit(rateLimiter);
       decrementer = pullConcurrencyLimiter.increment();
-      pullBandRateLimiter.allow(KsqlQueryType.PULL);
+      pullBandRateLimiter.allow();
       final Decrementer finalDecrementer = decrementer;
 
-      final PullQueryResult result = ksqlEngine.executeTablePullQuery(
-          analysis,
+      final PullQueryResult result = ksqlEngine.executePullQuery(
           serviceContext,
           statement,
           routing,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
@@ -95,9 +95,7 @@ public class SlidingWindowRateLimiter {
     if (this.numBytesInWindow > throttleLimit) {
       LOG.warn("Hit bandwidth rate limit of " + throttleLimit + "MB with use of "
           + numBytesInWindow + "MB");
-      throw new KsqlApiException("Host is at bandwidth rate limit for "
-          + ksqlQueryType.toString().toLowerCase() + " queries.",
-          ERROR_CODE_BAD_REQUEST);
+      throw new KsqlException("Host is at bandwidth rate limit for pull queries.");
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SlidingWindowRateLimiter.java
@@ -23,6 +23,8 @@ import io.confluent.ksql.util.Pair;
 import java.util.LinkedList;
 import java.util.Queue;
 import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * SlidingWindowRateLimiter keeps a log of timestamps and the size for each response returned by
@@ -36,6 +38,7 @@ import org.apache.kafka.common.utils.Time;
 
 public class SlidingWindowRateLimiter {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SlidingWindowRateLimiter.class);
   private static long NUM_BYTES_IN_ONE_MEGABYTE = 1 * 1024 * 1024;
 
   /**
@@ -90,7 +93,11 @@ public class SlidingWindowRateLimiter {
       this.numBytesInWindow -= responseSizesLog.poll().right;
     }
     if (this.numBytesInWindow > throttleLimit) {
-      throw new KsqlException("Host is at bandwidth rate limit for pull queries.");
+      LOG.warn("Hit bandwidth rate limit of " + throttleLimit + "MB with use of "
+          + numBytesInWindow + "MB");
+      throw new KsqlApiException("Host is at bandwidth rate limit for "
+          + ksqlQueryType.toString().toLowerCase() + " queries.",
+          ERROR_CODE_BAD_REQUEST);
     }
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -108,11 +108,10 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
     try {
       PullQueryExecutionUtil.checkRateLimit(rateLimiter);
       decrementer = concurrencyLimiter.increment();
-      pullBandRateLimiter.allow(KsqlQueryType.PULL);
+      pullBandRateLimiter.allow();
       final Decrementer finalDecrementer = decrementer;
 
-      result = ksqlEngine.executeTablePullQuery(
-          analysis,
+      result = ksqlEngine.executePullQuery(
           serviceContext,
           query,
           routing,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
@@ -404,16 +403,16 @@ public class StreamedQueryResource implements KsqlConfigurable {
 
     // Only check the rate limit at the forwarding host
     Decrementer decrementer = null;
-    if (!isAlreadyForwarded) {
-      PullQueryExecutionUtil.checkRateLimit(rateLimiter);
-      decrementer = concurrencyLimiter.increment();
-    }
-    pullBandRateLimiter.allow();
-
-    final Optional<Decrementer> optionalDecrementer = Optional.ofNullable(decrementer);
-
     try {
-      final PullQueryResult result = ksqlEngine.executePullQuery(
+      if (!isAlreadyForwarded) {
+        PullQueryExecutionUtil.checkRateLimit(rateLimiter);
+        decrementer = concurrencyLimiter.increment();
+      }
+      pullBandRateLimiter.allow(KsqlQueryType.PULL);
+
+      final Optional<Decrementer> optionalDecrementer = Optional.ofNullable(decrementer);
+      final PullQueryResult result = ksqlEngine.executeTablePullQuery(
+          analysis,
           serviceContext,
           configured,
           routing,
@@ -436,8 +435,10 @@ public class StreamedQueryResource implements KsqlConfigurable {
           connectionClosedFuture);
 
       return EndpointResponse.ok(pullQueryStreamWriter);
-    } catch (Throwable t) {
-      optionalDecrementer.ifPresent(Decrementer::decrementAtMostOnce);
+    } catch (final Throwable t) {
+      if (decrementer != null) {
+        decrementer.decrementAtMostOnce();
+      }
       throw t;
     }
   }
@@ -507,14 +508,6 @@ public class StreamedQueryResource implements KsqlConfigurable {
 
     log.info("Streaming query '{}'", statement.getStatementText());
     return EndpointResponse.ok(queryStreamWriter);
-  }
-
-  private static String writeValueAsString(final Object object) {
-    try {
-      return OBJECT_MAPPER.writeValueAsString(object);
-    } catch (final JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   private EndpointResponse handlePrintTopic(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -408,11 +408,10 @@ public class StreamedQueryResource implements KsqlConfigurable {
         PullQueryExecutionUtil.checkRateLimit(rateLimiter);
         decrementer = concurrencyLimiter.increment();
       }
-      pullBandRateLimiter.allow(KsqlQueryType.PULL);
+      pullBandRateLimiter.allow();
 
       final Optional<Decrementer> optionalDecrementer = Optional.ofNullable(decrementer);
-      final PullQueryResult result = ksqlEngine.executeTablePullQuery(
-          analysis,
+      final PullQueryResult result = ksqlEngine.executePullQuery(
           serviceContext,
           configured,
           routing,


### PR DESCRIPTION
cherry pick https://github.com/confluentinc/ksql/commit/0e0551970190861edaa1f7dc4c68ab279597d30b for 0.21 hotfix

* fix: Always dec. concurrency counter, even hitting rate limits

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

