### PR TITLE
fix: correctly capture rows returned for scalable push query metrics

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/ScalablePushQueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/ScalablePushQueryMetadataTest.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.when;
 import io.confluent.ksql.internal.ScalablePushQueryMetrics;
 import io.confluent.ksql.physical.scalablepush.PushQueryQueuePopulator;
 import io.confluent.ksql.physical.scalablepush.PushRouting.PushConnectionsHandle;
-import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.query.TransientQueryQueue;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.PushQueryMetadata.ResultType;
 import java.util.Optional;
@@ -45,7 +45,7 @@ public class ScalablePushQueryMetadataTest {
   @Mock
   private LogicalSchema logicalSchema;
   @Mock
-  private BlockingRowQueue blockingRowQueue;
+  private TransientQueryQueue transientQueryQueue;
   @Mock
   private PushQueryQueuePopulator populator;
   @Mock
@@ -64,7 +64,7 @@ public class ScalablePushQueryMetadataTest {
     query = new ScalablePushQueryMetadata(
         logicalSchema,
         new QueryId("queryid"),
-        blockingRowQueue,
+        transientQueryQueue,
         metrics,
         ResultType.STREAM,
         populator,


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
Correctly capture rows returned for scalable push query metrics, by using a TransientQueryQueue in the scalable push query metadata, since that is the queue we pass in anyway during instantiation.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
Unit tests updated 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

