### PR TITLE
feat: add configurations around endpoint logging

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -371,9 +371,10 @@ public class KsqlRestConfig extends AbstractConfig {
       = "Whether or not to log the query portion of the URI when logging endpoints. Note that"
       + " enabling this may log sensitive information.";
 
-  public static final String KSQL_ENDPOINT_LOGGING_FILTER_CONFIG = "ksql.endpoint.logging.filter";
-  public static final String KSQL_ENDPOINT_LOGGING_FILTER_DEFAULT = "";
-  public static final String KSQL_ENDPOINT_LOGGING_FILTER_DOC =
+  public static final String KSQL_ENDPOINT_LOGGING_IGNORED_PATHS_REGEX_CONFIG
+      = "ksql.endpoint.logging.ignored.paths.regex";
+  public static final String KSQL_ENDPOINT_LOGGING_IGNORED_PATHS_REGEX_DEFAULT = "";
+  public static final String KSQL_ENDPOINT_LOGGING_IGNORED_PATHS_REGEX_DOC =
       "A regex that allows users to filter out logging from certain endpoints. Without this filter,"
           + " all endpoints are logged. An example usage of this configuration would be to disable"
           + " heartbeat logging (e.g. ksql.endpoint.logging.filter=.*heartbeat.* ) which can"
@@ -710,11 +711,11 @@ public class KsqlRestConfig extends AbstractConfig {
             Importance.LOW,
             KSQL_LOCAL_COMMANDS_LOCATION_DOC
         ).define(
-            KSQL_ENDPOINT_LOGGING_FILTER_CONFIG,
+            KSQL_ENDPOINT_LOGGING_IGNORED_PATHS_REGEX_CONFIG,
             Type.STRING,
-            KSQL_ENDPOINT_LOGGING_FILTER_DEFAULT,
+            KSQL_ENDPOINT_LOGGING_IGNORED_PATHS_REGEX_DEFAULT,
             Importance.LOW,
-            KSQL_ENDPOINT_LOGGING_FILTER_DOC
+            KSQL_ENDPOINT_LOGGING_IGNORED_PATHS_REGEX_DOC
         ).define(
             KSQL_ENDPOINT_LOGGING_LOG_QUERIES_CONFIG,
             Type.BOOLEAN,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/LoggingHandlerTest.java
@@ -155,7 +155,7 @@ public class LoggingHandlerTest {
     // Given:
     when(response.getStatusCode()).thenReturn(200);
     config = new KsqlRestConfig(
-        ImmutableMap.of(KsqlRestConfig.KSQL_ENDPOINT_LOGGING_FILTER_CONFIG, ".*query.*")
+        ImmutableMap.of(KsqlRestConfig.KSQL_ENDPOINT_LOGGING_IGNORED_PATHS_REGEX_CONFIG, ".*query.*")
     );
     when(server.getConfig()).thenReturn(config);
     loggingHandler = new LoggingHandler(server, loggingRateLimiter, logger, clock);
@@ -176,7 +176,7 @@ public class LoggingHandlerTest {
     // Given:
     when(response.getStatusCode()).thenReturn(200);
     config = new KsqlRestConfig(
-        ImmutableMap.of(KsqlRestConfig.KSQL_ENDPOINT_LOGGING_FILTER_CONFIG, ".*random.*")
+        ImmutableMap.of(KsqlRestConfig.KSQL_ENDPOINT_LOGGING_IGNORED_PATHS_REGEX_CONFIG, ".*random.*")
     );
     when(server.getConfig()).thenReturn(config);
     loggingHandler = new LoggingHandler(server, loggingRateLimiter, logger, clock);


### PR DESCRIPTION
### Description 

Endpoint logging potentially contains sensitive information. This patch allows some more configuration to control this behavior by introducing two configurations:

- a configuration to avoid filtering the query portion of the URI, this is the disabled by default
- a configuration to filter out endpoints altogether. this can be used (1) if a security leak is identified in production that cannot be covered by the previous config or (2) to prevent logging of verbose endpoints (such as the heartbeat endpoint)

### Testing done 

Unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

