### PR TITLE
chore: add stabilization callback to version correctly

### DIFF
--- a/release_stabilization.py
+++ b/release_stabilization.py
@@ -3,5 +3,7 @@ class Callbacks:
     def __init__(self, working_dir, leaf, dry_run):
         self.leaf = leaf
 
+    """This is a callback to Confluent's cloud release tooling,
+    and allows us to have consistent versioning"""
     def version_as_leaf(self):
         return self.leaf == 'cc-docker-ksql'


### PR DESCRIPTION
### Description 
Add a callback to the release stabilization so that ksql nanoversioned artifacts will be versioned as `0.20.0-rc2 `instead of `7.1.0-ksql.17-77-rc2`

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
Should be a no-op for the ksql repo, but will manually test that it gets versioned as expected.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

