### PR TITLE
chore: Recommend CheckStyle version 8.24 or higher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ You can set up IntelliJ for CheckStyle. First install the CheckStyle IDEA plugin
 
     IntelliJ → Preferences → Tools → CheckStyle
 
-    In top left corner select CheckStyle version 8.18 (newer versions fail to parse the provided XML)
+    In top left corner select CheckStyle version 8.44 or newer (older versions fail to parse the provided XML)
 
     - Add a new configurations file using the '+' button:
        Description: Confluent Checks


### PR DESCRIPTION
### Description 

Contributing.md guide suggests to select `CheckStyle version 8.18 (newer versions fail to parse the provided XML)`. Importing `checkstyle.xml` with this version fails with `com.puppycrawl.tools.checkstyle.api.CheckstyleException: LineLength is not allowed as a child in Checker`. It does work, however, with versions 8.24 or higher (e.g. 9.0). I suppose that the configuration changed since the guide was written.

### Testing done 

I tested the change manually - checked the earliest CheckStyle version that allows importing the xml. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

