### PR TITLE
chore: update VERSION_PATTERN to work with stabilized final release candidates 

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/KsqlVersion.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/KsqlVersion.java
@@ -39,12 +39,12 @@ public final class KsqlVersion implements Comparable<KsqlVersion> {
    *  (?:-([A-Za-z0-9]+|\d+))*
    *  A KsqlVersion can also have a stabilization artifact such as: 7.1.0-ksqldb-rest-app.21-496-rc1
    *  The ".21-496-rc1" is captured by the third part of the regex as:
-   *  (\.\d+-\d+-\w*)?
+   *  (\.\d+-\d+)?(-rc\d*)?
   */
   private static final Pattern VERSION_PATTERN = Pattern.compile(
           "(?<major>\\d+)\\.(?<minor>\\d+)(?<patch>.\\d+)?"
               + "(?:-([A-Za-z0-9]+|\\d+))*"
-              + "(\\.\\d+-\\d+-\\w*)?");
+              + "(\\.\\d+-\\d+)?(-rc\\d*)?");
 
   @EffectivelyImmutable
   private static final Comparator<KsqlVersion> COMPARATOR =

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
@@ -75,12 +75,22 @@ public class KsqlVersionTest {
   }
 
   @Test
-  public void shouldParseReleaseStabilizations() {
+  public void shouldParseReleaseStabilizationsCandidates() {
     // When:
     final KsqlVersion result = KsqlVersion.parse("7.1.0-ksqldb-rest-app.2-496-rc1");
 
     // Then:
     assertThat(result.getName(), is("7.1.0-ksqldb-rest-app.2-496-rc1"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(7, 1, 0)));
+  }
+
+  @Test
+  public void shouldParseReleaseStabilizationsFinalCandidates() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("7.1.0-ksqldb-rest-app.2-496");
+
+    // Then:
+    assertThat(result.getName(), is("7.1.0-ksqldb-rest-app.2-496"));
     assertThat(result.getVersion(), is(SemanticVersion.of(7, 1, 0)));
   }
 
@@ -103,7 +113,7 @@ public class KsqlVersionTest {
 
     // Then:
     assertThat(e.getMessage(), is("Failed to parse version: '7.1.0-ksqldb-rest-app.2--rc1'. "
-            + "Version must be in format '(?<major>\\d+)\\.(?<minor>\\d+)(?<patch>.\\d+)?(?:-([A-Za-z0-9]+|\\d+))*(\\.\\d+-\\d+-\\w*)?'. "));
+            + "Version must be in format '(?<major>\\d+)\\.(?<minor>\\d+)(?<patch>.\\d+)?(?:-([A-Za-z0-9]+|\\d+))*(\\.\\d+-\\d+)?(-rc\\d*)?'. "));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Updates the regex so that it will work with `7.1.0-ksqldb-rest-app.6-535` which is what we produce when we build the final RCs and not just `7.1.0-ksqldb-rest-app.6-535-rc1`.

### Testing done 
Unit tests updated

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

