### PR TITLE
test: improve error message for SystemAuthenticationFunctionalTest

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/HighAvailabilityTestUtil.java
@@ -189,13 +189,7 @@ class HighAvailabilityTestUtil {
       final KsqlHostInfoEntity remoteServer,
       final Map<KsqlHostInfoEntity, HostStatusEntity> clusterStatus
   ) {
-    for( Entry<KsqlHostInfoEntity, HostStatusEntity> entry: clusterStatus.entrySet()) {
-      if (entry.getKey().getPort() == remoteServer.getPort()
-          && entry.getValue().getHostAlive()) {
-        return true;
-      }
-    }
-    return false;
+    return clusterStatus.get(remoteServer).getHostAlive();
   }
 
   private static boolean allServersDiscovered(


### PR DESCRIPTION
### Description 

This test has been a bit flaky, and my suspicion is a race condition between the cluster being "up" and the next cluster request (namely, we wait for host0 then wait for host1 - by the time host1 is up host0 could have gone down again). This improved error message will confirm/deny that next time the flake hits.

### Testing done 

Ran the test locally.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

