### PR TITLE
test: Fix and improve the test QuickDegradeAndRestoreCommandTopicIntegrationTest

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/QuickDegradeAndRestoreCommandTopicIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/QuickDegradeAndRestoreCommandTopicIntegrationTest.java
@@ -17,6 +17,7 @@ import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.restore.KsqlRestoreCommandTopic;
+import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.ReservedInternalTopics;
@@ -44,7 +45,11 @@ import org.junit.rules.TemporaryFolder;
 
 @Category({IntegrationTest.class})
 public class QuickDegradeAndRestoreCommandTopicIntegrationTest {
-  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.builder()
+      .withKafkaCluster(
+          EmbeddedSingleNodeKafkaCluster.newBuilder()
+              .withoutAutoCreateTopics()
+      ).build();
 
   @ClassRule
   public static final RuleChain CHAIN = RuleChain

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -576,9 +576,6 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     // Need to know where ZK is:
     config.put(KafkaConfig.ZkConnectProp(), zookeeper.connectString());
     config.put(AclAuthorizer.ZkUrlProp(), zookeeper.connectString());
-    // Create topics explicitly when needed to avoid a race which
-    // automatically recreates deleted command topic:
-    config.put(KafkaConfig.AutoCreateTopicsEnableProp(), false);
     // Default to small number of partitions for auto-created topics:
     config.put(KafkaConfig.NumPartitionsProp(), 1);
     // Allow tests to delete topics:
@@ -695,6 +692,14 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
       brokerConfig.put(AclAuthorizer.AllowEveryoneIfNoAclIsFoundProp(),
           true);
       brokerConfig.put(KafkaConfig.ListenersProp(), "PLAINTEXT://:0");
+      brokerConfig.put(KafkaConfig.AutoCreateTopicsEnableProp(), true);
+    }
+
+    public Builder withoutAutoCreateTopics() {
+      // Create topics explicitly when needed to avoid a race which
+      // automatically recreates deleted topic:
+      brokerConfig.put(KafkaConfig.AutoCreateTopicsEnableProp(), false);
+      return this;
     }
 
     public Builder withoutPlainListeners() {


### PR DESCRIPTION
### Description 
[KSQL-7430](https://confluentinc.atlassian.net/browse/KSQL-7430)
Improve the test QuickDegradeAndRestoreCommandTopicIntegrationTest by checking for topic deletion status via assertThatEventually() before checking for degraded state and also after right after deleting the command topic. 

Also, fixed a race which lead to automatic recreation of deleted command topic by setting Kafka config: auto.create.topics.enable to be false in QuickDegradeAndRestoreCommandTopicIntegrationTest.

### Testing done 
Tested the change locally by running integration tests multiple times .

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

