### PR TITLE
fix: Add user-friendly error message for SELECT null AS column

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SelectionUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/SelectionUtil.java
@@ -126,6 +126,10 @@ public final class SelectionUtil {
       } else {
         final Expression expression = select.getExpression();
         final SqlType type = expressionTypeManager.getExpressionSqlType(expression);
+        if (type == null) {
+          throw new IllegalArgumentException("Can't infer a type of null. Please explicitly cast "
+              + "it to a required type, e.g. CAST(null AS VARCHAR).");
+        }
         builder.valueColumn(select.getAlias(), type);
       }
     }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
@@ -261,6 +261,17 @@
       }
     },
     {
+      "name": "null as column",
+      "statements": [
+        "CREATE STREAM INPUT (COL0 INT KEY) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT COL0, null as COL2 FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Can't infer a type of null. Please explicitly cast it to a required type, e.g. CAST(null AS VARCHAR)."
+      }
+    },
+    {
       "name": "null if",
       "statements": [
         "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",


### PR DESCRIPTION
### Description 

Consider the following query `SELECT NULL AS FOO FROM INVENTORY EMIT CHANGES LIMIT 1`. 

Without this patch, such query throws an error with message `type`. FWIW this error message comes from [here](https://github.com/confluentinc/ksql/blob/4275a42a6e59c76a7a2fb98044b5b19a34ca57b4/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java#L67).

This patch improves UX by adding a more specific message with a suggestion how to fix the error:

```
Can't infer a type of null. Please explicitly cast it to a required type, e.g. CAST(null AS VARCHAR).
```

### Testing done 

I added a new functional test case for `null` handling.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

