### PR TITLE
chore: pull internal KsqlConfigs into InternalKsqlConfig and label remaining as SERVER vs QUERY level

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilder.java
@@ -65,7 +65,6 @@ public class PropertiesListTableBuilder implements TableBuilder<PropertiesList> 
       } else {
         // all configs are server-level by default, unless explicitly handled per query
         level = "SERVER";
-        // TODO -- what are these configs? maybe streams/producer configs? only the overridden ones, or others? test
       }
       final String value = property.getValue() == null ? "NULL" : property.getValue();
       final String scope = property.getScope();

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilder.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilder.java
@@ -83,6 +83,7 @@ public class PropertiesListTableBuilder implements TableBuilder<PropertiesList> 
 
     return properties.getProperties().stream()
         .map(toPropertyDef)
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/InternalKsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/InternalKsqlConfig.java
@@ -1,0 +1,568 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.confluent.ksql.util;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.ValidString;
+
+import io.confluent.ksql.configdef.ConfigValidators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Map;
+
+import static io.confluent.ksql.configdef.ConfigValidators.zeroOrPositive;
+import static io.confluent.ksql.util.KsqlConfig.CONNECT_URL_PROPERTY;
+import static io.confluent.ksql.util.KsqlConfig.CONNECT_WORKER_CONFIG_FILE_PROPERTY;
+import static io.confluent.ksql.util.KsqlConfig.DEFAULT_CONNECT_URL;
+import static io.confluent.ksql.util.KsqlConfig.DEFAULT_EXT_DIR;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ACCESS_VALIDATOR_AUTO;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ACCESS_VALIDATOR_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ACCESS_VALIDATOR_OFF;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ACCESS_VALIDATOR_ON;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_AUTH_CACHE_EXPIRY_TIME_SECS;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_AUTH_CACHE_EXPIRY_TIME_SECS_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_AUTH_CACHE_EXPIRY_TIME_SECS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_AUTH_CACHE_MAX_ENTRIES;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_AUTH_CACHE_MAX_ENTRIES_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_AUTH_CACHE_MAX_ENTRIES_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_COLLECT_UDF_METRICS;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CUSTOM_METRICS_TAGS;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CUSTOM_METRICS_TAGS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ENABLE_ACCESS_VALIDATOR;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ENABLE_UDFS;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ERROR_CLASSIFIER_REGEX_PREFIX;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ERROR_CLASSIFIER_REGEX_PREFIX_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_EXT_DIR;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_HIDDEN_TOPICS_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_HIDDEN_TOPICS_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_HIDDEN_TOPICS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_INSERT_INTO_VALUES_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_INTERNAL_TOPIC_MIN_INSYNC_REPLICAS_PROPERTY;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_INTERNAL_TOPIC_REPLICAS_PROPERTY;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_LAMBDAS_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_LAMBDAS_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_LAMBDAS_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_METASTORE_BACKUP_LOCATION;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_METASTORE_BACKUP_LOCATION_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_METASTORE_BACKUP_LOCATION_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERYANONYMIZER_CLUSTER_NAMESPACE;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERYANONYMIZER_CLUSTER_NAMESPACE_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERYANONYMIZER_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERYANONYMIZER_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_ENABLE_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_ENABLE_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_ENABLE_STANDBY_READS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_INTERPRETER_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_QPS_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_QPS_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_QPS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_METRICS_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_METRICS_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_RANGE_SCAN_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_RANGE_SCAN_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_RANGE_SCAN_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_THREAD_POOL_SIZE_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_MAX_HOURLY_BANDWIDTH_MEGABYTES_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_MAX_HOURLY_BANDWIDTH_MEGABYTES_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_STREAM_PULL_QUERY_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_STREAM_PULL_QUERY_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_STREAM_PULL_QUERY_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_READONLY_TOPICS_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_READONLY_TOPICS_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_READONLY_TOPICS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ROWPARTITION_ROWOFFSET_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SECURITY_EXTENSION_CLASS;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SECURITY_EXTENSION_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SECURITY_EXTENSION_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SERVICE_ID_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SERVICE_ID_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SUPPRESS_BUFFER_SIZE_BYTES;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SUPPRESS_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SUPPRESS_ENABLED_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SUPPRESS_ENABLED_DOC;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_UDF_SECURITY_MANAGER_ENABLED;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE_DEFAULT;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_VARIABLE_SUBSTITUTION_ENABLE_DOC;
+import static io.confluent.ksql.util.KsqlConfig.METRIC_REPORTER_CLASSES_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.METRIC_REPORTER_CLASSES_DOC;
+import static io.confluent.ksql.util.KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY;
+
+public class InternalKsqlConfig extends AbstractConfig {
+    private static final Logger LOG = LoggerFactory.getLogger(InternalKsqlConfig.class);
+
+    public static final ConfigDef CONFIG_DEF;
+
+    static {
+        CONFIG_DEF = new ConfigDef()
+            .define(
+                KSQL_SERVICE_ID_CONFIG,
+                ConfigDef.Type.STRING,
+                KSQL_SERVICE_ID_DEFAULT,
+                ConfigDef.Importance.MEDIUM,
+                "Indicates the ID of the ksql service. It will be used as prefix for "
+                    + "all implicitly named resources created by this instance in Kafka. "
+                    + "By convention, the id should end in a seperator character of some form, e.g. "
+                    + "a dash or underscore, as this makes identifiers easier to read."
+            )
+            .define(
+                SCHEMA_REGISTRY_URL_PROPERTY,
+                ConfigDef.Type.STRING,
+                "",
+                new ConfigDef.NonNullValidator(),
+                ConfigDef.Importance.MEDIUM,
+                "The URL for the schema registry"
+            )
+            .define(
+                CONNECT_URL_PROPERTY,
+                ConfigDef.Type.STRING,
+                DEFAULT_CONNECT_URL,
+                Importance.MEDIUM,
+                "The URL for the connect deployment, defaults to http://localhost:8083"
+            )
+            .define(
+                CONNECT_WORKER_CONFIG_FILE_PROPERTY,
+                ConfigDef.Type.STRING,
+                "",
+                Importance.LOW,
+                "The path to a connect worker configuration file. An empty value for this configuration"
+                    + "will prevent connect from starting up embedded within KSQL. For more information"
+                    + " on configuring connect, see "
+                    + "https://docs.confluent.io/current/connect/userguide.html#configuring-workers."
+            )
+            .define(
+                KSQL_ENABLE_UDFS,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.MEDIUM,
+                "Whether or not custom UDF jars found in the ext dir should be loaded. Default is true "
+            )
+            .define(
+                KSQL_COLLECT_UDF_METRICS,
+                ConfigDef.Type.BOOLEAN,
+                false,
+                ConfigDef.Importance.LOW,
+                "Whether or not metrics should be collected for custom udfs. Default is false. Note: "
+                    + "this will add some overhead to udf invocation. It is recommended that this "
+                    + " be set to false in production."
+            )
+            .define(
+                KSQL_EXT_DIR,
+                ConfigDef.Type.STRING,
+                DEFAULT_EXT_DIR,
+                ConfigDef.Importance.LOW,
+                "The path to look for and load extensions such as UDFs from."
+            )
+            .define(
+                KSQL_INTERNAL_TOPIC_REPLICAS_PROPERTY,
+                Type.SHORT,
+                (short) 1,
+                ConfigDef.Importance.MEDIUM,
+                "The replication factor for the internal topics of KSQL server."
+            )
+            .define(
+                KSQL_INTERNAL_TOPIC_MIN_INSYNC_REPLICAS_PROPERTY,
+                Type.SHORT,
+                (short) 1,
+                ConfigDef.Importance.MEDIUM,
+                "The minimum number of insync replicas for the internal topics of KSQL server."
+            )
+            .define(
+                KSQL_UDF_SECURITY_MANAGER_ENABLED,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.LOW,
+                "Enable the security manager for UDFs. Default is true and will stop UDFs from"
+                    + " calling System.exit or executing processes"
+            )
+            .define(
+                KSQL_INSERT_INTO_VALUES_ENABLED,
+                Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.LOW,
+                "Enable the INSERT INTO ... VALUES functionality."
+            )
+            .define(
+                KSQL_SECURITY_EXTENSION_CLASS,
+                Type.CLASS,
+                KSQL_SECURITY_EXTENSION_DEFAULT,
+                ConfigDef.Importance.LOW,
+                KSQL_SECURITY_EXTENSION_DOC
+            )
+            .define(
+                KSQL_CUSTOM_METRICS_TAGS,
+                ConfigDef.Type.STRING,
+                "",
+                ConfigDef.Importance.LOW,
+                KSQL_CUSTOM_METRICS_TAGS_DOC
+            )
+            .define(
+                KSQL_QUERYANONYMIZER_CLUSTER_NAMESPACE,
+                ConfigDef.Type.STRING,
+                null,
+                ConfigDef.Importance.LOW,
+                KSQL_QUERYANONYMIZER_CLUSTER_NAMESPACE_DOC
+            )
+            .define(
+                KSQL_QUERYANONYMIZER_ENABLED,
+                ConfigDef.Type.BOOLEAN,
+                true,
+                ConfigDef.Importance.LOW,
+                KSQL_QUERYANONYMIZER_ENABLED_DOC
+            )
+            .define(
+                KSQL_ENABLE_ACCESS_VALIDATOR,
+                Type.STRING,
+                KSQL_ACCESS_VALIDATOR_AUTO,
+                ValidString.in(
+                    KSQL_ACCESS_VALIDATOR_ON,
+                    KSQL_ACCESS_VALIDATOR_OFF,
+                    KSQL_ACCESS_VALIDATOR_AUTO
+                ),
+                ConfigDef.Importance.LOW,
+                KSQL_ACCESS_VALIDATOR_DOC
+            )
+            .define(METRIC_REPORTER_CLASSES_CONFIG,
+                     Type.LIST,
+                     "",
+                     Importance.LOW,
+                     METRIC_REPORTER_CLASSES_DOC
+            )
+            .define(
+                KSQL_PULL_QUERIES_ENABLE_CONFIG,
+                Type.BOOLEAN,
+                KSQL_QUERY_PULL_ENABLE_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PULL_ENABLE_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_ENABLE_STANDBY_READS,
+                Type.BOOLEAN,
+                KSQL_QUERY_PULL_ENABLE_STANDBY_READS_DEFAULT,
+                Importance.MEDIUM,
+                KSQL_QUERY_PULL_ENABLE_STANDBY_READS_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG,
+                Type.LONG,
+                KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_DEFAULT,
+                zeroOrPositive(),
+                Importance.MEDIUM,
+                KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_DOC
+            )
+            .define(
+                KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG,
+                Type.INT,
+                KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DEFAULT,
+                Importance.MEDIUM,
+                KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DOC
+            )
+            .define(
+                KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG,
+                Type.LONG,
+                KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT,
+                Importance.MEDIUM,
+                KSQL_SHUTDOWN_TIMEOUT_MS_DOC
+            )
+            .define(
+                KSQL_AUTH_CACHE_EXPIRY_TIME_SECS,
+                Type.LONG,
+                KSQL_AUTH_CACHE_EXPIRY_TIME_SECS_DEFAULT,
+                Importance.LOW,
+                KSQL_AUTH_CACHE_EXPIRY_TIME_SECS_DOC
+            )
+            .define(
+                KSQL_AUTH_CACHE_MAX_ENTRIES,
+                Type.LONG,
+                KSQL_AUTH_CACHE_MAX_ENTRIES_DEFAULT,
+                Importance.LOW,
+                KSQL_AUTH_CACHE_MAX_ENTRIES_DOC
+            )
+            .define(
+                KSQL_HIDDEN_TOPICS_CONFIG,
+                Type.LIST,
+                KSQL_HIDDEN_TOPICS_DEFAULT,
+                ConfigValidators.validRegex(),
+                Importance.LOW,
+                KSQL_HIDDEN_TOPICS_DOC
+            )
+            .define(
+                KSQL_READONLY_TOPICS_CONFIG,
+                Type.LIST,
+                KSQL_READONLY_TOPICS_DEFAULT,
+                ConfigValidators.validRegex(),
+                Importance.LOW,
+                KSQL_READONLY_TOPICS_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_METRICS_ENABLED,
+                Type.BOOLEAN,
+                true,
+                Importance.LOW,
+                KSQL_QUERY_PULL_METRICS_ENABLED_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_MAX_QPS_CONFIG,
+                Type.INT,
+                KSQL_QUERY_PULL_MAX_QPS_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PULL_MAX_QPS_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_CONFIG,
+                Type.INT,
+                KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PULL_MAX_CONCURRENT_REQUESTS_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG,
+                Type.INT,
+                KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_DEFAULT,
+                Importance.HIGH,
+                KSQL_QUERY_PULL_MAX_HOURLY_BANDWIDTH_MEGABYTES_DOC
+            )
+            .define(
+                KSQL_QUERY_PUSH_V2_MAX_HOURLY_BANDWIDTH_MEGABYTES_CONFIG,
+                Type.INT,
+                KSQL_QUERY_PUSH_V2_MAX_HOURLY_BANDWIDTH_MEGABYTES_DEFAULT,
+                Importance.HIGH,
+                KSQL_QUERY_PUSH_V2_MAX_HOURLY_BANDWIDTH_MEGABYTES_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_THREAD_POOL_SIZE_CONFIG,
+                Type.INT,
+                KSQL_QUERY_PULL_THREAD_POOL_SIZE_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PULL_THREAD_POOL_SIZE_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_CONFIG,
+                Type.INT,
+                KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PULL_ROUTER_THREAD_POOL_SIZE_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_TABLE_SCAN_ENABLED,
+                Type.BOOLEAN,
+                KSQL_QUERY_PULL_TABLE_SCAN_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PULL_TABLE_SCAN_ENABLED_DOC
+            )
+            .define(
+                KSQL_QUERY_STREAM_PULL_QUERY_ENABLED,
+                Type.BOOLEAN,
+                KSQL_QUERY_STREAM_PULL_QUERY_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_STREAM_PULL_QUERY_ENABLED_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_RANGE_SCAN_ENABLED,
+                Type.BOOLEAN,
+                KSQL_QUERY_PULL_RANGE_SCAN_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PULL_RANGE_SCAN_ENABLED_DOC
+            )
+            .define(
+                KSQL_QUERY_PULL_INTERPRETER_ENABLED,
+                Type.BOOLEAN,
+                KSQL_QUERY_PULL_INTERPRETER_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PULL_INTERPRETER_ENABLED_DOC
+            )
+            .define(
+                KSQL_QUERY_PUSH_V2_ENABLED,
+                Type.BOOLEAN,
+                KSQL_QUERY_PUSH_V2_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PUSH_V2_ENABLED_DOC
+            )
+            .define(
+                KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED,
+                Type.BOOLEAN,
+                KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PUSH_V2_REGISTRY_INSTALLED_DOC
+            )
+            .define(
+                KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY,
+                Type.BOOLEAN,
+                KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PUSH_V2_NEW_NODE_CONTINUITY_DOC
+            )
+            .define(
+                KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED,
+                Type.BOOLEAN,
+                KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_PUSH_V2_INTERPRETER_ENABLED_DOC
+            )
+            .define(
+                KSQL_ERROR_CLASSIFIER_REGEX_PREFIX,
+                Type.STRING,
+                "",
+                Importance.LOW,
+                KSQL_ERROR_CLASSIFIER_REGEX_PREFIX_DOC
+            )
+            .define(
+                KSQL_CREATE_OR_REPLACE_ENABLED,
+                Type.BOOLEAN,
+                KSQL_CREATE_OR_REPLACE_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_CREATE_OR_REPLACE_ENABLED_DOC
+            )
+            .define(
+                KSQL_METASTORE_BACKUP_LOCATION,
+                Type.STRING,
+                KSQL_METASTORE_BACKUP_LOCATION_DEFAULT,
+                Importance.LOW,
+                KSQL_METASTORE_BACKUP_LOCATION_DOC
+            )
+            .define(
+                KSQL_SUPPRESS_ENABLED,
+                Type.BOOLEAN,
+                KSQL_SUPPRESS_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_SUPPRESS_ENABLED_DOC
+            )
+            // TODO if/when suppress is officially supported, move this back to KsqlConfig
+            .define(
+                KSQL_SUPPRESS_BUFFER_SIZE_BYTES,
+                Type.LONG,
+                KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DEFAULT,
+                Importance.LOW,
+                KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DOC
+            )
+            .define(
+                KSQL_PROPERTIES_OVERRIDES_DENYLIST,
+                Type.LIST,
+                "",
+                Importance.LOW,
+                KSQL_PROPERTIES_OVERRIDES_DENYLIST_DOC
+            )
+            .define(
+                KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS,
+                Type.INT,
+                KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DEFAULT,
+                Importance.LOW,
+                KSQL_QUERY_STATUS_RUNNING_THRESHOLD_SECS_DOC
+            )
+            .define(
+                KSQL_VARIABLE_SUBSTITUTION_ENABLE,
+                Type.BOOLEAN,
+                KSQL_VARIABLE_SUBSTITUTION_ENABLE_DEFAULT,
+                Importance.LOW,
+                KSQL_VARIABLE_SUBSTITUTION_ENABLE_DOC
+            )
+            .define(
+                KSQL_LAMBDAS_ENABLED,
+                Type.BOOLEAN,
+                KSQL_LAMBDAS_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_LAMBDAS_ENABLED_DOC
+            )
+            .define(
+                KSQL_ROWPARTITION_ROWOFFSET_ENABLED,
+                Type.BOOLEAN,
+                KSQL_ROWPARTITION_ROWOFFSET_DEFAULT,
+                Importance.LOW,
+                KSQL_ROWPARTITION_ROWOFFSET_DOC
+            )
+            .define(
+                KSQL_SHARED_RUNTIME_ENABLED,
+                Type.BOOLEAN,
+                KSQL_SHARED_RUNTIME_ENABLED_DEFAULT,
+                Importance.MEDIUM,
+                KSQL_SHARED_RUNTIME_ENABLED_DOC
+            )
+            .define(
+                KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED,
+                Type.BOOLEAN,
+                KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DEFAULT,
+                Importance.LOW,
+                KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DOC
+            )
+            .withClientSslSupport();
+    }
+
+    public InternalKsqlConfig(final Map<?, ?> props) {
+        super(CONFIG_DEF, props);
+    }
+
+}

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -48,6 +50,7 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
@@ -900,6 +903,7 @@ public class KsqlConfig extends AbstractConfig {
   }
 
   private final Map<String, ConfigValue> ksqlStreamConfigProps;
+  private final InternalKsqlConfig internalKsqlConfigs;
 
   public KsqlConfig(final Map<?, ?> props) {
     this(ConfigGeneration.CURRENT, props);
@@ -933,6 +937,7 @@ public class KsqlConfig extends AbstractConfig {
             generation == ConfigGeneration.CURRENT
                 ? config.defaultValueCurrent : config.defaultValueLegacy));
     this.ksqlStreamConfigProps = buildStreamingConfig(streamsConfigDefaults, originals());
+    this.internalKsqlConfigs = new InternalKsqlConfig(props);
   }
 
   private static Set<String> streamTopicConfigNames() {
@@ -967,6 +972,116 @@ public class KsqlConfig extends AbstractConfig {
                      final Map<String, ConfigValue> ksqlStreamConfigProps) {
     super(configDef(generation), values);
     this.ksqlStreamConfigProps = ksqlStreamConfigProps;
+    this.internalKsqlConfigs = new InternalKsqlConfig(values);
+  }
+
+  @Override
+  public void ignore(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      internalKsqlConfigs.ignore(key);
+    } else {
+      super.ignore(key);
+    }
+  }
+
+  @Override
+  public Short getShort(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getShort(key);
+    } else {
+      return super.getShort(key);
+    }
+  }
+
+  @Override
+  public Integer getInt(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getInt(key);
+    } else {
+      return super.getInt(key);
+    }
+  }
+
+  @Override
+  public Long getLong(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getLong(key);
+    } else {
+      return super.getLong(key);
+    }
+  }
+
+  @Override
+  public Double getDouble(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getDouble(key);
+    } else {
+      return super.getDouble(key);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<String> getList(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getList(key);
+    } else {
+      return super.getList(key);
+    }
+  }
+
+  @Override
+  public Boolean getBoolean(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getBoolean(key);
+    } else {
+      return super.getBoolean(key);
+    }
+  }
+
+  @Override
+  public String getString(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getString(key);
+    } else {
+      return super.getString(key);
+    }
+  }
+
+  @Override
+  public ConfigDef.Type typeOf(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.typeOf(key);
+    } else {
+      return super.typeOf(key);
+    }
+  }
+
+  @Override
+  public String documentationOf(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.documentationOf(key);
+    } else {
+      return super.documentationOf(key);
+    }
+  }
+
+  @Override
+  public Password getPassword(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getPassword(key);
+    } else {
+      return super.getPassword(key);
+    }
+  }
+
+  @Override
+  public Class<?> getClass(String key) {
+    if (InternalKsqlConfig.CONFIG_DEF.names().contains(key)) {
+      return internalKsqlConfigs.getClass(key);
+    } else {
+      return super.getClass(key);
+    }
   }
 
   public Map<String, Object> getKsqlStreamConfigProps(final String applicationId) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -100,6 +100,11 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY =
       "ksql.sink.window.change.log.additional.retention";
+  private static final String SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY_DOC =
+      "The default window change log additional retention time. This "
+          + "is a streams config value which will be added to a windows maintainMs to ensure "
+          + "data is not deleted from the log prematurely. Allows for clock drift. "
+          + "Default is 1 day";
 
   public static final String
       FAIL_ON_DESERIALIZATION_ERROR_CONFIG = "ksql.fail.on.deserialization.error";
@@ -122,6 +127,12 @@ public class KsqlConfig extends AbstractConfig {
       KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG = "ksql.transient.prefix";
   public static final String
       KSQL_TRANSIENT_QUERY_NAME_PREFIX_DEFAULT = "transient_";
+  private static final String KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG_DOC =
+      "Second part of the prefix for transient queries. For instance if "
+          + "the prefix is transient_ the query name would be "
+          + "ksql_transient_4120896722607083946_1509389010601 where 'ksql_' is the first prefix"
+          + " and '_transient' is the second part of the prefix for the query id the third and "
+          + "4th parts are a random long value and the current timestamp.";
 
   public static final String
       KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG = "ksql.output.topic.name.prefix";
@@ -684,11 +695,7 @@ public class KsqlConfig extends AbstractConfig {
             ConfigDef.Type.STRING,
             KSQL_TRANSIENT_QUERY_NAME_PREFIX_DEFAULT,
             ConfigDef.Importance.MEDIUM,
-            "Second part of the prefix for transient queries. For instance if "
-                + "the prefix is transient_ the query name would be "
-                + "ksql_transient_4120896722607083946_1509389010601 where 'ksql_' is the first prefix"
-                + " and '_transient' is the second part of the prefix for the query id the third and "
-                + "4th parts are a random long value and the current timestamp. "
+            KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG_DOC
         )
         .define(
             KSQL_CUSTOM_METRICS_EXTENSION,
@@ -748,10 +755,7 @@ public class KsqlConfig extends AbstractConfig {
             ConfigDef.Type.LONG,
             KsqlConstants.defaultSinkWindowChangeLogAdditionalRetention,
             ConfigDef.Importance.MEDIUM,
-            "The default window change log additional retention time. This "
-            + "is a streams config value which will be added to a windows maintainMs to ensure "
-            + "data is not deleted from the log prematurely. Allows for clock drift. "
-            + "Default is 1 day",
+            SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY_DOC,
             "SERVER",
             1,
             Width.NONE,


### PR DESCRIPTION
Try to distinguish between internal configs that shouldn't be displayed/modified, and the actual server/query level configs controllable by the user.

This allows us to filter out the internal configs when responding to a `list properties;` command, and also tack on a new `Level` field that is either `QUERY` or `SERVER`. 

Still a WIP: need to pull in and explicitly label the handful of streams configs that remain at the QUERY level (all other streams/consumer/producer configs will default to SERVER)
 |
 L--> also tests: I think we need to add a test that will make sure devs can't add new configs to KsqlConfig without correctly classifying them/updating the appropriate places. We should be able to make this as painless as possible by removing most if not all of the hard-coded configs, but will still require them to consider whether to place it with the internal configs or not