### PR TITLE
fix: Print only failed line on parsing exception

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -1217,6 +1217,27 @@ public class CliTest {
   }
 
   @Test
+  public void shouldPrintOnlyFailedStatementFromScriptFile() throws Exception {
+    // Given:
+    final File scriptFile = TMP.newFile("script.sql");
+    Files.write(scriptFile.toPath(), (""
+        + "drop stream if exists s1;\n"
+        + "create stream if not exist s1(id int) with (kafka_topic='s1', value_format='json', "
+        + "partitions=1);\n").getBytes(StandardCharsets.UTF_8));
+
+    // When:
+    localCli.runScript(scriptFile.getPath());
+
+    // Then:
+    final String out = terminal.getOutputString();
+    final String expected = "Statement: create stream if not exist s1(id int) "
+        + "with (kafka_topic='s1', value_format='json', partitions=1);\n"
+        + "Caused by: line 2:22: no viable alternative at input 'create stream if not";
+    assertThat(out, containsString(expected));
+    assertThat(out, not(containsString("drop stream if exists")));
+  }
+
+  @Test
   public void shouldUpdateCommandSequenceNumber() throws Exception {
     // Given:
     final String statementText = "create stream foo;";

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultKsqlParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/DefaultKsqlParser.java
@@ -47,6 +47,10 @@ public class DefaultKsqlParser implements KsqlParser {
           .map(DefaultKsqlParser::parsedStatement)
           .collect(Collectors.toList());
 
+    } catch (final ParsingException e) {
+      // ParsingException counts lines starting from 1
+      final String failedLine =  sql.split(System.lineSeparator())[e.getLineNumber() - 1];
+      throw new ParseFailedException(e.getMessage(), failedLine, e);
     } catch (final Exception e) {
       throw new ParseFailedException(e.getMessage(), sql, e);
     }


### PR DESCRIPTION
### Description 

With this patch CLI displays only the failed SQL statement out of all the executed statements in the batch. Fixes #6850. See comments starting from https://github.com/confluentinc/ksql/issues/6850#issuecomment-948798751 for the root cause analysis and rationale for the fix.

### Testing done 

I added an integration test that does `runScript` and asserts that the error message contains only the failed statement.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

