### PR TITLE
fix: make singular time units work as function arguments

### DIFF
--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -307,8 +307,8 @@ primaryExpression
     ;
 
 functionArgument
-    : expression
-    | windowUnit
+    : windowUnit
+    | expression
     ;
 
 timeZoneSpecifier

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -401,7 +401,30 @@ public class AstBuilderTest {
   }
 
   @Test
-  public void shouldBuildIntervalUnit() {
+  public void shouldBuildIntervalUnitSingular() {
+    // Given:
+    final SingleStatementContext stmt = givenQuery("SELECT TIMESTAMPADD(MINUTE, 5, Col4) FROM TEST1;");
+
+    // When:
+    final Query result = (Query) builder.buildStatement(stmt);
+
+    // Then:
+    assertThat(result.getSelect(), is(new Select(ImmutableList.of(
+        new SingleColumn(
+            new FunctionCall(
+                FunctionName.of("TIMESTAMPADD"),
+                ImmutableList.of(
+                    new IntervalUnit(TimeUnit.MINUTES),
+                    new IntegerLiteral(5),
+                    column("COL4")
+                )
+            ),
+            Optional.empty())
+    ))));
+  }
+
+  @Test
+  public void shouldBuildIntervalUnitPlural() {
     // Given:
     final SingleStatementContext stmt = givenQuery("SELECT TIMESTAMPADD(MINUTES, 5, Col4) FROM TEST1;");
 


### PR DESCRIPTION
### Description 
For some reason, the SQL parser was parsing singular time units (MINUTE, SECOND etc) as column names instead of time units, even though plural words work. This query failed with `SELECT column 'MINUTE' cannot be resolved `:

```
SELECT TIMESTAMPADD(MINUTE, 5, Col4) FROM TEST1;
```

While this one passes:

```
SELECT TIMESTAMPADD(MINUTES, 5, Col4) FROM TEST1;
```

The fix is to swap the order of `expression` and `windowUnit` under `functionArgument` in `SqlBase.g4`, and I do not understand why it works.

This was one of the problems present in #8279 

### Testing done 
Added a unit test for singular time units. It fails without the fix.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")