### PR TITLE
fix: Pull query table scans support LIKE and BETWEEN operators

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullQueryRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullQueryRewriter.java
@@ -108,7 +108,7 @@ public final class PullQueryRewriter {
       final ComparisonExpression rightComparisonExpression = new ComparisonExpression(
               node.getLocation(), Type.LESS_THAN_OR_EQUAL, node.getValue(),
               node.getMax());
-      Expression currentExpression = new LogicalBinaryExpression(
+      final Expression currentExpression = new LogicalBinaryExpression(
               node.getLocation(), LogicalBinaryExpression.Type.AND, leftComparisonExpression,
               rightComparisonExpression);
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullQueryRewriter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/PullQueryRewriter.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter;
 import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter.Context;
 import io.confluent.ksql.engine.rewrite.StatementRewriteForMagicPseudoTimestamp;
+import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -36,8 +37,14 @@ public final class PullQueryRewriter {
   public static Expression rewrite(final Expression expression) {
     final Expression pseudoTimestamp = new StatementRewriteForMagicPseudoTimestamp()
         .rewrite(expression);
-    final Expression inPredicatesRemoved = rewriteInPredicates(pseudoTimestamp);
+    final Expression betweenPredicatesRemoved = rewriteBetweenPredicates(pseudoTimestamp);
+    final Expression inPredicatesRemoved = rewriteInPredicates(betweenPredicatesRemoved);
     return LogicRewriter.rewriteDNF(inPredicatesRemoved);
+  }
+
+  public static Expression rewriteBetweenPredicates(final Expression expression) {
+    return new ExpressionTreeRewriter<>(new BetweenPredicateRewriter()::process)
+            .rewrite(expression, null);
   }
 
   public static Expression rewriteInPredicates(final Expression expression) {
@@ -77,6 +84,35 @@ public final class PullQueryRewriter {
         return Optional.of(currentExpression);
       }
       throw new IllegalStateException("Shouldn't have an empty in predicate");
+    }
+  }
+
+  private static final class BetweenPredicateRewriter extends
+          VisitParentExpressionVisitor<Optional<Expression>, Context<Void>> {
+
+    @Override
+    public Optional<Expression> visitExpression(
+            final Expression node,
+            final Context<Void> context) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Expression> visitBetweenPredicate(
+            final BetweenPredicate node,
+            final Context<Void> context
+    ) {
+      final ComparisonExpression leftComparisonExpression = new ComparisonExpression(
+              node.getLocation(), Type.GREATER_THAN_OR_EQUAL, node.getValue(),
+              node.getMin());
+      final ComparisonExpression rightComparisonExpression = new ComparisonExpression(
+              node.getLocation(), Type.LESS_THAN_OR_EQUAL, node.getValue(),
+              node.getMax());
+      Expression currentExpression = new LogicalBinaryExpression(
+              node.getLocation(), LogicalBinaryExpression.Type.AND, leftComparisonExpression,
+              rightComparisonExpression);
+
+      return Optional.of(currentExpression);
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryFilterNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/QueryFilterNode.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.analyzer.PullQueryValidator;
 import io.confluent.ksql.engine.generic.GenericExpressionResolver;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
-import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -365,7 +364,8 @@ public class QueryFilterNode extends SingleSourcePlanNode {
     @Override
     public Void visitLikePredicate(final LikePredicate node, final Object context) {
       if (node.getValue() instanceof UnqualifiedColumnReferenceExp) {
-        final UnqualifiedColumnReferenceExp column = (UnqualifiedColumnReferenceExp) node.getValue();
+        final UnqualifiedColumnReferenceExp column =
+                (UnqualifiedColumnReferenceExp) node.getValue();
         final ColumnName columnName = column.getColumnName();
         final Column col = schema.findColumn(columnName)
                 .orElseThrow(() -> invalidWhereClauseException(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullQueryRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/PullQueryRewriterTest.java
@@ -38,6 +38,14 @@ public class PullQueryRewriterTest {
             + "(ORDERS.ITEMID = 'c'))))");
   }
 
+  @Test
+  public void shouldRewriteBetweenPredicate() {
+    assertRewrite("ORDERS", "ORDERID BETWEEN 2 AND 5",
+            "((ORDERS.ORDERID >= 2) AND (ORDERS.ORDERID <= 5))");
+    assertRewrite("ORDERS", "ORDERS.ITEMID BETWEEN 'a' AND 'b'",
+            "((ORDERS.ITEMID >= 'a') AND (ORDERS.ITEMID <= 'b'))");
+  }
+
   private void assertRewrite(final String table, final String expressionStr,
       final String expectedStr) {
     Expression expression = getWhereExpression(table, expressionStr);

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
@@ -9,7 +9,8 @@
         "CREATE TABLE INPUT (ID STRING PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
         "SELECT ID, V0, V1 FROM MATVIEW WHERE ID LIKE '%1';",
-        "SELECT ID, V0, V1 FROM MATVIEW WHERE V0 LIKE 'v12%';"
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE V0 LIKE 'v12%';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE '12' LIKE '12';"
       ],
       "properties": {
         "ksql.query.pull.table.scan.enabled":  true
@@ -31,21 +32,29 @@
         {"query": [
           {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
           {"row":{"columns":["12", "v12a", "v12b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["10", "v10a", "v10b"]}},
+          {"row":{"columns":["11", "v11a", "v11b"]}},
+          {"row":{"columns":["12", "v12a", "v12b"]}},
+          {"row":{"columns":["13", "v13a", "v13b"]}},
+          {"row":{"columns":["14", "v14a", "v14b"]}}
         ]}
       ]
     },
     {
-      "name": "like operator must fail on non-varchar columns",
+      "name": "like operator must fail on non-string pattern",
       "statements": [
         "CREATE TABLE INPUT (ID INTEGER PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
-        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID LIKE '%12';"
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID LIKE 12;"
       ],
       "properties": {
-        "ksql.query.pull.table.scan.enabled":  false
+        "ksql.query.pull.table.scan.enabled":  true
       },
       "expectedError": {
-        "message": "The column type for Like condition must be VARCHAR. The column type is INTEGER"
+        "message": "Like condition on non-string pattern io.confluent.ksql.execution.expression.tree.IntegerLiteral"
       }
     },
     {
@@ -53,9 +62,10 @@
       "statements": [
         "CREATE STREAM INPUT (ID1 STRING KEY, ID2 INT, V0 STRING) WITH (kafka_topic='test_topic', format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID1, ID2, V0, COUNT(1) AS COUNT FROM INPUT GROUP BY ID1, ID2, V0;",
-        "SELECT * FROM AGGREGATE WHERE ID1 BETWEEN '10' and '11';",
-        "SELECT * FROM AGGREGATE WHERE ID2 BETWEEN 10 and 12;",
-        "SELECT * FROM AGGREGATE WHERE V0 BETWEEN 'v10a' and 'v12a';"
+        "SELECT * FROM AGGREGATE WHERE ID1 BETWEEN '10' AND '11';",
+        "SELECT * FROM AGGREGATE WHERE ID2 BETWEEN 10 AND 12;",
+        "SELECT * FROM AGGREGATE WHERE V0 BETWEEN 'v10a' AND 'v12a';",
+        "SELECT * FROM AGGREGATE WHERE 10 BETWEEN 9 AND 11;"
       ],
       "properties": {
         "ksql.query.pull.table.scan.enabled":  true
@@ -82,6 +92,122 @@
           {"header":{"schema":"`ID1` STRING KEY, `ID2` INTEGER KEY, `V0` STRING KEY, `COUNT` BIGINT"}},
           {"row":{"columns":["9", 12, "v12a", 1]}},
           {"row":{"columns":["11", 10, "v10a", 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID1` STRING KEY, `ID2` INTEGER KEY, `V0` STRING KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["9", 12, "v12a", 1]}},
+          {"row":{"columns":["10", 15, "v15a", 1]}},
+          {"row":{"columns":["11", 10, "v10a", 1]}}
+        ]}
+      ]
+    },
+    {
+      "name": "between operator must fail on non-matching literal",
+      "statements": [
+        "CREATE TABLE INPUT (ID INTEGER PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE V0 BETWEEN 10 AND 'v10a';"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "expectedError": {
+        "message": "Invalid expression: Cannot compare V0 (STRING) to 10 (INTEGER) with GREATER_THAN_OR_EQUAL"
+      }
+    },
+    {
+      "name": "test with 3 partitions",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON', PARTITIONS=3);",
+        "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID LIKE '12%';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE V0 LIKE '%v11%';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID BETWEEN '10' AND '11';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE V1 BETWEEN 'v10b' AND 'v11b';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID BETWEEN '10' AND '11' AND V0 IN ('v11a', 'v12a');"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"v0": "v10a", "v1": "v10b"}},
+        {"topic": "test_topic", "timestamp": 12355, "key": "11", "value": {"v0": "v11a", "v1": "v11b"}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "12", "value": {"v0": "v12a", "v1": "v12b"}},
+        {"topic": "test_topic", "timestamp": 12375, "key": "13", "value": {"v0": "v13a", "v1": "v13b"}},
+        {"topic": "test_topic", "timestamp": 12385, "key": "14", "value": {"v0": "v14a", "v1": "v14b"}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["12", "v12a", "v12b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["10", "v10a", "v10b"]}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["10", "v10a", "v10b"]}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
+        ]}
+      ]
+    },
+    {
+      "name": "test with 4 partitions",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON', PARTITIONS=4);",
+        "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID LIKE '12%';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE V0 LIKE '%v11%';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID BETWEEN '10' AND '11';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE V1 BETWEEN 'v10b' AND 'v11b';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID BETWEEN '10' AND '11' AND V0 IN ('v11a', 'v12a');"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"v0": "v10a", "v1": "v10b"}},
+        {"topic": "test_topic", "timestamp": 12355, "key": "11", "value": {"v0": "v11a", "v1": "v11b"}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "12", "value": {"v0": "v12a", "v1": "v12b"}},
+        {"topic": "test_topic", "timestamp": 12375, "key": "13", "value": {"v0": "v13a", "v1": "v13b"}},
+        {"topic": "test_topic", "timestamp": 12385, "key": "14", "value": {"v0": "v14a", "v1": "v14b"}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["12", "v12a", "v12b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["10", "v10a", "v10b"]}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["10", "v10a", "v10b"]}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
         ]}
       ]
     }

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
@@ -54,7 +54,21 @@
         "ksql.query.pull.table.scan.enabled":  true
       },
       "expectedError": {
-        "message": "Like condition on non-string pattern io.confluent.ksql.execution.expression.tree.IntegerLiteral"
+        "message": "The column type for Like condition must be VARCHAR. The column type is INTEGER"
+      }
+    },
+    {
+      "name": "like operator must fail if table-scan is disabled",
+      "statements": [
+        "CREATE TABLE INPUT (ID INTEGER PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE '12' LIKE '12';"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false
+      },
+      "expectedError": {
+        "message": "Like condition must be between strings"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
@@ -1,0 +1,75 @@
+{
+  "comments": [
+    "Tests covering pull queries with predicates"
+  ],
+  "tests": [
+    {
+      "name": "like condition must succeed with table scan enabled ",
+      "statements": [
+        "CREATE TABLE INPUT (ID STRING PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID LIKE '%1';",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE V0 LIKE 'v12%';"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {"v0": "v10a", "v1": "v10b"}},
+        {"topic": "test_topic", "timestamp": 12355, "key": "11", "value": {"v0": "v11a", "v1": "v11b"}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "12", "value": {"v0": "v12a", "v1": "v12b"}},
+        {"topic": "test_topic", "timestamp": 12375, "key": "13", "value": {"v0": "v13a", "v1": "v13b"}},
+        {"topic": "test_topic", "timestamp": 12385, "key": "14", "value": {"v0": "v14a", "v1": "v14b"}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["11", "v11a", "v11b"]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID` STRING KEY, `V0` STRING, `V1` STRING"}},
+          {"row":{"columns":["12", "v12a", "v12b"]}}
+        ]}
+      ]
+    },
+    {
+      "name": "between condition must succeed with table scan enabled",
+      "statements": [
+        "CREATE STREAM INPUT (ID1 STRING KEY, ID2 INT, V0 STRING) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ID1, ID2, V0, COUNT(1) AS COUNT FROM INPUT GROUP BY ID1, ID2, V0;",
+        "SELECT * FROM AGGREGATE WHERE ID1 BETWEEN '10' and '11';",
+        "SELECT * FROM AGGREGATE WHERE ID2 BETWEEN 10 and 12;",
+        "SELECT * FROM AGGREGATE WHERE V0 BETWEEN 'v10a' and 'v12a';"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  true
+      },
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {"id2": 10, "v0": "v10a"}},
+        {"topic": "test_topic", "timestamp": 12365, "key": "9", "value": {"id2": 12, "v0": "v12a"}},
+        {"topic": "test_topic", "timestamp": 12375, "key": "10", "value": {"id2": 15, "v0": "v15a"}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ID1` STRING KEY, `ID2` INTEGER KEY, `V0` STRING KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["11", 10, "v10a", 1]}},
+          {"row":{"columns":["10", 15, "v15a", 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID1` STRING KEY, `ID2` INTEGER KEY, `V0` STRING KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["9", 12, "v12a", 1]}},
+          {"row":{"columns":["11", 10, "v10a", 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ID1` STRING KEY, `ID2` INTEGER KEY, `V0` STRING KEY, `COUNT` BIGINT"}},
+          {"row":{"columns":["9", 12, "v12a", 1]}},
+          {"row":{"columns":["11", 10, "v10a", 1]}}
+        ]}
+      ]
+    }
+  ]
+}

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
@@ -4,7 +4,7 @@
   ],
   "tests": [
     {
-      "name": "like condition must succeed with table scan enabled ",
+      "name": "like operator must succeed with table scan enabled ",
       "statements": [
         "CREATE TABLE INPUT (ID STRING PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
@@ -35,7 +35,7 @@
       ]
     },
     {
-      "name": "between condition must succeed with table scan enabled",
+      "name": "between operator must succeed with table scan enabled",
       "statements": [
         "CREATE STREAM INPUT (ID1 STRING KEY, ID2 INT, V0 STRING) WITH (kafka_topic='test_topic', format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID1, ID2, V0, COUNT(1) AS COUNT FROM INPUT GROUP BY ID1, ID2, V0;",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
@@ -4,7 +4,7 @@
   ],
   "tests": [
     {
-      "name": "like operator must succeed with table scan enabled ",
+      "name": "like operator on key and non-key columns",
       "statements": [
         "CREATE TABLE INPUT (ID STRING PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
@@ -35,7 +35,22 @@
       ]
     },
     {
-      "name": "between operator must succeed with table scan enabled",
+      "name": "like operator must fail on non-varchar columns",
+      "statements": [
+        "CREATE TABLE INPUT (ID INTEGER PRIMARY KEY, V0 STRING, V1 STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE MATVIEW AS SELECT ID, V0, V1 FROM INPUT;",
+        "SELECT ID, V0, V1 FROM MATVIEW WHERE ID LIKE '%12';"
+      ],
+      "properties": {
+        "ksql.query.pull.table.scan.enabled":  false,
+        "ksql.query.pull.range.scan.enabled":  true
+      },
+      "expectedError": {
+        "message": "The column type for Like condition must be VARCHAR. The column type is INTEGER"
+      }
+    },
+    {
+      "name": "between operator on key and non-key columns",
       "statements": [
         "CREATE STREAM INPUT (ID1 STRING KEY, ID2 INT, V0 STRING) WITH (kafka_topic='test_topic', format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT ID1, ID2, V0, COUNT(1) AS COUNT FROM INPUT GROUP BY ID1, ID2, V0;",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-predicates.json
@@ -42,8 +42,7 @@
         "SELECT ID, V0, V1 FROM MATVIEW WHERE ID LIKE '%12';"
       ],
       "properties": {
-        "ksql.query.pull.table.scan.enabled":  false,
-        "ksql.query.pull.range.scan.enabled":  true
+        "ksql.query.pull.table.scan.enabled":  false
       },
       "expectedError": {
         "message": "The column type for Like condition must be VARCHAR. The column type is INTEGER"


### PR DESCRIPTION
### Description 

Add the support of LIKE and BETWEEN operators for pull query table scans.
This problem was reported in #7793 

### Testing done 

Add new tests to Integration Test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

