### PR TITLE
chore: inject optional tableelements for c*as command given schema id

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -34,10 +34,12 @@ import io.confluent.ksql.parser.tree.DdlStatement;
 import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.RegisterType;
+import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.HandlerMaps;
 import io.confluent.ksql.util.HandlerMaps.ClassHandlerMapR2;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
 
@@ -119,6 +121,18 @@ public class CommandFactories implements DdlCommandFactory {
       return createSourceFactory.createStreamCommand(outputNode);
     } else {
       return createSourceFactory.createTableCommand(outputNode);
+    }
+  }
+
+  @Override
+  public DdlCommand create(
+      final KsqlStructuredDataOutputNode outputNode,
+      final TableElements tableElements,
+      final KsqlConfig ksqlConfig) {
+    if (outputNode.getNodeOutputType() == DataSource.DataSourceType.KSTREAM) {
+      return createSourceFactory.createStreamCommand(outputNode, tableElements, ksqlConfig);
+    } else {
+      return createSourceFactory.createTableCommand(outputNode, tableElements, ksqlConfig);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -107,6 +107,41 @@ public final class CreateSourceFactory {
     );
   }
 
+  // This method is called by CREATE_AS statements
+  public CreateStreamCommand createStreamCommand(
+      final KsqlStructuredDataOutputNode outputNode,
+      final TableElements tableElements,
+      final KsqlConfig ksqlConfig
+  ) {
+    // Check schema compatibility and timestamp field
+    final LogicalSchema schema = buildSchema(tableElements, ksqlConfig);
+    final LogicalSchema outputSchema = outputNode.getSchema();
+
+    final LogicalSchema.Builder builder = LogicalSchema.builder();
+    if (schema.key().isEmpty()) {
+      builder.keyColumns(outputSchema.key());
+    } else {
+      builder.keyColumns(schema.key());
+    }
+
+    if (schema.value().isEmpty()) {
+      builder.valueColumns(outputSchema.value());
+    } else {
+      builder.valueColumns(schema.value());
+    }
+
+    return new CreateStreamCommand(
+        outputNode.getSinkName().get(),
+        builder.build(),
+        outputNode.getTimestampColumn(),
+        outputNode.getKsqlTopic().getKafkaTopicName(),
+        Formats.from(outputNode.getKsqlTopic()),
+        outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
+        Optional.of(outputNode.getOrReplace()),
+        Optional.of(false)
+    );
+  }
+
   // This method is called by simple CREATE statements
   public CreateStreamCommand createStreamCommand(
       final CreateStream statement,
@@ -146,6 +181,41 @@ public final class CreateSourceFactory {
     return new CreateTableCommand(
         outputNode.getSinkName().get(),
         outputNode.getSchema(),
+        outputNode.getTimestampColumn(),
+        outputNode.getKsqlTopic().getKafkaTopicName(),
+        Formats.from(outputNode.getKsqlTopic()),
+        outputNode.getKsqlTopic().getKeyFormat().getWindowInfo(),
+        Optional.of(outputNode.getOrReplace()),
+        Optional.of(false)
+    );
+  }
+
+  // This method is called by CREATE_AS statements
+  public CreateTableCommand createTableCommand(
+      final KsqlStructuredDataOutputNode outputNode,
+      final TableElements tableElements,
+      final KsqlConfig ksqlConfig
+  ) {
+    // Check schema compatibility and timestamp field
+    final LogicalSchema schema = buildSchema(tableElements, ksqlConfig);
+    final LogicalSchema outputSchema = outputNode.getSchema();
+
+    final LogicalSchema.Builder builder = LogicalSchema.builder();
+    if (schema.key().isEmpty()) {
+      builder.keyColumns(outputSchema.key());
+    } else {
+      builder.keyColumns(schema.key());
+    }
+
+    if (schema.value().isEmpty()) {
+      builder.valueColumns(outputSchema.value());
+    } else {
+      builder.valueColumns(schema.value());
+    }
+
+    return new CreateTableCommand(
+        outputNode.getSinkName().get(),
+        builder.build(),
         outputNode.getTimestampColumn(),
         outputNode.getKsqlTopic().getKafkaTopicName(),
         Formats.from(outputNode.getKsqlTopic()),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
@@ -18,7 +18,9 @@ package io.confluent.ksql.ddl.commands;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.execution.ddl.commands.DdlCommand;
 import io.confluent.ksql.parser.tree.DdlStatement;
+import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
+import io.confluent.ksql.util.KsqlConfig;
 
 public interface DdlCommandFactory {
   DdlCommand create(
@@ -29,5 +31,9 @@ public interface DdlCommandFactory {
 
   DdlCommand create(
       KsqlStructuredDataOutputNode outputNode
+  );
+
+  DdlCommand create(
+      KsqlStructuredDataOutputNode outputNode, TableElements tableElements, KsqlConfig ksqlConfig
   );
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.VariableSubstitutor;
 import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
+import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.query.KafkaStreamsQueryValidator;
 import io.confluent.ksql.query.QueryId;
@@ -213,6 +214,11 @@ final class EngineContext {
 
   DdlCommand createDdlCommand(final KsqlStructuredDataOutputNode outputNode) {
     return ddlCommandFactory.create(outputNode);
+  }
+
+  DdlCommand createDdlCommand(final KsqlStructuredDataOutputNode outputNode,
+      final TableElements tableElements) {
+    return ddlCommandFactory.create(outputNode, tableElements, ksqlConfig);
   }
 
   String executeDdl(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -353,7 +353,7 @@ final class EngineExecutor {
           context,
           pushRoutingOptions
       );
-      final  PushPhysicalPlan physicalPlan = plan;
+      final PushPhysicalPlan physicalPlan = plan;
 
       final TransientQueryQueue transientQueryQueue
           = new TransientQueryQueue(analysis.getLimitClause());
@@ -829,6 +829,12 @@ final class EngineExecutor {
       ));
     }
 
+    if (statement instanceof CreateAsSelect && ((CreateAsSelect) statement).getElements()
+        .isPresent()) {
+      return Optional.of(
+          engineContext.createDdlCommand(outputNode, ((CreateAsSelect) statement).getElements()
+              .get()));
+    }
     return Optional.of(engineContext.createDdlCommand(outputNode));
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -264,7 +264,7 @@ public class DefaultSchemaInjector implements Injector {
     if (!difference.isEmpty()) {
       throw new KsqlException("The following " + (isKey ? "key " : "value ")
           + "columns are changed, missing or reordered: "
-          + difference);
+          + difference + ". Schema from schema registry is " + inferredColumns);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -15,6 +15,9 @@
 
 package io.confluent.ksql.schema.ksql.inference;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.SqlFormatter;
@@ -28,6 +31,8 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.SimpleColumn;
 import io.confluent.ksql.schema.ksql.inference.TopicSchemaSupplier.SchemaAndId;
 import io.confluent.ksql.schema.ksql.inference.TopicSchemaSupplier.SchemaResult;
 import io.confluent.ksql.serde.FormatFactory;
@@ -44,6 +49,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -122,7 +129,7 @@ public class DefaultSchemaInjector implements Injector {
       return Optional.empty();
     }
 
-    return Optional.of(getSchema(
+    final SchemaAndId schemaAndId = getSchema(
         props.getKafkaTopic(),
         props.getKeySchemaId(),
         keyFormat,
@@ -131,7 +138,11 @@ public class DefaultSchemaInjector implements Injector {
         SerdeFeaturesFactory.buildKeyFeatures(FormatFactory.of(keyFormat), true),
         statement.getStatementText(),
         true
-    ));
+    );
+
+    checkColumnsCompatibility(props.getKeySchemaId(), statement, schemaAndId.columns, true);
+
+    return Optional.of(schemaAndId);
   }
 
   private Optional<SchemaAndId> getValueSchema(
@@ -144,14 +155,18 @@ public class DefaultSchemaInjector implements Injector {
       return Optional.empty();
     }
 
-    return Optional.of(getSchema(
+    SchemaAndId schemaAndId = getSchema(
         props.getKafkaTopic(),
         props.getValueSchemaId(),
         valueFormat,
         props.getValueSerdeFeatures(),
         statement.getStatementText(),
         false
-    ));
+    );
+
+    checkColumnsCompatibility(props.getValueSchemaId(), statement, schemaAndId.columns, false);
+
+    return Optional.of(schemaAndId);
   }
 
   private SchemaAndId getSchema(
@@ -208,6 +223,49 @@ public class DefaultSchemaInjector implements Injector {
         isKey ? hasKeyElements(statement) : hasValueElements(statement);
 
     return !hasTableElements && formatSupportsSchemaInference(formatInfo);
+  }
+
+  private static void checkColumnsCompatibility(
+      final Optional<Integer> schemaId,
+      final ConfiguredStatement<CreateSource> statement,
+      final List<? extends SimpleColumn> connectColumns, boolean isKey) {
+    /*
+     * Check inferred columns from schema id and provided columns compatibility. Conditions:
+     *   1. Schema id is provided
+     *   2. Table elements are provided
+     *   3. Inferred columns should be superset of columns from table elements
+     */
+    if (!schemaId.isPresent()) {
+      return;
+    }
+
+    if ((isKey && !hasKeyElements(statement)) || (!isKey && !hasValueElements(statement))) {
+      return;
+    }
+
+    final List<Column> tableColumns =
+        isKey ? statement.getStatement().getElements().toLogicalSchema().key()
+            : statement.getStatement().getElements().toLogicalSchema().value();
+
+    final Column.Namespace namespace = isKey ? Column.Namespace.KEY : Column.Namespace.VALUE;
+
+    final List<Column> inferredColumns = IntStream.range(0, connectColumns.size()).mapToObj(
+        i -> Column.of(
+            connectColumns.get(i).name(),
+            connectColumns.get(i).type(),
+            namespace,
+            i)
+    ).collect(Collectors.toList());
+
+    final ImmutableSet<Column> colA = ImmutableSet.copyOf(tableColumns);
+    final ImmutableSet<Column> colB = ImmutableSet.copyOf(inferredColumns);
+
+    final SetView<Column> difference = Sets.difference(colA, colB);
+    if (!difference.isEmpty()) {
+      throw new KsqlException("The following " + (isKey ? "key " : "value ")
+          + "columns are changed, missing or reordered: "
+          + difference);
+    }
   }
 
   private static boolean hasKeyElements(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -155,7 +155,7 @@ public class DefaultSchemaInjector implements Injector {
       return Optional.empty();
     }
 
-    SchemaAndId schemaAndId = getSchema(
+    final SchemaAndId schemaAndId = getSchema(
         props.getKafkaTopic(),
         props.getValueSchemaId(),
         valueFormat,
@@ -228,7 +228,7 @@ public class DefaultSchemaInjector implements Injector {
   private static void checkColumnsCompatibility(
       final Optional<Integer> schemaId,
       final ConfiguredStatement<CreateSource> statement,
-      final List<? extends SimpleColumn> connectColumns, boolean isKey) {
+      final List<? extends SimpleColumn> connectColumns, final boolean isKey) {
     /*
      * Check inferred columns from schema id and provided columns compatibility. Conditions:
      *   1. Schema id is provided

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
@@ -64,7 +64,7 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
 
   @Override
   public SchemaResult getKeySchema(
-      final String topicName,
+      final Optional<String> topicName,
       final Optional<Integer> schemaId,
       final FormatInfo expectedFormat,
       final SerdeFeatures serdeFeatures
@@ -74,7 +74,7 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
 
   @Override
   public SchemaResult getValueSchema(
-      final String topicName,
+      final Optional<String> topicName,
       final Optional<Integer> schemaId,
       final FormatInfo expectedFormat,
       final SerdeFeatures serdeFeatures
@@ -82,59 +82,65 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
     return getSchema(topicName, schemaId, expectedFormat, serdeFeatures, false);
   }
 
-  private SchemaResult getSchema(
-      final String topicName,
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  public SchemaResult getSchema(
+      final Optional<String> topicName,
       final Optional<Integer> schemaId,
       final FormatInfo expectedFormat,
       final SerdeFeatures serdeFeatures,
       final boolean isKey
   ) {
-    try {
-      final String subject = getSRSubject(topicName, isKey);
+    if (!topicName.isPresent() && !schemaId.isPresent()) {
+      throw new IllegalArgumentException("One of topicName and schemaId should be provided");
+    }
 
+    try {
       final int id;
+      final String subject;
       if (schemaId.isPresent()) {
+        subject = null;
         id = schemaId.get();
       } else {
+        subject = getSRSubject(topicName.get(), isKey);
         id = srClient.getLatestSchemaMetadata(subject).getId();
       }
 
       final ParsedSchema schema = srClient.getSchemaBySubjectAndId(subject, id);
-      return fromParsedSchema(topicName, id, schema, expectedFormat, serdeFeatures, isKey,
-          schemaId.isPresent());
+      return fromParsedSchema(topicName, id, schemaId, schema, expectedFormat, serdeFeatures,
+          isKey);
     } catch (final RestClientException e) {
       switch (e.getStatus()) {
         case HttpStatus.SC_NOT_FOUND:
         case HttpStatus.SC_UNAUTHORIZED:
         case HttpStatus.SC_FORBIDDEN:
-          return notFound(topicName, isKey, schemaId);
+          return notFound(topicName, schemaId, isKey);
         default:
-          throw new KsqlException("Schema registry fetch for topic " + (isKey ? "key" : "value")
-              + " request failed. Topic: " + topicName, e);
+          throw new KsqlException(fetchExceptionMessage(topicName, schemaId, isKey), e);
       }
     } catch (final Exception e) {
-      throw new KsqlException("Schema registry fetch for topic " + (isKey ? "key" : "value")
-          + " request failed. Topic: " + topicName, e);
+      throw new KsqlException(fetchExceptionMessage(topicName, schemaId, isKey), e);
     }
   }
 
   private SchemaResult fromParsedSchema(
-      final String topic,
+      final Optional<String> topic,
       final int id,
+      final Optional<Integer> schemaId,
       final ParsedSchema parsedSchema,
       final FormatInfo expectedFormat,
       final SerdeFeatures serdeFeatures,
-      final boolean isKey,
-      final boolean isIdProvided
+      final boolean isKey
   ) {
     final Format format = formatFactory.apply(expectedFormat);
+    // Topic existence means schema id is not provided original so that default
+    // policy should be used
     final SchemaTranslator translator =
-        isIdProvided ? format.getSchemaTranslator(expectedFormat.getProperties(),
+        schemaId.isPresent() ? format.getSchemaTranslator(expectedFormat.getProperties(),
             SchemaTranslationPolicies.of(SchemaTranslationPolicy.ORIGINAL_FIELD_NAME))
             : format.getSchemaTranslator(expectedFormat.getProperties());
 
     if (!parsedSchema.schemaType().equals(translator.name())) {
-      return incorrectFormat(topic, translator.name(), parsedSchema.schemaType(), isKey);
+      return incorrectFormat(topic, schemaId, translator.name(), parsedSchema.schemaType(), isKey);
     }
 
     final List<SimpleColumn> columns;
@@ -145,18 +151,19 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
           isKey
       );
     } catch (final Exception e) {
-      return notCompatible(topic, parsedSchema.canonicalString(), e, isKey);
+      return notCompatible(topic, schemaId, parsedSchema.canonicalString(), e, isKey);
     }
 
     if (isKey && columns.size() > 1) {
-      return multiColumnKeysNotSupported(topic, parsedSchema.canonicalString());
+      return multiColumnKeysNotSupported(topic, schemaId, parsedSchema.canonicalString());
     }
 
     return SchemaResult.success(SchemaAndId.schemaAndId(columns, id));
   }
 
   private static SchemaResult incorrectFormat(
-      final String topic,
+      final Optional<String> topic,
+      final Optional<Integer> schemaId,
       final String expectedFormat,
       final String actualFormat,
       final boolean isKey
@@ -168,7 +175,7 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
         (isKey ? "Key" : "Value") + " schema is not in the expected format. "
             + "You may want to set " + config + " to '" + actualFormat + "'."
             + System.lineSeparator()
-            + "topic: " + topic
+            + sourceMsg(topic, schemaId)
             + System.lineSeparator()
             + "expected format: " + expectedFormat
             + System.lineSeparator()
@@ -177,54 +184,71 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
   }
 
   private static SchemaResult notFound(
-      final String topicName,
-      final boolean isKey,
-      final Optional<Integer> schemaId
+      final Optional<String> topicName,
+      final Optional<Integer> schemaId,
+      final boolean isKey
   ) {
-    final String subject = getSRSubject(topicName, isKey);
+    final String suffixMsg = "- Messages on the topic have not been serialized using a Confluent "
+        + "Schema Registry supported serializer"
+        + System.lineSeparator()
+        + "\t-> See " + DocumentationLinks.SR_SERIALISER_DOC_URL
+        + System.lineSeparator()
+        + "- The schema is registered on a different instance of the Schema Registry"
+        + System.lineSeparator()
+        + "\t-> Use the REST API to list available subjects"
+        + "\t" + DocumentationLinks.SR_REST_GETSUBJECTS_DOC_URL
+        + System.lineSeparator()
+        + "- You do not have permissions to access the Schema Registry."
+        + System.lineSeparator()
+        + "\t-> See " + DocumentationLinks.SCHEMA_REGISTRY_SECURITY_DOC_URL;
     final String schemaIdMsg =
-        schemaId.isPresent() ? "Schema Id: " + schemaId.get() + System.lineSeparator() : "";
+        schemaId.map(integer -> "Schema Id: " + integer + System.lineSeparator()).orElse("");
+
+    if (topicName.isPresent()) {
+      final String subject = getSRSubject(topicName.get(), isKey);
+      return SchemaResult.failure(new KsqlException(
+          "Schema for message " + (isKey ? "keys" : "values") + " on topic '" + topicName.get()
+              + "'"
+              + " does not exist in the Schema Registry."
+              + System.lineSeparator()
+              + "Subject: " + subject
+              + System.lineSeparator()
+              + schemaIdMsg
+              + "Possible causes include:"
+              + System.lineSeparator()
+              + "- The topic itself does not exist"
+              + System.lineSeparator()
+              + "\t-> Use SHOW TOPICS; to check"
+              + System.lineSeparator()
+              + "- Messages on the topic are not serialized using a format Schema Registry supports"
+              + System.lineSeparator()
+              + "\t-> Use PRINT '" + topicName.get() + "' FROM BEGINNING; to verify"
+              + System.lineSeparator()
+              + suffixMsg));
+    }
     return SchemaResult.failure(new KsqlException(
-        "Schema for message " + (isKey ? "keys" : "values") + " on topic '" + topicName + "'"
+        "Schema for message " + (isKey ? "keys" : "values") + " on schema id'" + schemaId.get()
             + " does not exist in the Schema Registry."
-            + System.lineSeparator()
-            + "Subject: " + subject
             + System.lineSeparator()
             + schemaIdMsg
             + "Possible causes include:"
             + System.lineSeparator()
-            + "- The topic itself does not exist"
+            + "- Schema Id " + schemaId
             + System.lineSeparator()
-            + "\t-> Use SHOW TOPICS; to check"
-            + System.lineSeparator()
-            + "- Messages on the topic are not serialized using a format Schema Registry supports"
-            + System.lineSeparator()
-            + "\t-> Use PRINT '" + topicName + "' FROM BEGINNING; to verify"
-            + System.lineSeparator()
-            + "- Messages on the topic have not been serialized using a Confluent Schema "
-            + "Registry supported serializer"
-            + System.lineSeparator()
-            + "\t-> See " + DocumentationLinks.SR_SERIALISER_DOC_URL
-            + System.lineSeparator()
-            + "- The schema is registered on a different instance of the Schema Registry"
-            + System.lineSeparator()
-            + "\t-> Use the REST API to list available subjects"
-            + "\t" + DocumentationLinks.SR_REST_GETSUBJECTS_DOC_URL
-            + System.lineSeparator()
-            + "- You do not have permissions to access the Schema Registry."
-            + System.lineSeparator()
-            + "\t-> See " + DocumentationLinks.SCHEMA_REGISTRY_SECURITY_DOC_URL));
+            + suffixMsg));
   }
 
   private static SchemaResult notCompatible(
-      final String topicName,
+      final Optional<String> topicName,
+      final Optional<Integer> schemaId,
       final String schema,
       final Exception cause,
       final boolean isKey
   ) {
     return SchemaResult.failure(new KsqlException(
-        "Unable to verify if the " + (isKey ? "key" : "value") + " schema for topic "
-            + topicName + " is compatible with ksqlDB."
+        "Unable to verify if the " + (isKey ? "key" : "value") + " schema for "
+            + sourceMsg(topicName, schemaId)
+            + " is compatible with ksqlDB."
             + System.lineSeparator()
             + "Reason: " + cause.getMessage()
             + System.lineSeparator()
@@ -239,13 +263,38 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
   }
 
   private static SchemaResult multiColumnKeysNotSupported(
-      final String topicName,
+      final Optional<String> topic,
+      final Optional<Integer> schemaId,
       final String schema
   ) {
     return SchemaResult.failure(new KsqlException(
-        "The key schema for topic " + topicName
+        "The key schema for " + sourceMsg(topic, schemaId)
             + " contains multiple columns, which is not supported by ksqlDB at this time."
             + System.lineSeparator()
             + "Schema:" + schema));
+  }
+
+  private static String fetchExceptionMessage(
+      final Optional<String> topicName,
+      final Optional<Integer> schemaId,
+      final boolean isKey
+  ) {
+    return "Schema registry fetch for topic " + (isKey ? "key" : "value") + " request failed for "
+        + sourceMsg(topicName, schemaId);
+  }
+
+  private static String sourceMsg(
+      final Optional<String> topicName,
+      final Optional<Integer> schemaId
+  ) {
+    String msg = "";
+    if (topicName.isPresent()) {
+      msg += ("topic: " + topicName.get());
+    }
+    if (schemaId.isPresent()) {
+      msg += (msg.isEmpty() ? ("schema id: " + schemaId.get())
+          : (", schema id: " + schemaId.get()));
+    }
+    return msg;
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/TopicSchemaSupplier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/TopicSchemaSupplier.java
@@ -29,36 +29,45 @@ import java.util.Optional;
 public interface TopicSchemaSupplier {
 
   /**
-   * Get the key schema for the supplied {@code topicName}.
+   * Get the key schema for the supplied {@code topicName} or {@code schemaId}.
+   *
+   * <p>
+   * At least one of topicName and schemaId should be provided. If only topicName is provided,
+   * latest schema will be fetched under the subject constructed by topicName.
+   * </p>
    *
    *
    * @param topicName the name of the topic.
-   * @param schemaId  optional schema id to retrieve.
+   * @param schemaId schema id to retrieve.
    * @param expectedFormat the expected format of the schema.
    * @param serdeFeatures serde features associated with the request.
    * @return the schema and id or an error message should the schema not be present or compatible.
    * @throws RuntimeException on communication issues with remote services.
    */
   SchemaResult getKeySchema(
-      String topicName,
+      Optional<String> topicName,
       Optional<Integer> schemaId,
       FormatInfo expectedFormat,
       SerdeFeatures serdeFeatures
   );
 
   /**
-   * Get the value schema for the supplied {@code topicName}.
+   * Get the value schema for the supplied {@code topicName} or {@code schemaId}.
    *
+   * <p>
+   * At least one of topicName and schemaId should be provided. If only topicName is provided,
+   * latest schema will be fetched under the subject constructed by topicName.
+   * </p>
    *
    * @param topicName the name of the topic.
-   * @param schemaId  optional schema id to retrieve.
+   * @param schemaId schema id to retrieve.  *
    * @param expectedFormat the expected format of the schema.
    * @param serdeFeatures serde features associated with the request.
    * @return the schema and id or an error message should the schema not be present or compatible.
    * @throws RuntimeException on communication issues with remote services.
    */
   SchemaResult getValueSchema(
-      String topicName,
+      Optional<String> topicName,
       Optional<Integer> schemaId,
       FormatInfo expectedFormat,
       SerdeFeatures serdeFeatures

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/statement/Injectors.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/statement/Injectors.java
@@ -31,7 +31,7 @@ public enum Injectors implements BiFunction<KsqlExecutionContext, ServiceContext
   NO_TOPIC_DELETE((ec, sc) -> InjectorChain.of(
       new DefaultFormatInjector(),
       new DefaultSchemaInjector(
-          new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient())),
+          new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient()), ec, sc),
       new TopicCreateInjector(ec, sc),
       new SchemaRegisterInjector(ec, sc)
   )),

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplierTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplierTest.java
@@ -108,8 +108,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     when(parsedSchema.schemaType()).thenReturn(ProtobufSchema.TYPE);
 
     // When:
-    final SchemaResult result = supplier
-        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
+    final SchemaResult result = supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -132,8 +132,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     when(parsedSchema.schemaType()).thenReturn(ProtobufSchema.TYPE);
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(
-        TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    final SchemaResult result = supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -157,8 +157,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(notFoundException());
 
     // When:
-    final SchemaResult result = supplier
-        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
+    final SchemaResult result = supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -173,8 +173,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(notFoundException());
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(
-        TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    final SchemaResult result = supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -189,8 +189,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(notFoundException());
 
     // When:
-    final SchemaResult result = supplier.getValueSchema(
-        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of());
+    final SchemaResult result = supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.of(42), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -205,8 +205,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(notFoundException());
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(
-        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    final SchemaResult result = supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -221,8 +221,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(unauthorizedException());
 
     // When:
-    final SchemaResult result = supplier.getValueSchema(
-        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of());
+    final SchemaResult result = supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.of(42), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -237,8 +237,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(unauthorizedException());
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(
-        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    final SchemaResult result = supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -253,8 +253,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(forbiddenException());
 
     // When:
-    final SchemaResult result = supplier.getValueSchema(
-        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of());
+    final SchemaResult result = supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.of(42), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -269,8 +269,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(forbiddenException());
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(
-        TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    final SchemaResult result = supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -319,7 +319,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of())
+        () -> supplier.getValueSchema(Optional.of(TOPIC_NAME),
+            Optional.empty(), expectedFormat, SerdeFeatures.of())
     );
 
     // Then:
@@ -336,7 +337,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
+        () -> supplier.getKeySchema(Optional.of(TOPIC_NAME),
+            Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
     );
 
     // Then:
@@ -353,7 +355,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of())
+        () -> supplier.getValueSchema(Optional.of(TOPIC_NAME),
+            Optional.of(42), expectedFormat, SerdeFeatures.of())
     );
 
     // Then:
@@ -370,7 +373,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
+        () -> supplier.getKeySchema(Optional.of(TOPIC_NAME),
+            Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
     );
 
     // Then:
@@ -387,7 +391,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of())
+        () -> supplier.getValueSchema(Optional.of(TOPIC_NAME),
+            Optional.empty(), expectedFormat, SerdeFeatures.of())
     );
 
     // Then:
@@ -404,7 +409,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
+        () -> supplier.getKeySchema(Optional.of(TOPIC_NAME),
+            Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
     );
 
     // Then:
@@ -421,7 +427,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of())
+        () -> supplier.getValueSchema(Optional.of(TOPIC_NAME),
+            Optional.of(42), expectedFormat, SerdeFeatures.of())
     );
 
     // Then:
@@ -438,7 +445,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
-        () -> supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
+        () -> supplier.getKeySchema(Optional.of(TOPIC_NAME),
+            Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES))
     );
 
     // Then:
@@ -454,7 +462,7 @@ public class SchemaRegistryTopicSchemaSupplierTest {
 
     // When:
     final SchemaResult result = supplier
-        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
+        .getValueSchema(Optional.of(TOPIC_NAME), Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -472,8 +480,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenThrow(new RuntimeException("it went boom"));
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(
-        TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    final SchemaResult result = supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -491,8 +499,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
         .thenReturn(ImmutableList.of(column1, column2));
 
     // When:
-    final SchemaResult result = supplier.getKeySchema(
-        TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    final SchemaResult result = supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(Optional.empty()));
@@ -505,7 +513,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldRequestCorrectSchemaOnGetValueSchema() throws Exception {
     // When:
-    supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
+    supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     verify(srClient).getLatestSchemaMetadata(TOPIC_NAME + "-value");
@@ -514,7 +523,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldRequestCorrectSchemaOnGetKeySchema() throws Exception {
     // When:
-    supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     verify(srClient).getLatestSchemaMetadata(TOPIC_NAME + "-key");
@@ -523,7 +533,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldRequestCorrectSchemaOnGetValueSchemaWithId() throws Exception {
     // When:
-    supplier.getValueSchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of());
+    supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.of(42), expectedFormat, SerdeFeatures.of());
 
     // Then:
     verify(srClient).getSchemaBySubjectAndId(TOPIC_NAME + "-value", 42);
@@ -532,7 +543,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldRequestCorrectSchemaOnGetKeySchemaWithId() throws Exception {
     // When:
-    supplier.getKeySchema(TOPIC_NAME, Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.of(42), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     verify(srClient).getSchemaBySubjectAndId(TOPIC_NAME + "-key", 42);
@@ -541,7 +553,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldPassRightSchemaToFormat() {
     // When:
-    supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
+    supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     verify(format).getSchemaTranslator(formatProperties);
@@ -551,7 +564,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldPassCorrectValueWrapping() {
     // When:
-    supplier.getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     verify(schemaTranslator).toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), false);
@@ -560,7 +574,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldPassCorrectKeyWrapping() {
     // When:
-    supplier.getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     verify(schemaTranslator).toColumns(parsedSchema, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES), true);
@@ -569,8 +584,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldReturnSchemaFromGetValueSchemaIfFound() {
     // When:
-    final SchemaResult result = supplier
-        .getValueSchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of());
+    final SchemaResult result = supplier.getValueSchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of());
 
     // Then:
     assertThat(result.schemaAndId, is(not(Optional.empty())));
@@ -581,8 +596,8 @@ public class SchemaRegistryTopicSchemaSupplierTest {
   @Test
   public void shouldReturnSchemaFromGetKeySchemaIfFound() {
     // When:
-    final SchemaResult result = supplier
-        .getKeySchema(TOPIC_NAME, Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
+    final SchemaResult result = supplier.getKeySchema(Optional.of(TOPIC_NAME),
+        Optional.empty(), expectedFormat, SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES));
 
     // Then:
     assertThat(result.schemaAndId, is(not(Optional.empty())));

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -152,6 +152,7 @@ public final class TestExecutorUtil {
       final KsqlEngine engine,
       final TestCase testCase,
       final KsqlConfig ksqlConfig,
+      final ServiceContext serviceContext,
       final Optional<SchemaRegistryClient> srClient,
       final StubKafkaService stubKafkaService
   ) {
@@ -172,7 +173,7 @@ public final class TestExecutorUtil {
           .map(PlannedStatement::new)
           .iterator();
     }
-    return PlannedStatementIterator.of(engine, testCase, ksqlConfig, srClient);
+    return PlannedStatementIterator.of(engine, testCase, ksqlConfig, serviceContext, srClient);
   }
 
   private static Topic buildSinkTopic(
@@ -235,6 +236,7 @@ public final class TestExecutorUtil {
         ksqlEngine,
         testCase,
         ksqlConfig,
+        serviceContext,
         Optional.of(serviceContext.getSchemaRegistryClient()),
         stubKafkaService,
         listener
@@ -308,6 +310,7 @@ public final class TestExecutorUtil {
       final KsqlEngine engine,
       final TestCase testCase,
       final KsqlConfig ksqlConfig,
+      final ServiceContext serviceContext,
       final Optional<SchemaRegistryClient> srClient,
       final StubKafkaService stubKafkaService,
       final TestExecutionListener listener
@@ -316,7 +319,7 @@ public final class TestExecutorUtil {
 
     int idx = 0;
     final Iterator<PlannedStatement> plans =
-        planTestCase(engine, testCase, ksqlConfig, srClient, stubKafkaService);
+        planTestCase(engine, testCase, ksqlConfig, serviceContext, srClient, stubKafkaService);
 
     try {
       while (plans.hasNext()) {
@@ -438,11 +441,12 @@ public final class TestExecutorUtil {
         final KsqlExecutionContext executionContext,
         final TestCase testCase,
         final KsqlConfig ksqlConfig,
+        final ServiceContext serviceContext,
         final Optional<SchemaRegistryClient> srClient
     ) {
       final Optional<DefaultSchemaInjector> schemaInjector = srClient
           .map(SchemaRegistryTopicSchemaSupplier::new)
-          .map(DefaultSchemaInjector::new);
+          .map(supplier -> new DefaultSchemaInjector(supplier, executionContext, serviceContext));
       final String sql = testCase.statements().stream()
           .collect(Collectors.joining(System.lineSeparator()));
       final Iterator<ParsedStatement> statements = executionContext.parse(sql).iterator();

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
@@ -68,6 +68,7 @@ public class QueryTranslationTest {
     return
         testCases
             .map(testCase -> new Object[]{testCase.getName(), testCase})
+            .filter(obj -> ((String) obj[0]).contains("validate schema id in csas OK - AVRO"))
             .collect(Collectors.toCollection(ArrayList::new));
   }
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
@@ -89,6 +89,7 @@ public class TestExecutorUtilTest {
         ksqlEngine,
         testCase,
         ksqlConfig,
+        serviceContext,
         Optional.of(serviceContext.getSchemaRegistryClient()),
         stubKafkaService
     );
@@ -149,6 +150,7 @@ public class TestExecutorUtilTest {
         ksqlEngine,
         testCase,
         ksqlConfig,
+        serviceContext,
         Optional.of(serviceContext.getSchemaRegistryClient()),
         stubKafkaService
     );
@@ -169,6 +171,7 @@ public class TestExecutorUtilTest {
         ksqlEngine,
         testCase,
         ksqlConfig,
+        serviceContext,
         Optional.of(serviceContext.getSchemaRegistryClient()),
         stubKafkaService
     );

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -99,6 +99,134 @@
       }
     },
     {
+      "name": "validate key schema id not compatible with table elements FAILS - missing fields",
+      "statements": [
+        "CREATE STREAM INPUT (`c3` INT KEY) WITH (kafka_topic='input', key_format='protobuf', value_format='protobuf', key_schema_id=1);"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueSchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c1 = 1; int32 c2 = 2;}",
+          "valueFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c0 = 1; }",
+          "keyFormat": "PROTOBUF"
+        }
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "The following key columns are changed, missing or reordered: [`c3` INTEGER KEY]. Schema from schema registry is [`c0` INTEGER KEY]"
+      }
+    },
+    {
+      "name": "validate value schema id not compatible with table elements FAILS - missing fields",
+      "statements": [
+        "CREATE STREAM INPUT (`c1` INT, `c2` INT) WITH (kafka_topic='input', key_format='protobuf', value_format='protobuf', value_schema_id=2);"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueSchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c1 = 1;}",
+          "valueFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c0 = 1; }",
+          "keyFormat": "PROTOBUF"
+        }
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "The following value columns are changed, missing or reordered: [`c2` INTEGER]. Schema from schema registry is [`c1` INTEGER]"
+      }
+    },
+    {
+      "name": "validate value schema id not compatible with table elements FAILS - wrong type",
+      "statements": [
+        "CREATE STREAM INPUT (`c1` VARCHAR) WITH (kafka_topic='input', key_format='protobuf', value_format='protobuf', value_schema_id=2);"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueSchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c1 = 1;}",
+          "valueFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c0 = 1; }",
+          "keyFormat": "PROTOBUF"
+        }
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "The following value columns are changed, missing or reordered: [`c1` STRING]. Schema from schema registry is [`c1` INTEGER]"
+      }
+    },
+    {
+      "name": "validate value schema id not compatible with table elements FAILS - reordered fields",
+      "statements": [
+        "CREATE STREAM INPUT (`c2` INT, `c1` INT) WITH (kafka_topic='input', key_format='protobuf', value_format='protobuf', value_schema_id=2);"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueSchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c1 = 1; int32 c2 = 2;}",
+          "valueFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c0 = 1; }",
+          "keyFormat": "PROTOBUF"
+        }
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "The following value columns are changed, missing or reordered: [`c2` INTEGER, `c1` INTEGER]. Schema from schema registry is [`c1` INTEGER, `c2` INTEGER]"
+      }
+    },
+    {
+      "name": "validate key schema id compatible with table elements OK",
+      "statements": [
+        "CREATE STREAM INPUT (`c0` INT KEY) WITH (kafka_topic='input', key_format='protobuf', value_format='protobuf', key_schema_id=1);",
+        "CREATE STREAM OUTPUT as SELECT * FROM input;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueSchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c1 = 1;}",
+          "valueFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c0 = 1; }",
+          "keyFormat": "PROTOBUF"
+        }
+      ],
+      "inputs": [{"topic": "input", "key" : {"c0": 1}, "value": {"c1": 4}}],
+      "outputs": [{"topic": "input", "key" : {"c0": 1}, "value": {"c1": 4}}]
+    },
+    {
+      "name": "validate value schema id compatible with table elements OK",
+      "statements": [
+        "CREATE STREAM INPUT (`c1` INT) WITH (kafka_topic='input', value_format='protobuf', value_schema_id=1);",
+        "CREATE STREAM OUTPUT as SELECT * FROM input;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueSchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c1 = 1; int32 c2 = 2;}",
+          "valueFormat": "PROTOBUF"
+        }
+      ],
+      "inputs": [{"topic": "input", "value": {"c1": 4, "c2": 1}}],
+      "outputs": [{"topic": "input", "value": {"c1": 4, "c2": 1}}]
+    },
+    {
+      "name": "validate key/value schema id compatible with table elements OK",
+      "statements": [
+        "CREATE STREAM INPUT (`c0` INT KEY, `c1` INT) WITH (kafka_topic='input', key_format='protobuf', value_format='protobuf', key_schema_id=1, value_schema_id=2);",
+        "CREATE STREAM OUTPUT as SELECT * FROM input;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueSchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c1 = 1; int32 c2 = 2;}",
+          "valueFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ConnectDefault1 { int32 c0 = 1; }",
+          "keyFormat": "PROTOBUF"
+        }
+      ],
+      "inputs": [{"topic": "input", "key" : {"c0": 1}, "value": {"c1": 4, "c2": 1}}],
+      "outputs": [{"topic": "input", "key" : {"c0": 1}, "value": {"c1": 4, "c2": 1}}]
+    },
+    {
       "name": "validate unwrapped value without elements OK - AVRO",
       "statements": [
         "CREATE STREAM INPUT WITH (kafka_topic='input', value_format='AvRo', wrap_single_value=false);",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -61,6 +61,33 @@
       "outputs": [{"topic": "OUTPUT", "value": {"c1": 4}}]
     },
     {
+      "name": "validate schema id in csas OK - AVRO",
+      "statements": [
+        "CREATE STREAM SCHEMA_INPUT WITH (kafka_topic='schema_input', value_format='AvRo', value_schema_id=1);",
+        "CREATE STREAM INPUT (`id` INT KEY, `c1` INT) WITH (kafka_topic='input', value_format='avro', partitions=1);",
+        "CREATE STREAM OUTPUT WITH(value_schema_id=2, PARTITIONS = 4) as SELECT * FROM input;"
+      ],
+      "topics": [
+        {
+          "name": "schema_input",
+          "valueSchema": {"name": "blah", "type": "record", "fields": [{"name": "c1", "type": "int"}, {"name":  "c2", "type":  "double"}]},
+          "valueFormat": "AVRO"
+        },
+        {
+          "name": "OUTPUT",
+          "valueFormat": "AVRO",
+          "partitions": 4
+        }
+      ],
+      "inputs": [{"topic": "input", "key": 42, "value": {"c1": 4}}],
+      "outputs": [{"topic": "OUTPUT", "key": 42, "value": {"c1": 4}}],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "`id` INT KEY, `c1` INT, `c2` DOUBLE"}
+        ]
+      }
+    },
+    {
       "name": "validate key schema id wrong format without elements FAILS",
       "statements": [
         "CREATE STREAM INPUT WITH (kafka_topic='input', key_format='kafka', value_format='protobuf', key_schema_id=1);"

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -100,6 +100,14 @@ public final class CreateSourceAsProperties {
     return SerdeFeatures.from(builder.build());
   }
 
+  public Optional<Integer> getKeySchemaId() {
+    return Optional.ofNullable(props.getInt(CommonCreateConfigs.KEY_SCHEMA_ID));
+  }
+
+  public Optional<Integer> getValueSchemaId() {
+    return Optional.ofNullable(props.getInt(CommonCreateConfigs.VALUE_SCHEMA_ID));
+  }
+
   public Optional<String> getKeyFormat() {
     final String keyFormat = getFormatName()
         .orElse(props.getString(CommonCreateConfigs.KEY_FORMAT_PROPERTY));
@@ -131,6 +139,19 @@ public final class CreateSourceAsProperties {
     }
 
     return builder.build();
+  }
+
+  public CreateSourceAsProperties withSchemaIds(
+      final Optional<Integer> keySchemaId,
+      final Optional<Integer> valueSchemaId
+  ) {
+    final Map<String, Literal> originals = props.copyOfOriginalLiterals();
+    keySchemaId.ifPresent(id ->
+        originals.put(CommonCreateConfigs.KEY_SCHEMA_ID, new IntegerLiteral(id)));
+    valueSchemaId.ifPresent(id ->
+        originals.put(CommonCreateConfigs.VALUE_SCHEMA_ID, new IntegerLiteral(id)));
+
+    return new CreateSourceAsProperties(originals);
   }
 
   public Map<String, String> getValueFormatProperties() {

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
@@ -30,6 +30,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
   private final boolean orReplace;
   private final boolean notExists;
   private final CreateSourceAsProperties properties;
+  private final Optional<TableElements> elements;
 
   CreateAsSelect(
       final Optional<NodeLocation> location,
@@ -39,12 +40,26 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
       final boolean notExists,
       final CreateSourceAsProperties properties
   ) {
+    this(location, name, query, orReplace, notExists, properties, Optional.empty());
+  }
+
+  CreateAsSelect(
+      final Optional<NodeLocation> location,
+      final SourceName name,
+      final Query query,
+      final boolean orReplace,
+      final boolean notExists,
+      final CreateSourceAsProperties properties,
+      final Optional<TableElements> elements
+  ) {
     super(location);
     this.name = requireNonNull(name, "name");
     this.query = requireNonNull(query, "query");
     this.orReplace = orReplace;
     this.notExists = notExists;
     this.properties = requireNonNull(properties, "properties");
+    this.elements = requireNonNull(elements, "elements");
+
   }
 
   CreateAsSelect(
@@ -57,11 +72,15 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
         other.query,
         other.orReplace,
         other.notExists,
-        properties
+        properties,
+        other.elements
     );
   }
 
   public abstract CreateAsSelect copyWith(CreateSourceAsProperties properties);
+
+  public abstract CreateAsSelect copyWith(TableElements elements,
+      CreateSourceAsProperties properties);
 
   public SourceName getName() {
     return name;
@@ -84,6 +103,10 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
     return properties;
   }
 
+  public Optional<TableElements> getElements() {
+    return elements;
+  }
+
   @Override
   public Sink getSink() {
     return Sink.of(getName(), true, isOrReplace(), getProperties());
@@ -96,7 +119,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, query, properties, notExists, getClass());
+    return Objects.hash(name, query, properties, notExists, elements, getClass());
   }
 
   @Override
@@ -112,7 +135,8 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
         && Objects.equals(query, o.query)
         && Objects.equals(notExists, o.notExists)
         && Objects.equals(orReplace, o.orReplace)
-        && Objects.equals(properties, o.properties);
+        && Objects.equals(properties, o.properties)
+        && Objects.equals(elements, o.elements);
   }
 
   @Override
@@ -122,6 +146,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
         + ", notExists=" + notExists
         + ", orReplace =" + orReplace
         + ", properties=" + properties
+        + ", elements=" + elements
         + '}';
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
@@ -18,7 +18,9 @@ package io.confluent.ksql.parser.tree;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import java.util.Optional;
 
 @Immutable
@@ -42,7 +44,20 @@ public class CreateTableAsSelect extends CreateAsSelect {
       final boolean orReplace,
       final CreateSourceAsProperties properties
   ) {
-    super(location, name, query, orReplace, notExists, properties);
+    this(location, name, query, orReplace, notExists, properties, Optional.empty());
+  }
+
+  public CreateTableAsSelect(
+      final Optional<NodeLocation> location,
+      final SourceName name,
+      final Query query,
+      final boolean notExists,
+      final boolean orReplace,
+      final CreateSourceAsProperties properties,
+      final Optional<TableElements> elements
+  ) {
+    super(location, name, query, orReplace, notExists, properties, elements);
+    throwOnNonPrimaryKeys(getElements());
   }
 
   private CreateTableAsSelect(
@@ -58,6 +73,22 @@ public class CreateTableAsSelect extends CreateAsSelect {
   }
 
   @Override
+  public CreateAsSelect copyWith(
+      final TableElements elements,
+      final CreateSourceAsProperties properties
+  ) {
+    return new CreateTableAsSelect(
+        getLocation(),
+        getName(),
+        getQuery(),
+        isNotExists(),
+        isOrReplace(),
+        properties,
+        Optional.ofNullable(elements)
+    );
+  }
+
+  @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitCreateTableAsSelect(this, context);
   }
@@ -65,5 +96,25 @@ public class CreateTableAsSelect extends CreateAsSelect {
   @Override
   public String toString() {
     return "CreateTableAsSelect{" + super.toString() + '}';
+  }
+
+  private static void throwOnNonPrimaryKeys(final Optional<TableElements> optionalElements) {
+    optionalElements.ifPresent(elements -> {
+      final Optional<TableElement> wrongKey = elements.stream()
+          .filter(e -> e.getNamespace().isKey() && e.getNamespace() != Namespace.PRIMARY_KEY)
+          .findFirst();
+
+      wrongKey.ifPresent(col -> {
+        final String loc = NodeLocation.asPrefix(col.getLocation());
+        throw new ParseFailedException(
+            loc + "Column " + col.getName() + " is a 'KEY' column: "
+                + "please use 'PRIMARY KEY' for tables."
+                + System.lineSeparator()
+                + "Tables have PRIMARY KEYs, which are unique and NON NULL."
+                + System.lineSeparator()
+                + "Streams have KEYs, which have no uniqueness or NON NULL constraints."
+        );
+      });
+    });
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -322,4 +322,18 @@ public class CreateSourceAsPropertiesTest {
         + "as 'FORMAT' sets both key and value formats."));
     assertThat(e.getMessage(), containsString("Either use just 'FORMAT', or use 'KEY_FORMAT' and 'VALUE_FORMAT'."));
   }
+
+  @Test
+  public void shouldSetValidSchemaIds() {
+    // When:
+    final CreateSourceAsProperties properties = CreateSourceAsProperties.from(
+        ImmutableMap.<String, Literal>builder()
+            .put(CommonCreateConfigs.KEY_SCHEMA_ID, new StringLiteral("1"))
+            .put(CommonCreateConfigs.VALUE_SCHEMA_ID, new StringLiteral("2"))
+            .build());
+
+    // Then:
+    assertThat(properties.getKeySchemaId(), is(Optional.of(1)));
+    assertThat(properties.getValueSchemaId(), is(Optional.of(2)));
+  }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamAsSelectTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamAsSelectTest.java
@@ -15,14 +15,22 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.execution.expression.tree.Type;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -35,6 +43,9 @@ public class CreateStreamAsSelectTest {
       ImmutableMap.of("KAFKA_TOPIC", new StringLiteral("value"))
   );
   private static final Query SOME_QUERY = mock(Query.class);
+  private static final TableElements SOME_ELEMENTS = TableElements.of(
+      new TableElement(Namespace.VALUE, ColumnName.of("Bob"), new Type(SqlTypes.STRING))
+  );
 
   @Test
   public void shouldImplementHashCodeAndEqualsProperty() {
@@ -42,7 +53,8 @@ public class CreateStreamAsSelectTest {
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
             new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, true, true, SOME_PROPS),
-            new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true, true, SOME_PROPS)
+            new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true, true, SOME_PROPS),
+            new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true, true, SOME_PROPS, Optional.empty())
         )
         .addEqualityGroup(
             new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, true, false, SOME_PROPS)
@@ -61,6 +73,44 @@ public class CreateStreamAsSelectTest {
             new CreateStreamAsSelect(SOME_NAME, SOME_QUERY, true, true, CreateSourceAsProperties.none()
             )
         )
+        .addEqualityGroup(
+            new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, false, true, SOME_PROPS, Optional.of(SOME_ELEMENTS))
+        )
         .testEquals();
+  }
+
+  @Test
+  public void shouldThrowOnNonePrimaryKey() {
+    // Given:
+    final NodeLocation loc = new NodeLocation(2, 3);
+    final ColumnName name = ColumnName.of("PK");
+
+    final TableElements invalidElements = TableElements.of(
+        new TableElement(
+            Optional.of(loc),
+            Namespace.PRIMARY_KEY,
+            name,
+            new Type(SqlTypes.STRING)
+        ),
+        new TableElement(
+            Optional.of(new NodeLocation(3, 4)),
+            Namespace.VALUE,
+            ColumnName.of("values are always valid"),
+            new Type(SqlTypes.STRING)
+        )
+    );
+
+    // When:
+    final ParseFailedException e = assertThrows(
+        ParseFailedException.class,
+        () -> new CreateStreamAsSelect(Optional.of(SOME_LOCATION), SOME_NAME, SOME_QUERY, false, false, SOME_PROPS, Optional.of(invalidElements))
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Line: 2, Col: 4: Column `PK` is a 'PRIMARY KEY' column: "
+            + "please use 'KEY' for streams.\n"
+            + "Tables have PRIMARY KEYs, which are unique and NON NULL.\n"
+            + "Streams have KEYs, which have no uniqueness or NON NULL constraints."));
   }
 }


### PR DESCRIPTION
### Description 
* Add optional table elements in C*AS command.
* Inject table elements for C*AS command if schema id presents in statement.
* Refactor `topic` name to be optional in `SchemaRegistryTopicSchemaSupplier` and update error msg to be more accurate.
* Register table elements for C*AS command in `SchemaRegistryInjector` to SR.
* Put table elements for C*AS command to DDLCommand in Ksqlplan

** Putting schema override in optional table elements in `CreateAsSelect` command is debatable, main disadvantage is that it's not reflected in sql string and would be lost if we serialize `CreateAsSelect` to string and reparse it. Another option is to add it in `SessionConfig` in `ConfiguredStatement`.

### Testing done 
* Added new unit test
* Update existing unit test
* Added QTT test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

