### PR TITLE
docs: Removed extra blank lines in the middle of sentence

### DIFF
--- a/docs/developer-guide/ksqldb-reference/aggregate-functions.md
+++ b/docs/developer-guide/ksqldb-reference/aggregate-functions.md
@@ -112,12 +112,10 @@ EARLIEST_BY_OFFSET(col1, [ignoreNulls])
 Stream
 
 Return the earliest value for the specified column. The earliest value in the partition
-
 has the lowest offset. 
 
 
 The optional `ignoreNulls` parameter, available since version 0.13.0, controls whether nulls are ignored. The default
-
 is to ignore null values.
 
 
@@ -131,12 +129,10 @@ EARLIEST_BY_OFFSET(col1, earliestN, [ignoreNulls])
 Stream
 
 Return the earliest _N_ values for the specified column as an `ARRAY`. The earliest values
-
 in the partition have the lowest offsets.
 
 
 The optional `ignoreNulls` parameter controls whether nulls are ignored. The default
-
 is to ignore null values.
 
 
@@ -173,12 +169,10 @@ LATEST_BY_OFFSET(col1, [ignoreNulls])
 Stream
 
 Return the latest value for the specified column. The latest value in the partition
-
 has the largest offset. 
 
 
 The optional `ignoreNulls` parameter, available since version 0.13.0, controls whether nulls are ignored. The default
-
 is to ignore null values.
 
 
@@ -191,12 +185,10 @@ LATEST_BY_OFFSET(col1, latestN, [ignoreNulls])
 Stream
 
 Returns the latest _N_ values for the specified column as an `ARRAY`. The latest values have
-
 the largest offset.
 
 
 The optional `ignoreNulls` parameter controls whether nulls are ignored. The default is to ignore
-
 null values. 
 
 ## `MAX`


### PR DESCRIPTION
### Description 

The aggregate function docs has [blank lines in the middle of the sentence](https://docs.ksqldb.io/en/latest/developer-guide/ksqldb-reference/aggregate-functions/#earliest_by_offset) which causes it to appear split as shown below. 

<img width="778" alt="Screen Shot 2021-10-28 at 7 46 05 PM" src="https://user-images.githubusercontent.com/8467404/139351113-caf09cf0-da72-45fa-9fc7-7db5b46fd181.png">

Removed the extra blank lines.

### Testing done 
Only docs change, no code change.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

