### PR TITLE
feat: [UIF-1010] Add swiftype metatag for site of ksqldb

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <meta class="swiftype" name="site-id" data-type="integer" content="4" />
+{% endblock %}


### PR DESCRIPTION
### Description
https://confluentinc.atlassian.net/browse/UIF-1010

In order to support more sophisticated, faceted search in docs.confluent.io, we are looking at adding some meta tags to a number of websites that are currently included in docs' swiftype search engine. This will allow search results to be targeted at specific sites (and languages).  

The following sites are involved:

Site | Id
-- | --
https://docs.confluent.io/ | 1
https://www.confluent.io/blog/ | 2
https://developer.confluent.io/ | 3
https://docs.ksqldb.io/en/latest/ | 4
https://kafka-tutorials.confluent.io/ | 5
https://api.telemetry.confluent.cloud/docs | 6

The change involved is minimal and would be to add the following meta tag into the main template file of each site:
`<meta class="swiftype" name="site-id" data-type="integer" content="4" />`

Please let me know if there is any issue that you foresee with this change or if you have any questions. 
  
Additional reading: https://swiftype.com/documentation/site-search/guides/schema-design#crawler

![Screen Shot 2021-11-01 at 4 23 18 PM](https://user-images.githubusercontent.com/3315522/139755106-c785b655-27ad-48f0-bd9b-0efd4137f2a8.png)


