### PR TITLE
fix: dont throw error on processing local commands, just log 

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/LocalCommands.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/LocalCommands.java
@@ -87,8 +87,8 @@ public class LocalCommands implements Closeable {
 
         markFileAsProcessed(file);
       } catch (Exception e) {
-        LOG.error("Error processing local commands " + file.getAbsolutePath(), e);
-        throw new KsqlServerException("Error processing local commands", e);
+        LOG.error("Error processing local commands " + file.getAbsolutePath()
+                + ". There may be orphaned transient topics or abandoned state stores.", e);
       }
     }
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsTest.java
@@ -187,7 +187,7 @@ public class LocalCommandsTest {
   }
 
   @Test
-  public void shouldFailToCleanup() throws IOException {
+  public void shouldNotFailToCleanup() throws IOException {
     // Given
     final File dir = commandsDir.newFolder();
     LocalCommands localCommands = LocalCommands.open(ksqlEngine, dir);
@@ -199,13 +199,9 @@ public class LocalCommandsTest {
     LocalCommands localCommands2 = LocalCommands.open(ksqlEngine, dir);
     localCommands2.write(metadata3);
     // Need to create a new local commands in order not to skip the "current" file we just wrote.
-    final Exception e = assertThrows(
-        KsqlServerException.class,
-        () -> localCommands2.processLocalCommandFiles(serviceContext)
-    );
+    localCommands2.processLocalCommandFiles(serviceContext);
 
-    // Then
-    assertThat(e.getMessage(), containsString("Error processing local commands"));
+    // Then no exception should be thrown
     verify(ksqlEngine).cleanupOrphanedInternalTopics(any(), eq(ImmutableSet.of(QUERY_APP_ID1)));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsTest.java
@@ -187,12 +187,11 @@ public class LocalCommandsTest {
   }
 
   @Test
-  public void shouldNotFailToCleanup() throws IOException {
+  public void shouldNotThrowWhenFailToCleanup() throws IOException {
     // Given
     final File dir = commandsDir.newFolder();
     LocalCommands localCommands = LocalCommands.open(ksqlEngine, dir);
-    doThrow(new RuntimeException("Error")).when(ksqlEngine)
-        .cleanupOrphanedInternalTopics(any(), any());
+    doThrow(new KsqlServerException("Error")).when(localCommandsFile).readRecords();
 
     // When
     localCommands.write(metadata1);


### PR DESCRIPTION
### Description 
We had multiple on call incidents where a race condition occurs when writing to the local commands file which corrupts it. Processing this corrupt local commands file on startup kills the ksqldb app. The local commands is meant to only be a best effort attempt at cleaning up orphaned transient topics #6714 and abandoned state stores #6720, so we should not kill the ksqldb app if we fail to clean these up. Instead of throwing an error we now simply just log the error and continue on. 

Follow up work will be done to log the race conditions that result in the corrupted local commands file. 

Updated unit tests
