### PR TITLE
chore: bump command version from 10 to 11 for v0.23

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 public class Command {
 
   @VisibleForTesting
-  public static final int VERSION = 10;
+  public static final int VERSION = 11;
 
   private final String statement;
   private final Map<String, Object> overwriteProperties;


### PR DESCRIPTION
### Description 
Command version in 0.22.0 release is 10. We need to bump it to 11 for 0.23.
