### PR TITLE
feat: add HEADERS column type to syntax

### DIFF
--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -127,7 +127,11 @@ tableElements
     ;
 
 tableElement
-    : identifier type ((PRIMARY)? KEY)?
+    : identifier type (((PRIMARY)? KEY) | headerType)?
+    ;
+
+headerType
+    : HEADERS
     ;
 
 tableProperties
@@ -538,6 +542,7 @@ ADD: 'ADD';
 ALTER: 'ALTER';
 VARIABLES: 'VARIABLES';
 PLUGINS: 'PLUGINS';
+HEADERS: 'HEADERS';
 
 IF: 'IF';
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -152,6 +152,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Statements;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UndefineVariable;
@@ -1242,7 +1243,7 @@ public class AstBuilder {
     public Node visitTableElement(final SqlBaseParser.TableElementContext context) {
       return new TableElement(
           getLocation(context),
-          TableElement.getNamespaceFromContext(context),
+          Namespace.of(context),
           ColumnName.of(ParserUtil.getIdentifierText(context.identifier())),
           typeParser.getType(context.type())
       );

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -152,7 +152,6 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Statements;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UndefineVariable;
@@ -1243,9 +1242,7 @@ public class AstBuilder {
     public Node visitTableElement(final SqlBaseParser.TableElementContext context) {
       return new TableElement(
           getLocation(context),
-          context.KEY() == null
-              ? Namespace.VALUE
-              : context.PRIMARY() == null ? Namespace.KEY : Namespace.PRIMARY_KEY,
+          TableElement.getNamespaceFromContext(context),
           ColumnName.of(ParserUtil.getIdentifierText(context.identifier())),
           typeParser.getType(context.type())
       );

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.util.KsqlException;
@@ -87,9 +86,7 @@ public final class SchemaParser {
         .stream()
         .map(ctx -> new TableElement(
             getLocation(ctx),
-            ctx.KEY() == null
-                ? Namespace.VALUE
-                : ctx.PRIMARY() == null ? Namespace.KEY : Namespace.PRIMARY_KEY,
+            TableElement.getNamespaceFromContext(ctx),
             ColumnName.of(ParserUtil.getIdentifierText(ctx.identifier())),
             typeParser.getType(ctx.type())
         ))

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.TableElement;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.util.KsqlException;
@@ -86,7 +87,7 @@ public final class SchemaParser {
         .stream()
         .map(ctx -> new TableElement(
             getLocation(ctx),
-            TableElement.getNamespaceFromContext(ctx),
+            Namespace.of(ctx),
             ColumnName.of(ParserUtil.getIdentifierText(ctx.identifier())),
             typeParser.getType(ctx.type())
         ))

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -705,6 +705,9 @@ public final class SqlFormatter {
         case KEY:
           postFix = " KEY";
           break;
+        case HEADERS:
+          postFix = " HEADERS";
+          break;
         default:
           postFix = "";
           break;

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
@@ -52,6 +52,15 @@ public final class TableElement extends AstNode {
     public boolean isKey() {
       return this == KEY || this == PRIMARY_KEY;
     }
+
+    public static Namespace of(final SqlBaseParser.TableElementContext context) {
+      if (context.headerType() != null) {
+        return Namespace.HEADERS;
+      }
+      return context.KEY() == null
+          ? Namespace.VALUE
+          : context.PRIMARY() == null ? Namespace.KEY : Namespace.PRIMARY_KEY;
+    }
   }
 
   private final Namespace namespace;
@@ -132,14 +141,5 @@ public final class TableElement extends AstNode {
         + ", type=" + type
         + ", namespace=" + namespace
         + '}';
-  }
-
-  public static Namespace getNamespaceFromContext(final SqlBaseParser.TableElementContext context) {
-    if (context.headerType() != null) {
-      return Namespace.HEADERS;
-    }
-    return context.KEY() == null
-        ? Namespace.VALUE
-        : context.PRIMARY() == null ? Namespace.KEY : Namespace.PRIMARY_KEY;
   }
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
@@ -21,6 +21,7 @@ import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
+import io.confluent.ksql.parser.SqlBaseParser;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -42,10 +43,14 @@ public final class TableElement extends AstNode {
     /**
      * Non-key colunns:
      */
-    VALUE;
+    VALUE,
+    /**
+     * Header-backed columns
+     */
+    HEADERS;
 
     public boolean isKey() {
-      return this != VALUE;
+      return this == KEY || this == PRIMARY_KEY;
     }
   }
 
@@ -127,5 +132,14 @@ public final class TableElement extends AstNode {
         + ", type=" + type
         + ", namespace=" + namespace
         + '}';
+  }
+
+  public static Namespace getNamespaceFromContext(final SqlBaseParser.TableElementContext context) {
+    if (context.headerType() != null) {
+      return Namespace.HEADERS;
+    }
+    return context.KEY() == null
+        ? Namespace.VALUE
+        : context.PRIMARY() == null ? Namespace.KEY : Namespace.PRIMARY_KEY;
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -53,6 +54,7 @@ import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.Select;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Table;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.schema.Operator;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -865,5 +867,18 @@ public class AstBuilderTest {
             ParseFailedException.class,
             () -> givenQuery("CREATE STREAM INPUT (K BIGINT (KEY)) WITH (kafka_topic='input',value_format='JSON');")
     );
+  }
+
+  @Test
+  public void shouldSupportHeadersColumns() {
+    // Given:
+    final SingleStatementContext stmt
+        = givenQuery("CREATE STREAM INPUT (K BIGINT HEADERS) WITH (kafka_topic='input',value_format='JSON');");
+
+    // When:
+    final CreateStream createStream = (CreateStream) builder.buildStatement(stmt);
+
+    // Then:
+    assertEquals(createStream.getElements().stream().findFirst().get().getNamespace(), Namespace.HEADERS);
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SchemaParserTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SchemaParserTest.java
@@ -99,6 +99,21 @@ public class SchemaParserTest {
   }
 
   @Test
+  public void shouldParseValidSchemaWithHeaderField() {
+    // Given:
+    final String schema = "K STRING HEADERS, bar INT";
+
+    // When:
+    final TableElements elements = parser.parse(schema);
+
+    // Then:
+    assertThat(elements, contains(
+        new TableElement(Namespace.HEADERS, ColumnName.of("K"), new Type(SqlTypes.STRING)),
+        new TableElement(Namespace.VALUE, BAR, new Type(SqlTypes.INTEGER))
+    ));
+  }
+
+  @Test
   public void shouldParseQuotedSchema() {
     // Given:
     final String schema = "`END` VARCHAR";

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -140,6 +140,11 @@ public class SqlFormatterTest {
           CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("topic_test"))
   );
 
+  private static final TableElements ELEMENTS_WITH_HEADER = TableElements.of(
+      new TableElement(Namespace.HEADERS, ColumnName.of("k3"), new Type(SqlTypes.STRING)),
+      new TableElement(Namespace.VALUE, ColumnName.of("Foo"), new Type(SqlTypes.STRING))
+  );
+  
   private static final TableElements ELEMENTS_WITH_KEY = TableElements.of(
       new TableElement(Namespace.KEY, ColumnName.of("k3"), new Type(SqlTypes.STRING)),
       new TableElement(Namespace.VALUE, ColumnName.of("Foo"), new Type(SqlTypes.STRING))
@@ -220,6 +225,25 @@ public class SqlFormatterTest {
     );
 
     metaStore.putSource(ksqlTableTable, false);
+  }
+
+  @Test
+  public void shouldFormatCreateStreamStatementWithHeader() {
+    // Given:
+    final CreateStream createStream = new CreateStream(
+        TEST,
+        ELEMENTS_WITH_HEADER,
+        false,
+        false,
+        SOME_WITH_PROPS,
+        false);
+
+    // When:
+    final String sql = SqlFormatter.formatSql(createStream);
+
+    // Then:
+    assertThat(sql, is("CREATE STREAM TEST (`k3` STRING HEADERS, `Foo` STRING) "
+        + "WITH (KAFKA_TOPIC='topic_test', VALUE_FORMAT='JSON');"));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static io.confluent.ksql.parser.tree.TableElement.Namespace.HEADERS;
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.KEY;
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.PRIMARY_KEY;
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.VALUE;
@@ -55,6 +56,9 @@ public class TableElementTest {
         )
         .addEqualityGroup(
             new TableElement(PRIMARY_KEY, NAME, new Type(SqlTypes.STRING))
+        )
+        .addEqualityGroup(
+            new TableElement(HEADERS, NAME, new Type(SqlTypes.STRING))
         )
         .testEquals();
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static io.confluent.ksql.parser.tree.TableElement.Namespace.HEADERS;
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.KEY;
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.PRIMARY_KEY;
 import static io.confluent.ksql.parser.tree.TableElement.Namespace.VALUE;
@@ -96,12 +97,37 @@ public class TableElementsTest {
   }
 
   @Test
+  public void shouldThrowOnDuplicateHeaderColumns() {
+    // Given:
+    final List<TableElement> elements = ImmutableList.of(
+        tableElement(KEY, "k0", STRING_TYPE),
+        tableElement(KEY, "k0", STRING_TYPE),
+        tableElement(KEY, "k1", STRING_TYPE),
+        tableElement(PRIMARY_KEY, "k1", STRING_TYPE)
+    );
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> TableElements.of(elements)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Duplicate column names:"));
+    assertThat(e.getMessage(), containsString(
+        "k0"));
+    assertThat(e.getMessage(), containsString(
+        "k1"));
+  }
+
+  @Test
   public void shouldThrowOnDuplicateValueColumns() {
     // Given:
     final List<TableElement> elements = ImmutableList.of(
-        tableElement(VALUE, "v0", INT_TYPE),
-        tableElement(VALUE, "v0", INT_TYPE),
-        tableElement(VALUE, "v1", INT_TYPE),
+        tableElement(HEADERS, "v0", INT_TYPE),
+        tableElement(HEADERS, "v0", INT_TYPE),
+        tableElement(HEADERS, "v1", INT_TYPE),
         tableElement(VALUE, "v1", INT_TYPE)
     );
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
@@ -100,9 +100,9 @@ public class TableElementsTest {
   public void shouldThrowOnDuplicateHeaderColumns() {
     // Given:
     final List<TableElement> elements = ImmutableList.of(
-        tableElement(KEY, "k0", STRING_TYPE),
-        tableElement(KEY, "k0", STRING_TYPE),
-        tableElement(KEY, "k1", STRING_TYPE),
+        tableElement(HEADERS, "k0", STRING_TYPE),
+        tableElement(HEADERS, "k0", STRING_TYPE),
+        tableElement(HEADERS, "k1", STRING_TYPE),
         tableElement(PRIMARY_KEY, "k1", STRING_TYPE)
     );
 
@@ -125,9 +125,9 @@ public class TableElementsTest {
   public void shouldThrowOnDuplicateValueColumns() {
     // Given:
     final List<TableElement> elements = ImmutableList.of(
-        tableElement(HEADERS, "v0", INT_TYPE),
-        tableElement(HEADERS, "v0", INT_TYPE),
-        tableElement(HEADERS, "v1", INT_TYPE),
+        tableElement(VALUE, "v0", INT_TYPE),
+        tableElement(VALUE, "v0", INT_TYPE),
+        tableElement(VALUE, "v1", INT_TYPE),
         tableElement(VALUE, "v1", INT_TYPE)
     );
 

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/util/GrammarTokenExporterTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/util/GrammarTokenExporterTest.java
@@ -40,8 +40,8 @@ public class GrammarTokenExporterTest {
       "MAP", "SET", "DEFINE", "UNDEFINE", "RESET", "SESSION", "SAMPLE", "EXPORT",
       "CATALOG", "PROPERTIES", "BEGINNING", "UNSET", "RUN", "SCRIPT", "DECIMAL",
       "KEY", "CONNECTOR", "CONNECTORS", "SINK", "SOURCE", "NAMESPACE", "MATERIALIZED",
-      "VIEW", "PRIMARY", "REPLACE", "ASSERT", "ADD", "ALTER", "VARIABLES", "PLUGINS", "IF",
-      "EQ", "NEQ", "LT", "LTE", "GT", "GTE", "PLUS", "MINUS", "ASTERISK", "SLASH",
+      "VIEW", "PRIMARY", "REPLACE", "ASSERT", "ADD", "ALTER", "VARIABLES", "PLUGINS", "HEADERS",
+      "IF", "EQ", "NEQ", "LT", "LTE", "GT", "GTE", "PLUS", "MINUS", "ASTERISK", "SLASH",
       "PERCENT", "CONCAT", "ASSIGN", "STRING", "IDENTIFIER", "VARIABLE", "EXPONENT",
       "DIGIT", "LETTER", "WS"));
 


### PR DESCRIPTION
### Description 
Adds `HEADERS` as a column type (like `KEY` or `PRIMARY KEY`) as a part of https://github.com/confluentinc/ksql/pull/8293

At some point in the future, changes will be made to
1. Reject `HEADERS` columns that are not of type `ARRAY<STRUCT<key STRING, value BYTES>>`
2. Add `HEADER(key)` to the syntax

### Testing done 
Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

