### PR TITLE
docs: cherry-pick: bump mkdocs from 1.1.2 to 1.2.3 in /docs (DOCS-10740)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs==1.1.2
+mkdocs==1.2.3
 mdx_gh_links==0.2
-mkdocs-macros-plugin==0.5.0
+mkdocs-macros-plugin==0.6.0
 mkdocs-git-revision-date-plugin==0.3.1
 pymdown-extensions==8.1
 Pygments==2.7.4


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/8316.

* chore(deps): bump mkdocs from 1.1.2 to 1.2.3 in /docs

Bumps [mkdocs](https://github.com/mkdocs/mkdocs) from 1.1.2 to 1.2.3.
- [Release notes](https://github.com/mkdocs/mkdocs/releases)
- [Commits](https://github.com/mkdocs/mkdocs/compare/1.1.2...1.2.3)

---
updated-dependencies:
- dependency-name: mkdocs
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

* docs: update mkdocs-macros-plugin to 0.6.0

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Jim Galasyn <jim.galasyn@confluent.io>

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

