### PR TITLE
fix: if not exists return type

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
@@ -37,6 +37,10 @@ final class DdlDmlResponseHandlers {
       final JsonObject ksqlEntity,
       final CompletableFuture<ExecuteStatementResult> cf
   ) {
+    if (isIfNotExistsWarning(ksqlEntity)) {
+      cf.complete(new ExecuteStatementResultImpl(Optional.empty()));
+      return;
+    }
     if (!isCommandStatusEntity(ksqlEntity)) {
       handleUnexpectedEntity(ksqlEntity, cf);
       return;
@@ -66,6 +70,13 @@ final class DdlDmlResponseHandlers {
   private static boolean isCommandStatusEntity(final JsonObject ksqlEntity) {
     return ksqlEntity.getString("commandId") != null
         && ksqlEntity.getJsonObject("commandStatus") != null;
+  }
+
+  private static boolean isIfNotExistsWarning(final JsonObject ksqlEntity) {
+    return ksqlEntity.getString("statementText") != null
+        && ksqlEntity.getString("statementText").contains("IF NOT EXISTS")
+        && ksqlEntity.getString("message") != null
+        && ksqlEntity.getString("message").contains("A stream with the same name already exists.");
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
@@ -38,7 +38,7 @@ final class DdlDmlResponseHandlers {
       final CompletableFuture<ExecuteStatementResult> cf
   ) {
     if (isIfNotExistsWarning(ksqlEntity)) {
-      cf.complete(new ExecuteStatementResultImpl(Optional.of(ksqlEntity.getString("message"))));
+      cf.complete(new ExecuteStatementResultImpl(Optional.empty()));
       return;
     }
     if (!isCommandStatusEntity(ksqlEntity)) {

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
@@ -38,7 +38,7 @@ final class DdlDmlResponseHandlers {
       final CompletableFuture<ExecuteStatementResult> cf
   ) {
     if (isIfNotExistsWarning(ksqlEntity)) {
-      cf.complete(new ExecuteStatementResultImpl(Optional.empty()));
+      cf.complete(new ExecuteStatementResultImpl(Optional.of(ksqlEntity.getString("message"))));
       return;
     }
     if (!isCommandStatusEntity(ksqlEntity)) {
@@ -75,9 +75,8 @@ final class DdlDmlResponseHandlers {
   private static boolean isIfNotExistsWarning(final JsonObject ksqlEntity) {
     return ksqlEntity.getString("statementText") != null
         && ksqlEntity.getString("statementText").contains("IF NOT EXISTS")
-        && ksqlEntity.getString("message") != null
-        && ksqlEntity.getString("message").contains("with the same name already exists.")
-        && ksqlEntity.getString("warnings") != null;
+        && ksqlEntity.getString("@type") != null
+        && ksqlEntity.getString("@type").equals("warning_entity");
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/DdlDmlResponseHandlers.java
@@ -76,7 +76,8 @@ final class DdlDmlResponseHandlers {
     return ksqlEntity.getString("statementText") != null
         && ksqlEntity.getString("statementText").contains("IF NOT EXISTS")
         && ksqlEntity.getString("message") != null
-        && ksqlEntity.getString("message").contains("A stream with the same name already exists.");
+        && ksqlEntity.getString("message").contains("with the same name already exists.")
+        && ksqlEntity.getString("warnings") != null;
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -805,7 +805,9 @@ public class ClientTest extends BaseApiTest {
 
 
     // Then
-    assertThat(result.queryId(), equalTo(Optional.empty()));
+    assertThat(result.queryId(),
+        equalTo(Optional.of("Cannot add stream `HIGH_VALUE_STOCK_TRADES`: A stream with the same name already exists."
+        )));
   }
 
   @Test

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -806,8 +806,7 @@ public class ClientTest extends BaseApiTest {
 
     // Then
     assertThat(result.queryId(),
-        equalTo(Optional.of("Cannot add stream `HIGH_VALUE_STOCK_TRADES`: A stream with the same name already exists."
-        )));
+        equalTo(Optional.empty()));
   }
 
   @Test

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.api.client.QueryInfo.QueryType;
 import io.confluent.ksql.api.client.exception.KsqlClientException;
 import io.confluent.ksql.api.client.exception.KsqlException;
 import io.confluent.ksql.api.client.impl.ConnectorTypeImpl;
+import io.confluent.ksql.api.client.impl.ExecuteStatementResultImpl;
 import io.confluent.ksql.api.client.impl.StreamedQueryResultImpl;
 import io.confluent.ksql.api.client.util.ClientTestUtil;
 import io.confluent.ksql.api.client.util.ClientTestUtil.TestSubscriber;
@@ -84,6 +85,7 @@ import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.entity.TypeList;
+import io.confluent.ksql.rest.entity.WarningEntity;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.util.AppInfo;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryStatus;
@@ -787,6 +789,23 @@ public class ClientTest extends BaseApiTest {
     assertThat(e.getCause(), instanceOf(KsqlClientException.class));
     assertThat(e.getCause().getMessage(), containsString("Received 500 response from server"));
     assertThat(e.getCause().getMessage(), containsString("something bad"));
+  }
+
+  @Test
+  public void shouldHandleIfNotExistsWarningResponseFromExecuteStatement() throws Exception {
+    // Given
+    KsqlEntity ksqlEntity = new WarningEntity(
+        "CREATE STREAM IF NOT EXISTS ",
+        "Cannot add stream `HIGH_VALUE_STOCK_TRADES`: A stream with the same name already exists."
+    );
+    testEndpoints.setKsqlEndpointResponse(Collections.singletonList(ksqlEntity));
+
+
+    final ExecuteStatementResult result = javaClient.executeStatement("CSAS;").get();
+
+
+    // Then
+    assertThat(result.queryId(), equalTo(Optional.empty()));
   }
 
   @Test

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.api.client.ColumnType;
 import io.confluent.ksql.api.client.ConnectorDescription;
 import io.confluent.ksql.api.client.ConnectorInfo;
 import io.confluent.ksql.api.client.ConnectorType;
+import io.confluent.ksql.api.client.ExecuteStatementResult;
 import io.confluent.ksql.api.client.KsqlArray;
 import io.confluent.ksql.api.client.KsqlObject;
 import io.confluent.ksql.api.client.QueryInfo;
@@ -317,6 +318,18 @@ public class ClientIntegrationTest {
     for (final StreamedQueryResult streamedQueryResult : streamedQueryResults) {
       assertThat(streamedQueryResult.isComplete(), is(false));
     }
+  }
+
+  @Test
+  public void shouldOnlyWarnForDuplicateIfNotExists() throws Exception {
+    // When
+    ExecuteStatementResult result;
+    client.executeStatement("CREATE STREAM FOO (id INT KEY, bar VARCHAR) WITH(value_format='json', kafka_topic='foo', partitions=6);").get();
+    client.executeStatement("CREATE STREAM IF NOT EXISTS BAR AS SELECT * FROM FOO EMIT CHANGES;").get();
+    result = client.executeStatement("CREATE STREAM IF NOT EXISTS BAR AS SELECT * FROM FOO EMIT CHANGES;").get();
+
+    //Then
+    assertThat(result.queryId().get(), is("Cannot add stream `BAR`: A stream with the same name already exists."));
   }
 
   @Test

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -329,7 +329,7 @@ public class ClientIntegrationTest {
     result = client.executeStatement("CREATE STREAM IF NOT EXISTS BAR AS SELECT * FROM FOO EMIT CHANGES;").get();
 
     //Then
-    assertThat(result.queryId().get(), is("Cannot add stream `BAR`: A stream with the same name already exists."));
+    assertThat(result.queryId(), is(Optional.empty()));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestEndpoints.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
@@ -55,7 +56,7 @@ public class TestEndpoints implements Endpoints {
 
   private Supplier<RowGenerator> rowGeneratorFactory;
   private TestInsertsSubscriber insertsSubscriber;
-  private List<KsqlEntity> ksqlEndpointResponse;
+  private KsqlEntityList ksqlEndpointResponse;
   private String lastSql;
   private JsonObject lastProperties;
   private JsonObject lastSessionVariables;
@@ -241,7 +242,7 @@ public class TestEndpoints implements Endpoints {
   }
 
   public synchronized void setKsqlEndpointResponse(final List<KsqlEntity> entities) {
-    this.ksqlEndpointResponse = ImmutableList.copyOf(entities);
+    this.ksqlEndpointResponse = new KsqlEntityList(ImmutableList.copyOf(entities));
   }
 
   public synchronized String getLastSql() {


### PR DESCRIPTION
```
ksql> CREATE STREAM IF NOT EXISTS BAR AS SELECT * FROM FOO EMIT CHANGES;

 Message                                                              
----------------------------------------------------------------------
 Cannot add stream `BAR`: A stream with the same name already exists. 
----------------------------------------------------------------------
ksql> CREATE STREAM FOO (id INT KEY, bar VARCHAR) WITH(value_format='json', kafka_topic='foo', partitions=6);
Cannot add stream 'FOO': A stream with the same name already exists
ksql> 

```

