### PR TITLE
test: add BytesLiteral as immutable type everywhere

### DIFF
--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/ImmutabilityTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.cli;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,6 +76,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedStream.class)
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/functional/ImmutabilityTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/functional/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.test.functional;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -77,6 +78,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
         .withKnownImmutableType(Windows.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }

--- a/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/ImmutabilityTest.java
+++ b/ksqldb-metastore/src/test/java/io/confluent/ksql/metastore/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.metastore;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,6 +76,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedStream.class)
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/ImmutabilityTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.parser;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,6 +76,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedStream.class)
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/app/ImmutabilityTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/app/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.app;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,6 +76,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedStream.class)
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/ImmutabilityTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.client;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,6 +76,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedStream.class)
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/ImmutabilityTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.execution.streams;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,6 +76,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedStream.class)
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }

--- a/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/ImmutabilityTest.java
+++ b/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/ImmutabilityTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.version.metrics;
 
+import io.confluent.ksql.execution.expression.tree.BytesLiteral;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.util.Collection;
 import java.util.Objects;
@@ -75,6 +76,7 @@ public class ImmutabilityTest {
         .withKnownImmutableType(KGroupedStream.class)
         .withKnownImmutableType(KGroupedTable.class)
         .withKnownImmutableType(Serde.class)
+        .withKnownImmutableType(BytesLiteral.class)
         .test(modelClass);
   }
 }


### PR DESCRIPTION
### Description 
Add BytesLiteral to all the immutability tests in packages that depend on `ksqldb-execution` so that `mvn test` and intellij runs would pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

