### PR TITLE
fix: return error message if table functions are used inside a CASE

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -24,12 +24,14 @@ import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
 import io.confluent.ksql.analyzer.Analysis.Into;
 import io.confluent.ksql.analyzer.Analysis.JoinInfo;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.execution.expression.formatter.ExpressionFormatter;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
+import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.TraversalExpressionVisitor;
 import io.confluent.ksql.execution.streams.PartitionByParamsFactory;
 import io.confluent.ksql.execution.util.ColumnExtractor;
@@ -696,6 +698,17 @@ class Analyzer {
     private final class TableFunctionVisitor extends TraversalExpressionVisitor<Void> {
 
       private Optional<FunctionName> tableFunctionName = Optional.empty();
+      private Optional<SearchedCaseExpression> searchedCaseExpression = Optional.empty();
+
+      @Override
+      public Void visitSearchedCaseExpression(
+          final SearchedCaseExpression node,
+          final Void context
+      ) {
+        searchedCaseExpression = Optional.of(node);
+        super.visitSearchedCaseExpression(node, context);
+        return null;
+      }
 
       @Override
       public Void visitFunctionCall(final FunctionCall functionCall, final Void context) {
@@ -712,6 +725,11 @@ class Analyzer {
 
           if (analysis.getGroupBy().isPresent()) {
             throw new KsqlException("Table functions cannot be used with aggregations.");
+          }
+
+          if (searchedCaseExpression.isPresent()) {
+            throw new KsqlException("Table functions cannot be used in CASE: "
+                + ExpressionFormatter.formatExpression(searchedCaseExpression.get()));
           }
 
           analysis.addTableFunction(functionCall);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
@@ -98,8 +98,9 @@ public class FlatMapNode extends SingleSourcePlanNode {
     final ImmutableMap.Builder<Integer, Expression> buildContext = ImmutableMap
         .builder();
 
-    for (int idx = 0; idx < analysis.getSelectItems().size(); idx++) {
-      final SelectItem selectItem = analysis.getSelectItems().get(idx);
+    final List<SelectItem> selectItems = analysis.getSelectItems();
+    for (int idx = 0; idx < selectItems.size(); idx++) {
+      final SelectItem selectItem = selectItems.get(idx);
       if (!(selectItem instanceof SingleColumn)) {
         continue;
       }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -21,15 +21,18 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
@@ -50,9 +53,12 @@ import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -72,6 +78,9 @@ public class AnalyzerFunctionalTest {
   private static final ColumnName COL1 = ColumnName.of("COL1");
   private static final ColumnName COL2 = ColumnName.of("COL2");
 
+  @Mock
+  private FunctionRegistry functionRegistry;
+
   private MutableMetaStore jsonMetaStore;
   private MutableMetaStore avroMetaStore;
 
@@ -80,7 +89,7 @@ public class AnalyzerFunctionalTest {
 
   @Before
   public void init() {
-    jsonMetaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
+    jsonMetaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
     avroMetaStore = MetaStoreFixture.getNewMetaStore(
         new InternalFunctionRegistry(),
         ValueFormat.of(FormatInfo.of(FormatFactory.AVRO.name()), SerdeFeatures.of())
@@ -91,6 +100,11 @@ public class AnalyzerFunctionalTest {
     query = parseSingle("Select COL0, COL1 from TEST1;");
 
     registerKafkaSource();
+  }
+
+  @After
+  public void tearDown() {
+    Mockito.reset(functionRegistry);
   }
 
   @Test
@@ -286,6 +300,25 @@ public class AnalyzerFunctionalTest {
     // Then:
     assertThat(e.getMessage(), containsString(
         "N-way joins do not support multiple occurrences of the same source. Source: 'TEST2'"));
+  }
+
+  @Test
+  public void shouldFailOnTableFunctionInsideCaseFunction() {
+    // Given:
+    final Query query = parseSingle("SELECT CASE WHEN false then EXPLODE(ARRAY[1.2]) END FROM test1;");
+    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", ROWPARTITION_ROWOFFSET_ENABLED);
+    when(functionRegistry.isTableFunction(FunctionName.of("EXPLODE"))).thenReturn(true);
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> analyzer.analyze(query, Optional.empty())
+    );
+
+    // Then:
+    assertThat(e.getMessage(), containsString(
+        "Table functions cannot be used in CASE: "
+            + "(CASE WHEN false THEN EXPLODE(ARRAY[1.2]) END)"));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/8065#event-5563432289

The last comment on https://github.com/confluentinc/ksql/issues/8065#event-5563432289 suggested that table functions should not be allowed in CASE functions. 

Today, we support one table function only (`EXPLODE`) which returns one column and several rows. But if in the future we support other tables functions (created with SQL UDTF for example) that return different columns, then mixing UDTF with CASE will complicate the resulted schema.

A quick example why not to support this case. The CASE will attempt to return 1 column for IDs < then 10, but 8 columns for > 10. This is not possible to do.
```
SELECT CASE
    WHEN s1.id >= 10 THEN
        tableFunctionReturns1Column()
    ELSE
       tableFunctionReturns2Columns()
   END
FROM ...
```

The following error is displayed when using this case:
```
ksql> select case when false then explode(array[1.2]) end from arraytest2 emit changes limit 1;
Table functions cannot be used in CASE: (CASE WHEN false THEN EXPLODE(ARRAY[1.2]) END)
```



### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

