### PR TITLE
fix: make parse_date able to parse partial dates

### DIFF
--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3.1</version>
+            <version>3.5</version>
         </dependency>
 
         <dependency>

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/ParseDate.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/datetime/ParseDate.java
@@ -63,7 +63,7 @@ public class ParseDate {
         throw new KsqlFunctionException("Date format contains time field.");
       }
       return new Date(time);
-    } catch (final ExecutionException | ParseException e) {
+    } catch (final ExecutionException | RuntimeException | ParseException e) {
       throw new KsqlFunctionException("Failed to parse date '" + formattedDate
           + "' with formatter '" + formatPattern
           + "': " + e.getMessage(), e);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseDateTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseDateTest.java
@@ -46,6 +46,35 @@ public class ParseDateTest {
   }
 
   @Test
+  public void shouldConvertYearMonthToDate() {
+    // When:
+    final Date result = udf.parseDate("2021-12", "yyyy-MM");
+
+    // Then:
+    assertThat(result.getTime(), is(1638316800000L));
+  }
+
+  @Test
+  public void shouldConvertYearToDate() {
+    // When:
+    final Date result = udf.parseDate("2022", "yyyy");
+
+    // Then:
+    assertThat(result.getTime(), is(1640995200000L));
+  }
+
+  @Test
+  public void shouldRejectIncompleteDates() {
+    // When:
+    final Exception e = assertThrows(
+        KsqlFunctionException.class,
+        () -> udf.parseDate("2021-01", "yyyy-dd"));
+
+    // Then:
+    assertThat(e.getMessage(), is("Failed to parse date '2021-01' with formatter 'yyyy-dd': Cannot create DATE out of the fields provided."));
+  }
+
+  @Test
   public void shouldConvertCaseInsensitiveStringToDate() {
     // When:
     final Date result = udf.parseDate("01-dec-2021", "dd-MMM-yyyy");

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseDateTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/datetime/ParseDateTest.java
@@ -64,17 +64,6 @@ public class ParseDateTest {
   }
 
   @Test
-  public void shouldRejectIncompleteDates() {
-    // When:
-    final Exception e = assertThrows(
-        KsqlFunctionException.class,
-        () -> udf.parseDate("2021-01", "yyyy-dd"));
-
-    // Then:
-    assertThat(e.getMessage(), is("Failed to parse date '2021-01' with formatter 'yyyy-dd': Cannot create DATE out of the fields provided."));
-  }
-
-  @Test
   public void shouldConvertCaseInsensitiveStringToDate() {
     // When:
     final Date result = udf.parseDate("01-dec-2021", "dd-MMM-yyyy");

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/parse-date.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/parse-date.json
@@ -11,13 +11,15 @@
         {"topic": "test_topic", "key": "1", "value": "1,zero,11/05/2019,dd/MM/yyyy"},
         {"topic": "test_topic", "key": "2", "value": "2,zero,01-Jan-2022,dd-MMM-yyyy"},
         {"topic": "test_topic", "key": "3", "value": "3,yyy,01-01-1970,dd-MM-yyyy"},
-        {"topic": "test_topic", "key": "4", "value": "4,yyy,01-JAN-2022,dd-MMM-yyyy"}
+        {"topic": "test_topic", "key": "4", "value": "4,yyy,01-JAN-2022,dd-MMM-yyyy"},
+        {"topic": "test_topic", "key": "4", "value": "4,yyy,JAN-2022,MMM-yyyy"}
       ],
       "outputs": [
         {"topic": "TS", "key": "0", "value": "0,17662"},
         {"topic": "TS", "key": "1", "value": "1,18027"},
         {"topic": "TS", "key": "2", "value": "2,18993"},
         {"topic": "TS", "key": "3", "value": "3,0"},
+        {"topic": "TS", "key": "4", "value": "4,18993"},
         {"topic": "TS", "key": "4", "value": "4,18993"}
       ]
     }

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <commons-text.version>1.8</commons-text.version>
         <csv.version>1.4</csv.version>
         <commons.compress.version>1.21</commons.compress.version>
-        <lang3.version>3.3.1</lang3.version>
+        <lang3.version>3.5</lang3.version>
         <guava.version>30.1.1-jre</guava.version>
         <protobuf.version>3.17.0</protobuf.version>
         <retrying.version>2.0.0</retrying.version>


### PR DESCRIPTION
### Description 
Fixes #8328

Reason it didn't work is because `LocalDate` doesn't do partial parsing. `LocalTime` does partial parsing for `hh:mm`, but not just `hh`. I think that is fine though.

`StringToDate` also has this problem, but I did not fix that because it is deprecated.



### Testing done 
Unit + QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

