### PR TITLE
chore: adapt to the new API for NamedTopology builders and runtimes

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -85,12 +85,13 @@ public final class QueryPlan  {
     return Objects.equals(sources, queryPlan.sources)
         && Objects.equals(sink, queryPlan.sink)
         && Objects.equals(physicalPlan, queryPlan.physicalPlan)
+        && Objects.equals(runtimeId, queryPlan.runtimeId)
         && Objects.equals(queryId, queryPlan.queryId);
   }
 
   @Override
   public int hashCode() {
 
-    return Objects.hash(sources, sink, physicalPlan, queryId);
+    return Objects.hash(sources, sink, physicalPlan, queryId, runtimeId);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -123,9 +123,9 @@ public class QueryRegistryImpl implements QueryRegistry {
         .filter(Optional::isPresent)
         .map(Optional::get)
         .collect(Collectors.toList());
-    this.streams = original.streams.stream()
+    streams.addAll(original.streams.stream()
         .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)
-        .collect(Collectors.toList());
+        .collect(Collectors.toList()));
 
     sandbox = true;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -119,7 +119,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.statementString = Objects.requireNonNull(statementString, "statementString");
     this.executionPlan = Objects.requireNonNull(executionPlan, "executionPlan");
     this.applicationId = Objects.requireNonNull(applicationId, "applicationId");
-    this.topology = Objects.requireNonNull(topology, "kafkaTopicClient");
+    this.topology = Objects.requireNonNull(topology, "namedTopology");
     this.sharedKafkaStreamsRuntime =
         Objects.requireNonNull(sharedKafkaStreamsRuntime, "sharedKafkaStreamsRuntime");
     this.sinkDataSource = requireNonNull(sinkDataSource, "sinkDataSource");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -15,105 +15,192 @@
 
 package io.confluent.ksql.util;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
+import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
-import java.time.Duration;
+import io.confluent.ksql.rest.entity.StreamsTaskMetadata;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StreamsMetadata;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
-import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
+import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
-  private final Logger log = LoggerFactory.getLogger(SandboxedSharedKafkaStreamsRuntimeImpl.class);
+public class SandboxedSharedKafkaStreamsRuntimeImpl implements SharedKafkaStreamsRuntime {
+  private static final Logger LOG = LoggerFactory.getLogger(SharedKafkaStreamsRuntimeImpl.class);
+
+  private final KafkaStreamsNamedTopologyWrapper kafkaStreams;
+  private final Map<String, Object> streamsProperties;
+  private final Map<String, PersistentQueriesInSharedRuntimesImpl> metadata;
+  private final Map<QueryId, Set<SourceName>> sources;
+  private final KafkaStreamsBuilder kafkaStreamsBuilder;
 
   public SandboxedSharedKafkaStreamsRuntimeImpl(
-      final SharedKafkaStreamsRuntime sharedRuntime
+      final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime
   ) {
-    super(
-        sharedRuntime.getKafkaStreamsBuilder(),
-        getSandboxStreamsProperties(sharedRuntime),
-        new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), 0)
+    streamsProperties = new ConcurrentHashMap<>(sharedKafkaStreamsRuntime.getStreamProperties());
+    streamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG,
+        "_confluent-ksql-" + UUID.randomUUID() + "-validation"
     );
-
-    for (BinPackedPersistentQueryMetadataImpl query : sharedRuntime.collocatedQueries.values()) {
+    kafkaStreamsBuilder = sharedKafkaStreamsRuntime.getKafkaStreamsBuilder();
+    kafkaStreams = kafkaStreamsBuilder.buildNamedTopologyWrapper(streamsProperties);
+    metadata = new ConcurrentHashMap<>(sharedKafkaStreamsRuntime.getMetadata());
+    sources = new ConcurrentHashMap<>(sharedKafkaStreamsRuntime.getSourcesMap());
+    for (PersistentQueriesInSharedRuntimesImpl queryMetadata : metadata.values()) {
       //kafkaStreams.addNamedTopology(queryMetadata.getTopology());
     }
   }
 
-  public SandboxedSharedKafkaStreamsRuntimeImpl(
-      final KafkaStreamsBuilder kafkaStreamsBuilder,
-      final int maxQueryErrorsQueueSize,
-      final Map<String, Object> streamsProperties
-  ) {
-    super(
-        kafkaStreamsBuilder,
-        streamsProperties,
-        new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), maxQueryErrorsQueueSize)
-    );
+  public SandboxedSharedKafkaStreamsRuntimeImpl(final KafkaStreamsBuilder kafkaStreamsBuilder,
+                                                final int maxQueryErrorsQueueSize,
+                                                final Map<String, Object> streamsProperties) {
+    kafkaStreams = kafkaStreamsBuilder.buildNamedTopologyWrapper(streamsProperties);
+    this.streamsProperties = ImmutableMap.copyOf(streamsProperties);
+    metadata = new ConcurrentHashMap<>();
+    sources = new ConcurrentHashMap<>();
+    this.kafkaStreamsBuilder = kafkaStreamsBuilder;
   }
 
-  private static Map<String, Object> getSandboxStreamsProperties(
-      final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime
-  ) {
-    final Map<String, Object> sandboxStreamsProperties =
-        new ConcurrentHashMap<>(sharedKafkaStreamsRuntime.getStreamProperties());
-    sandboxStreamsProperties.put(
-        StreamsConfig.APPLICATION_ID_CONFIG,
-        sharedKafkaStreamsRuntime.getStreamProperties().get(StreamsConfig.APPLICATION_ID_CONFIG)
-            + UUID.randomUUID().toString()
-            + "-validation"
-    );
-    return sandboxStreamsProperties;
+  public void markSources(final QueryId queryId, final Set<SourceName> sourceNames) {
+    sources.put(queryId, sourceNames);
   }
 
-  @Override
   public void register(
       final QueryErrorClassifier errorClassifier,
-      final BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata,
-      final QueryId queryId
-  ) {
+      final Map<String, Object> streamsProperties,
+      final PersistentQueriesInSharedRuntimesImpl persistentQueriesInSharedRuntimesImpl,
+      final QueryId queryId) {
     if (!sources.containsKey(queryId)) {
       if (sources
           .values()
           .stream()
           .flatMap(Collection::stream)
-          .anyMatch(t -> binpackedPersistentQueryMetadata.getSourceNames().contains(t))) {
+          .anyMatch(t -> persistentQueriesInSharedRuntimesImpl.getSourceNames().contains(t))) {
         throw new IllegalArgumentException(
             queryId.toString() + ": was not reserved on this runtime");
       } else {
-        sources.put(queryId, binpackedPersistentQueryMetadata.getSourceNames());
+        sources.put(queryId, persistentQueriesInSharedRuntimesImpl.getSourceNames());
       }
     }
-    collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
-    log.debug("mapping {}", collocatedQueries);
+
+    metadata.put(queryId.toString(), persistentQueriesInSharedRuntimesImpl);
+    LOG.debug("mapping {}", metadata);
   }
 
-  @Override
   public StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
       final Throwable e
   ) {
-    return StreamThreadExceptionResponse.REPLACE_THREAD;
+    return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
   }
 
-  @Override
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "must expose streams")
+  public KafkaStreams getKafkaStreams() {
+    return kafkaStreams;
+  }
+
+  public KafkaStreams.State state() {
+    return kafkaStreams.state();
+  }
+
+  public Collection<StreamsMetadata> allMetadata() {
+    return kafkaStreams.metadataForAllStreamsClients();
+  }
+
+  public Set<StreamsTaskMetadata> getTaskMetadata() {
+    return kafkaStreams.metadataForLocalThreads()
+        .stream()
+        .flatMap(t -> t.activeTasks().stream())
+        .map(StreamsTaskMetadata::fromStreamsTaskMetadata)
+        .collect(Collectors.toSet());
+  }
+
+  public boolean isError(final QueryId queryId) {
+    return false;
+  }
+
   public void stop(final QueryId queryId) {
+
   }
 
-  @Override
   public synchronized void close() {
-    log.debug("Closing validation runtime {}", getApplicationId());
     kafkaStreams.close();
     kafkaStreams.cleanUp();
   }
 
-  @Override
   public void start(final QueryId queryId) {
+    if (metadata.containsKey(queryId.toString()) && !metadata.get(queryId.toString()).everStarted) {
+      if (!kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
+        //kafkaStreams.addNamedTopology(metadata.get(queryId.toString()).getTopology());
+      } else {
+        throw new IllegalArgumentException("not done removing query: " + queryId);
+      }
+    } else {
+      throw new IllegalArgumentException("query: " + queryId + " not added to runtime");
+    }
   }
 
+  public List<QueryError> getQueryErrors() {
+    return Collections.emptyList();
+  }
+
+  public Map<String, Map<Integer, LagInfo>> allLocalStorePartitionLags(final QueryId queryId) {
+    try {
+      return kafkaStreams.allLocalStorePartitionLags();
+    } catch (IllegalStateException | StreamsException e) {
+      LOG.error(e.getMessage());
+      return ImmutableMap.of();
+    }
+  }
+
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "streamsProperties is immutable")
+  public Map<String, Object> getStreamProperties() {
+    return streamsProperties;
+  }
+
+  public Set<SourceName> getSources() {
+    return ImmutableSet.copyOf(
+        sources
+            .values()
+            .stream()
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet()));
+  }
+
+  public Set<QueryId> getQueries() {
+    return ImmutableSet.copyOf(sources.keySet());
+  }
+
+  @Override
+  public KafkaStreamsBuilder getKafkaStreamsBuilder() {
+    return kafkaStreamsBuilder;
+  }
+
+  @Override
+  public Map<String, PersistentQueriesInSharedRuntimesImpl> getMetadata() {
+    return ImmutableMap.copyOf(metadata);
+  }
+
+  @Override
+  public Map<QueryId, Set<SourceName>> getSourcesMap() {
+    return ImmutableMap.copyOf(sources);
+  }
+
+  public void addQueryError(final QueryError e) {
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -15,192 +15,105 @@
 
 package io.confluent.ksql.util;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
-import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.rest.entity.StreamsTaskMetadata;
+import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsMetadata;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
-import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SandboxedSharedKafkaStreamsRuntimeImpl implements SharedKafkaStreamsRuntime {
-  private static final Logger LOG = LoggerFactory.getLogger(SharedKafkaStreamsRuntimeImpl.class);
-
-  private final KafkaStreamsNamedTopologyWrapper kafkaStreams;
-  private final Map<String, Object> streamsProperties;
-  private final Map<String, PersistentQueriesInSharedRuntimesImpl> metadata;
-  private final Map<QueryId, Set<SourceName>> sources;
-  private final KafkaStreamsBuilder kafkaStreamsBuilder;
+public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
+  private final Logger log = LoggerFactory.getLogger(SandboxedSharedKafkaStreamsRuntimeImpl.class);
 
   public SandboxedSharedKafkaStreamsRuntimeImpl(
-      final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime
+      final SharedKafkaStreamsRuntime sharedRuntime
   ) {
-    streamsProperties = new ConcurrentHashMap<>(sharedKafkaStreamsRuntime.getStreamProperties());
-    streamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG,
-        "_confluent-ksql-" + UUID.randomUUID() + "-validation"
+    super(
+        sharedRuntime.getKafkaStreamsBuilder(),
+        getSandboxStreamsProperties(sharedRuntime),
+        new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), 0)
     );
-    kafkaStreamsBuilder = sharedKafkaStreamsRuntime.getKafkaStreamsBuilder();
-    kafkaStreams = kafkaStreamsBuilder.buildNamedTopologyWrapper(streamsProperties);
-    metadata = new ConcurrentHashMap<>(sharedKafkaStreamsRuntime.getMetadata());
-    sources = new ConcurrentHashMap<>(sharedKafkaStreamsRuntime.getSourcesMap());
-    for (PersistentQueriesInSharedRuntimesImpl queryMetadata : metadata.values()) {
+
+    for (BinPackedPersistentQueryMetadataImpl query : sharedRuntime.collocatedQueries.values()) {
       //kafkaStreams.addNamedTopology(queryMetadata.getTopology());
     }
   }
 
-  public SandboxedSharedKafkaStreamsRuntimeImpl(final KafkaStreamsBuilder kafkaStreamsBuilder,
-                                                final int maxQueryErrorsQueueSize,
-                                                final Map<String, Object> streamsProperties) {
-    kafkaStreams = kafkaStreamsBuilder.buildNamedTopologyWrapper(streamsProperties);
-    this.streamsProperties = ImmutableMap.copyOf(streamsProperties);
-    metadata = new ConcurrentHashMap<>();
-    sources = new ConcurrentHashMap<>();
-    this.kafkaStreamsBuilder = kafkaStreamsBuilder;
+  public SandboxedSharedKafkaStreamsRuntimeImpl(
+      final KafkaStreamsBuilder kafkaStreamsBuilder,
+      final int maxQueryErrorsQueueSize,
+      final Map<String, Object> streamsProperties
+  ) {
+    super(
+        kafkaStreamsBuilder,
+        streamsProperties,
+        new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), maxQueryErrorsQueueSize)
+    );
   }
 
-  public void markSources(final QueryId queryId, final Set<SourceName> sourceNames) {
-    sources.put(queryId, sourceNames);
+  private static Map<String, Object> getSandboxStreamsProperties(
+      final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime
+  ) {
+    final Map<String, Object> sandboxStreamsProperties =
+        new ConcurrentHashMap<>(sharedKafkaStreamsRuntime.getStreamProperties());
+    sandboxStreamsProperties.put(
+        StreamsConfig.APPLICATION_ID_CONFIG,
+        sharedKafkaStreamsRuntime.getStreamProperties().get(StreamsConfig.APPLICATION_ID_CONFIG)
+            + UUID.randomUUID().toString()
+            + "-validation"
+    );
+    return sandboxStreamsProperties;
   }
 
+  @Override
   public void register(
       final QueryErrorClassifier errorClassifier,
-      final Map<String, Object> streamsProperties,
-      final PersistentQueriesInSharedRuntimesImpl persistentQueriesInSharedRuntimesImpl,
-      final QueryId queryId) {
+      final BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata,
+      final QueryId queryId
+  ) {
     if (!sources.containsKey(queryId)) {
       if (sources
           .values()
           .stream()
           .flatMap(Collection::stream)
-          .anyMatch(t -> persistentQueriesInSharedRuntimesImpl.getSourceNames().contains(t))) {
+          .anyMatch(t -> binpackedPersistentQueryMetadata.getSourceNames().contains(t))) {
         throw new IllegalArgumentException(
             queryId.toString() + ": was not reserved on this runtime");
       } else {
-        sources.put(queryId, persistentQueriesInSharedRuntimesImpl.getSourceNames());
+        sources.put(queryId, binpackedPersistentQueryMetadata.getSourceNames());
       }
     }
-
-    metadata.put(queryId.toString(), persistentQueriesInSharedRuntimesImpl);
-    LOG.debug("mapping {}", metadata);
+    collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
+    log.debug("mapping {}", collocatedQueries);
   }
 
+  @Override
   public StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
       final Throwable e
   ) {
-    return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
+    return StreamThreadExceptionResponse.REPLACE_THREAD;
   }
 
-  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "must expose streams")
-  public KafkaStreams getKafkaStreams() {
-    return kafkaStreams;
-  }
-
-  public KafkaStreams.State state() {
-    return kafkaStreams.state();
-  }
-
-  public Collection<StreamsMetadata> allMetadata() {
-    return kafkaStreams.metadataForAllStreamsClients();
-  }
-
-  public Set<StreamsTaskMetadata> getTaskMetadata() {
-    return kafkaStreams.metadataForLocalThreads()
-        .stream()
-        .flatMap(t -> t.activeTasks().stream())
-        .map(StreamsTaskMetadata::fromStreamsTaskMetadata)
-        .collect(Collectors.toSet());
-  }
-
-  public boolean isError(final QueryId queryId) {
-    return false;
-  }
-
+  @Override
   public void stop(final QueryId queryId) {
-
   }
 
+  @Override
   public synchronized void close() {
+    log.debug("Closing validation runtime {}", getApplicationId());
     kafkaStreams.close();
     kafkaStreams.cleanUp();
   }
 
+  @Override
   public void start(final QueryId queryId) {
-    if (metadata.containsKey(queryId.toString()) && !metadata.get(queryId.toString()).everStarted) {
-      if (!kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
-        //kafkaStreams.addNamedTopology(metadata.get(queryId.toString()).getTopology());
-      } else {
-        throw new IllegalArgumentException("not done removing query: " + queryId);
-      }
-    } else {
-      throw new IllegalArgumentException("query: " + queryId + " not added to runtime");
-    }
   }
 
-  public List<QueryError> getQueryErrors() {
-    return Collections.emptyList();
-  }
-
-  public Map<String, Map<Integer, LagInfo>> allLocalStorePartitionLags(final QueryId queryId) {
-    try {
-      return kafkaStreams.allLocalStorePartitionLags();
-    } catch (IllegalStateException | StreamsException e) {
-      LOG.error(e.getMessage());
-      return ImmutableMap.of();
-    }
-  }
-
-  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "streamsProperties is immutable")
-  public Map<String, Object> getStreamProperties() {
-    return streamsProperties;
-  }
-
-  public Set<SourceName> getSources() {
-    return ImmutableSet.copyOf(
-        sources
-            .values()
-            .stream()
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet()));
-  }
-
-  public Set<QueryId> getQueries() {
-    return ImmutableSet.copyOf(sources.keySet());
-  }
-
-  @Override
-  public KafkaStreamsBuilder getKafkaStreamsBuilder() {
-    return kafkaStreamsBuilder;
-  }
-
-  @Override
-  public Map<String, PersistentQueriesInSharedRuntimesImpl> getMetadata() {
-    return ImmutableMap.copyOf(metadata);
-  }
-
-  @Override
-  public Map<QueryId, Set<SourceName>> getSourcesMap() {
-    return ImmutableMap.copyOf(sources);
-  }
-
-  public void addQueryError(final QueryError e) {
-  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -225,7 +225,6 @@ public class QueryBuilderTest {
     when(namedTopologyBuilder.build()).thenReturn(namedTopology);
     when(config.getConfig(true)).thenReturn(ksqlConfig);
     when(config.getOverrides()).thenReturn(OVERRIDES);
-    when(kstream.filter(any())).thenReturn(kstream);
     sharedKafkaStreamsRuntimes = new ArrayList<>();
 
     queryBuilder = new QueryBuilder(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -80,6 +80,9 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyBuilder;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -155,6 +158,8 @@ public class QueryBuilderTest {
   @Mock
   private StreamsBuilder streamsBuilder;
   @Mock
+  private NamedTopologyBuilder namedTopologyBuilder;
+  @Mock
   private FunctionRegistry functionRegistry;
   @Mock
   private KafkaStreams kafkaStreams;
@@ -162,6 +167,8 @@ public class QueryBuilderTest {
   private KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper;
   @Mock
   private Topology topology;
+  @Mock
+  private NamedTopology namedTopology;
   @Mock
   private KsMaterializationFactory ksMaterializationFactory;
   @Mock
@@ -197,6 +204,7 @@ public class QueryBuilderTest {
     when(ksqlTopic.getValueFormat()).thenReturn(VALUE_FORMAT);
     when(kafkaStreamsBuilder.build(any(), any())).thenReturn(kafkaStreams);
     when(kafkaStreamsBuilder.buildNamedTopologyWrapper(any())).thenReturn(kafkaStreamsNamedTopologyWrapper);
+    when(kafkaStreamsNamedTopologyWrapper.newNamedTopologyBuilder(any(), any())).thenReturn(namedTopologyBuilder);
     when(tableHolder.getMaterializationBuilder()).thenReturn(Optional.of(materializationBuilder));
     when(materializationBuilder.build()).thenReturn(materializationInfo);
     when(materializationInfo.getStateStoreSchema()).thenReturn(aggregationSchema);
@@ -214,6 +222,7 @@ public class QueryBuilderTest {
     when(ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(false);
     when(physicalPlan.build(any())).thenReturn(tableHolder);
     when(streamsBuilder.build(any())).thenReturn(topology);
+    when(namedTopologyBuilder.build()).thenReturn(namedTopology);
     when(config.getConfig(true)).thenReturn(ksqlConfig);
     when(config.getOverrides()).thenReturn(OVERRIDES);
     when(kstream.filter(any())).thenReturn(kstream);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -61,8 +61,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class QueryMetadataTest {
 
-  private static long RETRY_BACKOFF_INITIAL_MS = 1;
-  private static long RETRY_BACKOFF_MAX_MS = 10;
+  private static final long RETRY_BACKOFF_INITIAL_MS = 1;
+  private static final long RETRY_BACKOFF_MAX_MS = 10;
   private static final String QUERY_APPLICATION_ID = "Query1";
   private static final QueryId QUERY_ID = new QueryId("queryId");
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()


### PR DESCRIPTION
Extracting some self-contained pieces of the mega-PR [#8219](https://github.com/confluentinc/ksql/pull/8219) before I tackle any of the large refactoring that was suggested.

This PR just prepares only the necessary changes for us to finally merge [https://github.com/apache/kafka/pull/11272](#11272)  without breaking the build. Since we were already starting up an empty KafkaStreams, the only changes we need here are to get the `TopologyBuilder` from this KafkaStreams