### PR TITLE
Compare Double test expectations with error epsilon

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/ExpTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/ExpTest.java
@@ -16,6 +16,7 @@ package io.confluent.ksql.function.udf.math;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.nullValue;
 
 import org.junit.Before;
@@ -39,22 +40,22 @@ public class ExpTest {
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.exp(-1), is(0.36787944117144233));
-    assertThat(udf.exp(-1L), is(0.36787944117144233));
-    assertThat(udf.exp(-1.0), is(0.36787944117144233));
+    assertThat(udf.exp(-1), is(closeTo(0.36787944117144233, 0.00000000000000005)));
+    assertThat(udf.exp(-1L), is(closeTo(0.36787944117144233, 0.00000000000000005)));
+    assertThat(udf.exp(-1.0), is(closeTo(0.36787944117144233, 0.00000000000000005)));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.exp(0), is(1.0));
-    assertThat(udf.exp(0L), is(1.0));
-    assertThat(udf.exp(0.0), is(1.0));
+    assertThat(udf.exp(0), is(closeTo(1.0, 0.1)));
+    assertThat(udf.exp(0L), is(closeTo(1.0, 0.1)));
+    assertThat(udf.exp(0.0), is(closeTo(1.0, 0.1)));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.exp(1), is(2.718281828459045));
-    assertThat(udf.exp(1L), is(2.718281828459045));
-    assertThat(udf.exp(1.0), is(2.718281828459045));
+    assertThat(udf.exp(1), is(closeTo(2.718281828459045, 0.00000000000005)));
+    assertThat(udf.exp(1L), is(closeTo(2.718281828459045, 0.00000000000005)));
+    assertThat(udf.exp(1.0), is(closeTo(2.718281828459045, 0.00000000000005)));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/ExpTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/ExpTest.java
@@ -40,22 +40,22 @@ public class ExpTest {
 
   @Test
   public void shouldHandleNegative() {
-    assertThat(udf.exp(-1), is(closeTo(0.36787944117144233, 0.00000000000000005)));
-    assertThat(udf.exp(-1L), is(closeTo(0.36787944117144233, 0.00000000000000005)));
-    assertThat(udf.exp(-1.0), is(closeTo(0.36787944117144233, 0.00000000000000005)));
+    assertThat(udf.exp(-1), is(closeTo(0.36787944117144233, 1E-15)));
+    assertThat(udf.exp(-1L), is(closeTo(0.36787944117144233, 1E-15)));
+    assertThat(udf.exp(-1.0), is(closeTo(0.36787944117144233, 1E-15)));
   }
 
   @Test
   public void shouldHandleZero() {
-    assertThat(udf.exp(0), is(closeTo(1.0, 0.1)));
-    assertThat(udf.exp(0L), is(closeTo(1.0, 0.1)));
-    assertThat(udf.exp(0.0), is(closeTo(1.0, 0.1)));
+    assertThat(udf.exp(0), is(closeTo(1.0, 1E-15)));
+    assertThat(udf.exp(0L), is(closeTo(1.0, 1E-15)));
+    assertThat(udf.exp(0.0), is(closeTo(1.0, 1E-15)));
   }
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.exp(1), is(closeTo(2.718281828459045, 0.00000000000005)));
-    assertThat(udf.exp(1L), is(closeTo(2.718281828459045, 0.00000000000005)));
-    assertThat(udf.exp(1.0), is(closeTo(2.718281828459045, 0.00000000000005)));
+    assertThat(udf.exp(1), is(closeTo(2.718281828459045, 1E-15)));
+    assertThat(udf.exp(1L), is(closeTo(2.718281828459045, 1E-15)));
+    assertThat(udf.exp(1.0), is(closeTo(2.718281828459045, 1E-15)));
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SqrtTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/SqrtTest.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.function.udf.math;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -51,8 +52,8 @@ public class SqrtTest {
 
   @Test
   public void shouldHandlePositive() {
-    assertThat(udf.sqrt(4), is(2.0));
-    assertThat(udf.sqrt(3), is(1.7320508075688772));
-    assertThat(udf.sqrt(1.0), is(1.0));
+    assertThat(udf.sqrt(4), is(closeTo(2.0, 1E-15)));
+    assertThat(udf.sqrt(3), is(closeTo(1.7320508075688772, 1E-15)));
+    assertThat(udf.sqrt(1.0), is(closeTo(1.0, 1E-15)));
   }
 }


### PR DESCRIPTION
### Description 

io.confluent.ksql.function.udf.math.ExpTest fails on Linux ARM64 with:

```
[INFO] Running io.confluent.ksql.function.udf.math.ExpTest
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.054 s <<< FAILURE! - in io.confluent.ksql.function.udf.math.ExpTest
[ERROR] io.confluent.ksql.function.udf.math.ExpTest.shouldHandlePositive  Time elapsed: 0.013 s  <<< FAILURE!
java.lang.AssertionError: 

Expected: is <2.718281828459045>
     but: was <2.7182818284590455>
	at io.confluent.ksql.function.udf.math.ExpTest.shouldHandlePositive(ExpTest.java:56)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ExpTest.shouldHandlePositive:56 
Expected: is <2.718281828459045>
     but: was <2.7182818284590455>
[INFO] 
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0
```


### Testing done 

Updated the tests to use approximation. Testing `double`s for equality is not stable.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

