### PR TITLE
chore: update netty/vertx to account for CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.8</vertx.version>
+        <vertx.version>3.9.10</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -140,9 +140,9 @@
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
         <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against 4.1.49.Final -->
-        <netty.version>4.1.65.Final</netty.version>
+        <netty.version>4.1.69.Final</netty.version>
         <!-- This matches the version in common -->
-        <netty-codec-http2-version>4.1.65.Final</netty-codec-http2-version>
+        <netty-codec-http2-version>4.1.69.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
     </properties>
 


### PR DESCRIPTION
### Description 

The old netty version had CVE-2021-37137, this bumps both vertx and netty to account for it.

### Testing done 

Ran all the unit tests, working now on testing it to make sure basic auth works end-to-end.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

