### PR TITLE
feat: add detailed error log for test-runner

### DIFF
--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -539,18 +539,20 @@ public class RestTestExecutor implements Closeable {
             "could not get expected value from test record: " + expected));
     final long expectedTimestamp = expected.timestamp().orElse(actualTimestamp);
 
-    final AssertionError error = new AssertionError(
-        "Expected <" + expectedKey + ", " + expectedValue + "> "
+    final String errorMessage = "Expected <" + expectedKey + ", " + expectedValue + "> "
             + "with timestamp=" + expectedTimestamp
             + " but was <" + actualKey + ", " + actualValue + "> "
-            + "with timestamp=" + actualTimestamp);
+            + "with timestamp=" + actualTimestamp;
+
+    final AssertionError error = new AssertionError(errorMessage);
 
     if (!Objects.equals(actualKey, expectedKey)) {
       throw error;
     }
 
-    if (!ExpectedRecordComparator.matches(actualValue, expectedValue)) {
-      throw error;
+    final Optional<String> detailedMessage = ExpectedRecordComparator.matches(actualValue, expectedValue);
+    if (detailedMessage.isPresent()) {
+      throw new AssertionError(errorMessage + " caused " + detailedMessage.get());
     }
 
     if (actualTimestamp != expectedTimestamp) {

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/ExpectedRecordComparatorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/ExpectedRecordComparatorTest.java
@@ -85,7 +85,7 @@ public class ExpectedRecordComparatorTest {
             + "Expected: " + expected
             + System.lineSeparator()
             + "Actual: " + actual,
-        ExpectedRecordComparator.matches(actual, expected)
+        !ExpectedRecordComparator.matches(actual, expected).isPresent()
     );
   }
 
@@ -96,7 +96,7 @@ public class ExpectedRecordComparatorTest {
             + "Expected: " + expected
             + System.lineSeparator()
             + "Actual: " + actual,
-        !ExpectedRecordComparator.matches(actual, expected)
+        ExpectedRecordComparator.matches(actual, expected).isPresent()
     );
   }
 }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
@@ -123,8 +123,10 @@ public class KsqlTestingToolTest {
         Optional.empty());
 
     // Then:
-    assertThat(errContent.toString(UTF_8),
-        containsString("Test failed: Topic 'S1', message 0: Expected <\"1001\", \"101\"> with timestamp=0 but was <101, \"101\"> with timestamp=0\n"));
+    final String expected = "Test failed: Topic 'S1', message 0: Expected <\"1001\", \"101\"> with timestamp=0 "
+            + "but was <101, \"101\"> with timestamp=0 caused 101 not match \"1001\"\n";
+
+    assertThat(errContent.toString(UTF_8), containsString(expected));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Now error message formats as:
`Expected <expected_key, expected_value> with timestamp=expected_ts but was <actual_key, actual_value> with timestamp=actual_ts
`

But with big messages it is not readable:

`>>>>> Test failed: Topic 'its.canonical-enriched.transit-fact', message 0: Expected <"6b79b7a0-2e5c-11eb-8588-0800200c9a66", {"id":"6b79b7a0-2e5c-11eb-8588-0800200c9a66","sourceMetadataPacket":{"fileId":"fa-transit/2020-11-24/6b79b7a0-2e5c-11eb-8588-0800200c9a66/metadata.json","contentType":"application/json"},"fixationAt":"2020-11-24T13:53:23+03:00","acceptedAt":"2020-11-24T10:53:25Z","address":"а/д Таврово - Соломино - Разумное км 2+310","location":{"latitude":50.506485,"longitude":36.608693},"speed":55.7,"speedLimit":60,"azimuth":176.5,"direction":"TO","lane":{"number":1,"name":"В город"},"vehicle":{"vrp":{"number":"A123AA00","coords":{"leftUpper":{"x":1418,"y":363},"rightUpper":{"x":1479,"y":364},"rightLower":{"x":1478,"y":378},"leftLower":{"x":1418,"y":376}},"score":0.99,"color":"WHITE","country":"RUS","area":"31"},"boundingBox":{"leftUpper":{"x":1263,"y":198},"rightLower":{"x":1575,"y":461}},"color":{"value":"WHITE","score":0.99},"type":{"score":0.99,"value":"CAR"},"model":{"value":"FORD-FIESTA","score":0.99}},"device":{"serialNumber":"001614","vendor":"Ультра","address":"Россия, Таврово, 2-й Магистральный мкр.","location":{"latitude":50.506485,"longitude":36.608693},"conformityCertificate":{"number":"74935","expirationDate":"2024-12-09"},"verificationCertificate":{"number":"6/651-976-19","expirationDate":"2021-10-14"}},"violation":{"type":"AVG_SPEED_OVER"},"mainPhoto":{"fileId":"fa-transit/2020-11-24/6b79b7a0-2e5c-11eb-8588-0800200c9a66/main-photo.jpeg","contentType":"image/jpeg","contentHash":"3a84b2f508f5b93056e427aa67ad0c88d1b5366c6d423f59b61ece99286005d9"},"vrpPhoto":{"fileId":"fa-transit/2020-11-24/6b79b7a0-2e5c-11eb-8588-0800200c9a66/vrp-photo.jpeg","contentType":"image/jpeg","contentHash":"7fad0599b76b402d981d63576f3ea43a1d596148ed54bdd438196e64b4821da0"},"vehicleVrpNumber":"A123AA00","vehicleCard":{"color":{"value":{"string":"Черный"}},"type":{"value":null},"model":{"value":{"string":"Hyundai Creta"}}},"vehicleCardUpdatedAt":"2021-10-07T16:36:50.000+0300","deviceId":"Ультра-001614","districtId":"42","clusterId":133,"clusterLocation":{"latitude":34.01486,"longitude":21.056},"deviceLocationId":2,"deviceLocationUpdatedAt":"2021-10-22T09:42:15+03:00"}> with timestamp=10 but was <6b79b7a0-2e5c-11eb-8588-0800200c9a66, {mainPhoto={contentType=image/jpeg, fileId=fa-transit/2020-11-24/6b79b7a0-2e5c-11eb-8588-0800200c9a66/main-photo.jpeg, contentHash=3a84b2f508f5b93056e427aa67ad0c88d1b5366c6d423f59b61ece99286005d9}, sourceMetadataPacket={contentType=application/json, fileId=fa-transit/2020-11-24/6b79b7a0-2e5c-11eb-8588-0800200c9a66/metadata.json}, azimuth=176.5, clusterId=null, vehicleCard=null, deviceLocationId=null, deviceId=null, speed=55.7, vehicle={boundingBox={rightLower={x=1575, y=461}, leftUpper={x=1263, y=198}}, color={score=0.99, value=WHITE}, vrp={area=31, number=A123AA00, score=0.99, country=RUS, color=WHITE, coords={rightLower={x=1478, y=378}, leftLower={x=1418, y=376}, rightUpper={x=1479, y=364}, leftUpper={x=1418, y=363}}}, model={score=0.99, value=FORD-FIESTA}, type={score=0.99, value=CAR}}, vrpPhoto={contentType=image/jpeg, fileId=fa-transit/2020-11-24/6b79b7a0-2e5c-11eb-8588-0800200c9a66/vrp-photo.jpeg, contentHash=7fad0599b76b402d981d63576f3ea43a1d596148ed54bdd438196e64b4821da0}, vehicleVrpNumber=null, clusterLocation=null, fixationAt=2020-11-24T13:53:23+03:00, id=6b79b7a0-2e5c-11eb-8588-0800200c9a66, deviceLocationUpdatedAt=null, lane={number=1, name=В город}, acceptedAt=2020-11-24T10:53:25Z, direction=TO, address=а/д Таврово - Соломино - Разумное км 2+310, speedLimit=60, vehicleCardUpdatedAt=null, districtId=null, violation={type=AVG_SPEED_OVER}, location={latitude=50.506485, longitude=36.608693}, device={verificationCertificate={number=6/651-976-19, expirationDate=2021-10-14}, serialNumber=001614, address=Россия, Таврово, 2-й Магистральный мкр., vendor=Ультра, conformityCertificate={number=74935, expirationDate=2024-12-09}, location={latitude=50.506485, longitude=36.608693}}}> with timestamp=10`

This pull request adds detailed messages after **caused** word:

`>>>>> Test failed: Topic 'its.canonical-enriched.transit-fact', message 0: Expected <"6b79b7a0-2e5c-11eb-8588-0800200c9a66", {...}> with timestamp=10 caused vehicleVrpNumber = null but expected "A123AA00" (null is not a string)`