### PR TITLE
feat: add headers to the logical schema

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -579,9 +579,9 @@ public final class LogicalSchema {
         final Optional<String> headerKey
     ) {
       if (headerKey.isPresent()) {
-        addColumn(Column.of(columnName, SqlTypes.BYTES, HEADERS, 0, headerKey));
+        addColumn(Column.of(columnName, SqlTypes.BYTES, HEADERS, seenHeaders.size(), headerKey));
       } else {
-        addColumn(Column.of(columnName, HEADERS_TYPE, HEADERS, 0, headerKey));
+        addColumn(Column.of(columnName, HEADERS_TYPE, HEADERS, seenHeaders.size(), headerKey));
       }
       return this;
     }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -15,9 +15,11 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import static io.confluent.ksql.schema.ksql.Column.Namespace.HEADERS;
 import static io.confluent.ksql.schema.ksql.Column.Namespace.KEY;
 import static io.confluent.ksql.schema.ksql.Column.Namespace.VALUE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.CURRENT_PSEUDOCOLUMN_VERSION_NUMBER;
+import static io.confluent.ksql.schema.ksql.SystemColumns.HEADERS_TYPE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWOFFSET_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWOFFSET_TYPE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWPARTITION_NAME;
@@ -36,9 +38,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.DuplicateColumnException;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -86,6 +90,14 @@ public final class LogicalSchema {
   public List<Column> value() {
     return byNamespace()
         .get(VALUE);
+  }
+
+  /**
+   * @return the headers in the schema.
+   */
+  public List<Column> headers() {
+    return byNamespace()
+        .get(HEADERS);
   }
 
   /**
@@ -372,16 +384,18 @@ public final class LogicalSchema {
     final Map<Namespace, List<Column>> byNamespace = byNamespace();
 
     final List<Column> key = byNamespace.get(Namespace.KEY);
+    final List<Column> headers = byNamespace.get(HEADERS);
 
     final ImmutableList.Builder<Column> builder = ImmutableList.builder();
 
     final List<Column> keyColumns = keyColumns(byNamespace);
 
-    final List<Column> nonPseudoAndKeyCols = nonPseudoAndKeyColsAsValueCols(
+    final List<Column> nonPseudoAndKeyCols = nonPseudoHeaderAndKeyColsAsValueCols(
         byNamespace, pseudoColumnVersion);
 
     builder.addAll(keyColumns);
     builder.addAll(nonPseudoAndKeyCols);
+    builder.addAll(headers);
 
     int valueIndex = nonPseudoAndKeyCols.size();
 
@@ -414,6 +428,10 @@ public final class LogicalSchema {
       builder.add(Column.of(c.name(), c.type(), VALUE, valueIndex++));
     }
 
+    for (final Column c : headers) {
+      builder.add(Column.of(c.name(), c.type(), VALUE, valueIndex++));
+    }
+
     if (windowedKey) {
       builder.add(
           Column.of(WINDOWSTART_NAME, WINDOWBOUND_TYPE, VALUE, valueIndex++));
@@ -434,11 +452,13 @@ public final class LogicalSchema {
     final Map<Namespace, List<Column>> byNamespace = byNamespace();
 
     final List<Column> keyColumns = keyColumns(byNamespace);
+    final List<Column> headerColumns = byNamespace.get(HEADERS);
 
-    final List<Column> nonPseudoAndKeyCols = nonPseudoAndKeyColsAsValueCols(
+    final List<Column> nonPseudoAndKeyCols = nonPseudoHeaderAndKeyColsAsValueCols(
         byNamespace, pseudoColumnVersion);
 
     builder.addAll(keyColumns);
+    builder.addAll(headerColumns);
     builder.addAll(nonPseudoAndKeyCols);
 
     return new LogicalSchema(builder.build());
@@ -457,7 +477,7 @@ public final class LogicalSchema {
 
     final List<Column> keyColumns = keyColumns(byNamespace);
 
-    final List<Column> nonPseudoAndKeyCols = nonPseudoAndKeyColsAsValueCols(
+    final List<Column> nonPseudoAndKeyCols = nonPseudoHeaderAndKeyColsAsValueCols(
         byNamespace, pseudoColumnVersion);
 
     int valueIndex = nonPseudoAndKeyCols.size();
@@ -476,13 +496,14 @@ public final class LogicalSchema {
   }
 
   /**
-   * Adds columns, except for key and pseudocolumns, to an immutable list and returns the list
+   * Adds columns, except for key, header and pseudocolumns, to an immutable list and returns the
+   * list
    * @param byNamespace map of columns grouped by key and value
    * @param pseudoColumnVersion the pseudocolumn version used to evaluate if a column is a system
    *                            column or not
    * @return an immutable list containing the non pseudo and key columns in this LogicalSchema
    * */
-  private List<Column> nonPseudoAndKeyColsAsValueCols(
+  private List<Column> nonPseudoHeaderAndKeyColsAsValueCols(
       final Map<Namespace, List<Column>> byNamespace,
       final int pseudoColumnVersion
   ) {
@@ -498,6 +519,11 @@ public final class LogicalSchema {
 
       if (findColumnMatching(
           withNamespace(Namespace.KEY).and(withName(c.name()))).isPresent()) {
+        continue;
+      }
+
+      if (findColumnMatching(
+          withNamespace(Namespace.HEADERS).and(withName(c.name()))).isPresent()) {
         continue;
       }
 
@@ -533,15 +559,31 @@ public final class LogicalSchema {
     private final ImmutableList.Builder<Column> columns = ImmutableList.builder();
     private final Set<ColumnName> seenKeys = new HashSet<>();
     private final Set<ColumnName> seenValues = new HashSet<>();
+    private final Set<ColumnName> seenHeaders = new HashSet<>();
+    private final Set<String> seenHeaderKeys = new HashSet<>();
 
     private Builder(final ImmutableList<Column> columns) {
       columns.forEach(col -> {
         if (col.namespace() == KEY) {
           keyColumn(col.name(), col.type());
+        } else if (col.namespace() == HEADERS) {
+          headerColumn(col.name(), col.headerKey());
         } else {
           valueColumn(col.name(), col.type());
         }
       });
+    }
+
+    public Builder headerColumn(
+        final ColumnName columnName,
+        final Optional<String> headerKey
+    ) {
+      if (headerKey.isPresent()) {
+        addColumn(Column.of(columnName, SqlTypes.BYTES, HEADERS, 0, headerKey));
+      } else {
+        addColumn(Column.of(columnName, HEADERS_TYPE, HEADERS, 0, headerKey));
+      }
+      return this;
     }
 
     public Builder keyColumns(final Iterable<? extends SimpleColumn> columns) {
@@ -590,6 +632,24 @@ public final class LogicalSchema {
           }
           break;
 
+        case HEADERS:
+          if (!seenHeaders.add(column.name())) {
+            throw new DuplicateColumnException(column.namespace(), column);
+          }
+
+          if (seenHeaderKeys.contains(null)) {
+            throw new KsqlException("Schema already contains a HEADERS column.");
+          }
+
+          if (column.headerKey().isPresent()) {
+            if (!seenHeaderKeys.add(column.headerKey().get())) {
+              throw new KsqlException("Schema already contains a HEADER('"
+                  + column.headerKey().get() + "') column.");
+            }
+          } else {
+            seenHeaderKeys.add(null);
+          }
+          break;
         default:
           throw new UnsupportedOperationException("Unsupported column type: " + column);
       }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/SystemColumns.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.types.SqlArray;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
@@ -60,6 +62,11 @@ public final class SystemColumns {
       WINDOWSTART_NAME,
       WINDOWEND_NAME
   );
+
+  public static final SqlType HEADERS_TYPE = SqlArray.of(
+      SqlStruct.builder()
+          .field("KEY", SqlTypes.STRING)
+          .field("VALUE", SqlTypes.BYTES).build());
 
   private static final List<PseudoColumn> pseudoColumns = ImmutableList.of(
       PseudoColumn.of(

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/DuplicateColumnException.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/DuplicateColumnException.java
@@ -39,7 +39,7 @@ public class DuplicateColumnException extends KsqlException {
   private static String buildMessage(final Namespace namespace, final Column column) {
     return String.format(
         "Duplicate %s columns found in schema: %s",
-        namespace == Namespace.KEY ? "key" : "value",
+        namespace.name().toLowerCase(),
         column
     );
   }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/config/KsqlConfigResolverTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/config/KsqlConfigResolverTest.java
@@ -70,7 +70,7 @@ public class KsqlConfigResolverTest {
   @Test
   public void shouldReturnUnresolvedForOtherKsqlFunctionProperty() {
     assertThat(
-        resolver.resolve(KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX + "some_udf.some.prop", true),
+        resolver.resolve("ksql.fail.on.production.error", true),
         is(unresolvedItem(KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX + "some_udf.some.prop")));
   }
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/config/KsqlConfigResolverTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/config/KsqlConfigResolverTest.java
@@ -70,7 +70,7 @@ public class KsqlConfigResolverTest {
   @Test
   public void shouldReturnUnresolvedForOtherKsqlFunctionProperty() {
     assertThat(
-        resolver.resolve("ksql.fail.on.production.error", true),
+        resolver.resolve(KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX + "some_udf.some.prop", true),
         is(unresolvedItem(KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX + "some_udf.some.prop")));
   }
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnMatchers.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnMatchers.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.is;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+import java.util.Optional;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
@@ -65,6 +66,19 @@ public final class ColumnMatchers {
     );
   }
 
+  public static <T extends Column> Matcher<T> headersColumn(
+      final ColumnName name,
+      final SqlType type,
+      final Optional<String> headerKey
+  ) {
+    return allOf(
+        hasName(name),
+        hasType(type),
+        hasNamespace(Namespace.HEADERS),
+        hasHeaderKey(headerKey)
+    );
+  }
+
   public static <T extends SimpleColumn> Matcher<T> hasName(final ColumnName name) {
     return new FeatureMatcher<T, ColumnName>(
         is(name),
@@ -100,6 +114,19 @@ public final class ColumnMatchers {
       @Override
       protected Namespace featureValueOf(final Column actual) {
         return actual.namespace();
+      }
+    };
+  }
+
+  private static <T extends Column> Matcher<T> hasHeaderKey(final Optional<String> key) {
+    return new FeatureMatcher<T, Optional<String>>(
+        is(key),
+        "column with header key",
+        "header key"
+    ) {
+      @Override
+      protected Optional<String> featureValueOf(final Column actual) {
+        return actual.headerKey();
       }
     };
   }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import static io.confluent.ksql.schema.ksql.Column.Namespace.HEADERS;
 import static io.confluent.ksql.schema.ksql.Column.Namespace.KEY;
 import static io.confluent.ksql.schema.ksql.Column.Namespace.VALUE;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
@@ -30,12 +31,13 @@ import com.google.common.testing.NullPointerTester;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.utils.FormatOptions;
+import java.util.Optional;
 import org.junit.Test;
 
 public class ColumnTest {
 
   private static final ColumnName SOME_NAME = ColumnName.of("SomeName");
-  private static final ColumnName SOME_OHTER_NAME = ColumnName.of("SOMENAME");
+  private static final ColumnName SOME_OTHER_NAME = ColumnName.of("SOMENAME");
 
   @SuppressWarnings("UnstableApiUsage")
   @Test
@@ -55,7 +57,7 @@ public class ColumnTest {
             Column.of(SOME_NAME, INTEGER, VALUE, 10)
         )
         .addEqualityGroup(
-            Column.of(SOME_OHTER_NAME, INTEGER, VALUE, 10)
+            Column.of(SOME_OTHER_NAME, INTEGER, VALUE, 10)
         )
         .addEqualityGroup(
             Column.of(SOME_NAME, DOUBLE, VALUE, 10)
@@ -65,6 +67,15 @@ public class ColumnTest {
         )
         .addEqualityGroup(
             Column.of(SOME_NAME, INTEGER, VALUE, 5)
+        )
+        .addEqualityGroup(
+            Column.of(SOME_NAME, INTEGER, HEADERS, 5)
+        )
+        .addEqualityGroup(
+            Column.of(SOME_NAME, INTEGER, HEADERS, 5, Optional.of("key1"))
+        )
+        .addEqualityGroup(
+            Column.of(SOME_NAME, INTEGER, HEADERS, 5, Optional.of("key2"))
         )
         .testEquals();
   }
@@ -87,6 +98,10 @@ public class ColumnTest {
   public void shouldReturnNamespace() {
     assertThat(Column.of(SOME_NAME, BOOLEAN, KEY, 10)
         .namespace(), is(KEY));
+    assertThat(Column.of(SOME_NAME, BOOLEAN, HEADERS, 10)
+        .namespace(), is(HEADERS));
+    assertThat(Column.of(SOME_NAME, BOOLEAN, HEADERS, 10, Optional.of("key"))
+        .namespace(), is(HEADERS));
   }
 
   @Test
@@ -102,6 +117,11 @@ public class ColumnTest {
 
     assertThat(Column.of(SOME_NAME, INTEGER, KEY, 10).toString(),
         is("`SomeName` INTEGER KEY"));
+
+    assertThat(Column.of(SOME_NAME, INTEGER, HEADERS, 10).toString(),
+        is("`SomeName` INTEGER HEADERS"));
+    assertThat(Column.of(SOME_NAME, INTEGER, HEADERS, 10, Optional.of("abc")).toString(),
+        is("`SomeName` INTEGER HEADER('abc')"));
   }
 
   @Test

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.schema.ksql;
 import static io.confluent.ksql.schema.ksql.ColumnMatchers.headersColumn;
 import static io.confluent.ksql.schema.ksql.ColumnMatchers.keyColumn;
 import static io.confluent.ksql.schema.ksql.ColumnMatchers.valueColumn;
-import static io.confluent.ksql.schema.ksql.SystemColumns.HEADERS_TYPE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWOFFSET_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWPARTITION_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWPARTITION_ROWOFFSET_PSEUDOCOLUMN_VERSION;
@@ -45,7 +44,10 @@ import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
+import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.util.KsqlConfig;
@@ -88,6 +90,11 @@ public class LogicalSchemaTest {
       .headerColumn(H0, Optional.of("key0"))
       .headerColumn(H1, Optional.of("key1"))
       .build();
+
+  private static final SqlType HEADERS_TYPE = SqlArray.of(
+      SqlStruct.builder()
+          .field("KEY", SqlTypes.STRING)
+          .field("VALUE", SqlTypes.BYTES).build());
 
   @SuppressWarnings("UnstableApiUsage")
   @Test
@@ -256,6 +263,10 @@ public class LogicalSchemaTest {
 
     assertThat(SCHEMA_WITH_EXTRACTED_HEADERS.findColumn(H0), is(Optional.of(
         Column.of(H0, BYTES, Namespace.HEADERS, 0, Optional.of("key0"))
+    )));
+
+    assertThat(SCHEMA_WITH_EXTRACTED_HEADERS.findColumn(H1), is(Optional.of(
+        Column.of(H1, BYTES, Namespace.HEADERS, 1, Optional.of("key1"))
     )));
   }
 

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -15,8 +15,10 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import static io.confluent.ksql.schema.ksql.ColumnMatchers.headersColumn;
 import static io.confluent.ksql.schema.ksql.ColumnMatchers.keyColumn;
 import static io.confluent.ksql.schema.ksql.ColumnMatchers.valueColumn;
+import static io.confluent.ksql.schema.ksql.SystemColumns.HEADERS_TYPE;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWOFFSET_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWPARTITION_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.ROWPARTITION_ROWOFFSET_PSEUDOCOLUMN_VERSION;
@@ -26,6 +28,7 @@ import static io.confluent.ksql.schema.ksql.SystemColumns.WINDOWEND_NAME;
 import static io.confluent.ksql.schema.ksql.SystemColumns.WINDOWSTART_NAME;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BIGINT;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.BOOLEAN;
+import static io.confluent.ksql.schema.ksql.types.SqlTypes.BYTES;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.DOUBLE;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.INTEGER;
 import static io.confluent.ksql.schema.ksql.types.SqlTypes.STRING;
@@ -53,6 +56,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import scala.Some;
 
 @SuppressWarnings({"UnstableApiUsage", "unchecked"})
 @RunWith(MockitoJUnitRunner.class)
@@ -65,6 +69,8 @@ public class LogicalSchemaTest {
   private static final ColumnName V1 = ColumnName.of("v1");
   private static final ColumnName F0 = ColumnName.of("f0");
   private static final ColumnName F1 = ColumnName.of("f1");
+  private static final ColumnName H0 = ColumnName.of("h0");
+  private static final ColumnName H1 = ColumnName.of("h1");
   private static final ColumnName VALUE = ColumnName.of("value");
   private static final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
 
@@ -72,6 +78,15 @@ public class LogicalSchemaTest {
       .valueColumn(F0, STRING)
       .keyColumn(K0, BIGINT)
       .valueColumn(F1, BIGINT)
+      .headerColumn(H0, Optional.empty())
+      .build();
+
+  private static final LogicalSchema SCHEMA_WITH_EXTRACTED_HEADERS = LogicalSchema.builder()
+      .valueColumn(F0, STRING)
+      .keyColumn(K0, BIGINT)
+      .valueColumn(F1, BIGINT)
+      .headerColumn(H0, Optional.of("key0"))
+      .headerColumn(H1, Optional.of("key1"))
       .build();
 
   @SuppressWarnings("UnstableApiUsage")
@@ -234,12 +249,24 @@ public class LogicalSchemaTest {
   }
 
   @Test
-  public void shouldPreferKeyOverValueAndMetaColumns() {
+  public void shouldGetHeaderColumns() {
+    assertThat(SOME_SCHEMA.findColumn(H0), is(Optional.of(
+        Column.of(H0, HEADERS_TYPE, Namespace.HEADERS, 0, Optional.empty())
+    )));
+
+    assertThat(SCHEMA_WITH_EXTRACTED_HEADERS.findColumn(H0), is(Optional.of(
+        Column.of(H0, BYTES, Namespace.HEADERS, 0, Optional.of("key0"))
+    )));
+  }
+
+  @Test
+  public void shouldPreferKeyOverValueHeaderAndMetaColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         // Implicit meta ROWTIME
         .valueColumn(ROWTIME_NAME, BIGINT)
         .keyColumn(ROWTIME_NAME, BIGINT)
+        .headerColumn(ROWTIME_NAME, Optional.empty())
         .build();
 
     // Then:
@@ -250,13 +277,14 @@ public class LogicalSchemaTest {
   }
 
   @Test
-  public void shouldPreferValueOverMetaColumns() {
+  public void shouldPreferValueOverHeaderAndMetaColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .keyColumn(K0, INTEGER)
         .valueColumn(ROWTIME_NAME, BIGINT)
         .valueColumn(ROWOFFSET_NAME, BIGINT)
         .valueColumn(ROWPARTITION_NAME, INTEGER)
+        .headerColumn(ROWPARTITION_NAME, Optional.empty())
         .build();
 
     // Then:
@@ -290,18 +318,35 @@ public class LogicalSchemaTest {
   }
 
   @Test
+  public void shouldExposeHeaderColumns() {
+    assertThat(SOME_SCHEMA.headers(), contains(
+        headersColumn(H0, HEADERS_TYPE, Optional.empty())
+    ));
+  }
+
+  @Test
+  public void shouldExposeExtractedHeaderColumns() {
+    assertThat(SCHEMA_WITH_EXTRACTED_HEADERS.headers(), contains(
+        headersColumn(H0, BYTES, Optional.of("key0")),
+        headersColumn(H1, BYTES, Optional.of("key1"))
+    ));
+  }
+
+  @Test
   public void shouldExposeAllColumnsWithoutImplicits() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(F0, STRING)
         .keyColumn(K0, BIGINT)
         .valueColumn(F1, BIGINT)
+        .headerColumn(H0, Optional.empty())
         .build();
 
     assertThat(schema.columns(), contains(
         valueColumn(F0, STRING),
         keyColumn(K0, BIGINT),
-        valueColumn(F1, BIGINT)
+        valueColumn(F1, BIGINT),
+        headersColumn(H0, HEADERS_TYPE, Optional.empty())
     ));
   }
 
@@ -321,6 +366,7 @@ public class LogicalSchemaTest {
             .build())
         .valueColumn(ColumnName.of("f7"), SqlTypes.array(STRING))
         .valueColumn(ColumnName.of("f8"), SqlTypes.map(SqlTypes.STRING, STRING))
+        .headerColumn(H0, Optional.empty())
         .build();
 
     // When:
@@ -337,18 +383,59 @@ public class LogicalSchemaTest {
             + "`f5` STRING, "
             + "`f6` STRUCT<`a` BIGINT>, "
             + "`f7` ARRAY<STRING>, "
-            + "`f8` MAP<STRING, STRING>"
+            + "`f8` MAP<STRING, STRING>, "
+            + "`h0` ARRAY<STRUCT<`KEY` STRING, `VALUE` BYTES>> HEADERS"
     ));
   }
 
   @Test
-  public void shouldSupportKeyInterleavedWithValueColumns() {
+  public void shouldConvertSchemaWithExtractedHeadersToString() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(K0, BIGINT)
+        .keyColumn(K1, DOUBLE)
+        .valueColumn(F0, BOOLEAN)
+        .valueColumn(F1, INTEGER)
+        .valueColumn(ColumnName.of("f2"), BIGINT)
+        .valueColumn(ColumnName.of("f4"), DOUBLE)
+        .valueColumn(ColumnName.of("f5"), STRING)
+        .valueColumn(ColumnName.of("f6"), SqlTypes.struct()
+            .field("a", BIGINT)
+            .build())
+        .valueColumn(ColumnName.of("f7"), SqlTypes.array(STRING))
+        .valueColumn(ColumnName.of("f8"), SqlTypes.map(SqlTypes.STRING, STRING))
+        .headerColumn(H0, Optional.of("key"))
+        .build();
+
+    // When:
+    final String s = schema.toString();
+
+    // Then:
+    assertThat(s, is(
+        "`k0` BIGINT KEY, "
+            + "`k1` DOUBLE KEY, "
+            + "`f0` BOOLEAN, "
+            + "`f1` INTEGER, "
+            + "`f2` BIGINT, "
+            + "`f4` DOUBLE, "
+            + "`f5` STRING, "
+            + "`f6` STRUCT<`a` BIGINT>, "
+            + "`f7` ARRAY<STRING>, "
+            + "`f8` MAP<STRING, STRING>, "
+            + "`h0` BYTES HEADER('key')"
+    ));
+  }
+
+  @Test
+  public void shouldSupportKeyAndHeadersInterleavedWithValueColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(F0, BOOLEAN)
         .keyColumn(K0, BIGINT)
         .valueColumn(V0, INTEGER)
+        .headerColumn(H0, Optional.of("key0"))
         .keyColumn(K1, DOUBLE)
+        .headerColumn(H1, Optional.of("key1"))
         .valueColumn(V1, BOOLEAN)
         .build();
 
@@ -360,7 +447,9 @@ public class LogicalSchemaTest {
         "`f0` BOOLEAN, "
             + "`k0` BIGINT KEY, "
             + "`v0` INTEGER, "
+            + "`h0` BYTES HEADER('key0'), "
             + "`k1` DOUBLE KEY, "
+            + "`h1` BYTES HEADER('key1'), "
             + "`v1` BOOLEAN"
     ));
   }
@@ -392,13 +481,14 @@ public class LogicalSchemaTest {
   }
 
   @Test
-  public void shouldAddMetaAndKeyColumnsToValue() {
+  public void shouldAddMetaHeadersAndKeyColumnsToValue() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .keyColumn(K0, INTEGER)
         .keyColumn(K1, STRING)
         .valueColumn(F0, STRING)
         .valueColumn(F1, BIGINT)
+        .headerColumn(H0, Optional.empty())
         .build();
 
     // When:
@@ -410,11 +500,13 @@ public class LogicalSchemaTest {
         .keyColumn(K1, STRING)
         .valueColumn(F0, STRING)
         .valueColumn(F1, BIGINT)
+        .headerColumn(H0, Optional.empty())
         .valueColumn(ROWTIME_NAME, BIGINT)
         .valueColumn(ROWPARTITION_NAME, INTEGER)
         .valueColumn(ROWOFFSET_NAME, BIGINT)
         .valueColumn(K0, INTEGER)
         .valueColumn(K1, STRING)
+        .valueColumn(H0, HEADERS_TYPE)
         .build()
     ));
   }
@@ -510,12 +602,13 @@ public class LogicalSchemaTest {
   }
 
   @Test
-  public void shouldAddMetaAndKeyColumnsOnlyOnce() {
+  public void shouldAddMetaHeaderAndKeyColumnsOnlyOnce() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(F0, STRING)
         .keyColumn(K0, INTEGER)
         .valueColumn(F1, BIGINT)
+        .headerColumn(H0, Optional.of("key0"))
         .build()
         .withPseudoAndKeyColsInValue(false, ksqlConfig);
 
@@ -588,6 +681,7 @@ public class LogicalSchemaTest {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .keyColumn(K0, INTEGER)
+        .headerColumn(H0, Optional.empty())
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, BIGINT)
         .build()
@@ -599,6 +693,7 @@ public class LogicalSchemaTest {
     // Then:
     assertThat(result, is(LogicalSchema.builder()
         .keyColumn(K0, INTEGER)
+        .headerColumn(H0, Optional.empty())
         .valueColumn(F0, BIGINT)
         .valueColumn(F1, BIGINT)
         .build()
@@ -697,6 +792,30 @@ public class LogicalSchemaTest {
   }
 
   @Test
+  public void shouldRemoveHeadersColumnsWhereEverTheyAre() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(K0, STRING)
+        .headerColumn(H0, Optional.empty())
+        .valueColumn(F0, BIGINT)
+        .valueColumn(H0, BIGINT)
+        .valueColumn(F1, BIGINT)
+        .build();
+
+    // When
+    final LogicalSchema result = schema.withoutPseudoAndKeyColsInValue();
+
+    // Then:
+    assertThat(result, is(LogicalSchema.builder()
+        .keyColumn(K0, STRING)
+        .headerColumn(H0, Optional.empty())
+        .valueColumn(F0, BIGINT)
+        .valueColumn(F1, BIGINT)
+        .build()
+    ));
+  }
+
+  @Test
   public void shouldRemoveAllButKeyCols() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
@@ -786,6 +905,57 @@ public class LogicalSchemaTest {
   }
 
   @Test
+  public void shouldThrowOnDuplicateHeaderColumnName() {
+    // Given:
+    final Builder builder = LogicalSchema.builder()
+        .headerColumn(H0, Optional.of("key0"));
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> builder.headerColumn(H0, Optional.of("key1"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Duplicate headers columns found in schema: `h0` BYTES"));
+  }
+
+  @Test
+  public void shouldThrowOnMultipleHeadersColumns() {
+    // Given:
+    final Builder builder = LogicalSchema.builder()
+        .headerColumn(H0, Optional.empty());
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> builder.headerColumn(F0, Optional.empty())
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Schema already contains a HEADERS column."));
+  }
+
+  @Test
+  public void shouldThrowOnRepeatedHeaderKey() {
+    // Given:
+    final Builder builder = LogicalSchema.builder()
+        .headerColumn(H0, Optional.of("key"));
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> builder.headerColumn(F0, Optional.of("key"))
+    );
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Schema already contains a HEADER('key') column."));
+  }
+
+  @Test
   public void shouldSupportCopyingColumnsFromOtherSchemas() {
     // When:
     final LogicalSchema schema = LogicalSchema.builder()
@@ -857,6 +1027,7 @@ public class LogicalSchemaTest {
         .valueColumn(F0, STRING)
         .keyColumn(K0, BIGINT)
         .valueColumn(F1, BIGINT)
+        .headerColumn(H0, Optional.empty())
         .keyColumn(K1, INTEGER)
         .valueColumn(V1, STRING)
         .build()));

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElements.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/TableElements.java
@@ -90,6 +90,8 @@ public final class TableElements implements Iterable<TableElement> {
 
       if (tableElement.getConstraints().isKey() || tableElement.getConstraints().isPrimaryKey()) {
         builder.keyColumn(fieldName, fieldType);
+      } else if (tableElement.getConstraints().isHeaders()) {
+        builder.headerColumn(fieldName, tableElement.getConstraints().getHeaderKey());
       } else {
         builder.valueColumn(fieldName, fieldType);
       }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static io.confluent.ksql.schema.ksql.SystemColumns.HEADERS_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -30,6 +29,8 @@ import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.ColumnConstraints.Builder;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlArray;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
@@ -295,7 +296,10 @@ public class TableElementsTest {
     // Given:
     final TableElements tableElements = TableElements.of(
         tableElement("v0", INT_TYPE),
-        tableElement("h0", new Type(HEADERS_TYPE), HEADERS_CONSTRAINT)
+        tableElement("h0", new Type(SqlArray.of(
+            SqlStruct.builder()
+                .field("KEY", SqlTypes.STRING)
+                .field("VALUE", SqlTypes.BYTES).build())), HEADERS_CONSTRAINT)
     );
 
     // When:

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderV1.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilderV1.java
@@ -284,7 +284,9 @@ final class SourceBuilderV1 extends SourceBuilderBase {
 
     return table
         .transformValues(new AddKeyAndPseudoColumns<>(
-            keyGenerator, streamSource.getPseudoColumnVersion()));
+            keyGenerator,
+            streamSource.getPseudoColumnVersion(),
+            streamSource.getSourceSchema().headers()));
   }
 
   private <K> KStream<K, GenericRow> buildKStream(
@@ -298,7 +300,8 @@ final class SourceBuilderV1 extends SourceBuilderBase {
 
     final int pseudoColumnVersion = streamSource.getPseudoColumnVersion();
     return stream
-        .transformValues(new AddKeyAndPseudoColumns<>(keyGenerator, pseudoColumnVersion));
+        .transformValues(new AddKeyAndPseudoColumns<>(
+            keyGenerator, pseudoColumnVersion, streamSource.getSourceSchema().headers()));
   }
 
   private static Function<GenericKey, Collection<?>> nonWindowedKeyGenerator(


### PR DESCRIPTION
### Description 
Adds `HEADERS` and `HEADER('key')` columns to the logical schema. 

Changes include
* Added a new property, `Optional<String> headerKey` to `Column`
* LogicalSchema builder can add header columns
* LogicalSchema builder checks that there is only one HEADER column, and that the same header key is not used twice

### Testing done 
Added unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

