### PR TITLE
fix: Makes tests wait only 500ms for consumer group cleanup

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -529,6 +529,12 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_VARIABLE_SUBSTITUTION_ENABLE_DOC
       = "Enable variable substitution on SQL statements.";
 
+  public static final String KSQL_QUERY_CLEANUP_SHUTDOWN_TIMEOUT_MS
+      = "ksql.query.cleanup.shutdown.timeout.ms";
+  public static final long KSQL_QUERY_CLEANUP_SHUTDOWN_TIMEOUT_MS_DEFAULT = 30000;
+  public static final String KSQL_QUERY_CLEANUP_SHUTDOWN_TIMEOUT_MS_DOC
+      = "The total time that the query cleanup spends trying to clean things up on shutdown.";
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -1164,6 +1170,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED_DOC
+        )
+        .define(
+            KSQL_QUERY_CLEANUP_SHUTDOWN_TIMEOUT_MS,
+            Type.LONG,
+            KSQL_QUERY_CLEANUP_SHUTDOWN_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_CLEANUP_SHUTDOWN_TIMEOUT_MS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -507,7 +507,9 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     primaryContext.getQueryRegistry().close(closeQueries);
 
     try {
-      cleanupService.stopAsync().awaitTerminated(30, TimeUnit.SECONDS);
+      cleanupService.stopAsync().awaitTerminated(
+          ksqlConfig.getLong(KsqlConfig.KSQL_QUERY_CLEANUP_SHUTDOWN_TIMEOUT_MS),
+          TimeUnit.MILLISECONDS);
     } catch (final TimeoutException e) {
       log.warn("Timed out while closing cleanup service. "
               + "External resources for the following applications may be orphaned: {}",

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -567,6 +567,7 @@ public class TestKsqlRestApp extends ExternalResource {
     configMap.put(KsqlConfig.KSQL_STREAMS_PREFIX + "auto.offset.reset", "earliest");
     configMap.put(KsqlConfig.KSQL_ENABLE_UDFS, false);
     configMap.put(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, false);
+    configMap.put(KsqlConfig.KSQL_QUERY_CLEANUP_SHUTDOWN_TIMEOUT_MS, 500L);
     configMap.putAll(additionalProps);
     return configMap;
   }


### PR DESCRIPTION
### Description 
Currently, the `QueryCleanupService` waits 30s on shutdown.  For some hard to debug reason, in tests, I constantly get `GroupNotEmptyException`s for query ids of queries that have been deleted in tests.  This makes mosts functional tests timeout at 30s.

This PR makes that value a config and sets it to 500ms in functional tests.  After all, when a server is shut down in a test, the state is going to be wiped out anyway.  This makes many functional tests go from 40s to 10s in my testing which makes it much easier to deal with and will hopefully speed up our test runs.

### Testing done 
Ran tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

