### PR TITLE
chore: reenable -Werror and fix a year's worth of accumulated errors

### DIFF
--- a/ksqldb-benchmark/pom.xml
+++ b/ksqldb-benchmark/pom.xml
@@ -103,7 +103,7 @@ questions.
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <compilerArgs>
-            <arg>-Xlint:all,-serial,-processing</arg>
+            <arg>${compile.warnings-args}</arg>
             <arg>${compile.warnings-flag}</arg>
           </compilerArgs>
           <showWarnings>true</showWarnings>

--- a/ksqldb-cli/pom.xml
+++ b/ksqldb-cli/pom.xml
@@ -123,7 +123,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial</arg>
+                        <arg>${compile.warnings-args}</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -125,7 +125,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial</arg>
+                        <arg>${compile.warnings-args}</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/CompatibleElement.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/CompatibleElement.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * Interface get a set of incompatible elements for an object
  * @see CompatibleSet
  */
-public interface CompatibleElement<T extends CompatibleElement> {
+public interface CompatibleElement<T extends CompatibleElement<T>> {
 
   Set<T> getIncompatibleWith();
 }

--- a/ksqldb-engine-common/pom.xml
+++ b/ksqldb-engine-common/pom.xml
@@ -59,8 +59,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <compilerArgs>
-            <arg>-Xlint:all,-serial</arg>
             <arg>${compile.warnings-flag}</arg>
+            <arg>${compile.warnings-args}</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/ksqldb-engine/pom.xml
+++ b/ksqldb-engine/pom.xml
@@ -190,7 +190,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial,-options,-path,-rawtypes</arg>
+                        <arg>${compile.warnings-args},-options,-path,-rawtypes</arg>
                         <arg>-parameters</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -390,7 +390,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   private TopicDescription getTopicDescription(final Admin admin, final String sourceTopicName) {
     final KafkaFuture<TopicDescription> topicDescriptionKafkaFuture = admin
         .describeTopics(Collections.singletonList(sourceTopicName))
-        .values()
+        .topicNameValues()
         .get(sourceTopicName);
 
     try {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -171,7 +171,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           () -> adminClient.get().describeTopics(
               ImmutableList.of(topic),
               new DescribeTopicsOptions().includeAuthorizedOperations(true)
-          ).values().get(topic).get(),
+          ).topicNameValues().get(topic).get(),
           RetryBehaviour.ON_RETRYABLE.and(e -> !(e instanceof UnknownTopicOrPartitionException))
       );
       return true;
@@ -205,7 +205,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           () -> adminClient.get().describeTopics(
               topicNames,
               new DescribeTopicsOptions().includeAuthorizedOperations(true)
-          ).all().get(),
+          ).allTopicNames().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
     } catch (final ExecutionException e) {
       throw new KafkaResponseGetFailedException(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetrics.java
@@ -87,7 +87,7 @@ public class PersistentQuerySaturationMetrics implements Runnable {
     this.reporter = Objects.requireNonNull(reporter, "reporter");
     this.window = Objects.requireNonNull(window, "window");
     this.sampleMargin = Objects.requireNonNull(sampleMargin, "sampleMargin");
-    this.customTags = Objects.requireNonNull(customTags, "customTags");
+    PersistentQuerySaturationMetrics.customTags = Objects.requireNonNull(customTags, "customTags");
   }
 
   @Override

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -178,6 +178,7 @@ public class KsqlEngineTest {
         is(SourceName.of("FOO")));
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void shouldCreateSourceTablesQueries() {
     // Given:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -52,10 +52,11 @@ public class StorageUtilizationMetricsReporterTest {
   @Captor
   private ArgumentCaptor<MetricValueProvider<?>> metricValueProvider;
 
+  @SuppressWarnings("unchecked")
   @Before
   public void setUp() {
     listener = new StorageUtilizationMetricsReporter(metrics);
-    when(metrics.metricName(any(), any(), (Map<String, String>) any())).thenAnswer(
+    when(metrics.metricName(any(), any(), any(Map.class))).thenAnswer(
       a -> new MetricName(a.getArgument(0), a.getArgument(1), "", a.getArgument(2)));
     StorageUtilizationMetricsReporter.setTags(BASE_TAGS);
   }
@@ -75,7 +76,7 @@ public class StorageUtilizationMetricsReporterTest {
     final File f = new File("/tmp/storage-test/");
     f.getParentFile().mkdirs();
     f.createNewFile();
-    listener.configureShared(f, metrics, BASE_TAGS);
+    StorageUtilizationMetricsReporter.configureShared(f, metrics, BASE_TAGS);
 
     // When:
     final Gauge<?> storageFreeGauge = verifyAndGetRegisteredMetric("node_storage_free_bytes", BASE_TAGS);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/consumer/ScalablePushConsumerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/consumer/ScalablePushConsumerTest.java
@@ -179,7 +179,6 @@ public class ScalablePushConsumerTest {
               consumer.newAssignment(ImmutableList.of(TP1));
               return RECORDS_JUST1;
             } else {
-              consumer.close();
               return EMPTY_RECORDS;
             }
           });
@@ -211,7 +210,6 @@ public class ScalablePushConsumerTest {
             count.incrementAndGet();
             if (count.get() == 2) {
               consumer.newAssignment(ImmutableList.of(TP0, TP1));
-              consumer.close();
             }
             return EMPTY_RECORDS;
           });

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -929,8 +929,8 @@ public class KafkaTopicClientImplTest {
       }
 
       final DescribeTopicsResult describeTopicsResult = mock(DescribeTopicsResult.class);
-      when(describeTopicsResult.values()).thenReturn(describe );
-      when(describeTopicsResult.all()).thenReturn(KafkaFuture.completedFuture(result));
+      when(describeTopicsResult.topicNameValues()).thenReturn(describe );
+      when(describeTopicsResult.allTopicNames()).thenReturn(KafkaFuture.completedFuture(result));
       return describeTopicsResult;
     };
   }
@@ -946,10 +946,10 @@ public class KafkaTopicClientImplTest {
           throw new IllegalStateException("Duplicate key");
         }
       }
-      when(describeTopicsResult.values()).thenReturn(map);
+      when(describeTopicsResult.topicNameValues()).thenReturn(map);
 
       final KafkaFuture<Map<String, TopicDescription>> f = failedFuture(e);
-      when(describeTopicsResult.all()).thenReturn(f);
+      when(describeTopicsResult.allTopicNames()).thenReturn(f);
       return describeTopicsResult;
     };
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetricsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetricsTest.java
@@ -355,6 +355,7 @@ public class PersistentQuerySaturationMetricsTest {
   private static final class GivenMetrics {
     final Map<MetricName, Metric> metrics = new HashMap<>();
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private GivenMetrics(final KafkaStreams kafkaStreams) {
       when(kafkaStreams.metrics()).thenReturn((Map) metrics);
     }

--- a/ksqldb-examples/pom.xml
+++ b/ksqldb-examples/pom.xml
@@ -71,7 +71,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial</arg>
+                        <arg>${compile.warnings-args}</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/ksqldb-execution/pom.xml
+++ b/ksqldb-execution/pom.xml
@@ -106,7 +106,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                  <configuration>
                      <compilerArgs>
-                         <arg>-Xlint:all,-serial,-rawtypes</arg>
+                         <arg>${compile.warnings-args},-rawtypes</arg>
                          <arg>${compile.warnings-flag}</arg>
                      </compilerArgs>
                  </configuration>

--- a/ksqldb-functional-tests/pom.xml
+++ b/ksqldb-functional-tests/pom.xml
@@ -170,7 +170,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <compilerArgs>
-            <arg>-Xlint:all,-serial</arg>
+            <arg>${compile.warnings-args}</arg>
             <arg>${compile.warnings-flag}</arg>
           </compilerArgs>
         </configuration>

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -147,6 +147,7 @@ public final class RecordNode {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private Object coerceRecord(
       final Object record,
       final ParsedSchema schema,

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -601,6 +601,7 @@ public class TestExecutor implements Closeable {
         .forEach(kafka::writeRecord);
   }
 
+  @SuppressWarnings("unchecked")
   private static Object coerceRecordFields(final Object record) {
     if (!(record instanceof Map)) {
       return record;

--- a/ksqldb-parser/pom.xml
+++ b/ksqldb-parser/pom.xml
@@ -100,7 +100,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial,-options,-path,-rawtypes</arg>
+                        <arg>${compile.warnings-args},-options,-path,-rawtypes</arg>
                         <arg>-parameters</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>

--- a/ksqldb-rest-app/pom.xml
+++ b/ksqldb-rest-app/pom.xml
@@ -192,7 +192,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial</arg>
+                        <arg>${compile.warnings-args}</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -36,7 +36,6 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -349,10 +348,12 @@ public class ServerVerticle extends AbstractVerticle {
 
   private void handleWebsocket(final RoutingContext routingContext) {
     final ApiSecurityContext apiSecurityContext = DefaultApiSecurityContext.create(routingContext);
-    final ServerWebSocket serverWebSocket = routingContext.request().upgrade();
-    endpoints
-        .executeWebsocketStream(serverWebSocket, routingContext.request().params(),
-            server.getWorkerExecutor(), apiSecurityContext, context);
+    routingContext.request().toWebSocket(future -> {
+      endpoints
+          .executeWebsocketStream(future.result(), routingContext.request().params(),
+                                  server.getWorkerExecutor(), apiSecurityContext, context);
+    });
+
   }
 
   private static void chcHandler(final RoutingContext routingContext) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -144,8 +144,8 @@ public class HealthCheckAgent {
         healthCheckAgent.serviceContext
             .getAdminClient()
             .describeTopics(Collections.singletonList(commandTopic),
-                new DescribeTopicsOptions().timeoutMs(DESCRIBE_TOPICS_TIMEOUT_MS))
-            .all()
+                            new DescribeTopicsOptions().timeoutMs(DESCRIBE_TOPICS_TIMEOUT_MS))
+            .allTopicNames()
             .get();
 
         isHealthy = true;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -99,7 +99,7 @@ public class HealthCheckAgentTest {
 
     final DescribeTopicsResult topicsResult = mock(DescribeTopicsResult.class);
     givenDescribeTopicsReturns(topicsResult);
-    when(topicsResult.all()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
+    when(topicsResult.allTopicNames()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.RUNNING);
 
     final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -54,7 +54,9 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.WebsocketVersion;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
@@ -374,8 +376,10 @@ public final class RestIntegrationTestUtil {
       final Vertx vertx = Vertx.vertx();
       final HttpClient httpClient = vertx.createHttpClient(options);
       final VertxCompletableFuture<Void> vcf = new VertxCompletableFuture<>();
-      final HttpClientRequest httpClientRequest = httpClient.request(method,
-          uri,
+      final HttpClientRequest httpClientRequest = httpClient.request(
+          method,
+          SocketAddress.inetSocketAddress(options.getDefaultPort(), options.getDefaultHost()),
+          new RequestOptions().setURI(uri),
           resp -> {
             resp.handler(buffer -> {
               try {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -295,7 +295,7 @@ public class QueryStreamWriterTest {
             ? null
             : GenericRow.genericRow(rows[i + 1]);
 
-        output.add(new KeyValueMetadata(KeyValue.keyValue(key, value)));
+        output.add(new KeyValueMetadata<>(KeyValue.keyValue(key, value)));
       }
 
       return null;
@@ -312,7 +312,7 @@ public class QueryStreamWriterTest {
             ? null
             : GenericRow.genericRow(rows[i + 1]);
 
-        output.add(new KeyValueMetadata(KeyValue.keyValue(key, value)));
+        output.add(new KeyValueMetadata<>(KeyValue.keyValue(key, value)));
       }
 
       return null;

--- a/ksqldb-rest-client/pom.xml
+++ b/ksqldb-rest-client/pom.xml
@@ -85,7 +85,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <compilerArgs>
-            <arg>-Xlint:all,-serial</arg>
+            <arg>${compile.warnings-args}</arg>
             <arg>${compile.warnings-flag}</arg>
           </compilerArgs>
         </configuration>

--- a/ksqldb-rest-model/pom.xml
+++ b/ksqldb-rest-model/pom.xml
@@ -78,7 +78,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial</arg>
+                        <arg>${compile.warnings-args}</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/ksqldb-serde/pom.xml
+++ b/ksqldb-serde/pom.xml
@@ -114,7 +114,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial</arg>
+                        <arg>${compile.warnings-args}</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/ksqldb-streams/pom.xml
+++ b/ksqldb-streams/pom.xml
@@ -82,7 +82,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial,-rawtypes</arg>
+                        <arg>${compile.warnings-args},-rawtypes</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -325,7 +325,8 @@ class KafkaEmbedded {
   public Map<String, Integer> getPartitionCount(final Collection<String> topics) {
     try (AdminClient adminClient = adminClient()) {
       final DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(topics);
-      final Map<String, TopicDescription> topicDescriptionMap = describeTopicsResult.all().get();
+      final Map<String, TopicDescription> topicDescriptionMap
+          = describeTopicsResult.allTopicNames().get();
       return topicDescriptionMap
           .entrySet()
           .stream()

--- a/ksqldb-tools/pom.xml
+++ b/ksqldb-tools/pom.xml
@@ -107,7 +107,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial</arg>
+                        <arg>${compile.warnings-args}</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/ksqldb-version-metrics-client/pom.xml
+++ b/ksqldb-version-metrics-client/pom.xml
@@ -76,7 +76,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>-Xlint:all,-options,-path,-unchecked,-serial,-rawtypes</arg>
+                        <arg>${compile.warnings-args},-options,-path,-unchecked,-rawtypes</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
         <compile.warnings-flag>-Werror</compile.warnings-flag>
+        <compile.warnings-args>-Xlint:all,-serial,-processing</compile.warnings-args>
         <!-- Only used to provide login module implementation for tests -->
         <jetty.version>9.4.28.v20200408</jetty.version>
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
@@ -670,7 +671,7 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial,-options,-path,-processing</arg>
+                        <arg>${compile.warnings-args},-options,-path,</arg>
                         <arg>-parameters</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -670,7 +670,7 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <compilerArgs>
-                        <arg>-Xlint:all,-serial,-options,-path</arg>
+                        <arg>-Xlint:all,-serial,-options,-path,-processing</arg>
                         <arg>-parameters</arg>
                         <arg>${compile.warnings-flag}</arg>
                     </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,7 @@
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
-        <!-- Temporarily disabling this because it is causing failures in packaging but not CI builds. -->
-        <!-- <compile.warnings-flag>-Werror</compile.warnings-flag> -->
+        <compile.warnings-flag>-Werror</compile.warnings-flag>
         <!-- Only used to provide login module implementation for tests -->
         <jetty.version>9.4.28.v20200408</jetty.version>
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>


### PR DESCRIPTION
Apparently we had "temporarily" disable the `-Werror` flag, which turned out to be over a year ago by now. This PR reenables it and handles all the warnings we have accumulated since it was commented out

