### PR TITLE
fix: Fixes a timestamp bug with Scalable Push Queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/ScalablePushRegistry.java
@@ -127,7 +127,7 @@ public class ScalablePushRegistry {
     final LatestConsumer latestConsumer = this.latestConsumer.get();
     // Even if it's closing async, we just call close anyway to try to do it immediately
     if (latestConsumer != null) {
-      latestConsumer.close();
+      latestConsumer.closeAsync();
     }
 
     executorService.shutdown();


### PR DESCRIPTION
### Description 
This PR actually fixes two bugs.  One is that there is a case where the last messages were produced to some output topic over 30s ago but the last latest consumer was run much longer before.  The intent is that we seek to latest since there are no recent messages but instead it would find null values in the map from the call to:

```
final Map<TopicPartition, OffsetAndTimestamp> offsetAndTimestampMap =
        consumer.offsetsForTimes(timestamps);
```

And the result is that it would not do a comparison and default to using committed offsets.  If the committed offsets were old, you'd get a lot of data!

Another fix is of calling the `close` method on `ScalablePushConsumer`, which would call `consumer.close()`, which could happen from another thread than the one the `KafkaConsumer` was on, which would result in an error message about threadsafety.  This was done in part because it was meant to stop immediately, but it turns out there's a `consumer.wakeup()` call which will immediately interrupt the poll and throw a `WakeupException`, which can be called from another thread.  This is now used in `ScalablePushConsumer.closeAsync` so that it closes quickly now rather than hanging on a poll.


### Testing done 
Unit and manual tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

