### PR TITLE
KSE-599: Add token field to JaasPrincipal

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasAuthProvider.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasAuthProvider.java
@@ -128,7 +128,7 @@ public class JaasAuthProvider implements AuthProvider {
     // We do the actual authorization here not in the User class
     final boolean authorized = validateRoles(lc, allowedRoles);
 
-    promise.complete(new JaasUser(username, authorized));
+    promise.complete(new JaasUser(username, password, authorized));
   }
 
   private static boolean validateRoles(final LoginContext lc, final List<String> allowedRoles) {
@@ -149,8 +149,9 @@ public class JaasAuthProvider implements AuthProvider {
     private final Principal principal;
     private boolean authorized;
 
-    JaasUser(final String username, final boolean authorized) {
-      this.principal = new JaasPrincipal(Objects.requireNonNull(username));
+    JaasUser(final String username, final String password, final boolean authorized) {
+      this.principal = new JaasPrincipal(Objects.requireNonNull(username),
+          Objects.requireNonNull(password));
       this.authorized = authorized;
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
@@ -15,18 +15,32 @@
 
 package io.confluent.ksql.api.auth;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
+import java.util.Base64;
 import java.util.Objects;
 
 /**
  * Principal implementation created when authenticating with the JaasAuthProvider
  */
-class JaasPrincipal implements Principal {
+public class JaasPrincipal implements Principal {
 
   private final String name;
 
-  JaasPrincipal(final String name) {
+  private final String token;
+
+  public JaasPrincipal(final String name, final String password) {
     this.name = Objects.requireNonNull(name);
+    this.token = createToken(name, Objects.requireNonNull(password));
+  }
+
+  private String createToken(final String name, final String secret) {
+    return Base64.getEncoder().encodeToString((name + ":" + secret)
+        .getBytes(StandardCharsets.ISO_8859_1));
+  }
+
+  public String getToken() {
+    return token;
   }
 
   @Override


### PR DESCRIPTION
### Description 

This patch adds `token` field to the `JaasPrincipal` and a `password` to the constructor. We need the token to authenticate to MDS with that principal. See https://github.com/confluentinc/confluent-security-plugins/pull/417 and https://github.com/confluentinc/confluent-cloud-plugins/pull/239 for more details.

### Testing done 

I ran relevant unit tests locally to make sure that changes in constructor don't break anything. Then, I built the `ksqldb-rest-app` jar and tested https://github.com/confluentinc/confluent-security-plugins/pull/417 with it. After that, I built `confluent-ksql-security-plugin` and tested https://github.com/confluentinc/confluent-cloud-plugins/pull/239 with it.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

