### PR TITLE
docs: fix docs to reflect that `fail.on.*.error` configs cannot be applied per query

### DIFF
--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -73,7 +73,7 @@ an external `ksql.connect.url`.
 
 ## `ksql.fail.on.deserialization.error`
 
-**Per query:** yes
+**Per query:** no
 
 Indicates whether to fail if corrupt messages are read. ksqlDB decodes
 messages at runtime when reading from a Kafka topic. The decoding that
@@ -91,7 +91,7 @@ add the following setting to your ksqlDB Server properties file:
 
 ## `ksql.fail.on.production.error`
 
-**Per query:** yes
+**Per query:** no
 
 Indicates whether to fail if ksqlDB fails to publish a record to an output
 topic due to a {{ site.ak }} producer exception. The default value in ksqlDB is


### PR DESCRIPTION
### Description 

The configs `ksql.fail.on.production.error` and `ksql.fail.on.deserialization.error` can only be set at a server level, and cannot be applied per-query. This PR fixes an error in the docs to reflect this.

Once merged, I'll cherry-pick to the (recent) live ksqlDB docs branches as well.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

