### PR TITLE
[WIP] fix: refactor the query validation path for shared runtimes

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/QueryApplicationId.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/QueryApplicationId.java
@@ -22,7 +22,17 @@ import io.confluent.ksql.query.QueryId;
  */
 public final class QueryApplicationId {
 
+  private static String SANDBOXED_ID_SUFFIX = "__validation";
+
   private QueryApplicationId() {
+  }
+
+  public static String getSandboxedRuntimeId(final String originalAppId) {
+    return originalAppId + SANDBOXED_ID_SUFFIX;
+  }
+
+  public static String extractOriginalIdFromSandboxedRuntimeId(final String sandboxedRuntimeId) {
+    return sandboxedRuntimeId.substring(0, sandboxedRuntimeId.lastIndexOf(SANDBOXED_ID_SUFFIX));
   }
 
   public static String buildSharedRuntimeId(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedBinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedBinPackedPersistentQueryMetadataImpl.java
@@ -23,16 +23,18 @@ public final class SandboxedBinPackedPersistentQueryMetadataImpl
     extends BinPackedPersistentQueryMetadataImpl {
   public static SandboxedBinPackedPersistentQueryMetadataImpl of(
       final BinPackedPersistentQueryMetadataImpl queryMetadata,
-      final QueryMetadata.Listener listener
+      final QueryMetadata.Listener listener,
+      final SandboxedSharedKafkaStreamsRuntimeImpl sandboxedRuntime
   ) {
-    return new SandboxedBinPackedPersistentQueryMetadataImpl(queryMetadata, listener);
+    return new SandboxedBinPackedPersistentQueryMetadataImpl(queryMetadata, listener, sandboxedRuntime);
   }
 
   private SandboxedBinPackedPersistentQueryMetadataImpl(
       final BinPackedPersistentQueryMetadataImpl queryMetadata,
-      final QueryMetadata.Listener listener
+      final QueryMetadata.Listener listener,
+      final SandboxedSharedKafkaStreamsRuntimeImpl sandboxedRuntime
   ) {
-    super(queryMetadata, listener);
+    super(queryMetadata, listener, sandboxedRuntime);
   }
 
   @Override

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
@@ -70,7 +70,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
     when(kafkaStreamsBuilder.buildNamedTopologyWrapper(any())).thenReturn(kafkaStreamsNamedTopologyWrapper).thenReturn(kafkaStreamsNamedTopologyWrapper2);
     validationSharedKafkaStreamsRuntime = new SandboxedSharedKafkaStreamsRuntimeImpl(
         kafkaStreamsBuilder,
-        5,
         streamProps
     );
     when(queryId.toString()).thenReturn("query 1");
@@ -78,7 +77,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
 
     validationSharedKafkaStreamsRuntime.markSources(queryId, Collections.singleton(SourceName.of("foo")));
     validationSharedKafkaStreamsRuntime.register(
-        queryErrorClassifier,
         persistentQueriesInSharedRuntimes,
         queryId);
     when(kafkaStreamsNamedTopologyWrapper.getTopologyByName(any())).thenReturn(Optional.empty());
@@ -101,7 +99,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
     //When:
     final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
         () -> validationSharedKafkaStreamsRuntime.register(
-            queryErrorClassifier,
             persistentQueriesInSharedRuntimes,
             queryId2));
     //Then

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
         <netty-codec-http2-version>4.1.69.Final</netty-codec-http2-version>
         <!-- Brought in by both schema registry and connect, we need to pick a version -->
         <jersey-common>2.34</jersey-common>
+        <kafka.version>3.2.0-SNAPSHOT</kafka.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
The initial PR implementing shared runtimes glossed over the validation since there were some tricky aspects to it, and we decided to address those as followup. This is that followup