### PR TITLE
chore: flaky test

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
@@ -214,7 +214,8 @@ public class ConsistencyOffsetVectorFunctionalTest {
     // Then
     assertThat(rows, hasSize(1));
     assertThat(batchedQueryResult.queryID().get(), is(nullValue()));
-    assertThat(((ClientImpl)client).getSerializedConsistencyVector(), is(notNullValue()));
+    assertThatEventually(() -> ((ClientImpl)client).getSerializedConsistencyVector(),
+                          is(notNullValue()));
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();
     verifyConsistencyVector(serializedCV);
   }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.api.client.BatchedQueryResult;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.ClientOptions;
+import io.confluent.ksql.api.client.Row;
 import io.confluent.ksql.api.client.StreamedQueryResult;
 import io.confluent.ksql.api.client.impl.ClientImpl;
 import io.confluent.ksql.integration.IntegrationTestHarness;
@@ -182,10 +183,10 @@ public class ConsistencyOffsetVectorFunctionalTest {
         true
     );
 
+    assertThatEventually(streamedQueryResult::isComplete, is(true));
     assertThat(((ClientImpl)client).getSerializedConsistencyVector(), is(notNullValue()));
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();
     verifyConsistencyVector(serializedCV);
-    assertThatEventually(streamedQueryResult::isComplete, is(true));
   }
 
   @Test
@@ -196,11 +197,11 @@ public class ConsistencyOffsetVectorFunctionalTest {
     streamedQueryResult.poll();
 
     // Then
+    assertThatEventually(streamedQueryResult::isComplete, is(true));
     assertThatEventually(() -> ((ClientImpl)client).getSerializedConsistencyVector(),
                          is(notNullValue()));
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();
     verifyConsistencyVector(serializedCV);
-    assertThatEventually(streamedQueryResult::isComplete, is(true));
   }
 
   @Test
@@ -208,9 +209,10 @@ public class ConsistencyOffsetVectorFunctionalTest {
     // When
     final BatchedQueryResult batchedQueryResult = client.executeQuery(
         PULL_QUERY_ON_TABLE, ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true));
-    batchedQueryResult.get();
+    final List<Row> rows = batchedQueryResult.get();
 
     // Then
+    assertThat(rows, hasSize(1));
     assertThat(batchedQueryResult.queryID().get(), is(nullValue()));
     assertThat(((ClientImpl)client).getSerializedConsistencyVector(), is(notNullValue()));
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();


### PR DESCRIPTION
### Description 
`shouldRoundTripCVWhenExecutePullQuery` and `shouldRoundTripCVWhenPullQueryOnTableSync` have flaky behavior on jenkins. I added some extra assertions that, even if they don't address the issue, may help us identify what is going on since I cannot reproduce these locally, 
### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

