### PR TITLE
test: cherry-pick #7863 to the 5.5.x branch

### DIFF
--- a/ksqldb-version-metrics-client/pom.xml
+++ b/ksqldb-version-metrics-client/pom.xml
@@ -54,16 +54,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <version>3.10.4</version>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -76,19 +69,6 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
             <version>${apache.httpcomponents.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <version>3.10.4</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
+++ b/ksqldb-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/VersionCheckerIntegrationTest.java
@@ -15,24 +15,20 @@
 
 package io.confluent.ksql.version.metrics;
 
-import static org.mockserver.model.HttpRequest.request;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 import io.confluent.support.metrics.BaseSupportConfig;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.test.TestUtils;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.mockserver.integration.ClientAndProxy;
-import org.mockserver.socket.PortFactory;
 
 public class VersionCheckerIntegrationTest {
-
-  private static int proxyPort;
-  private static ClientAndProxy clientAndProxy;
 
   @Rule
   public final Timeout timeout = Timeout.builder()
@@ -40,14 +36,16 @@ public class VersionCheckerIntegrationTest {
       .withLookingForStuckThread(true)
       .build();
 
-  @BeforeClass
-  public static void startProxy() {
-    proxyPort = PortFactory.findFreePort();
-    clientAndProxy = ClientAndProxy.startClientAndProxy(proxyPort);
-  }
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(
+      WireMockConfiguration.wireMockConfig()
+          .dynamicPort()
+  );
 
   @Test
   public void testMetricsAgent() throws InterruptedException {
+    WireMock.stubFor(WireMock.post("/ksql/anon").willReturn(WireMock.ok()));
 
     final KsqlVersionCheckerAgent versionCheckerAgent = new KsqlVersionCheckerAgent(
         () -> false
@@ -57,13 +55,13 @@ public class VersionCheckerIntegrationTest {
         .CONFLUENT_SUPPORT_METRICS_ENDPOINT_SECURE_ENABLE_CONFIG, "false");
     versionCheckProps.setProperty(
         BaseSupportConfig.CONFLUENT_SUPPORT_PROXY_CONFIG,
-        "http://localhost:" + proxyPort
+        "http://localhost:" + wireMockRule.port()
     );
     versionCheckerAgent.start(KsqlModuleType.SERVER, versionCheckProps);
 
     TestUtils.waitForCondition(() -> {
           try {
-            clientAndProxy.verify(request().withPath("/ksql/anon").withMethod("POST"));
+            WireMock.verify(WireMock.postRequestedFor(WireMock.urlPathEqualTo("/ksql/anon")));
             return true;
           } catch (final AssertionError e) {
             return false;


### PR DESCRIPTION
### Description 
After the netty version was bumped on 5.5.x, the version checker test started failing. This PR ports a fix that makes the test not dependent on specific netty versions.

### Testing done 
The test passes locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

