### PR TITLE
fix: Fixes flaky ScalablePushBandwidthThrottleIntegrationTest caused by timeout

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
@@ -97,7 +97,7 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
 
   @Rule
   public final Timeout timeout = Timeout.builder()
-      .withTimeout(2, TimeUnit.MINUTES)
+      .withTimeout(3, TimeUnit.MINUTES)
       .withLookingForStuckThread(true)
       .build();
 
@@ -133,6 +133,7 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
   @SuppressFBWarnings({"DLS_DEAD_LOCAL_STORE"})
   @Test
   public void scalablePushBandwidthThrottleTestHTTP1() {
+
     assertAllPersistentQueriesRunning();
     String veryLong = createDataSize(100000);
     String sql = "SELECT CONCAT(\'"+ veryLong + "\') as placeholder from " + AGG_TABLE + " EMIT CHANGES LIMIT 1;";

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
@@ -97,7 +97,7 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
 
   @Rule
   public final Timeout timeout = Timeout.builder()
-      .withTimeout(3, TimeUnit.MINUTES)
+      .withTimeout(4, TimeUnit.MINUTES)
       .withLookingForStuckThread(true)
       .build();
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
@@ -133,7 +133,6 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
   @SuppressFBWarnings({"DLS_DEAD_LOCAL_STORE"})
   @Test
   public void scalablePushBandwidthThrottleTestHTTP1() {
-
     assertAllPersistentQueriesRunning();
     String veryLong = createDataSize(100000);
     String sql = "SELECT CONCAT(\'"+ veryLong + "\') as placeholder from " + AGG_TABLE + " EMIT CHANGES LIMIT 1;";


### PR DESCRIPTION
### Description 
Because `ScalablePushBandwidthThrottleIntegrationTest` creates a server per test, the startup time is attributed to the test, so although there's a 2 minute limit, most of it can be taken up by this startup.  When the test then runs, the server gets terminated part way through and you get a funny connection closed error rather than a timeout, leading to confusion.

This ups the timeout of this test to prevent this.

### Testing done 
Ran the test and simulated slow startup and was able to reproduce flaky stacktraces.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

