### PR TITLE
feat: block inserting into sources with headers

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -302,6 +302,15 @@ public final class LogicalSchema {
   }
 
   /**
+   * @param columnName the column name to check
+   * @return {@code true} if the column matches the name of any key column.
+   */
+  public boolean isHeaderColumn(final ColumnName columnName) {
+    return findColumnMatching(withNamespace(HEADERS).and(withName(columnName)))
+        .isPresent();
+  }
+
+  /**
    * Returns True if this schema is compatible with {@code other} schema.
    */
   public boolean compatibleSchema(final LogicalSchema other) {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -848,6 +848,14 @@ public class LogicalSchemaTest {
   }
 
   @Test
+  public void shouldMatchHeaderColumnName() {
+    assertThat(SOME_SCHEMA.isHeaderColumn(H0), is(true));
+    assertThat(SOME_SCHEMA.isHeaderColumn(ROWPARTITION_NAME), is(false));
+    assertThat(SOME_SCHEMA.isHeaderColumn(K0), is(false));
+    assertThat(SOME_SCHEMA.isHeaderColumn(F0), is(false));
+  }
+
+  @Test
   public void shouldMatchMetaColumnName() {
     assertThat(SystemColumns.isPseudoColumn(ROWTIME_NAME, ROWTIME_PSEUDOCOLUMN_VERSION), is(true));
     assertThat(SOME_SCHEMA.isKeyColumn(ROWTIME_NAME), is(false));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -282,7 +282,8 @@ public class DistributingExecutor {
     }
 
     if (!dataSource.getSchema().headers().isEmpty()) {
-      throw new KsqlException("Cannot insert into a source with header columns");
+      throw new KsqlException("Cannot insert into " + insertInto.getTarget().text()
+          + " because it has header columns");
     }
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -163,7 +163,7 @@ public class DistributingExecutor {
         .inject(statement);
 
     if (injected.getStatement() instanceof InsertInto) {
-      throwIfInsertOnReadOnlyTopic(
+      validateInsertIntoQueries(
           executionContext.getMetaStore(),
           (InsertInto) injected.getStatement()
       );
@@ -266,7 +266,7 @@ public class DistributingExecutor {
     }
   }
 
-  private void throwIfInsertOnReadOnlyTopic(
+  private void validateInsertIntoQueries(
       final MetaStore metaStore,
       final InsertInto insertInto
   ) {
@@ -279,6 +279,10 @@ public class DistributingExecutor {
     if (internalTopics.isReadOnly(dataSource.getKafkaTopicName())) {
       throw new KsqlException("Cannot insert into read-only topic: "
           + dataSource.getKafkaTopicName());
+    }
+
+    if (!dataSource.getSchema().headers().isEmpty()) {
+      throw new KsqlException("Cannot insert into a source with header columns");
     }
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -32,7 +32,6 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.rest.SessionProperties;
-import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.registry.SchemaRegistryUtil;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -433,7 +433,7 @@ public class DistributingExecutorTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), is("Cannot insert into a source with header columns"));
+    assertThat(e.getMessage(), is("Cannot insert into s1 because it has header columns"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -1156,7 +1156,7 @@ public class InsertValuesExecutorTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), is("Cannot insert into a HEADER column"));
+    assertThat(e.getMessage(), is("Cannot insert into HEADER columns: HEAD0"));
   }
 
   @Test
@@ -1181,7 +1181,7 @@ public class InsertValuesExecutorTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), is("Cannot insert into a HEADER column"));
+    assertThat(e.getMessage(), is("Cannot insert into HEADER columns: HEAD0, HEAD1"));
   }
 
   @Test
@@ -1225,7 +1225,7 @@ public class InsertValuesExecutorTest {
     );
 
     // Then:
-    assertThat(e.getMessage(), is("Cannot insert into a HEADER column"));
+    assertThat(e.getMessage(), is("Cannot insert into HEADER columns: HEAD0"));
   }
 
   private static ConfiguredStatement<InsertValues> givenInsertValues(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.GenericKey.genericKey;
 import static io.confluent.ksql.GenericRow.genericRow;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,6 +48,7 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
+import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
@@ -109,6 +111,8 @@ public class InsertValuesExecutorTest {
   private static final ColumnName COL0 = ColumnName.of("COL0");
   private static final ColumnName COL1 = ColumnName.of("COL1");
   private static final ColumnName INT_COL = ColumnName.of("INT");
+  private static final ColumnName HEAD0 = ColumnName.of("HEAD0");
+  private static final ColumnName HEAD1 = ColumnName.of("HEAD1");
 
   private static final LogicalSchema SINGLE_VALUE_COLUMN_SCHEMA = LogicalSchema.builder()
       .keyColumn(K0, SqlTypes.STRING)
@@ -119,6 +123,21 @@ public class InsertValuesExecutorTest {
       .keyColumn(K0, SqlTypes.STRING)
       .valueColumn(COL0, SqlTypes.STRING)
       .valueColumn(COL1, SqlTypes.BIGINT)
+      .build();
+
+  private static final LogicalSchema SCHEMA_WITH_HEADERS = LogicalSchema.builder()
+      .keyColumn(K0, SqlTypes.STRING)
+      .valueColumn(COL0, SqlTypes.STRING)
+      .valueColumn(COL1, SqlTypes.BIGINT)
+      .headerColumn(HEAD0, Optional.empty())
+      .build();
+
+  private static final LogicalSchema SCHEMA_WITH_KEY_HEADERS = LogicalSchema.builder()
+      .keyColumn(K0, SqlTypes.STRING)
+      .valueColumn(COL0, SqlTypes.STRING)
+      .valueColumn(COL1, SqlTypes.BIGINT)
+      .headerColumn(HEAD0, Optional.of("a"))
+      .headerColumn(HEAD1, Optional.of("b"))
       .build();
 
   private static final LogicalSchema BIG_SCHEMA = LogicalSchema.builder()
@@ -1114,6 +1133,99 @@ public class InsertValuesExecutorTest {
     assertThat(e.getMessage(), containsString(
         "Authorization denied to Write on Schema Registry subject: ["
             + KsqlConstants.getSRSubject(TOPIC_NAME, false)));
+  }
+
+  @Test
+  public void shouldThrowOnInsertHeaders() {
+    // Given:
+    givenSourceStreamWithSchema(SCHEMA_WITH_HEADERS, SerdeFeatures.of(), SerdeFeatures.of());
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        allColumnNames(SCHEMA_WITH_HEADERS),
+        ImmutableList.of(
+            new StringLiteral("key"),
+            new StringLiteral("str"),
+            new LongLiteral(2L),
+            new NullLiteral()
+        )
+    );
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> executor.execute(statement, mock(SessionProperties.class), engine, serviceContext)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("Cannot insert into a HEADER column"));
+  }
+
+  @Test
+  public void shouldThrowOnInsertKeyHeaders() {
+    // Given:
+    givenSourceStreamWithSchema(SCHEMA_WITH_KEY_HEADERS, SerdeFeatures.of(), SerdeFeatures.of());
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        allColumnNames(SCHEMA_WITH_KEY_HEADERS),
+        ImmutableList.of(
+            new StringLiteral("key"),
+            new StringLiteral("str"),
+            new LongLiteral(2L),
+            new NullLiteral(),
+            new NullLiteral()
+        )
+    );
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> executor.execute(statement, mock(SessionProperties.class), engine, serviceContext)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("Cannot insert into a HEADER column"));
+  }
+
+  @Test
+  public void shouldInsertValuesIntoHeaderSchemaValueColumns() {
+    // Given:
+    givenSourceStreamWithSchema(SCHEMA_WITH_HEADERS, SerdeFeatures.of(), SerdeFeatures.of());
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(K0, COL0, COL1),
+        ImmutableList.of(
+            new StringLiteral("key"),
+            new StringLiteral("str"),
+            new LongLiteral(2L)
+        )
+    );
+
+    // When:
+    executor.execute(statement, mock(SessionProperties.class), engine, serviceContext);
+
+    // Then:
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldThrowOnInsertAllWithHeaders() {
+    // Given:
+    givenSourceStreamWithSchema(SCHEMA_WITH_HEADERS, SerdeFeatures.of(), SerdeFeatures.of());
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(),
+        ImmutableList.of(
+            new StringLiteral("key"),
+            new StringLiteral("str"),
+            new LongLiteral(2L),
+            new NullLiteral()
+        )
+    );
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> executor.execute(statement, mock(SessionProperties.class), engine, serviceContext)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("Cannot insert into a HEADER column"));
   }
 
   private static ConfiguredStatement<InsertValues> givenInsertValues(


### PR DESCRIPTION
### Description 
Makes the following statements fail:
* `INSERT INTO ... SELECT ...` if the target source has header columns
* `INSERT VALUES ...` if one of the target columns is a header column

### Testing done 
Manually tested and added unit tests. Integration tests will be in another PR.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

