### PR TITLE
chore: add key/value schema name prop and refactor

### DIFF
--- a/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksqldb-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Pair;
 import java.io.FileNotFoundException;
@@ -203,7 +204,7 @@ public class SerdeBenchmark {
       if (AvroFormat.NAME.equals(formatName)) {
         return FormatInfo.of(
             FormatFactory.AVRO.name(),
-            ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "benchmarkSchema")
+            ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "benchmarkSchema")
         );
       }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -39,6 +39,8 @@ public final class CommonCreateConfigs {
 
   // Persistence Props:
   public static final String VALUE_AVRO_SCHEMA_FULL_NAME = "VALUE_AVRO_SCHEMA_FULL_NAME";
+  public static final String KEY_SCHEMA_FULL_NAME = "KEY_SCHEMA_FULL_NAME";
+  public static final String VALUE_SCHEMA_FULL_NAME = "VALUE_SCHEMA_FULL_NAME";
   public static final String VALUE_FORMAT_PROPERTY = "VALUE_FORMAT";
   public static final String KEY_FORMAT_PROPERTY = "KEY_FORMAT";
   public static final String FORMAT_PROPERTY = "FORMAT";
@@ -129,6 +131,20 @@ public final class CommonCreateConfigs {
             "The fully qualified name of the Avro schema to use"
         )
         .define(
+            KEY_SCHEMA_FULL_NAME,
+            ConfigDef.Type.STRING,
+            null,
+            Importance.LOW,
+            "The fully qualified name of the schema to use"
+        )
+        .define(
+            VALUE_SCHEMA_FULL_NAME,
+            ConfigDef.Type.STRING,
+            null,
+            Importance.LOW,
+            "The fully qualified name of the schema to use"
+        )
+        .define(
             KEY_DELIMITER_PROPERTY,
             ConfigDef.Type.STRING,
             null,
@@ -177,22 +193,35 @@ public final class CommonCreateConfigs {
 
   public static void validateKeyValueFormats(final Map<String, Object> configs) {
     final Object value = configs.get(FORMAT_PROPERTY);
-    if (value == null) {
+    if (value != null) {
+      if (configs.get(KEY_FORMAT_PROPERTY) != null) {
+        throw new KsqlException("Cannot supply both '" + KEY_FORMAT_PROPERTY + "' and '"
+            + FORMAT_PROPERTY + "' properties, as '" + FORMAT_PROPERTY
+            + "' sets both key and value "
+            + "formats. Either use just '" + FORMAT_PROPERTY + "', or use '" + KEY_FORMAT_PROPERTY
+            + "' and '" + VALUE_FORMAT_PROPERTY + "'.");
+      }
+      if (configs.get(VALUE_FORMAT_PROPERTY) != null) {
+        throw new KsqlException("Cannot supply both '" + VALUE_FORMAT_PROPERTY + "' and '"
+            + FORMAT_PROPERTY + "' properties, as '" + FORMAT_PROPERTY
+            + "' sets both key and value "
+            + "formats. Either use just '" + FORMAT_PROPERTY + "', or use '" + KEY_FORMAT_PROPERTY
+            + "' and '" + VALUE_FORMAT_PROPERTY + "'.");
+      }
+    }
+
+    final Object avroValueSchemaFullName = configs.get(VALUE_AVRO_SCHEMA_FULL_NAME);
+    if (avroValueSchemaFullName == null) {
       return;
     }
 
-    if (configs.get(KEY_FORMAT_PROPERTY) != null) {
-      throw new KsqlException("Cannot supply both '" + KEY_FORMAT_PROPERTY + "' and '"
-          + FORMAT_PROPERTY + "' properties, as '" + FORMAT_PROPERTY + "' sets both key and value "
-          + "formats. Either use just '" + FORMAT_PROPERTY + "', or use '" + KEY_FORMAT_PROPERTY
-          + "' and '" + VALUE_FORMAT_PROPERTY + "'.");
+    final Object valueSchemaFullName = configs.get(VALUE_SCHEMA_FULL_NAME);
+    if (valueSchemaFullName != null) {
+      throw new KsqlException("Cannot supply both '" + VALUE_AVRO_SCHEMA_FULL_NAME + "' and '"
+          + VALUE_SCHEMA_FULL_NAME + "' properties. Please only set '" + VALUE_SCHEMA_FULL_NAME
+          + "'.");
     }
-    if (configs.get(VALUE_FORMAT_PROPERTY) != null) {
-      throw new KsqlException("Cannot supply both '" + VALUE_FORMAT_PROPERTY + "' and '"
-          + FORMAT_PROPERTY + "' properties, as '" + FORMAT_PROPERTY + "' sets both key and value "
-          + "formats. Either use just '" + FORMAT_PROPERTY + "', or use '" + KEY_FORMAT_PROPERTY
-          + "' and '" + VALUE_FORMAT_PROPERTY + "'.");
-    }
+
   }
 
   private CommonCreateConfigs() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -229,7 +229,12 @@ public final class CreateSourceFactory {
       final KsqlConfig ksqlConfig
   ) {
     final FormatInfo keyFormat = SourcePropertiesUtil.getKeyFormat(props, name);
+    // Validate format name and property
+    FormatFactory.of(keyFormat);
+
     final FormatInfo valueFormat = SourcePropertiesUtil.getValueFormat(props);
+    // Validate format name and property
+    FormatFactory.of(valueFormat);
 
     final SerdeFeatures keyFeatures = keySerdeFeaturesSupplier.build(
         schema,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -229,12 +229,7 @@ public final class CreateSourceFactory {
       final KsqlConfig ksqlConfig
   ) {
     final FormatInfo keyFormat = SourcePropertiesUtil.getKeyFormat(props, name);
-    // Validate format name and property
-    FormatFactory.of(keyFormat);
-
     final FormatInfo valueFormat = SourcePropertiesUtil.getValueFormat(props);
-    // Validate format name and property
-    FormatFactory.of(valueFormat);
 
     final SerdeFeatures keyFeatures = keySerdeFeaturesSupplier.build(
         schema,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -36,7 +36,6 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.SerdeFeaturesFactory;
-import io.confluent.ksql.serde.connect.ConnectFormat;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.util.ErrorMessageUtil;
@@ -120,11 +119,11 @@ public class DefaultSchemaInjector implements Injector {
     // Only store raw schema if schema id is provided by user
     if (withSchema.getProperties().getKeySchemaId().isPresent()) {
       keySchema.map(
-          schemaAndId -> overrideBuilder.put(ConnectFormat.KEY_SCHEMA_ID, schemaAndId));
+          schemaAndId -> overrideBuilder.put(CommonCreateConfigs.KEY_SCHEMA_ID, schemaAndId));
     }
     if (withSchema.getProperties().getValueSchemaId().isPresent()) {
       valueSchema.map(
-          schemaAndId -> overrideBuilder.put(ConnectFormat.VALUE_SCHEMA_ID,
+          schemaAndId -> overrideBuilder.put(CommonCreateConfigs.VALUE_SCHEMA_ID,
               schemaAndId));
     }
     final ConfiguredStatement<CreateSource> configured = ConfiguredStatement

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -46,7 +46,7 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlParserTestUtil;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -120,7 +120,7 @@ public class AnalyzerFunctionalTest {
     assertThat(analysis.getInto(), is(not(Optional.empty())));
     assertThat(analysis.getInto().get().getNewTopic().get().getValueFormat(), is(FormatInfo.of(
         FormatFactory.AVRO.name(),
-        ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "com.custom.schema"))
+        ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "com.custom.schema"))
     ));
   }
 
@@ -153,7 +153,7 @@ public class AnalyzerFunctionalTest {
     assertThat(analysis.getInto(), is(not(Optional.empty())));
     assertThat(analysis.getInto().get().getNewTopic().get().getValueFormat(),
         is(FormatInfo.of(FormatFactory.AVRO.name(),
-            ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "org.ac.s1"))));
+            ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "org.ac.s1"))));
   }
 
   @Test
@@ -166,7 +166,7 @@ public class AnalyzerFunctionalTest {
         "s0",
         KeyFormat.nonWindowed(FormatInfo.of(FormatFactory.KAFKA.name()), SerdeFeatures.of()),
         ValueFormat.of(FormatInfo.of(
-            FormatFactory.AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "org.ac.s1")),
+            FormatFactory.AVRO.name(), ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "org.ac.s1")),
             SerdeFeatures.of())
     );
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -78,7 +78,7 @@ import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.ValueSerdeFactory;
 import io.confluent.ksql.serde.WindowInfo;
-import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
@@ -832,7 +832,7 @@ public class CreateSourceFactoryTest {
     // Then:
     assertThat(
         cmd.getFormats().getValueFormat(),
-        is(FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "full.schema.name"))));
+        is(FormatInfo.of(AVRO.name(), ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "full.schema.name"))));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.serde.GenericKeySerDe;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.SchemaTranslator;
 import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
@@ -722,7 +723,7 @@ public final class IntegrationTestHarness extends ExternalResource {
     final SchemaRegistryClient srClient = serviceContext.get().getSchemaRegistryClient();
     try {
       final Map<String, String> formatProps = ImmutableMap
-          .of(AvroFormat.FULL_SCHEMA_NAME, "test_" + topicName);
+          .of(ConnectProperties.FULL_SCHEMA_NAME, "test_" + topicName);
 
       final SchemaTranslator translator = new AvroFormat().getSchemaTranslator(formatProps);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -40,7 +40,7 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -144,7 +144,7 @@ public class KsqlStructuredDataOutputNodeTest {
     KeyFormat.nonWindowed(
         FormatInfo.of(
             FormatFactory.AVRO.name(),
-            ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "key-name")
+            ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "key-name")
         ),
         SerdeFeatures.of()
     );
@@ -152,7 +152,7 @@ public class KsqlStructuredDataOutputNodeTest {
     ValueFormat.of(
         FormatInfo.of(
             FormatFactory.AVRO.name(),
-            ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "name")
+            ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "name")
         ),
         SerdeFeatures.of()
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
@@ -61,8 +61,8 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
-import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.serde.connect.ConnectFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -590,7 +590,7 @@ public class DefaultSchemaInjectorTest {
     verify(schemaSupplier).getKeySchema(
         KAFKA_TOPIC,
         Optional.empty(),
-        FormatInfo.of("AVRO", ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "io.confluent.ksql.avro_schemas.CtKey")),
+        FormatInfo.of("AVRO", ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "io.confluent.ksql.avro_schemas.CtKey")),
         SerdeFeatures.of(SerdeFeature.UNWRAP_SINGLES)
     );
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/serde/SerdeFeaturesFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/serde/SerdeFeaturesFactoryTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.serde.delimited.DelimitedFormat;
 import io.confluent.ksql.serde.json.JsonFormat;
 import io.confluent.ksql.serde.kafka.KafkaFormat;
@@ -361,7 +362,7 @@ public class SerdeFeaturesFactoryTest {
     // Given:
     final FormatInfo formatInfo = FormatInfo.of(
         AvroFormat.NAME,
-        ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "io.confluent.ksql.avro_schemas.Foo"));
+        ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "io.confluent.ksql.avro_schemas.Foo"));
     final KeyFormat format = KeyFormat.nonWindowed(
         formatInfo,
         SerdeFeatures.of(SerdeFeature.WRAP_SINGLES));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
@@ -46,7 +46,7 @@ import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
@@ -291,12 +291,12 @@ public class TopicDeleteInjectorTest {
     // Given:
     when(topic.getKeyFormat())
         .thenReturn(KeyFormat.of(FormatInfo.of(
-            FormatFactory.AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "foo")),
+            FormatFactory.AVRO.name(), ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "foo")),
             SerdeFeatures.of(),
             Optional.empty()));
     when(topic.getValueFormat())
         .thenReturn(ValueFormat.of(FormatInfo.of(
-            FormatFactory.AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "foo")),
+            FormatFactory.AVRO.name(), ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "foo")),
             SerdeFeatures.of()));
 
     doThrow(new RestClientException("Subject not found.", 404, 40401))

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/runtime/RuntimeBuildContextTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/runtime/RuntimeBuildContextTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +29,6 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.context.QueryContext;
-import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -51,7 +49,7 @@ import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.ValueSerdeFactory;
 import io.confluent.ksql.serde.WindowInfo;
-import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import java.time.Duration;
@@ -87,7 +85,7 @@ public class RuntimeBuildContextTest {
 
   private static final FormatInfo FORMAT_INFO = FormatInfo
       .of(FormatFactory.AVRO.name(),
-          ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "io.confluent.ksql"));
+          ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "io.confluent.ksql"));
 
   private static final WindowInfo WINDOW_INFO = WindowInfo
       .of(WindowType.TUMBLING, Optional.of(Duration.ofMillis(1000)));

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/driver/AssertExecutor.java
@@ -84,7 +84,8 @@ public final class AssertExecutor {
           (cs, cfg) -> cs.getProperties().getKeyFormat(cs.getName()).map(FormatInfo::getFormat)
               .orElse(cfg.getString(KsqlConfig.KSQL_DEFAULT_KEY_FORMAT_CONFIG)),
           "key format properties",
-          CommonCreateConfigs.KEY_DELIMITER_PROPERTY
+          CommonCreateConfigs.KEY_DELIMITER_PROPERTY,
+          CommonCreateConfigs.KEY_SCHEMA_FULL_NAME
       )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getFormat(),
           (cs, cfg) -> cs.getProperties().getValueFormat().map(FormatInfo::getFormat)
@@ -97,6 +98,7 @@ public final class AssertExecutor {
           (cs, cfg) -> cs.getProperties().getValueFormatProperties(),
           "value format properties",
           CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME,
+          CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME,
           CommonCreateConfigs.VALUE_DELIMITER_PROPERTY
       )).add(new SourceProperty(
           ds -> ds.getKsqlTopic().getValueFormat().getFormatInfo().getProperties()

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.properties.with.CreateAsConfigs;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.serde.delimited.DelimitedFormat;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
@@ -118,11 +119,15 @@ public final class CreateSourceAsProperties {
       final String keyFormat
   ) {
     final Builder<String, String> builder = ImmutableMap.builder();
-    if (AvroFormat.NAME.equalsIgnoreCase(keyFormat)) {
+
+    final String schemaName = props.getString(CommonCreateConfigs.KEY_SCHEMA_FULL_NAME);
+    if (schemaName != null) {
+      builder.put(ConnectProperties.FULL_SCHEMA_NAME, schemaName);
+    } else if (AvroFormat.NAME.equalsIgnoreCase(keyFormat)) {
       // ensure that the schema name for the key is unique to the sink - this allows
       // users to always generate valid, non-conflicting avro record definitions in
       // generated Java classes (https://github.com/confluentinc/ksql/issues/6465)
-      builder.put(AvroFormat.FULL_SCHEMA_NAME, AvroFormat.getKeySchemaName(name));
+      builder.put(ConnectProperties.FULL_SCHEMA_NAME, AvroFormat.getKeySchemaName(name));
     }
 
     final String delimiter = props.getString(CommonCreateConfigs.KEY_DELIMITER_PROPERTY);
@@ -136,9 +141,12 @@ public final class CreateSourceAsProperties {
   public Map<String, String> getValueFormatProperties() {
     final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
-    final String schemaName = props.getString(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME);
+    final String avroSchemaName = props.getString(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME);
+    final String schemaName =
+        avroSchemaName == null ? props.getString(CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME)
+            : avroSchemaName;
     if (schemaName != null) {
-      builder.put(AvroFormat.FULL_SCHEMA_NAME, schemaName);
+      builder.put(ConnectProperties.FULL_SCHEMA_NAME, schemaName);
     }
 
     final String delimiter = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -170,11 +170,12 @@ public class CreateSourceAsPropertiesTest {
             .build());
 
     // Then:
-    assertThat(properties.getValueFormatProperties().get(ConnectProperties.FULL_SCHEMA_NAME), is("schema"));
+    assertThat(properties.getValueFormatProperties(),
+        hasEntry(ConnectProperties.FULL_SCHEMA_NAME, "schema"));
   }
 
   @Test
-  public void shouldSetFullKeySchemaName() {
+  public void shouldSetKeyFullSchemaName() {
     // Given:
     final CreateSourceAsProperties props = CreateSourceAsProperties
         .from(ImmutableMap.<String, Literal>builder()
@@ -182,7 +183,7 @@ public class CreateSourceAsPropertiesTest {
             .put(KEY_SCHEMA_FULL_NAME, new StringLiteral("KeySchema"))
             .build());
 
-    // When / Then:
+    // Then:
     assertThat(props.getKeyFormatProperties("json_sr", "foo"),
         hasEntry(ConnectProperties.FULL_SCHEMA_NAME, "KeySchema"));
   }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -19,10 +19,14 @@ import static com.google.common.collect.ImmutableMap.of;
 import static io.confluent.ksql.parser.properties.with.CreateSourceAsProperties.from;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
@@ -38,6 +42,7 @@ import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.serde.json.JsonFormat;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
@@ -124,7 +129,7 @@ public class CreateSourceAsPropertiesTest {
 
     // When:
     final String avroSchemaName = properties.getKeyFormatProperties("name", AvroFormat.NAME)
-        .get(AvroFormat.FULL_SCHEMA_NAME);
+        .get(ConnectProperties.FULL_SCHEMA_NAME);
 
     // Then:
     assertThat(avroSchemaName, is("io.confluent.ksql.avro_schemas.NameKey"));
@@ -139,7 +144,7 @@ public class CreateSourceAsPropertiesTest {
 
     // When:
     final String avroSchemaName = properties.getKeyFormatProperties("name", JsonFormat.NAME)
-        .get(AvroFormat.FULL_SCHEMA_NAME);
+        .get(ConnectProperties.FULL_SCHEMA_NAME);
 
     // Then:
     assertThat(avroSchemaName, nullValue());
@@ -149,10 +154,37 @@ public class CreateSourceAsPropertiesTest {
   public void shouldSetValidAvroSchemaName() {
     // When:
     final CreateSourceAsProperties properties = CreateSourceAsProperties.from(
-        ImmutableMap.of(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("schema")));
+        ImmutableMap.of(VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("schema")));
 
     // Then:
-    assertThat(properties.getValueFormatProperties().get(AvroFormat.FULL_SCHEMA_NAME), is("schema"));
+    assertThat(properties.getValueFormatProperties().get(ConnectProperties.FULL_SCHEMA_NAME), is("schema"));
+  }
+
+  @Test
+  public void shouldSetValueFullSchemaName() {
+    // When:
+    final CreateSourceAsProperties properties = CreateSourceAsProperties.from(
+        ImmutableMap.<String, Literal>builder()
+            .put(CommonCreateConfigs.VALUE_FORMAT_PROPERTY, new StringLiteral("Protobuf"))
+            .put(CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME, new StringLiteral("schema"))
+            .build());
+
+    // Then:
+    assertThat(properties.getValueFormatProperties().get(ConnectProperties.FULL_SCHEMA_NAME), is("schema"));
+  }
+
+  @Test
+  public void shouldSetFullKeySchemaName() {
+    // Given:
+    final CreateSourceAsProperties props = CreateSourceAsProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .put(FORMAT_PROPERTY, new StringLiteral("Json_sr"))
+            .put(KEY_SCHEMA_FULL_NAME, new StringLiteral("KeySchema"))
+            .build());
+
+    // When / Then:
+    assertThat(props.getKeyFormatProperties("json_sr", "foo"),
+        hasEntry(ConnectProperties.FULL_SCHEMA_NAME, "KeySchema"));
   }
 
   @Test
@@ -233,7 +265,7 @@ public class CreateSourceAsPropertiesTest {
   @Test
   public void shouldProperlyImplementEqualsAndHashCode() {
     final ImmutableMap<String, Literal> someConfig = ImmutableMap
-        .of(CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("schema"));
+        .of(VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("schema"));
 
     new EqualsTester()
         .addEqualityGroup(
@@ -285,6 +317,23 @@ public class CreateSourceAsPropertiesTest {
     // When / Then:
     assertThat(props.getKeyFormat(), is(Optional.of("KAFKA")));
     assertThat(props.getValueFormat(), is(Optional.of("AVRO")));
+  }
+
+  @Test
+  public void shouldThrowIfValueSchemaNameAndAvroSchemaNameProvided() {
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> CreateSourceAsProperties.from(
+            ImmutableMap.<String, Literal>builder()
+                .put(VALUE_SCHEMA_FULL_NAME, new StringLiteral("value_schema"))
+                .put(VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("value_schema"))
+                .build())
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("Cannot supply both 'VALUE_AVRO_SCHEMA_FULL_NAME' "
+        + "and 'VALUE_SCHEMA_FULL_NAME' properties. Please only set 'VALUE_SCHEMA_FULL_NAME'."));
   }
 
   @Test

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -20,8 +20,11 @@ import static io.confluent.ksql.parser.properties.with.CreateSourceAsProperties.
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.FORMAT_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.KEY_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.TIMESTAMP_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_AVRO_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_FORMAT_PROPERTY;
+import static io.confluent.ksql.properties.with.CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME;
 import static io.confluent.ksql.properties.with.CreateConfigs.WINDOW_SIZE_PROPERTY;
 import static io.confluent.ksql.properties.with.CreateConfigs.WINDOW_TYPE_PROPERTY;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,8 +49,7 @@ import io.confluent.ksql.properties.with.CreateConfigs;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
-import io.confluent.ksql.serde.avro.AvroFormat;
-import io.confluent.ksql.serde.connect.ConnectFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.util.KsqlException;
 import java.time.Duration;
 import java.util.HashMap;
@@ -303,7 +305,24 @@ public class CreateSourcePropertiesTest {
     // Then:
     assertThat(properties.getValueFormat()
         .map(FormatInfo::getProperties)
-        .map(props -> props.get(AvroFormat.FULL_SCHEMA_NAME)),
+        .map(props -> props.get(ConnectProperties.FULL_SCHEMA_NAME)),
+        is(Optional.of("schema")));
+  }
+
+  @Test
+  public void shouldSetValueFullSchemaName() {
+    // When:
+    final CreateSourceProperties properties = CreateSourceProperties.from(
+        ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(CommonCreateConfigs.VALUE_FORMAT_PROPERTY, new StringLiteral("Protobuf"))
+            .put(CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME, new StringLiteral("schema"))
+            .build());
+
+    // Then:
+    assertThat(properties.getValueFormat()
+        .map(FormatInfo::getProperties)
+        .map(props -> props.get(ConnectProperties.FULL_SCHEMA_NAME)),
         is(Optional.of("schema")));
   }
 
@@ -510,7 +529,24 @@ public class CreateSourcePropertiesTest {
     assertThat(props.getKeyFormat(SourceName.of("foo")).get().getFormat(), is("AVRO"));
     assertThat(props.getKeyFormat(
         SourceName.of("foo")).get().getProperties(),
-        hasEntry(AvroFormat.FULL_SCHEMA_NAME, "io.confluent.ksql.avro_schemas.FooKey"));
+        hasEntry(ConnectProperties.FULL_SCHEMA_NAME, "io.confluent.ksql.avro_schemas.FooKey"));
+  }
+
+  @Test
+  public void shouldSetFullKeySchemaName() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(FORMAT_PROPERTY, new StringLiteral("Json_sr"))
+            .put(KEY_SCHEMA_FULL_NAME, new StringLiteral("KeySchema"))
+            .build());
+
+    // When / Then:
+    assertThat(props.getKeyFormat(SourceName.of("foo")).get().getFormat(), is("JSON_SR"));
+    assertThat(props.getKeyFormat(
+        SourceName.of("foo")).get().getProperties(),
+        hasEntry(ConnectProperties.FULL_SCHEMA_NAME, "KeySchema"));
   }
 
   @Test
@@ -530,6 +566,24 @@ public class CreateSourcePropertiesTest {
     assertThat(e.getMessage(), containsString("Cannot supply both 'KEY_FORMAT' and 'FORMAT' properties, "
         + "as 'FORMAT' sets both key and value formats."));
     assertThat(e.getMessage(), containsString("Either use just 'FORMAT', or use 'KEY_FORMAT' and 'VALUE_FORMAT'."));
+  }
+
+  @Test
+  public void shouldThrowIfValueSchemaNameAndAvroSchemaNameProvided() {
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> CreateSourceProperties.from(
+            ImmutableMap.<String, Literal>builder()
+                .putAll(MINIMUM_VALID_PROPS)
+                .put(VALUE_SCHEMA_FULL_NAME, new StringLiteral("value_schema"))
+                .put(VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("value_schema"))
+                .build())
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is("Cannot supply both 'VALUE_AVRO_SCHEMA_FULL_NAME' "
+        + "and 'VALUE_SCHEMA_FULL_NAME' properties. Please only set 'VALUE_SCHEMA_FULL_NAME'."));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.serde.SchemaTranslator;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PageViewDataProvider;
@@ -172,7 +173,7 @@ public class KsqlResourceFunctionalTest {
     );
 
     final SchemaTranslator translator = new AvroFormat()
-        .getSchemaTranslator(ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "books_value"));
+        .getSchemaTranslator(ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "books_value"));
 
     final ParsedSchema keySchema = translator.toParsedSchema(
         PersistenceSchema.from(

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/avro/AvroFormat.java
@@ -37,8 +37,6 @@ public final class AvroFormat extends ConnectFormat {
       SerdeFeature.UNWRAP_SINGLES
   );
 
-  public static final String FULL_SCHEMA_NAME = AvroProperties.FULL_SCHEMA_NAME;
-
   public static final String NAME = "AVRO";
 
   @Override

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.connect;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.serde.FormatProperties;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Base class for properties that are common for Connect Format that support Schema Registry
+ */
+@Immutable
+public abstract class ConnectProperties {
+  public static final String FULL_SCHEMA_NAME = "fullSchemaName";
+  public static final String SCHEMA_ID = "schemaId";
+
+  private final ImmutableMap<String, String> properties;
+
+  public ConnectProperties(final String formatName, final Map<String, String> formatProps) {
+    this.properties = ImmutableMap.copyOf(formatProps);
+
+    FormatProperties.validateProperties(formatName, formatProps, getSupportedProperties());
+  }
+
+  public abstract ImmutableSet<String> getSupportedProperties();
+
+  protected abstract String getDefaultFullSchemaName();
+
+  public String getFullSchemaName() {
+    return properties.getOrDefault(FULL_SCHEMA_NAME, getDefaultFullSchemaName());
+  }
+
+  Optional<Integer> getSchemaId() {
+    final String schemaId = properties.get(SCHEMA_ID);
+    return schemaId == null ? Optional.empty() : Optional.of(Integer.parseInt(schemaId));
+  }
+}

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonFormat.java
@@ -56,6 +56,11 @@ public class JsonFormat extends ConnectFormat {
   }
 
   @Override
+  public Set<String> getSupportedProperties() {
+    return JsonProperties.SUPPORTED_PROPERTIES;
+  }
+
+  @Override
   protected <T> Serde<T> getConnectSerde(
       final ConnectSchema connectSchema,
       final Map<String, String> formatProps,

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,42 +13,34 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.serde.avro;
+package io.confluent.ksql.serde.json;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.errorprone.annotations.Immutable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.serde.connect.ConnectProperties;
 import java.util.Map;
 
-/**
- * Properties that can be set on the Avro format.
- */
-@Immutable
-class AvroProperties extends ConnectProperties {
+public class JsonProperties extends ConnectProperties {
 
-  static final String AVRO_SCHEMA_NAMESPACE = "io.confluent.ksql.avro_schemas";
-  static final String AVRO_SCHEMA_NAME = "KsqlDataSourceSchema";
-  static final String DEFAULT_AVRO_SCHEMA_FULL_NAME =
-      AVRO_SCHEMA_NAMESPACE + "." + AVRO_SCHEMA_NAME;
+  static final ImmutableSet<String> SUPPORTED_PROPERTIES = ImmutableSet.of();
 
-  static final ImmutableSet<String> SUPPORTED_PROPERTIES = ImmutableSet.of(
-      FULL_SCHEMA_NAME,
-      SCHEMA_ID
-  );
-
-  AvroProperties(final Map<String, String> formatProps) {
-    super(AvroFormat.NAME, formatProps);
+  JsonProperties(final String name, final Map<String, String> formatProps) {
+    super(name, formatProps);
   }
 
-  @Override
-  protected String getDefaultFullSchemaName() {
-    return DEFAULT_AVRO_SCHEMA_FULL_NAME;
+  JsonProperties(final Map<String, String> formatProps) {
+    super(JsonFormat.NAME, formatProps);
   }
 
   @Override
   @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public ImmutableSet<String> getSupportedProperties() {
     return SUPPORTED_PROPERTIES;
+  }
+
+  @Override
+  public String getDefaultFullSchemaName() {
+    throw new UnsupportedOperationException(
+        JsonFormat.NAME + " does not implement Schema Registry support");
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaFormat.java
@@ -52,7 +52,7 @@ public class JsonSchemaFormat extends ConnectFormat {
 
   @Override
   public Set<String> getSupportedProperties() {
-    return ImmutableSet.of();
+    return JsonSchemaProperties.SUPPORTED_PROPERTIES;
   }
 
   @Override

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaProperties.java
@@ -17,9 +17,10 @@ package io.confluent.ksql.serde.json;
 
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import java.util.Map;
 
-public class JsonSchemaProperties extends JsonProperties {
+public class JsonSchemaProperties extends ConnectProperties {
 
   static final ImmutableSet<String> SUPPORTED_PROPERTIES = ImmutableSet.of(
       FULL_SCHEMA_NAME,
@@ -38,6 +39,7 @@ public class JsonSchemaProperties extends JsonProperties {
 
   @Override
   public String getDefaultFullSchemaName() {
+    // Return null to be backward compatible for unset schema name
     return null;
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/json/JsonSchemaProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,42 +13,31 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.serde.avro;
+package io.confluent.ksql.serde.json;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.errorprone.annotations.Immutable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.confluent.ksql.serde.connect.ConnectProperties;
 import java.util.Map;
 
-/**
- * Properties that can be set on the Avro format.
- */
-@Immutable
-class AvroProperties extends ConnectProperties {
-
-  static final String AVRO_SCHEMA_NAMESPACE = "io.confluent.ksql.avro_schemas";
-  static final String AVRO_SCHEMA_NAME = "KsqlDataSourceSchema";
-  static final String DEFAULT_AVRO_SCHEMA_FULL_NAME =
-      AVRO_SCHEMA_NAMESPACE + "." + AVRO_SCHEMA_NAME;
+public class JsonSchemaProperties extends JsonProperties {
 
   static final ImmutableSet<String> SUPPORTED_PROPERTIES = ImmutableSet.of(
       FULL_SCHEMA_NAME,
       SCHEMA_ID
   );
 
-  AvroProperties(final Map<String, String> formatProps) {
-    super(AvroFormat.NAME, formatProps);
-  }
-
-  @Override
-  protected String getDefaultFullSchemaName() {
-    return DEFAULT_AVRO_SCHEMA_FULL_NAME;
+  JsonSchemaProperties(final Map<String, String> formatProps) {
+    super(JsonSchemaFormat.NAME, formatProps);
   }
 
   @Override
   @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public ImmutableSet<String> getSupportedProperties() {
     return SUPPORTED_PROPERTIES;
+  }
+
+  @Override
+  public String getDefaultFullSchemaName() {
+    return null;
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
@@ -52,7 +52,7 @@ public class ProtobufFormat extends ConnectFormat {
 
   @Override
   public Set<String> getSupportedProperties() {
-    return ImmutableSet.of();
+    return ProtobufProperties.SUPPORTED_PROPERTIES;
   }
 
   @Override

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,42 +13,32 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.serde.avro;
+package io.confluent.ksql.serde.protobuf;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.errorprone.annotations.Immutable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.serde.connect.ConnectProperties;
 import java.util.Map;
 
-/**
- * Properties that can be set on the Avro format.
- */
-@Immutable
-class AvroProperties extends ConnectProperties {
-
-  static final String AVRO_SCHEMA_NAMESPACE = "io.confluent.ksql.avro_schemas";
-  static final String AVRO_SCHEMA_NAME = "KsqlDataSourceSchema";
-  static final String DEFAULT_AVRO_SCHEMA_FULL_NAME =
-      AVRO_SCHEMA_NAMESPACE + "." + AVRO_SCHEMA_NAME;
+public class ProtobufProperties extends ConnectProperties {
 
   static final ImmutableSet<String> SUPPORTED_PROPERTIES = ImmutableSet.of(
       FULL_SCHEMA_NAME,
       SCHEMA_ID
   );
 
-  AvroProperties(final Map<String, String> formatProps) {
-    super(AvroFormat.NAME, formatProps);
-  }
-
-  @Override
-  protected String getDefaultFullSchemaName() {
-    return DEFAULT_AVRO_SCHEMA_FULL_NAME;
+  ProtobufProperties(final Map<String, String> formatProps) {
+    super(ProtobufFormat.NAME, formatProps);
   }
 
   @Override
   @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public ImmutableSet<String> getSupportedProperties() {
     return SUPPORTED_PROPERTIES;
+  }
+
+  @Override
+  public String getDefaultFullSchemaName() {
+    return null;
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
@@ -39,6 +39,7 @@ public class ProtobufProperties extends ConnectProperties {
 
   @Override
   public String getDefaultFullSchemaName() {
+    // Return null to be backward compatible for unset schema name
     return null;
   }
 }

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/FormatFactoryTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/FormatFactoryTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
-import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.util.KsqlException;
 import org.junit.Test;
 
@@ -50,7 +50,7 @@ public class FormatFactoryTest {
   @Test
   public void shouldThrowOnNonAvroWithAvroSchemaName() {
     // Given:
-    final FormatInfo format = FormatInfo.of("JSON", ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "foo"));
+    final FormatInfo format = FormatInfo.of("JSON", ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "foo"));
 
     // When:
     final Exception e = assertThrows(
@@ -65,7 +65,7 @@ public class FormatFactoryTest {
   @Test
   public void shouldThrowOnEmptyAvroSchemaName() {
     // Given:
-    final FormatInfo format = FormatInfo.of("AVRO", ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, " "));
+    final FormatInfo format = FormatInfo.of("AVRO", ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, " "));
 
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/KeyFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/KeyFormatTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
-import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import java.time.Duration;
 import java.util.Optional;
 import org.junit.Test;
@@ -86,7 +86,7 @@ public class KeyFormatTest {
   @Test
   public void shouldImplementToString() {
     // Given:
-    final FormatInfo formatInfo = FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something"));
+    final FormatInfo formatInfo = FormatInfo.of(AVRO.name(), ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "something"));
     final WindowInfo windowInfo = WindowInfo.of(HOPPING, Optional.of(Duration.ofMillis(10101)));
 
     final KeyFormat keyFormat = KeyFormat.windowed(formatInfo, SerdeFeatures.of(WRAP_SINGLES), windowInfo);
@@ -116,7 +116,7 @@ public class KeyFormatTest {
   @Test
   public void shouldGetFormatInfo() {
     // Given:
-    final FormatInfo format = FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something"));
+    final FormatInfo format = FormatInfo.of(AVRO.name(), ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "something"));
     final KeyFormat keyFormat = KeyFormat.nonWindowed(format, SerdeFeatures.of());
 
     // When:
@@ -169,13 +169,13 @@ public class KeyFormatTest {
   public void shouldHandleWindowedWithAvroSchemaName() {
     // Given:
     final KeyFormat keyFormat = KeyFormat.windowed(
-        FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something")),
+        FormatInfo.of(AVRO.name(), ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "something")),
         SerdeFeatures.of(),
         WindowInfo.of(HOPPING, Optional.of(Duration.ofMinutes(4)))
     );
 
     // Then:
-    assertThat(keyFormat.getFormatInfo(), is(FormatInfo.of(AVRO.name(), ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something"))));
+    assertThat(keyFormat.getFormatInfo(), is(FormatInfo.of(AVRO.name(), ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "something"))));
   }
 
   @Test

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/ValueFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/ValueFormatTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.is;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
-import io.confluent.ksql.serde.avro.AvroFormat;
+import io.confluent.ksql.serde.connect.ConnectProperties;
 import org.junit.Test;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -35,7 +35,7 @@ public class ValueFormatTest {
   private static final FormatInfo FORMAT_INFO =
       FormatInfo.of(
           AVRO.name(),
-          ImmutableMap.of(AvroFormat.FULL_SCHEMA_NAME, "something")
+          ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "something")
       );
 
   @Test

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroPropertiesTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroPropertiesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.avro;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.serde.connect.ConnectProperties;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Test;
+
+public class AvroPropertiesTest {
+
+  @Test
+  public void shouldGetSupportedProperties() {
+    // Given:
+    final AvroProperties properties = new AvroProperties(ImmutableMap.of());
+
+    // When:
+    final ImmutableSet<String> supportedProperties = properties.getSupportedProperties();
+
+    // Then:
+    assertThat(supportedProperties, is(AvroProperties.SUPPORTED_PROPERTIES));
+  }
+
+  @Test
+  public void shouldGetFullSchemaName() {
+    // Given:
+    final AvroProperties properties = new AvroProperties(
+        ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "schema"));
+
+    // When: Then:
+    assertThat(properties.getFullSchemaName(), is("schema"));
+  }
+
+  @Test
+  public void shouldGetDefaultFullSchemaName() {
+    // Given:
+    final AvroProperties properties = new AvroProperties(ImmutableMap.of());
+
+    // When: Then:
+    assertThat(properties.getFullSchemaName(), is(AvroProperties.DEFAULT_AVRO_SCHEMA_FULL_NAME));
+  }
+
+  @Test
+  public void shouldThrowWithUnsupportedProperty() {
+    // When:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> new AvroProperties(ImmutableMap.of("some_property", "value")));
+
+    // Then:
+    assertThat(e.getMessage(), is("AVRO does not support the following configs: [some_property]"));
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/JsonPropertiesTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/JsonPropertiesTest.java
@@ -18,12 +18,10 @@ package io.confluent.ksql.serde.json;
 import static io.confluent.ksql.serde.connect.ConnectProperties.FULL_SCHEMA_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import io.confluent.ksql.serde.connect.ConnectProperties;
 import io.confluent.ksql.util.KsqlException;
 import org.junit.Test;
 
@@ -61,7 +59,7 @@ public class JsonPropertiesTest {
 
     // When:
     final Exception e = assertThrows(UnsupportedOperationException.class,
-        properties::getFullSchemaName);
+        properties::getDefaultFullSchemaName);
 
     // Then:
     assertThat(e.getMessage(), is("JSON does not implement Schema Registry support"));

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/JsonPropertiesTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/JsonPropertiesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.json;
+
+import static io.confluent.ksql.serde.connect.ConnectProperties.FULL_SCHEMA_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.serde.connect.ConnectProperties;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Test;
+
+public class JsonPropertiesTest {
+
+  @Test
+  public void shouldGetSupportedProperties() {
+    // Given:
+    final JsonProperties properties = new JsonProperties(ImmutableMap.of());
+
+    // When:
+    final ImmutableSet<String> supportedProperties = properties.getSupportedProperties();
+
+    // Then:
+    assertThat(supportedProperties, is(JsonProperties.SUPPORTED_PROPERTIES));
+  }
+
+  @Test
+  public void shouldGetFullSchemaName() {
+    // Given:
+    final JsonProperties properties = new JsonProperties(ImmutableMap.of());
+
+    // When:
+    final Exception e = assertThrows(UnsupportedOperationException.class,
+        properties::getFullSchemaName);
+
+    // Then:
+    assertThat(e.getMessage(), is("JSON does not implement Schema Registry support"));
+  }
+
+  @Test
+  public void shouldGetDefaultFullSchemaName() {
+    // Given:
+    final JsonProperties properties = new JsonProperties(ImmutableMap.of());
+
+    // When:
+    final Exception e = assertThrows(UnsupportedOperationException.class,
+        properties::getFullSchemaName);
+
+    // Then:
+    assertThat(e.getMessage(), is("JSON does not implement Schema Registry support"));
+  }
+
+  @Test
+  public void shouldThrowWithUnsupportedProperty() {
+    // When:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> new JsonProperties(ImmutableMap.of(FULL_SCHEMA_NAME, "schema")));
+
+    // Then:
+    assertThat(e.getMessage(),
+        is("JSON does not support the following configs: [" + FULL_SCHEMA_NAME + "]"));
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/JsonSchemaPropertiesTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/json/JsonSchemaPropertiesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.json;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.serde.connect.ConnectProperties;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Test;
+
+public class JsonSchemaPropertiesTest {
+
+  @Test
+  public void shouldGetSupportedProperties() {
+    // Given:
+    final JsonSchemaProperties properties = new JsonSchemaProperties(ImmutableMap.of());
+
+    // When:
+    final ImmutableSet<String> supportedProperties = properties.getSupportedProperties();
+
+    // Then:
+    assertThat(supportedProperties, is(JsonSchemaProperties.SUPPORTED_PROPERTIES));
+  }
+
+  @Test
+  public void shouldGetFullSchemaName() {
+    // Given:
+    final JsonSchemaProperties properties = new JsonSchemaProperties(
+        ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "schema"));
+
+    // When: Then:
+    assertThat(properties.getFullSchemaName(), is("schema"));
+  }
+
+  @Test
+  public void shouldGetDefaultFullSchemaName() {
+    // Given:
+    final JsonSchemaProperties properties = new JsonSchemaProperties(ImmutableMap.of());
+
+    // When: Then:
+    assertThat(properties.getFullSchemaName(), is(nullValue()));
+  }
+
+  @Test
+  public void shouldThrowWithUnsupportedProperty() {
+    // When:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> new JsonSchemaProperties(ImmutableMap.of("some_property", "value")));
+
+    // Then:
+    assertThat(e.getMessage(), is("JSON_SR does not support the following configs: [some_property]"));
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufPropertiesTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufPropertiesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde.protobuf;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.serde.connect.ConnectProperties;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Test;
+
+public class ProtobufPropertiesTest {
+
+  @Test
+  public void shouldGetSupportedProperties() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(ImmutableMap.of());
+
+    // When:
+    final ImmutableSet<String> supportedProperties = properties.getSupportedProperties();
+
+    // Then:
+    assertThat(supportedProperties, is(ProtobufProperties.SUPPORTED_PROPERTIES));
+  }
+
+  @Test
+  public void shouldGetFullSchemaName() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(
+        ImmutableMap.of(ConnectProperties.FULL_SCHEMA_NAME, "schema"));
+
+    // When: Then:
+    assertThat(properties.getFullSchemaName(), is("schema"));
+  }
+
+  @Test
+  public void shouldGetDefaultFullSchemaName() {
+    // Given:
+    final ProtobufProperties properties = new ProtobufProperties(ImmutableMap.of());
+
+    // When: Then:
+    assertThat(properties.getFullSchemaName(), is(nullValue()));
+  }
+
+  @Test
+  public void shouldThrowWithUnsupportedProperty() {
+    // When:
+    final Exception e = assertThrows(KsqlException.class,
+        () -> new ProtobufProperties(ImmutableMap.of("some_property", "value")));
+
+    // Then:
+    assertThat(e.getMessage(), is("PROTOBUF does not support the following configs: [some_property]"));
+  }
+}


### PR DESCRIPTION
### Description 
* Add `KEY_SCHEMA_FULL_NAME` and `VALUE_SCHEMA_FULL_NAME` to set schema name explicitly for avro, protobuf and json_sr format
* Add properties for protobuf, json, json_sr and introduce base class `ConnectProperties`
* Refactor `key_schema_id`, `value_schema_id` in `ConnectFormat` to be just `schema_id` in `ConnectProperties` since it exists separately in key and value format properties so using same name is fine.

### Testing done 
Unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

