### PR TITLE
docs: Update packaging build number for artifacts

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,7 +252,7 @@ extra:
         kafkaversion: 3.0
         ksqldbversion: 0.22.0
         kstreamsbetatag: 7.1.0-beta210918170926
-        kstreamsbetabuild: 1
+        kstreamsbetabuild: 5
         cprelease: 7.0.0
         releasepostbranch: 7.0.0-post
         scalaversion: 2.13


### PR DESCRIPTION
### Description 
When we concatenate the packaging URL for Confluent Platform dependencies in the documentation (e.g. the sample Java client pom), both the artifact version and the build number must be accurate. This updates the build number for the 0.22.0 release.


