### PR TITLE
fix: allow valid @ character on JSON extract functions

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/json/JsonPathTokenizer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/json/JsonPathTokenizer.java
@@ -86,7 +86,7 @@ public class JsonPathTokenizer
   }
 
   private static boolean isUnquotedPathCharacter(final char c) {
-    return c == ':' || isUnquotedSubscriptCharacter(c);
+    return c == ':' || c == '@' || isUnquotedSubscriptCharacter(c);
   }
 
   private String matchUnquotedSubscript() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudfTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudfTest.java
@@ -47,6 +47,15 @@ public class JsonExtractStringKudfTest {
   }
 
   @Test
+  public void shouldExtractJsonFieldWithAtCharacter() {
+    // When:
+    final String result = udf.extract("{\"@type\": \"foo\"}", "$.@type");
+
+    // Then:
+    assertThat(result, is("foo"));
+  }
+
+  @Test
   public void shouldExtractJsonDoc() {
     // When:
     final String result = udf.extract(JSON_DOC, "$.thing1");

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/extract-json-field_-_concat_two_extracted_fields/7.2.0_1638208773077/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/extract-json-field_-_concat_two_extracted_fields/7.2.0_1638208773077/plan.json
@@ -1,0 +1,171 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, SOURCE STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `SOURCE` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.K K,\n  EXTRACTJSONFIELD(TEST.SOURCE, '$.name') SOURCE,\n  EXTRACTJSONFIELD(TEST.SOURCE, '$.version') VERSION,\n  CONCAT(EXTRACTJSONFIELD(TEST.SOURCE, '$.name'), EXTRACTJSONFIELD(TEST.SOURCE, '$.version')) BOTH,\n  EXTRACTJSONFIELD(TEST.SOURCE, '$.@type') TYPE\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `SOURCE` STRING, `VERSION` STRING, `BOTH` STRING, `TYPE` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`K` STRING KEY, `SOURCE` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "EXTRACTJSONFIELD(SOURCE, '$.name') AS SOURCE", "EXTRACTJSONFIELD(SOURCE, '$.version') AS VERSION", "CONCAT(EXTRACTJSONFIELD(SOURCE, '$.name'), EXTRACTJSONFIELD(SOURCE, '$.version')) AS BOTH", "EXTRACTJSONFIELD(SOURCE, '$.@type') AS TYPE" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.headers.columns.enabled" : "false",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.query.pull.consistency.token.enabled" : "false",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.schema.registry.url" : "",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.new.node.continuity" : "false",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/extract-json-field_-_concat_two_extracted_fields/7.2.0_1638208773077/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/extract-json-field_-_concat_two_extracted_fields/7.2.0_1638208773077/spec.json
@@ -1,0 +1,116 @@
+{
+  "version" : "7.2.0",
+  "timestamp" : 1638208773077,
+  "path" : "query-validation-tests/extract-json-field.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `SOURCE` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `SOURCE` STRING, `VERSION` STRING, `BOTH` STRING, `TYPE` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "concat two extracted fields",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "source" : "{\"name\": \"cdc\", \"version\": \"1\", \"@type\": \"UDF\"}"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "source" : "{\"name\": \"cdd\", \"version\": \"2\", \"@type\": \"VAL\"}}"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "SOURCE" : "cdc",
+        "VERSION" : "1",
+        "BOTH" : "cdc1",
+        "TYPE" : "UDF"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "SOURCE" : "cdd",
+        "VERSION" : "2",
+        "BOTH" : "cdd2",
+        "TYPE" : "VAL"
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (K STRING KEY, source VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT K, EXTRACTJSONFIELD(source, '$.name') AS SOURCE, EXTRACTJSONFIELD(source, '$.version') AS VERSION, CONCAT(EXTRACTJSONFIELD(source, '$.name'), EXTRACTJSONFIELD(source, '$.version')) AS BOTH, EXTRACTJSONFIELD(source, '$.@type') AS TYPE FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `SOURCE` STRING, `VERSION` STRING, `BOTH` STRING, `TYPE` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `SOURCE` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/extract-json-field_-_concat_two_extracted_fields/7.2.0_1638208773077/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/extract-json-field_-_concat_two_extracted_fields/7.2.0_1638208773077/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/extract-json-field.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/extract-json-field.json
@@ -7,15 +7,15 @@
       "name": "concat two extracted fields",
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, source VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT K, EXTRACTJSONFIELD(source, '$.name') AS SOURCE, EXTRACTJSONFIELD(source, '$.version') AS VERSION, CONCAT(EXTRACTJSONFIELD(source, '$.name'), EXTRACTJSONFIELD(source, '$.version')) AS BOTH FROM TEST;"
+        "CREATE STREAM OUTPUT AS SELECT K, EXTRACTJSONFIELD(source, '$.name') AS SOURCE, EXTRACTJSONFIELD(source, '$.version') AS VERSION, CONCAT(EXTRACTJSONFIELD(source, '$.name'), EXTRACTJSONFIELD(source, '$.version')) AS BOTH, EXTRACTJSONFIELD(source, '$.@type') AS TYPE FROM TEST;"
       ],
       "inputs": [
-        {"topic": "test_topic", "value": {"source": "{\"name\": \"cdc\", \"version\": \"1\"}"}},
-        {"topic": "test_topic", "value": {"source": "{\"name\": \"cdd\", \"version\": \"2\"}"}}
+        {"topic": "test_topic", "value": {"source": "{\"name\": \"cdc\", \"version\": \"1\", \"@type\": \"UDF\"}"}},
+        {"topic": "test_topic", "value": {"source": "{\"name\": \"cdd\", \"version\": \"2\", \"@type\": \"VAL\"}}"}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "value": {"SOURCE":"cdc","VERSION":"1","BOTH":"cdc1"}},
-        {"topic": "OUTPUT", "value": {"SOURCE":"cdd","VERSION":"2","BOTH":"cdd2"}}
+        {"topic": "OUTPUT", "value": {"SOURCE":"cdc","VERSION":"1","BOTH":"cdc1","TYPE":"UDF"}},
+        {"topic": "OUTPUT", "value": {"SOURCE":"cdd","VERSION":"2","BOTH":"cdd2","TYPE":"VAL"}}
       ]
     },
     {


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/8358

Easy fix that allows the `@` character in the JSON path name.
```
ksql> select EXTRACTJSONFIELD('{"@type": "foo"}', '$.@type') from test emit changes;
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|KSQL_COL_0                                                                                                                                                                    |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|foo
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

