### PR TITLE
fix: make to_bytes work with lowercase hex

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
@@ -15,7 +15,6 @@
 package io.confluent.ksql.util;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.BaseEncoding;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -24,6 +23,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import javax.xml.bind.DatatypeConverter;
 
 public final class BytesUtils {
   public enum Encoding {
@@ -179,11 +179,11 @@ public final class BytesUtils {
   }
 
   private static String hexEncoding(final byte[] value) {
-    return BaseEncoding.base16().encode(value);
+    return DatatypeConverter.printHexBinary(value);
   }
 
   private static byte[] hexDecoding(final String value) {
-    return BaseEncoding.base16().decode(value);
+    return DatatypeConverter.parseHexBinary(value);
   }
 
   private static String utf8Encoding(final byte[] value) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/ToBytesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/ToBytesTest.java
@@ -42,6 +42,8 @@ public class ToBytesTest {
             is(ByteBuffer.wrap(new byte[]{})));
         assertThat(udf.toBytes("1a2B", "hex"),
             is(ByteBuffer.wrap(new byte[]{26, 43})));
+        assertThat(udf.toBytes("1A2B", "hex"),
+            is(ByteBuffer.wrap(new byte[]{26, 43})));
     }
 
     @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/ToBytesTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/string/ToBytesTest.java
@@ -40,6 +40,8 @@ public class ToBytesTest {
             is(ByteBuffer.wrap(new byte[]{33})));
         assertThat(udf.toBytes("", "hex"),
             is(ByteBuffer.wrap(new byte[]{})));
+        assertThat(udf.toBytes("1a2B", "hex"),
+            is(ByteBuffer.wrap(new byte[]{26, 43})));
     }
 
     @Test

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes-and-strings.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes-and-strings.json
@@ -11,11 +11,13 @@
       ],
       "inputs": [
         {"topic": "test_topic", "key": null, "value": "21,IQ=="},
-        {"topic": "test_topic", "key": null, "value": "23,Iw=="}
+        {"topic": "test_topic", "key": null, "value": "23,Iw=="},
+        {"topic": "test_topic", "key": null, "value": "1aB2,GrI="}
       ],
       "outputs": [
         {"topic": "TS", "key": null, "value": "21,IQ==,21"},
-        {"topic": "TS", "key": null, "value": "23,Iw==,23"}
+        {"topic": "TS", "key": null, "value": "23,Iw==,23"},
+        {"topic": "TS", "key": null, "value": "1AB2,GrI=,1AB2"}
       ],
       "post": {
         "sources": [


### PR DESCRIPTION
### Description 
Fixes #8302

Replaces Google's BaseEncoding class with `javax.xml.bind.DatatypeConverter ` for Hex conversions.

### Testing done 
Added unit and QTT tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

