### PR TITLE
docs: cherry-pick: add Go and Python community clients to the list (DOCS-10933)

### DIFF
--- a/docs/developer-guide/ksqldb-clients/index.md
+++ b/docs/developer-guide/ksqldb-clients/index.md
@@ -14,5 +14,7 @@ The following unofficial clients are also available. These are contributed and
 maintained by community members:
 
 - [.NET client](https://github.com/tomasfabian/Kafka.DotNet.ksqlDB)
+- [Go client](https://github.com/thmeitz/ksqldb-go)
+- [Python client](https://github.com/bryanyang0528/ksql-python)
 
 To contribute a new client for your favorite language, see our [recommendations](contributing.md).


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/8311.