### PR TITLE
test: Attempts to speed up ScalablePushBandwidthThrottleIntegrationTest

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ScalablePushBandwidthThrottleIntegrationTest.java
@@ -134,11 +134,11 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
   @Test
   public void scalablePushBandwidthThrottleTestHTTP1() {
     assertAllPersistentQueriesRunning();
-    String veryLong = createDataSize(100000);
+    String veryLong = createDataSize(300000);
     String sql = "SELECT CONCAT(\'"+ veryLong + "\') as placeholder from " + AGG_TABLE + " EMIT CHANGES LIMIT 1;";
 
-    // scalable push query should succeed 10 times
-    for (int i = 0; i < 11; i += 1) {
+    // scalable push query should succeed 4 times
+    for (int i = 0; i < 4; i += 1) {
       final CompletableFuture<StreamedRow> header = new CompletableFuture<>();
       final CompletableFuture<List<StreamedRow>> complete = new CompletableFuture<>();
       makeRequestAndSetupSubscriber(sql,
@@ -154,14 +154,14 @@ public class ScalablePushBandwidthThrottleIntegrationTest {
       publisher.close();
     }
 
-    // scalable push query should fail on 11th try since it exceeds 1MB bandwidth limit
-      try {
-        makeQueryRequest(sql,
-            ImmutableMap.of("auto.offset.reset", "latest"));
-        throw new AssertionError("New scalable push query should have exceeded bandwidth limit ");
-      } catch (KsqlException e) {
-        assertThat(e.getMessage(), is(RATE_LIMIT_MESSAGE));
-      }
+    // scalable push query should fail on 5th try since it exceeds 1MB bandwidth limit
+    try {
+      makeQueryRequest(sql,
+          ImmutableMap.of("auto.offset.reset", "latest"));
+      throw new AssertionError("New scalable push query should have exceeded bandwidth limit ");
+    } catch (KsqlException e) {
+      assertThat(e.getMessage(), is(RATE_LIMIT_MESSAGE));
+    }
   }
 
   @SuppressFBWarnings({"DLS_DEAD_LOCAL_STORE"})


### PR DESCRIPTION
### Description 
I think this test is slow because the iterations can take a while to do, so this boils down the iterations to just 5 total rather than 12.

### Testing done 
Ran test locally.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

