### PR TITLE
docs: Corrected typo in REGEXP_EXTRACT section

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -890,7 +890,7 @@ REGEXP_EXTRACT('.*', col1)
 REGEXP_EXTRACT('(([AEIOU]).)', col1, 2)
 ```
 
-Extract the first subtring matched by the regex pattern from the input.
+Extract the first substring matched by the regex pattern from the input.
 
 A capturing group number can also be specified in order to return that specific group. If a number isn't specified,
 the entire substring is returned by default.


### PR DESCRIPTION
### Description 
Typo in REGEXP_EXTRACT section (`substring` instead of `subtring`)

### Testing done 
No code change, only documentation correction

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

