### PR TITLE
chore: Add metrics for push and pull limiters

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/PullQueryExecutionUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/PullQueryExecutionUtil.java
@@ -15,9 +15,7 @@
 
 package io.confluent.ksql.engine;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.RateLimiter;
 import io.confluent.ksql.analyzer.ImmutableAnalysis;
 import io.confluent.ksql.analyzer.PullQueryValidator;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -32,14 +30,6 @@ public final class PullQueryExecutionUtil {
 
   private PullQueryExecutionUtil() {
 
-  }
-
-  @VisibleForTesting
-  public static void checkRateLimit(final RateLimiter rateLimiter) {
-    if (!rateLimiter.tryAcquire()) {
-      throw new KsqlException("Host is at rate limit for pull queries. Currently set to "
-                                  + rateLimiter.getRate() + " qps.");
-    }
   }
 
   static PersistentQueryMetadata findMaterializingQuery(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/ConcurrencyLimiter.java
@@ -17,8 +17,14 @@ package io.confluent.ksql.rest.util;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.ReservedInternalTopics;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
 
 /**
  * Limits the concurrency of the caller by checking against a limit and if it's exceeded, throwing
@@ -32,17 +38,45 @@ public class ConcurrencyLimiter {
   private final Semaphore semaphore;
   private final int limit;
   private final String operationType;
+  private final Sensor rejectSensor;
 
-  public ConcurrencyLimiter(final int limit, final String operationType) {
+  public ConcurrencyLimiter(
+      final int limit,
+      final String operationType,
+      final Metrics metrics,
+      final Map<String, String> metricsTags) {
+
     this.semaphore = new Semaphore(limit);
     this.limit = limit;
     this.operationType = operationType;
+
+    metrics.addMetric(
+        new MetricName(
+            operationType + "-concurrency-limit-remaining",
+            ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX + "limits",
+            "The current value of the concurrency limiter",
+            metricsTags
+        ),
+        (metricConfig, l) -> semaphore.availablePermits()
+    );
+
+    this.rejectSensor = metrics.sensor("concurrency-limit-rejects");
+    rejectSensor.add(
+        new MetricName(
+            operationType + "-concurrency-limit-reject-count",
+            ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX + "limits",
+            "The number of requests rejected by this limiter",
+            metricsTags
+        ),
+        new CumulativeCount()
+    );
   }
 
   public Decrementer increment() {
     if (!semaphore.tryAcquire()) {
+      rejectSensor.record();
       throw new KsqlException(
-          String.format("Host is at concurrency limit for %s. Currently set to %d maximum "
+          String.format("Host is at concurrency limit for %s queries. Currently set to %d maximum "
               + "concurrent operations.", operationType, limit));
     }
     return new Decrementer();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/RateLimiter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/RateLimiter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.ReservedInternalTopics;
+import java.util.Map;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
+
+@SuppressWarnings("UnstableApiUsage")
+public class RateLimiter {
+
+  private final com.google.common.util.concurrent.RateLimiter rateLimiter;
+  private final Sensor rejectSensor;
+
+  public RateLimiter(
+      final double permitsPerSecond,
+      final String metricNamespace,
+      final Metrics metrics,
+      final Map<String, String> metricsTags) {
+    this.rateLimiter = com.google.common.util.concurrent.RateLimiter.create(permitsPerSecond);
+
+    this.rejectSensor = metrics.sensor("pull-rate-limit-rejects");
+    rejectSensor.add(
+        new MetricName(
+            metricNamespace + "-rate-limit-reject-count",
+            ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX + "limits",
+            "The number of requests rejected by this limiter",
+            metricsTags
+        ),
+        new CumulativeCount()
+    );
+  }
+
+  public void checkLimit() {
+    if (!rateLimiter.tryAcquire()) {
+      rejectSensor.record();
+      throw new KsqlException("Host is at rate limit for pull queries. Currently set to "
+          + rateLimiter.getRate() + " qps.");
+    }
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/SlidingWindowRateLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/SlidingWindowRateLimiterTest.java
@@ -6,46 +6,116 @@ import static org.junit.Assert.fail;
 
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.KsqlException;
-import org.junit.Before;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SlidingWindowRateLimiterTest {
-    private SlidingWindowRateLimiter limiter;
-    private static String RATE_LIMIT_MESSAGE = "Host is at bandwidth rate limit for pull queries.";
-    private static String TEST_SHOULD_NOT_FAIL = "This test should not throw an exception";
-
-    @Before
-    public void setUp() {
-        limiter = new SlidingWindowRateLimiter(1, 5L * 1000L);
-    }
+    private static final String RATE_LIMIT_MESSAGE =
+        "Host is at bandwidth rate limit for pull queries.";
+    private static final String TEST_SHOULD_NOT_FAIL = "This test should not throw an exception";
+    private static final String METRIC_PREFIX = "test";
 
     @Test
-    public void bigInitialResponse() {
-        Throwable exception = assertThrows(KsqlException.class, () -> {
+    public void addingToTheLimiter() {
+        final Metrics metrics = new Metrics();
+        final Map<String, String> tags = Collections.emptyMap();
+        final SlidingWindowRateLimiter limiter = new SlidingWindowRateLimiter(
+            1,
+            5L * 1000L,
+            METRIC_PREFIX,
+            metrics,
+            tags
+        );
+
+        assertEquals(1048576.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(0.0, getReject(metrics, tags), 0.0);
+
+        final Throwable exception = assertThrows(KsqlException.class, () -> {
             limiter.add(0L, 1148576L);
             limiter.allow(KsqlQueryType.PULL, 1000L);
         });
         assertEquals(RATE_LIMIT_MESSAGE, exception.getMessage());
+
+        assertEquals(-100000.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(1.0, getReject(metrics, tags), 0.0);
+    }
+
+    @Test
+    public void bigInitialResponse() {
+        final Metrics metrics = new Metrics();
+        final Map<String, String> tags = Collections.emptyMap();
+        final SlidingWindowRateLimiter limiter = new SlidingWindowRateLimiter(
+            1,
+            5L * 1000L,
+            METRIC_PREFIX,
+            metrics,
+            tags
+        );
+
+        assertEquals(1048576.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(0.0, getReject(metrics, tags), 0.0);
+
+        final Throwable exception = assertThrows(KsqlException.class, () -> {
+            limiter.add(0L, 1148576L);
+            limiter.allow(KsqlQueryType.PULL, 1000L);
+        });
+        assertEquals(RATE_LIMIT_MESSAGE, exception.getMessage());
+
+        assertEquals(-100000.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(1.0, getReject(metrics, tags), 0.0);
     }
 
     @Test
     public void uniformResponsesUnderLimit() {
+        final Metrics metrics = new Metrics();
+        final Map<String, String> tags = Collections.emptyMap();
+        final SlidingWindowRateLimiter limiter = new SlidingWindowRateLimiter(
+            1,
+            5L * 1000L,
+            METRIC_PREFIX,
+            metrics,
+            tags
+        );
+
+        assertEquals(1048576.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(0.0, getReject(metrics, tags), 0.0);
+
         try {
             for (long i = 0L; i < 30L; i += 1L) {
                 limiter.add(i * 500L, 100000L);
                 limiter.allow(KsqlQueryType.PULL, i * 500L + 1L);
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             fail(TEST_SHOULD_NOT_FAIL);
         }
+
+        assertEquals(48576.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(0.0, getReject(metrics, tags), 0.0);
     }
 
     @Test
     public void uniformResponsesOverLimit() {
-        Throwable exception = assertThrows(KsqlException.class, () -> {
+        final Metrics metrics = new Metrics();
+        final Map<String, String> tags = Collections.emptyMap();
+        final SlidingWindowRateLimiter limiter = new SlidingWindowRateLimiter(
+            1,
+            5L * 1000L,
+            METRIC_PREFIX,
+            metrics,
+            tags
+        );
+
+        assertEquals(1048576.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(0.0, getReject(metrics, tags), 0.0);
+
+        final Throwable exception = assertThrows(KsqlException.class, () -> {
             for (long i = 0L; i < 11L; i += 1L) {
                 limiter.add(i * 400L, 100000L);
                 limiter.allow(KsqlQueryType.PULL, i * 400L + 1L);
@@ -53,27 +123,49 @@ public class SlidingWindowRateLimiterTest {
         });
 
         assertEquals(RATE_LIMIT_MESSAGE, exception.getMessage());
+
+        assertEquals(-51424.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(1.0, getReject(metrics, tags), 0.0);
     }
 
     @Test
     public void justUnderForAWhileThenOverLimit() {
+        final Metrics metrics = new Metrics();
+        final Map<String, String> tags = Collections.emptyMap();
+        final SlidingWindowRateLimiter limiter = new SlidingWindowRateLimiter(
+            1,
+            5L * 1000L,
+            METRIC_PREFIX,
+            metrics,
+            tags
+        );
+
+        assertEquals(1048576.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(0.0, getReject(metrics, tags), 0.0);
+
         try {
             for (long i = 0L; i < 5L; i += 1L) {
                 limiter.add(i * 500L, i * 100000L);
                 limiter.allow(KsqlQueryType.PULL, i * 500L + 1L);
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             fail(TEST_SHOULD_NOT_FAIL);
         }
+
+        assertEquals(48576.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(0.0, getReject(metrics, tags), 0.0);
 
         try {
             limiter.allow(KsqlQueryType.PULL, 3499L);
             limiter.add(3500L, 80000L);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             fail(TEST_SHOULD_NOT_FAIL);
         }
 
-        Throwable exception = assertThrows(KsqlException.class, () -> {
+        assertEquals(-31424.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(0.0, getReject(metrics, tags), 0.0);
+
+        final Throwable exception = assertThrows(KsqlException.class, () -> {
             for (long i = 10L; i < 18L; i += 1L) {
                 limiter.add(i * 600L, 140000L);
                 limiter.allow(KsqlQueryType.PULL,i * 600L + 1L);
@@ -81,5 +173,30 @@ public class SlidingWindowRateLimiterTest {
         });
 
         assertEquals(RATE_LIMIT_MESSAGE, exception.getMessage());
+
+        assertEquals(-71424.0, getRemaining(metrics, tags), 0.0);
+        assertEquals(1.0, getReject(metrics, tags), 0.0);
+    }
+
+    private double getReject(final Metrics metrics, final Map<String, String> tags) {
+        final MetricName rejectMetricName = new MetricName(
+            METRIC_PREFIX + "-bandwidth-limit-reject-count",
+            "_confluent-ksql-limits",
+            "The number of requests rejected by this limiter",
+            tags
+        );
+        final KafkaMetric rejectMetric = metrics.metrics().get(rejectMetricName);
+        return (double) rejectMetric.metricValue();
+    }
+
+    private double getRemaining(final Metrics metrics, final Map<String, String> tags) {
+        final MetricName remainingMetricName = new MetricName(
+            METRIC_PREFIX + "-bandwidth-limit-remaining",
+            "_confluent-ksql-limits",
+            "The current value of the bandwidth limiter",
+            tags
+        );
+        final KafkaMetric remainingMetric = metrics.metrics().get(remainingMetricName);
+        return (double) remainingMetric.metricValue();
     }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.integration;
 
-import static io.confluent.ksql.rest.integration.HighAvailabilityTestUtil.sendClusterStatusRequest;
 import static io.confluent.ksql.rest.integration.HighAvailabilityTestUtil.waitForClusterToBeDiscovered;
 import static io.confluent.ksql.rest.integration.HighAvailabilityTestUtil.waitForRemoteServerToChangeStatus;
 import static io.confluent.ksql.rest.server.utils.TestUtils.findFreeLocalPort;
@@ -38,7 +37,6 @@ import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.rest.client.BasicCredentials;
 import io.confluent.ksql.rest.entity.ClusterStatusResponse;
-import io.confluent.ksql.rest.entity.HostStatusEntity;
 import io.confluent.ksql.rest.entity.KsqlHostInfoEntity;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/RateLimiterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/RateLimiterTest.java
@@ -16,11 +16,9 @@
 package io.confluent.ksql.rest.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
-import io.confluent.ksql.rest.util.ConcurrencyLimiter.Decrementer;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collections;
 import java.util.Map;
@@ -32,92 +30,54 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ConcurrencyLimiterTest {
+public class RateLimiterTest {
+
+  public static final String METRIC_NAMESPACE = "test";
 
   @Test
   public void shouldSucceedUnderLimit() {
     final Metrics metrics = new Metrics();
     final Map<String, String> tags = Collections.emptyMap();
-    ConcurrencyLimiter limiter = new ConcurrencyLimiter(
-        1,
-        "pull",
-        metrics,
-        tags
-    );
+    // It doesn't look like the underlying guava rate limiter has a way to control time, so we're
+    // just going to have to hope that these tests reliably run in under a second.
+    final RateLimiter limiter = new RateLimiter(1, METRIC_NAMESPACE, metrics, tags);
 
     assertThat(getReject(metrics, tags), is(0.0));
-    assertThat(getRemaining(metrics, tags), is(1.0));
 
-    Decrementer decrementer = limiter.increment();
+    limiter.checkLimit();
 
-    assertThat(limiter.getCount(), is(1));
     assertThat(getReject(metrics, tags), is(0.0));
-    assertThat(getRemaining(metrics, tags), is(0.0));
-
-    decrementer.decrementAtMostOnce();
-    decrementer.decrementAtMostOnce();
-
-    assertThat(limiter.getCount(), is(0));
-    assertThat(getReject(metrics, tags), is(0.0));
-    assertThat(getRemaining(metrics, tags), is(1.0));
-
   }
 
   @Test
   public void shouldError_atLimit() {
     final Metrics metrics = new Metrics();
     final Map<String, String> tags = Collections.emptyMap();
-    ConcurrencyLimiter limiter = new ConcurrencyLimiter(
-        1,
-        "pull",
-        metrics,
-        tags
-    );
+    // It doesn't look like the underlying guava rate limiter has a way to control time, so we're
+    // just going to have to hope that these tests reliably run in under a second.
+    final RateLimiter limiter = new RateLimiter(1, METRIC_NAMESPACE, metrics, tags);
 
     assertThat(getReject(metrics, tags), is(0.0));
-    assertThat(getRemaining(metrics, tags), is(1.0));
 
-    Decrementer decrementer = limiter.increment();
+    limiter.checkLimit();
+    final KsqlException ksqlException =
+        assertThrows(KsqlException.class, limiter::checkLimit);
 
-    assertThat(getReject(metrics, tags), is(0.0));
-    assertThat(getRemaining(metrics, tags), is(0.0));
-
-    final Exception e = assertThrows(
-        KsqlException.class,
-        limiter::increment
+    assertThat(
+        ksqlException.getMessage(),
+        is("Host is at rate limit for pull queries. Currently set to 1.0 qps.")
     );
-
-    assertThat(e.getMessage(), containsString("Host is at concurrency limit for pull queries."));
-    assertThat(limiter.getCount(), is(1));
     assertThat(getReject(metrics, tags), is(1.0));
-    assertThat(getRemaining(metrics, tags), is(0.0));
-
-    decrementer.decrementAtMostOnce();
-
-    assertThat(limiter.getCount(), is(0));
-    assertThat(getReject(metrics, tags), is(1.0));
-    assertThat(getRemaining(metrics, tags), is(1.0));
   }
 
   private double getReject(final Metrics metrics, final Map<String, String> tags) {
     final MetricName rejectMetricName = new MetricName(
-        "pull-concurrency-limit-reject-count",
+        METRIC_NAMESPACE + "-rate-limit-reject-count",
         "_confluent-ksql-limits",
         "The number of requests rejected by this limiter",
         tags
     );
     final KafkaMetric rejectMetric = metrics.metrics().get(rejectMetricName);
     return (double) rejectMetric.metricValue();
-  }
-
-  private double getRemaining(final Metrics metrics, final Map<String, String> tags) {
-    final MetricName remainingMetricName = new MetricName(
-        "pull-concurrency-limit-remaining",
-        "_confluent-ksql-limits",
-        "The current value of the concurrency limiter",
-        tags
-    );
-    final KafkaMetric remainingMetric = metrics.metrics().get(remainingMetricName);
-    return (double) remainingMetric.metricValue();
   }
 }


### PR DESCRIPTION
### Description 
It was previously not possible to observe the state of the limiters (how much remains toward the limit) or the number of requests that have been rejected. This work corrects that.

### Testing done 
I write unit tests and also checked the JMX metrics in a locally run ksql. I did not add an integration test for the metrics because ksql keeps its metrics in a static map, so there can be no isolation between tests. I decided not to tackle a full-blown refactor of the metrics framework right now.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

