### PR TITLE
feat: Validate connector config before creating it

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
@@ -43,6 +43,7 @@ import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.util.Timeout;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -64,6 +65,7 @@ public class DefaultConnectClient implements ConnectClient {
   private static final String CONNECTORS = "/connectors";
   private static final String STATUS = "/status";
   private static final String TOPICS = "/topics";
+  private static final String VALIDATE_CONNECTOR = CONNECTOR_PLUGINS + "/%s/config/validate";
   private static final int DEFAULT_TIMEOUT_MS = 5_000;
   private static final int MAX_ATTEMPTS = 3;
 
@@ -117,6 +119,39 @@ public class DefaultConnectClient implements ConnectClient {
           .ifPresent(error -> LOG.warn("Did not CREATE connector {}: {}", connector, error));
 
       return connectResponse;
+    } catch (final Exception e) {
+      throw new KsqlServerException(e);
+    }
+  }
+
+  @Override
+  public ConnectResponse<ConfigInfos> validate(
+      final String plugin,
+      final Map<String, String> config) {
+    try {
+      LOG.debug("Issuing validate request to Kafka Connect at URI {} for plugin {} and config {}",
+          connectUri,
+          plugin,
+          config);
+
+      final ConnectResponse<ConfigInfos> connectResponse = withRetries(() -> Request
+          .put(connectUri.resolve(String.format(VALIDATE_CONNECTOR, plugin)))
+          .setHeaders(headers())
+          .responseTimeout(Timeout.ofMilliseconds(DEFAULT_TIMEOUT_MS))
+          .connectTimeout(Timeout.ofMilliseconds(DEFAULT_TIMEOUT_MS))
+          .bodyString(MAPPER.writeValueAsString(config), ContentType.APPLICATION_JSON)
+          .execute()
+          .handleResponse(
+              createHandler(HttpStatus.SC_OK, new TypeReference<ConfigInfos>() {},
+                  Function.identity())));
+
+      connectResponse.error()
+          .ifPresent(error ->
+              LOG.warn("Did not VALIDATE connector configuration for plugin {} and config {}: {}",
+              plugin, config, error));
+
+      return connectResponse;
+
     } catch (final Exception e) {
       throw new KsqlServerException(e);
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
@@ -30,11 +30,16 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.metastore.model.MetaStoreMatchers.OptionalMatchers;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigValueInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -46,6 +51,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class DefaultConnectClientTest {
 
   private static final ObjectMapper MAPPER = ConnectJsonMapper.INSTANCE.get();
@@ -108,6 +114,79 @@ public class DefaultConnectClientTest {
     // Then:
     assertThat(response.datum(), OptionalMatchers.of(is(SAMPLE_INFO)));
     assertThat("Expected no error!", !response.error().isPresent());
+  }
+
+  @Test
+  public void testValidate() throws JsonProcessingException {
+    // Given:
+    final String plugin = SAMPLE_PLUGIN.className();
+    final String url = String.format("/connector-plugins/%s/config/validate", plugin);
+    final ConfigInfos body = new ConfigInfos(
+        plugin,
+        1,
+        ImmutableList.of("Common"),
+        ImmutableList.of(new ConfigInfo(new ConfigKeyInfo(
+            "file",
+            "STRING",
+            true,
+            "",
+            "HIGH",
+            "Destination filename.",
+            null,
+            -1,
+            "NONE",
+            "file",
+            Collections.emptyList()),
+            new ConfigValueInfo(
+                "file",
+                null,
+                Collections.emptyList(),
+                ImmutableList.of(
+                    "Missing required configuration \"file\" which has no default value."),
+                true)
+            )));
+
+    WireMock.stubFor(
+        WireMock.put(WireMock.urlEqualTo(url))
+            .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
+            .willReturn(WireMock.aResponse()
+                .withStatus(HttpStatus.SC_OK)
+                .withBody(MAPPER.writeValueAsString(body)))
+    );
+
+    // When:
+    final Map<String, String> config = ImmutableMap.of(
+        "connector.class", plugin,
+        "tasks.max", "1",
+        "topics", "test-topic"
+    );
+    final ConnectResponse<ConfigInfos> response = client.validate(plugin, config);
+
+    // Then:
+    assertThat(response.datum(), OptionalMatchers.of(is(body)));
+    assertThat("Expected no error!", !response.error().isPresent());
+  }
+
+  @Test
+  public void testValidateWithError() throws JsonProcessingException {
+    // Given:
+    final String plugin = SAMPLE_PLUGIN.className();
+    final String url = String.format("/connector-plugins/%s/config/validate", plugin);
+    WireMock.stubFor(
+        WireMock.put(WireMock.urlEqualTo(url))
+            .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
+            .willReturn(WireMock.aResponse()
+                .withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .withBody("Oh no!"))
+    );
+
+    // When:
+    final ConnectResponse<ConfigInfos> response =
+        client.validate(plugin, ImmutableMap.of());
+
+    // Then:
+    assertThat("Expected no datum!", !response.datum().isPresent());
+    assertThat(response.error(), OptionalMatchers.of(is("Oh no!")));
   }
 
   @Test

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/ConnectClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/ConnectClient.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.util.KsqlPreconditions;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorPluginInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -58,6 +59,14 @@ public interface ConnectClient {
    * @param config    the connector configuration
    */
   ConnectResponse<ConnectorInfo> create(String connector, Map<String, String> config);
+
+  /**
+   * Validates specified connector configuration for the given plugin.
+   *
+   * @param plugin  the name of the connector plugin
+   * @param config  the connector configuration
+   */
+  ConnectResponse<ConfigInfos> validate(String plugin, Map<String, String> config);
 
   /**
    * Get the status of {@code connector}.

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateConnector.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/CreateConnector.java
@@ -56,9 +56,9 @@ public class CreateConnector extends Statement {
       final String name,
       final Map<String, Literal> config,
       final Type type,
-      final boolean notExisits
+      final boolean notExists
   ) {
-    this(Optional.empty(), name, config, type, notExisits);
+    this(Optional.empty(), name, config, type, notExists);
   }
 
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.connect.supported.Connectors;
@@ -28,9 +29,14 @@ import io.confluent.ksql.services.ConnectClient;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.ParserUtil;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 
 public final class ConnectExecutor {
@@ -46,6 +52,13 @@ public final class ConnectExecutor {
   ) {
     final CreateConnector createConnector = statement.getStatement();
     final ConnectClient client = serviceContext.getConnectClient();
+
+    final List<String> errors = validate(createConnector, client);
+    if (!errors.isEmpty()) {
+      final String errorMessage = "Validation error: " + String.join("\n", errors);
+      return StatementExecutorResponse.handled(Optional.of(new ErrorEntity(
+          statement.getStatementText(), errorMessage)));
+    }
 
     final Optional<KsqlEntity> connectorsResponse = handleIfNotExists(
         statement, createConnector, client);
@@ -79,6 +92,45 @@ public final class ConnectExecutor {
 
     return StatementExecutorResponse.handled(response.error()
         .map(err -> new ErrorEntity(statement.getStatementText(), err)));
+  }
+
+  private static List<String> validate(final CreateConnector createConnector,
+      final ConnectClient client) {
+    final Map<String, String> config = new HashMap<>(createConnector.getConfig().size());
+    createConnector.getConfig().forEach((k, v) ->
+        // Parsing the statement wraps string fields with single quotes which breaks the
+        // validation.
+        config.put(k, ParserUtil.unquote(v.toString(),"'")));
+    config.put("name", createConnector.getName());
+
+    final String connectorType = config.get("connector.class");
+    // Request with an empty connector type in the url results in 404.
+    // Request with a connector type that contains only spaces results in 405.
+    // In both cases it is user-friendlier to return the actual error.
+    if (connectorType == null) {
+      // Return error message identical to the one produced by the connector
+      return ImmutableList.of(String.format(
+          "Connector config %s contains no connector type", config));
+    } else if (connectorType.trim().isEmpty()) {
+      return ImmutableList.of("Connector type cannot be empty");
+    }
+
+    final ConnectResponse<ConfigInfos> response = client.validate(connectorType, config);
+    if (response.error().isPresent()) {
+      return ImmutableList.of(response.error().get());
+    } else if (response.datum().isPresent()) {
+      return response
+          .datum()
+          .get()
+          .values()
+          .stream()
+          .filter(configInfo -> !configInfo.configValue().errors().isEmpty())
+          .map(configInfo -> configInfo.configValue().name()
+              + " - "
+              + String.join(". ", configInfo.configValue().errors()))
+          .collect(Collectors.toList());
+    }
+    return ImmutableList.of();
   }
 
   private static Optional<KsqlEntity> handleIfNotExists(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.execution;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,6 +48,10 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigKeyInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConfigValueInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 import org.junit.Before;
@@ -55,27 +60,30 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+@SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 @RunWith(MockitoJUnitRunner.class)
 public class ConnectExecutorTest {
 
   private static final KsqlConfig CONFIG = new KsqlConfig(ImmutableMap.of());
 
   private static final CreateConnector CREATE_CONNECTOR = new CreateConnector(
-      "foo", ImmutableMap.of("foo", new StringLiteral("bar")), Type.SOURCE,
-      false);
+      "foo", ImmutableMap.of("connector.class",
+        new StringLiteral("FileStreamSource")), Type.SOURCE, false);
 
   private static final ConfiguredStatement<CreateConnector> CREATE_CONNECTOR_CONFIGURED =
       ConfiguredStatement.of(PreparedStatement.of(
-          "CREATE SOURCE CONNECTOR foo WITH ('foo'='bar');",
+          "CREATE SOURCE CONNECTOR foo WITH ('connector.class'='FileStreamSource');",
           CREATE_CONNECTOR), SessionConfig.of(CONFIG, ImmutableMap.of()));
 
   private static final CreateConnector CREATE_DUPLICATE_CONNECTOR = new CreateConnector(
-      "foo", ImmutableMap.of("foo", new StringLiteral("bar")), Type.SOURCE,
+      "foo", ImmutableMap.of("connector.class",
+        new StringLiteral("FileStreamSource")), Type.SOURCE,
       true);
 
   private static final ConfiguredStatement<CreateConnector> CREATE_DUPLICATE_CONNECTOR_CONFIGURED =
       ConfiguredStatement.of(PreparedStatement.of(
-          "CREATE SOURCE CONNECTOR IF NOT EXISTS foo WITH ('foo'='bar');",
+          "CREATE SOURCE CONNECTOR IF NOT EXISTS foo "
+              + "WITH ('connector.class'='FileStreamSource');",
           CREATE_DUPLICATE_CONNECTOR), SessionConfig.of(CONFIG, ImmutableMap.of())
       );
 
@@ -93,20 +101,23 @@ public class ConnectExecutorTest {
   @Test
   public void shouldPassInCorrectArgsToConnectClient() {
     // Given:
-    givenSuccess();
+    givenValidationSuccess();
+    givenCreationSuccess();
 
     // When:
     ConnectExecutor
         .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext);
 
     // Then:
-    verify(connectClient).create(eq("foo"), (Map<String, String>) argThat(hasEntry("foo", "bar")));
+    verify(connectClient).create(eq("foo"),
+        (Map<String, String>) argThat(hasEntry("connector.class", "FileStreamSource")));
   }
 
   @Test
   public void shouldReturnConnectorInfoEntityOnSuccess() {
     // Given:
-    givenSuccess();
+    givenValidationSuccess();
+    givenCreationSuccess();
 
     // When:
     final Optional<KsqlEntity> entity = ConnectExecutor
@@ -118,13 +129,15 @@ public class ConnectExecutorTest {
   }
 
   @Test
-  public void shouldReturnErrorEntityOnError() {
+  public void shouldReturnErrorEntityOnCreationError() {
     // Given:
-    givenError();
+    givenValidationSuccess();
+    givenCreationError();
 
     // When:
     final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext).getEntity();
+        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null,
+            serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -132,8 +145,28 @@ public class ConnectExecutorTest {
   }
 
   @Test
+  public void shouldReturnErrorEntityOnValidationError() {
+    // Given:
+    givenValidationError();
+    givenCreationSuccess();
+
+    // When:
+    final Optional<KsqlEntity> entity = ConnectExecutor
+        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    final String expectedError = "Validation error: name - Name is missing\n"
+        + "hostname - Hostname is required. Some other error";
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(), is(expectedError));
+  }
+
+  @Test
   public void shouldReturnWarningWhenIfNotExistsSetConnectorExists() {
     //Given:
+    givenValidationSuccess();
     givenConnectorExists();
 
     //When
@@ -148,6 +181,7 @@ public class ConnectExecutorTest {
   @Test
   public void shouldReturnErrorIfConnectorExists() {
     //Given:
+    givenValidationSuccess();
     when(connectClient.create(anyString(), anyMap()))
         .thenReturn(
             ConnectResponse.failure("Connector foo already exists", HttpStatus.SC_CONFLICT));
@@ -161,7 +195,55 @@ public class ConnectExecutorTest {
     assertThat(entity.get(), instanceOf(ErrorEntity.class));
   }
 
-  private void givenSuccess() {
+  @Test
+  public void shouldReturnErrorIfConnectorTypeIsMissing() {
+    // Given:
+    final CreateConnector createConnectorMissingType = new CreateConnector(
+        "connector-name", ImmutableMap.of("foo", new StringLiteral("bar")),
+        Type.SOURCE, false);
+    final ConfiguredStatement<CreateConnector> createConnectorMissingTypeConfigured
+        = ConfiguredStatement.of(PreparedStatement.of(
+        "CREATE SOURCE CONNECTOR foo WITH ('foo'='bar');",
+        createConnectorMissingType), SessionConfig.of(CONFIG, ImmutableMap.of()));
+
+    // When:
+    final Optional<KsqlEntity> entity = ConnectExecutor
+        .execute(createConnectorMissingTypeConfigured, mock(SessionProperties.class),
+            null, serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    final String expectedError = "Validation error: "
+        + "Connector config {name=connector-name, foo=bar} contains no connector type";
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(), is(expectedError));
+  }
+
+  @Test
+  public void shouldReturnErrorIfConnectorTypeIsEmpty() {
+    // Given:
+    final CreateConnector createConnectorEmptyType = new CreateConnector(
+        "foo", ImmutableMap.of("connector.class", new StringLiteral(" ")),
+        Type.SOURCE, false);
+    final ConfiguredStatement<CreateConnector> createConnectorEmptyTypeConfigured
+        = ConfiguredStatement.of(PreparedStatement.of(
+        "CREATE SOURCE CONNECTOR foo WITH ('connector.class'=' ');",
+        createConnectorEmptyType), SessionConfig.of(CONFIG, ImmutableMap.of()));
+
+
+    // When:
+    final Optional<KsqlEntity> entity = ConnectExecutor
+        .execute(createConnectorEmptyTypeConfigured, mock(SessionProperties.class),
+            null, serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    final String expectedError = "Validation error: Connector type cannot be empty";
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(), is(expectedError));
+  }
+
+  private void givenCreationSuccess() {
     when(connectClient.create(anyString(), anyMap()))
         .thenReturn(ConnectResponse.success(
             new ConnectorInfo(
@@ -169,10 +251,56 @@ public class ConnectExecutorTest {
                 ImmutableMap.of(),
                 ImmutableList.of(),
                 ConnectorType.SOURCE), HttpStatus.SC_OK));
-
   }
 
-  private void givenError() {
+  private void givenValidationSuccess() {
+    when(connectClient.validate(anyString(), anyMap()))
+        .thenReturn(ConnectResponse.success(
+            new ConfigInfos(
+                "foo",
+                0,
+                ImmutableList.of(),
+                ImmutableList.of()), HttpStatus.SC_OK));
+  }
+
+  private void givenValidationError() {
+    final ConfigInfo configInfo1  = new ConfigInfo(new ConfigKeyInfo("name", "STRING",
+        true, null, "HIGH", "docs",
+            "Common", 1, "MEDIUM", "Connector name",
+        ImmutableList.of()),
+        new ConfigValueInfo("name", null, ImmutableList.of(), ImmutableList.of(
+            "Name is missing"), true));
+    final ConfigInfo configInfo2 = new ConfigInfo(new ConfigKeyInfo("hostname",
+        "STRING", false, null, "HIGH",
+        "docs for hostname",
+        "Common", 2, "MEDIUM", "hostname",
+        ImmutableList.of()),
+        new ConfigValueInfo("hostname", null, ImmutableList.of(),
+            ImmutableList.of("Hostname is required", "Some other error"), true));
+    final ConfigInfo configInfo3 = new ConfigInfo(new ConfigKeyInfo("port",
+        "INT", false, null, "HIGH",
+        "docs for port",
+        "Common", 3, "MEDIUM", "hostname",
+        ImmutableList.of()),
+        new ConfigValueInfo("port", null, ImmutableList.of(), ImmutableList.of(), true));
+    when(connectClient.validate(anyString(), anyMap()))
+        .thenReturn(ConnectResponse.success(
+            new ConfigInfos(
+                "foo",
+                2,
+                ImmutableList.of(),
+                ImmutableList.of(configInfo1, configInfo2, configInfo3)),
+            HttpStatus.SC_OK));
+  }
+
+  private void givenCreationError() {
+    when(connectClient.validate(anyString(), anyMap()))
+        .thenReturn(ConnectResponse.success(
+            new ConfigInfos(
+                "foo",
+                0,
+                ImmutableList.of(),
+                ImmutableList.of()), HttpStatus.SC_OK));
     when(connectClient.create(anyString(), anyMap()))
         .thenReturn(ConnectResponse.failure("error!", HttpStatus.SC_BAD_REQUEST));
   }


### PR DESCRIPTION
### Description 

With this patch `ConnectExecutor` validates the connector configuration before submitting a create request. 

#### Why?

Why do we need an additional request for validation? Isn't it enough to just return the error from the create request. Turns out, the errors returned by the create requests might not contain enough information to understand what is the actual issue. Here is an example error response:

```json
{
  "error_code": 400,
  "message": "Connector configuration is invalid and contains the following 1 error(s):\nA value is required\nYou can also find the above list of errors at the endpoint `/connector-plugins/{connectorType}/config/validate`"
}
```

From that message it is not clear what field is actually missing. In turn, suggested `/config/validate` endpoint provides structured per-field information. See https://docs.confluent.io/platform/current/connect/references/restapi.html#put--connector-plugins-(string-name)-config-validate for more details.

#### What?

* `io.confluent.ksql.services.ConnectClient` interface has a new method `validate` that calls `/config/validate` for the given plugin and configuration.
* `io.confluent.ksql.rest.server.execution.ConnectExecutor` has a new private `validate` method that returns a list of error messages, one string per field. If a field has multiple error messages, they are joined together. If the validate request fails (as in, 502 or 404), this failure is returned.
*  `io.confluent.ksql.rest.server.execution.ConnectExecutor#execute` calls `validate` before creating the connector. If `validate` returns at least one error, the method returns said error(s) and does not execute the create statement.

### Testing done 

* Added unit tests for `DefaultConnectClient#validate`.
* Added unit tests for validation errors in `ConnectExecutorTest`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

