### PR TITLE
feat: Adds support to /query-stream for http1.1 and StreamedRow json format

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -215,7 +215,7 @@ public class ClientTest extends BaseApiTest {
     // Then
     assertThat(streamedQueryResult.columnNames(), is(DEFAULT_COLUMN_NAMES));
     assertThat(streamedQueryResult.columnTypes(), is(DEFAULT_COLUMN_TYPES));
-    assertThat(streamedQueryResult.queryID(), is(nullValue()));
+    assertThat(streamedQueryResult.queryID(), is(notNullValue()));
 
     shouldReceiveRows(streamedQueryResult, true);
 
@@ -233,7 +233,7 @@ public class ClientTest extends BaseApiTest {
     // Then
     assertThat(streamedQueryResult.columnNames(), is(DEFAULT_COLUMN_NAMES));
     assertThat(streamedQueryResult.columnTypes(), is(DEFAULT_COLUMN_TYPES));
-    assertThat(streamedQueryResult.queryID(), is(nullValue()));
+    assertThat(streamedQueryResult.queryID(), is(notNullValue()));
 
     for (int i = 0; i < DEFAULT_JSON_ROWS.size(); i++) {
       final Row row = streamedQueryResult.poll();
@@ -475,7 +475,7 @@ public class ClientTest extends BaseApiTest {
     final BatchedQueryResult batchedQueryResult = javaClient.executeQuery(DEFAULT_PULL_QUERY);
 
     // Then
-    assertThat(batchedQueryResult.queryID().get(), is(nullValue()));
+    assertThat(batchedQueryResult.queryID().get(), is(notNullValue()));
 
     verifyRows(batchedQueryResult.get());
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -450,7 +450,7 @@ public class ClientIntegrationTest {
     // Then
     assertThat(streamedQueryResult.columnNames(), is(PULL_QUERY_COLUMN_NAMES));
     assertThat(streamedQueryResult.columnTypes(), is(PULL_QUERY_COLUMN_TYPES));
-    assertThat(streamedQueryResult.queryID(), is(nullValue()));
+    assertThat(streamedQueryResult.queryID(), is(notNullValue()));
 
     shouldReceiveRows(
         streamedQueryResult,
@@ -470,7 +470,7 @@ public class ClientIntegrationTest {
     // Then
     assertThat(streamedQueryResult.columnNames(), is(PULL_QUERY_COLUMN_NAMES));
     assertThat(streamedQueryResult.columnTypes(), is(PULL_QUERY_COLUMN_TYPES));
-    assertThat(streamedQueryResult.queryID(), is(nullValue()));
+    assertThat(streamedQueryResult.queryID(), is(notNullValue()));
 
     final Row row = streamedQueryResult.poll();
     verifyPullQueryRow(row);
@@ -564,7 +564,7 @@ public class ClientIntegrationTest {
     final BatchedQueryResult batchedQueryResult = client.executeQuery(PULL_QUERY_ON_TABLE);
 
     // Then
-    assertThat(batchedQueryResult.queryID().get(), is(nullValue()));
+    assertThat(batchedQueryResult.queryID().get(), is(notNullValue()));
 
     verifyPullQueryRows(batchedQueryResult.get()); 
   }
@@ -577,7 +577,7 @@ public class ClientIntegrationTest {
     final BatchedQueryResult batchedQueryResult = client.executeQuery("SELECT ${value} from ${AGG_TABLE} WHERE K=STRUCT(F1 := ARRAY['a']);");
 
     // Then
-    assertThat(batchedQueryResult.queryID().get(), is(nullValue()));
+    assertThat(batchedQueryResult.queryID().get(), is(notNullValue()));
     assertThat(batchedQueryResult.get().get(0).getBoolean(1), is(false));
   }
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
@@ -216,7 +216,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
 
     // Then
     assertThat(rows, hasSize(1));
-    assertThat(batchedQueryResult.queryID().get(), is(nullValue()));
+    assertThat(batchedQueryResult.queryID().get(), is(notNullValue()));
     assertThatEventually(() -> ((ClientImpl)client).getSerializedConsistencyVector(),
                           is(notNullValue()));
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();
@@ -280,7 +280,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
     batchedQueryResult.get();
 
     // Then
-    assertThat(batchedQueryResult.queryID().get(), is(nullValue()));
+    assertThat(batchedQueryResult.queryID().get(), is(notNullValue()));
     assertThat(((ClientImpl)client).getSerializedConsistencyVector(), is(isEmptyString()));
   }
 

--- a/ksqldb-api-reactive-streams-tck/src/test/java/io/confluent/ksql/api/tck/BlockingQueryPublisherVerificationTest.java
+++ b/ksqldb-api-reactive-streams-tck/src/test/java/io/confluent/ksql/api/tck/BlockingQueryPublisherVerificationTest.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.api.server.QueryHandle;
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.TransientQueryQueue;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.ConsistencyOffsetVector;
 import io.confluent.ksql.util.KeyValueMetadata;
 import io.vertx.core.Context;
@@ -95,6 +96,11 @@ public class BlockingQueryPublisherVerificationTest extends PublisherVerificatio
     @Override
     public List<String> getColumnTypes() {
       return new ArrayList<>();
+    }
+
+    @Override
+    public LogicalSchema getLogicalSchema() {
+      return LogicalSchema.builder().build();
     }
 
     @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/PullQueryQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/PullQueryQueue.java
@@ -161,7 +161,7 @@ public class PullQueryQueue implements BlockingRowQueue {
    * wants to end pull queries prematurely, such as when the client connection closes, this should
    * also be called then.
    */
-  private void closeInternal(boolean limitHit) {
+  private void closeInternal(final boolean limitHit) {
     if (!closed.getAndSet(true)) {
       // Unlike limits based on a number of rows which can be checked and possibly triggered after
       // every queuing of a row, pull queries just declare they've reached their limit when close is

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/PullQueryQueueTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/PullQueryQueueTest.java
@@ -54,6 +54,8 @@ public class PullQueryQueueTest {
   @Mock
   private LimitHandler limitHandler;
   @Mock
+  private CompletionHandler completionHandler;
+  @Mock
   private Runnable queuedCallback;
   private PullQueryQueue queue;
   private ScheduledExecutorService executorService;
@@ -116,13 +118,13 @@ public class PullQueryQueueTest {
   }
 
   @Test
-  public void shouldCallLimitHandlerOnClose() {
+  public void shouldCallCompleteOnClose() {
     // When:
     queue.close();
     queue.close();
 
     // Then:
-    verify(limitHandler, times(1)).limitReached();
+    verify(completionHandler, times(1)).complete();
   }
 
 
@@ -213,6 +215,7 @@ public class PullQueryQueueTest {
     queue = new PullQueryQueue(QUEUE_SIZE, 1, OptionalInt.empty());
 
     queue.setLimitHandler(limitHandler);
+    queue.setCompletionHandler(completionHandler);
     queue.setQueuedCallback(queuedCallback);
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/BlockingQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/BlockingQueryPublisher.java
@@ -59,6 +59,7 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
   private LogicalSchema logicalSchema;
   private QueryId queryId;
   private boolean complete;
+  private boolean hitLimit;
   private volatile boolean closed;
 
   public BlockingQueryPublisher(final Context ctx,
@@ -84,6 +85,7 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
         maybeSend();
       }
       complete = true;
+      hitLimit = true;
       // This allows us to hit the limit without having to queue one last row
       if (queue.isEmpty()) {
         ctx.runOnContext(v -> sendComplete());
@@ -150,6 +152,11 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
   @Override
   public QueryId queryId() {
     return queryId;
+  }
+
+  @Override
+  public boolean hitLimit() {
+    return hitLimit;
   }
 
   @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/BlockingQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/BlockingQueryPublisher.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.PullQueryQueue;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.reactive.BasePublisher;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KeyValueMetadata;
 import io.vertx.core.Context;
 import io.vertx.core.WorkerExecutor;
@@ -55,6 +56,7 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
   private QueryHandle queryHandle;
   private ImmutableList<String> columnNames;
   private ImmutableList<String> columnTypes;
+  private LogicalSchema logicalSchema;
   private QueryId queryId;
   private boolean complete;
   private volatile boolean closed;
@@ -69,6 +71,7 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
       final boolean isScalablePushQuery) {
     this.columnNames = ImmutableList.copyOf(queryHandle.getColumnNames());
     this.columnTypes = ImmutableList.copyOf(queryHandle.getColumnTypes());
+    this.logicalSchema = queryHandle.getLogicalSchema();
     this.queue = queryHandle.getQueue();
     this.isPullQuery = isPullQuery;
     this.isScalablePushQuery = isScalablePushQuery;
@@ -117,6 +120,11 @@ public class BlockingQueryPublisher extends BasePublisher<KeyValueMetadata<List<
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "columnTypes is ImmutableList")
   public List<String> getColumnTypes() {
     return columnTypes;
+  }
+
+  @Override
+  public LogicalSchema geLogicalSchema() {
+    return logicalSchema;
   }
 
   public void close() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/QueryEndpoint.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.server.query.QueryExecutor;
 import io.confluent.ksql.rest.server.query.QueryMetadataHolder;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.utils.FormatOptions;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -184,6 +185,11 @@ public class QueryEndpoint {
     }
 
     @Override
+    public LogicalSchema getLogicalSchema() {
+      return queryMetadata.getLogicalSchema();
+    }
+
+    @Override
     public void start() {
       queryMetadata.start();
     }
@@ -237,6 +243,11 @@ public class QueryEndpoint {
     @Override
     public List<String> getColumnTypes() {
       return colTypesFromSchema(result.getSchema().columns());
+    }
+
+    @Override
+    public LogicalSchema getLogicalSchema() {
+      return result.getSchema();
     }
 
     @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedQueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedQueryStreamResponseWriter.java
@@ -81,6 +81,16 @@ public class DelimitedQueryStreamResponseWriter implements QueryStreamResponseWr
     return this;
   }
 
+  @Override
+  public QueryStreamResponseWriter writeCompletionMessage(String completionMessage) {
+    return this;
+  }
+
+  @Override
+  public QueryStreamResponseWriter writeLimitMessage() {
+    return this;
+  }
+
 
   @Override
   public void end() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedQueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedQueryStreamResponseWriter.java
@@ -82,7 +82,7 @@ public class DelimitedQueryStreamResponseWriter implements QueryStreamResponseWr
   }
 
   @Override
-  public QueryStreamResponseWriter writeCompletionMessage(String completionMessage) {
+  public QueryStreamResponseWriter writeCompletionMessage(final String completionMessage) {
     return this;
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonQueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonQueryStreamResponseWriter.java
@@ -86,7 +86,7 @@ public class JsonQueryStreamResponseWriter implements QueryStreamResponseWriter 
   }
 
   @Override
-  public QueryStreamResponseWriter writeCompletionMessage(String completionMessage) {
+  public QueryStreamResponseWriter writeCompletionMessage(final String completionMessage) {
     return this;
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonQueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonQueryStreamResponseWriter.java
@@ -85,6 +85,15 @@ public class JsonQueryStreamResponseWriter implements QueryStreamResponseWriter 
     return this;
   }
 
+  @Override
+  public QueryStreamResponseWriter writeCompletionMessage(String completionMessage) {
+    return this;
+  }
+
+  @Override
+  public QueryStreamResponseWriter writeLimitMessage() {
+    return this;
+  }
 
   private void writeBuffer(final Buffer buffer) {
     final Buffer buff = Buffer.buffer().appendByte((byte) ',');

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -74,7 +74,7 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
   }
 
   @Override
-  public QueryStreamResponseWriter writeCompletionMessage(String completionMessage) {
+  public QueryStreamResponseWriter writeCompletionMessage(final String completionMessage) {
     final StreamedRow streamedRow = StreamedRow.finalMessage(completionMessage);
     writeBuffer(ServerUtils.serializeObject(streamedRow));
     return this;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -74,6 +74,20 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
   }
 
   @Override
+  public QueryStreamResponseWriter writeCompletionMessage(String completionMessage) {
+    final StreamedRow streamedRow = StreamedRow.finalMessage(completionMessage);
+    writeBuffer(ServerUtils.serializeObject(streamedRow));
+    return this;
+  }
+
+  @Override
+  public QueryStreamResponseWriter writeLimitMessage() {
+    final StreamedRow streamedRow = StreamedRow.finalMessage("Limit Reached");
+    writeBuffer(ServerUtils.serializeObject(streamedRow));
+    return this;
+  }
+
+  @Override
   public void end() {
     response.write("]").end();
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -1,0 +1,72 @@
+package io.confluent.ksql.api.server;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.ConsistencyToken;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.PushContinuationToken;
+import io.confluent.ksql.rest.entity.QueryResponseMetadata;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerResponse;
+
+public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter {
+
+  private final HttpServerResponse response;
+
+  public JsonStreamedRowResponseWriter(final HttpServerResponse response) {
+    this.response = response;
+  }
+
+  @Override
+  public QueryStreamResponseWriter writeMetadata(QueryResponseMetadata metaData) {
+    final StreamedRow streamedRow
+        = StreamedRow.header(new QueryId(metaData.queryId), metaData.schema);
+    final Buffer buff = Buffer.buffer().appendByte((byte) '[');
+    buff.appendBuffer(ServerUtils.serializeObject(streamedRow));
+    buff.appendString("\n");
+    response.write(buff);
+    return this;
+  }
+
+  @Override
+  public QueryStreamResponseWriter writeRow(GenericRow row) {
+    final StreamedRow streamedRow = StreamedRow.pushRow(row);
+    writeBuffer(ServerUtils.serializeObject(streamedRow));
+    return this;
+  }
+
+  @Override
+  public QueryStreamResponseWriter writeContinuationToken(
+      final PushContinuationToken pushContinuationToken) {
+    final StreamedRow streamedRow = StreamedRow.continuationToken(pushContinuationToken);
+    writeBuffer(ServerUtils.serializeObject(streamedRow));
+    return this;
+  }
+
+  @Override
+  public QueryStreamResponseWriter writeError(KsqlErrorMessage error) {
+    final StreamedRow streamedRow = StreamedRow.error(error);
+    writeBuffer(ServerUtils.serializeObject(streamedRow));
+    return this;
+  }
+
+  @Override
+  public QueryStreamResponseWriter writeConsistencyToken(ConsistencyToken consistencyToken) {
+    final StreamedRow streamedRow = StreamedRow.consistencyToken(consistencyToken);
+    writeBuffer(ServerUtils.serializeObject(streamedRow));
+    return this;
+  }
+
+  @Override
+  public void end() {
+    response.write("]").end();
+  }
+
+  private void writeBuffer(final Buffer buffer) {
+    final Buffer buff = Buffer.buffer().appendByte((byte) ',');
+    buff.appendBuffer(buffer);
+    buff.appendString("\n");
+    response.write(buff);
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.api.server;
 
 import io.confluent.ksql.GenericRow;
@@ -19,18 +34,18 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
   }
 
   @Override
-  public QueryStreamResponseWriter writeMetadata(QueryResponseMetadata metaData) {
+  public QueryStreamResponseWriter writeMetadata(final QueryResponseMetadata metaData) {
     final StreamedRow streamedRow
         = StreamedRow.header(new QueryId(metaData.queryId), metaData.schema);
     final Buffer buff = Buffer.buffer().appendByte((byte) '[');
     buff.appendBuffer(ServerUtils.serializeObject(streamedRow));
-    buff.appendString("\n");
+    buff.appendString(",\n");
     response.write(buff);
     return this;
   }
 
   @Override
-  public QueryStreamResponseWriter writeRow(GenericRow row) {
+  public QueryStreamResponseWriter writeRow(final GenericRow row) {
     final StreamedRow streamedRow = StreamedRow.pushRow(row);
     writeBuffer(ServerUtils.serializeObject(streamedRow));
     return this;
@@ -45,14 +60,14 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
   }
 
   @Override
-  public QueryStreamResponseWriter writeError(KsqlErrorMessage error) {
+  public QueryStreamResponseWriter writeError(final KsqlErrorMessage error) {
     final StreamedRow streamedRow = StreamedRow.error(error);
     writeBuffer(ServerUtils.serializeObject(streamedRow));
     return this;
   }
 
   @Override
-  public QueryStreamResponseWriter writeConsistencyToken(ConsistencyToken consistencyToken) {
+  public QueryStreamResponseWriter writeConsistencyToken(final ConsistencyToken consistencyToken) {
     final StreamedRow streamedRow = StreamedRow.consistencyToken(consistencyToken);
     writeBuffer(ServerUtils.serializeObject(streamedRow));
     return this;
@@ -64,9 +79,9 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
   }
 
   private void writeBuffer(final Buffer buffer) {
-    final Buffer buff = Buffer.buffer().appendByte((byte) ',');
+    final Buffer buff = Buffer.buffer();
     buff.appendBuffer(buffer);
-    buff.appendString("\n");
+    buff.appendString(",\n");
     response.write(buff);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.api.server;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.ApiJsonMapper;
@@ -34,6 +35,7 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
 
   private final HttpServerResponse response;
 
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
   public JsonStreamedRowResponseWriter(final HttpServerResponse response) {
     this.response = response;
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryHandle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryHandle.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.api.server;
 
 import io.confluent.ksql.query.BlockingRowQueue;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.ConsistencyOffsetVector;
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +31,8 @@ public interface QueryHandle {
   List<String> getColumnNames();
 
   List<String> getColumnTypes();
+
+  LogicalSchema getLogicalSchema();
 
   void start();
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamResponseWriter.java
@@ -36,6 +36,10 @@ public interface QueryStreamResponseWriter {
 
   QueryStreamResponseWriter writeConsistencyToken(ConsistencyToken consistencyToken);
 
+  QueryStreamResponseWriter writeCompletionMessage(String completionMessage);
+
+  QueryStreamResponseWriter writeLimitMessage();
+
   void end();
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -61,6 +61,7 @@ public class ServerVerticle extends AbstractVerticle {
 
   private static final String JSON_CONTENT_TYPE = "application/json";
   private static final String DELIMITED_CONTENT_TYPE = "application/vnd.ksqlapi.delimited.v1";
+  private static final String KSQL_JSON_CONTENT_TYPE = "application/vnd.ksqlapi.json.v1";
 
   private final Endpoints endpoints;
   private final HttpServerOptions httpServerOptions;
@@ -141,8 +142,9 @@ public class ServerVerticle extends AbstractVerticle {
     router.route(HttpMethod.POST, "/query-stream")
         .produces(DELIMITED_CONTENT_TYPE)
         .produces(JSON_CONTENT_TYPE)
+        .produces(KSQL_JSON_CONTENT_TYPE)
         .handler(BodyHandler.create(false))
-        .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server));
+        .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false));
     router.route(HttpMethod.POST, "/inserts-stream")
         .produces(DELIMITED_CONTENT_TYPE)
         .produces(JSON_CONTENT_TYPE)

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -61,7 +61,6 @@ public class ServerVerticle extends AbstractVerticle {
 
   private static final String JSON_CONTENT_TYPE = "application/json";
   private static final String DELIMITED_CONTENT_TYPE = "application/vnd.ksqlapi.delimited.v1";
-  private static final String KSQL_JSON_CONTENT_TYPE = "application/vnd.ksqlapi.json.v1";
 
   private final Endpoints endpoints;
   private final HttpServerOptions httpServerOptions;
@@ -142,7 +141,7 @@ public class ServerVerticle extends AbstractVerticle {
     router.route(HttpMethod.POST, "/query-stream")
         .produces(DELIMITED_CONTENT_TYPE)
         .produces(JSON_CONTENT_TYPE)
-        .produces(KSQL_JSON_CONTENT_TYPE)
+        .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .handler(BodyHandler.create(false))
         .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false));
     router.route(HttpMethod.POST, "/inserts-stream")

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/QueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/QueryPublisher.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.api.spi;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KeyValueMetadata;
 import java.util.List;
 import org.reactivestreams.Publisher;
@@ -37,6 +38,11 @@ public interface QueryPublisher extends Publisher<KeyValueMetadata<List<?>, Gene
    * @return List the types of the columns in the query results
    */
   List<String> getColumnTypes();
+
+  /**
+   * @return The logical schema associated with the query results
+   */
+  LogicalSchema geLogicalSchema();
 
   /**
    * Close the publisher

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/QueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/spi/QueryPublisher.java
@@ -63,4 +63,9 @@ public interface QueryPublisher extends Publisher<KeyValueMetadata<List<?>, Gene
    * The query id
    */
   QueryId queryId();
+
+  /**
+   * If the query was completed by hitting the limit.
+   */
+  boolean hitLimit();
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -115,7 +115,7 @@ public class ApiTest extends BaseApiTest {
     assertThat(queryResponse.rows, is(DEFAULT_JSON_ROWS));
     assertThat(server.getQueryIDs(), hasSize(0));
     String queryId = queryResponse.responseObject.getString("queryId");
-    assertThat(queryId, is(nullValue()));
+    assertThat(queryId, is("queryId"));
   }
 
   @Test
@@ -142,7 +142,7 @@ public class ApiTest extends BaseApiTest {
     assertThat(queryResponse.rows, is(DEFAULT_JSON_ROWS));
     assertThat(server.getQueryIDs(), hasSize(0));
     String queryId = queryResponse.responseObject.getString("queryId");
-    assertThat(queryId, is(nullValue()));
+    assertThat(queryId, is("queryId"));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -28,8 +28,11 @@ import io.confluent.ksql.api.server.ServerUtils;
 import io.confluent.ksql.api.utils.ListRowGenerator;
 import io.confluent.ksql.api.utils.QueryResponse;
 import io.confluent.ksql.api.utils.ReceiveStream;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.state.ServerState;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.security.KsqlDefaultSecurityExtension;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.vertx.core.Vertx;
@@ -72,6 +75,26 @@ public class BaseApiTest {
       .add("BOOLEAN").add("BIGINT").add("DOUBLE").add("DECIMAL(4, 2)").add("BYTES")
       .add("ARRAY<STRING>").add("MAP<STRING, STRING>").add("STRUCT<`F1` STRING, `F2` INTEGER>").add("INTEGER")
       .add("TIMESTAMP").add("DATE").add("TIME");
+  protected static final LogicalSchema DEFAULT_SCHEMA = LogicalSchema.builder()
+      .valueColumn(ColumnName.of("f_str"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("f_int"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("f_bool"), SqlTypes.BOOLEAN)
+      .valueColumn(ColumnName.of("f_long"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("f_double"), SqlTypes.DOUBLE)
+      .valueColumn(ColumnName.of("f_decimal"), SqlTypes.decimal(4, 2))
+      .valueColumn(ColumnName.of("f_bytes"), SqlTypes.BYTES)
+      .valueColumn(ColumnName.of("f_array"), SqlTypes.array(SqlTypes.STRING))
+      .valueColumn(ColumnName.of("f_map"), SqlTypes.map(SqlTypes.STRING, SqlTypes.STRING))
+      .valueColumn(ColumnName.of("f_struct"),
+          SqlTypes.struct()
+              .field("F1", SqlTypes.STRING)
+              .field("F2", SqlTypes.INTEGER)
+              .build())
+      .valueColumn(ColumnName.of("f_null"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("f_timestamp"), SqlTypes.TIMESTAMP)
+      .valueColumn(ColumnName.of("f_date"), SqlTypes.DATE)
+      .valueColumn(ColumnName.of("f_time"), SqlTypes.TIME)
+      .build();
   protected static final Schema F_STRUCT_SCHEMA = SchemaBuilder.struct()
         .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
         .field("F2", Schema.OPTIONAL_INT32_SCHEMA)
@@ -296,6 +319,7 @@ public class BaseApiTest {
         () -> new ListRowGenerator(
             DEFAULT_COLUMN_NAMES.getList(),
             DEFAULT_COLUMN_TYPES.getList(),
+            DEFAULT_SCHEMA,
             DEFAULT_GENERIC_ROWS));
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/Http2OnlyStreamTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/Http2OnlyStreamTest.java
@@ -36,18 +36,6 @@ public class Http2OnlyStreamTest extends BaseApiTest {
   }
 
   @Test
-  public void shouldRejectQueryUsingHttp11() throws Exception {
-
-    // Given:
-    JsonObject requestBody = new JsonObject().put("sql", DEFAULT_PULL_QUERY);
-    JsonObject properties = new JsonObject().put("prop1", "val1").put("prop2", 23);
-    requestBody.put("properties", properties);
-
-    // Then
-    shouldRejectRequestUsingHttp11("/query-stream", requestBody);
-  }
-
-  @Test
   public void shouldRejectInsertsUsingHttp11() throws Exception {
 
     // Given:

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestQueryPublisher.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestQueryPublisher.java
@@ -116,4 +116,9 @@ public class TestQueryPublisher
   public QueryId queryId() {
     return new QueryId("queryId");
   }
+
+  @Override
+  public boolean hitLimit() {
+    return false;
+  }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestQueryPublisher.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestQueryPublisher.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.api.spi.QueryPublisher;
 import io.confluent.ksql.api.utils.RowGenerator;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.reactive.BasePublisher;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KeyValue;
 import io.confluent.ksql.util.KeyValueMetadata;
 import io.vertx.core.Context;
@@ -94,6 +95,11 @@ public class TestQueryPublisher
   @Override
   public List<String> getColumnTypes() {
     return rowGenerator.getColumnTypes();
+  }
+
+  @Override
+  public LogicalSchema geLogicalSchema() {
+    return null;
   }
 
   @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestQueryPublisher.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/TestQueryPublisher.java
@@ -99,7 +99,7 @@ public class TestQueryPublisher
 
   @Override
   public LogicalSchema geLogicalSchema() {
-    return null;
+    return rowGenerator.getLogicalSchema();
   }
 
   @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/ApiIntegrationTest.java
@@ -307,7 +307,7 @@ public class ApiIntegrationTest {
     assertThat(response.rows, hasSize(1));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(expectedColumnNames));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(expectedColumnTypes));
-    assertThat(response.responseObject.getString("queryId"), is(nullValue()));
+    assertThat(response.responseObject.getString("queryId"), startsWith("query_"));
     assertThat(response.rows.get(0).getJsonObject(0).getJsonArray("F1").getString(0), is("a")); // rowkey
     assertThat(response.rows.get(0).getLong(1), is(1L)); // latest_by_offset(long)
   }
@@ -336,7 +336,7 @@ public class ApiIntegrationTest {
     assertThat(response.rows, hasSize(1));
     assertThat(response.responseObject.getJsonArray("columnNames"), is(expectedColumnNames));
     assertThat(response.responseObject.getJsonArray("columnTypes"), is(expectedColumnTypes));
-    assertThat(response.responseObject.getString("queryId"), is(nullValue()));
+    assertThat(response.responseObject.getString("queryId"), startsWith("query_"));
     assertThat(response.rows.get(0).getJsonObject(0).getJsonArray("F1").getString(0), is("a")); // rowkey
     assertThat(response.rows.get(0).getLong(1), is(1L)); // latest_by_offset(long)
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -276,5 +276,10 @@ public class PullQueryRunner extends BasePerfRunner {
     public QueryId queryId() {
       return new QueryId("queryId");
     }
+
+    @Override
+    public boolean hitLimit() {
+      return false;
+    }
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/PullQueryRunner.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_NAMES;
 import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_TYPES;
 import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_KEY;
 import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_ROW;
+import static io.confluent.ksql.api.perf.RunnerUtils.SCHEMA;
 import static io.confluent.ksql.util.KeyValue.keyValue;
 
 import io.confluent.ksql.GenericRow;
@@ -36,6 +37,7 @@ import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KeyValue;
 import io.confluent.ksql.util.KeyValueMetadata;
 import io.confluent.ksql.util.VertxCompletableFuture;
@@ -253,6 +255,11 @@ public class PullQueryRunner extends BasePerfRunner {
     @Override
     public List<String> getColumnTypes() {
       return DEFAULT_COLUMN_TYPES;
+    }
+
+    @Override
+    public LogicalSchema geLogicalSchema() {
+      return SCHEMA;
     }
 
     @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/QueryStreamRunner.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_NAMES;
 import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_COLUMN_TYPES;
 import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_KEY;
 import static io.confluent.ksql.api.perf.RunnerUtils.DEFAULT_ROW;
+import static io.confluent.ksql.api.perf.RunnerUtils.SCHEMA;
 
 import io.confluent.ksql.api.auth.ApiSecurityContext;
 import io.confluent.ksql.api.impl.BlockingQueryPublisher;
@@ -37,6 +38,7 @@ import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.ConsistencyOffsetVector;
 import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
@@ -236,6 +238,11 @@ public class QueryStreamRunner extends BasePerfRunner {
     @Override
     public List<String> getColumnTypes() {
       return DEFAULT_COLUMN_TYPES;
+    }
+
+    @Override
+    public LogicalSchema getLogicalSchema() {
+      return SCHEMA;
     }
 
     @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/RunnerUtils.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/perf/RunnerUtils.java
@@ -18,6 +18,9 @@ package io.confluent.ksql.api.perf;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -32,6 +35,11 @@ public class RunnerUtils {
       .of("name", "age", "male");
   protected static final List<String> DEFAULT_COLUMN_TYPES = ImmutableList
       .of("STRING", "INT", "BOOLEAN");
+  protected static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .keyColumn(ColumnName.of("name"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("age"), SqlTypes.INTEGER)
+      .keyColumn(ColumnName.of("male"), SqlTypes.BOOLEAN)
+      .build();
 
   protected static final List<?> DEFAULT_KEY = ImmutableList.of("tim");
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/utils/ListRowGenerator.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/utils/ListRowGenerator.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.api.utils;
 import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Iterator;
 import java.util.List;
 
@@ -25,12 +26,14 @@ public class ListRowGenerator implements RowGenerator {
 
   private final ImmutableList<String> columnNames;
   private final ImmutableList<String> columnTypes;
+  private final LogicalSchema logicalSchema;
   private final Iterator<GenericRow> iter;
 
   public ListRowGenerator(final List<String> columnNames, final List<String> columnTypes,
-      final List<GenericRow> rows) {
+      final LogicalSchema logicalSchema, final List<GenericRow> rows) {
     this.columnNames = ImmutableList.copyOf(columnNames);
     this.columnTypes = ImmutableList.copyOf(columnTypes);
+    this.logicalSchema = logicalSchema;
     this.iter = rows.iterator();
   }
 
@@ -44,6 +47,11 @@ public class ListRowGenerator implements RowGenerator {
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "columnTypes is ImmutableList")
   public List<String> getColumnTypes() {
     return columnTypes;
+  }
+
+  @Override
+  public LogicalSchema getLogicalSchema() {
+    return logicalSchema;
   }
 
   @Override

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/utils/RowGenerator.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/utils/RowGenerator.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.utils;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.List;
 
 public interface RowGenerator {
@@ -23,6 +24,8 @@ public interface RowGenerator {
   List<String> getColumnNames();
 
   List<String> getColumnTypes();
+
+  LogicalSchema getLogicalSchema();
 
   GenericRow getNext();
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -42,6 +42,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
@@ -110,9 +111,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Category({IntegrationTest.class})
+  @Category({IntegrationTest.class})
 public class RestApiTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RestApiTest.class);
 
   private static final int HEADER = 1;  // <-- some responses include a header as the first message.
   private static final int FOOTER = 1;  // <-- some responses include a footer as the last message.
@@ -911,52 +916,70 @@ public class RestApiTest {
   }
 
   @Test
-  public void shouldExecutePullQueryOverHttp11QueryStream() {
-    QueryStreamArgs queryStreamArgs = new QueryStreamArgs(
-        "SELECT COUNT, USERID from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';",
-        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+  public void shouldExecutePullQuery_allTypes() {
+    ImmutableList<String> formats = ImmutableList.of(
+        "application/vnd.ksqlapi.delimited.v1",
+        KsqlMediaType.KSQL_V1_JSON.mediaType());
+    ImmutableList<HttpVersion> httpVersions = ImmutableList.of(HTTP_1_1, HTTP_2);
+    ImmutableList<String> endpoints = ImmutableList.of("/query-stream");
 
-    QueryResponse[] queryResponse = new QueryResponse[1];
-    assertThatEventually(() -> {
-      try {
-        HttpResponse<Buffer> resp = RestIntegrationTestUtil.rawRestRequest(REST_APP,
-            HTTP_1_1, POST,
-            "/query-stream", queryStreamArgs, "application/vnd.ksqlapi.delimited.v1",
-            Optional.empty());
-        queryResponse[0] = new QueryResponse(resp.body().toString());
-        return queryResponse[0].rows.size();
-      } catch (Throwable t) {
-        return Integer.MAX_VALUE;
+    for (String format : formats) {
+      for (HttpVersion version : httpVersions) {
+        for (String endpoint : endpoints) {
+          LOG.info("Trying pull query combination {} {} {}", format, version, endpoint);
+          Object requestBody;
+          if (endpoint.equals("/query-stream")) {
+            requestBody = new QueryStreamArgs(
+                "SELECT COUNT, USERID from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';",
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+          } else {
+            fail("Unknown endpoint " + endpoint);
+            return;
+          }
+
+          // It would be nice to check the output the same way between all of the formats, but this
+          // is somewhat hard since they have different data, so we don't try.
+          if (format.equals("application/vnd.ksqlapi.delimited.v1")) {
+            QueryResponse[] queryResponse = new QueryResponse[1];
+            assertThatEventually(() -> {
+              try {
+                HttpResponse<Buffer> resp = RestIntegrationTestUtil.rawRestRequest(REST_APP,
+                    version, POST,
+                    endpoint, requestBody, "application/vnd.ksqlapi.delimited.v1",
+                    Optional.empty());
+                queryResponse[0] = new QueryResponse(resp.body().toString());
+                return queryResponse[0].rows.size();
+              } catch (Throwable t) {
+                return Integer.MAX_VALUE;
+              }
+            }, is(1));
+            assertThat(queryResponse[0].rows.get(0).getList(), is(ImmutableList.of(1, "USER_1")));
+          } else if (format.equals(KsqlMediaType.KSQL_V1_JSON.mediaType())) {
+            final Supplier<List<String>> call = () -> {
+              HttpResponse<Buffer> resp = RestIntegrationTestUtil.rawRestRequest(REST_APP,
+                  version, POST,
+                  endpoint, requestBody, KsqlMediaType.KSQL_V1_JSON.mediaType(),
+                  Optional.empty());
+              final String response = resp.body().toString();
+              return Arrays.asList(response.split(System.lineSeparator()));
+            };
+
+            // When:
+            final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1 + FOOTER));
+            // Then:
+            assertThat(messages, hasSize(HEADER + 1 + FOOTER));
+            assertThat(messages.get(0), startsWith("[{\"header\":{\"queryId\":\""));
+            assertThat(messages.get(0),
+                endsWith("\",\"schema\":\"`COUNT` BIGINT, `USERID` STRING KEY\"}},"));
+            assertThat(messages.get(1), is("{\"row\":{\"columns\":[1,\"USER_1\"]}},"));
+            assertThat(messages.get(2), is("{\"finalMessage\":\"Pull query complete\"}]"));
+          } else {
+            fail("Unknown format " + format);
+            return;
+          }
+        }
       }
-    }, is(1));
-    assertThat(queryResponse[0].rows.get(0).getList(), is(ImmutableList.of(1, "USER_1")));
-  }
-
-  @Test
-  public void shouldExecutePullQueryOverRest_queryStreamWithStreamedRow() {
-    // Given:
-    final Supplier<List<String>> call = () -> {
-      QueryStreamArgs queryStreamArgs = new QueryStreamArgs(
-          "SELECT COUNT, USERID from " + AGG_TABLE + " WHERE USERID='" + AN_AGG_KEY + "';",
-          Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
-      HttpResponse<Buffer> resp = RestIntegrationTestUtil.rawRestRequest(REST_APP,
-          HTTP_1_1, POST,
-          "/query-stream", queryStreamArgs, KsqlMediaType.KSQL_V1_JSON.mediaType(),
-          Optional.empty());
-      final String response = resp.body().toString();
-      return Arrays.asList(response.split(System.lineSeparator()));
-    };
-
-    // When:
-    final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1 + FOOTER));
-
-    // Then:
-    assertThat(messages, hasSize(HEADER + 1 + FOOTER));
-    assertThat(messages.get(0), startsWith("[{\"header\":{\"queryId\":\""));
-    assertThat(messages.get(0),
-        endsWith("\",\"schema\":\"`COUNT` BIGINT, `USERID` STRING KEY\"}},"));
-    assertThat(messages.get(1), is("{\"row\":{\"columns\":[1,\"USER_1\"]}},"));
-    assertThat(messages.get(2), is("{\"finalMessage\":\"Pull query complete\"}]"));
+    }
   }
 
   @Test

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryResponseMetadata.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryResponseMetadata.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -31,6 +32,9 @@ public class QueryResponseMetadata {
   public final String queryId;
   public final List<String> columnNames;
   public final List<String> columnTypes;
+
+  // Just used to pass data around rather than directly serialized in a response
+  @JsonIgnore
   public final LogicalSchema schema;
 
   public QueryResponseMetadata(

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryResponseMetadata.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryResponseMetadata.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -30,18 +31,22 @@ public class QueryResponseMetadata {
   public final String queryId;
   public final List<String> columnNames;
   public final List<String> columnTypes;
+  public final LogicalSchema schema;
 
   public QueryResponseMetadata(
       final @JsonProperty(value = "queryId") String queryId,
       final @JsonProperty(value = "columnNames") List<String> columnNames,
-      final @JsonProperty(value = "columnTypes") List<String> columnTypes) {
+      final @JsonProperty(value = "columnTypes") List<String> columnTypes,
+      final @JsonProperty(value = "schema") LogicalSchema schema) {
     this.queryId = queryId;
     this.columnNames = Collections.unmodifiableList(Objects.requireNonNull(columnNames));
     this.columnTypes = Collections.unmodifiableList(Objects.requireNonNull(columnTypes));
+    this.schema = schema;
   }
 
-  public QueryResponseMetadata(final List<String> columnNames, final List<String> columnTypes) {
-    this(null, columnNames, columnTypes);
+  public QueryResponseMetadata(final List<String> columnNames, final List<String> columnTypes,
+      final LogicalSchema schema) {
+    this(null, columnNames, columnTypes, schema);
   }
 
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
@@ -154,6 +154,18 @@ public final class StreamedRow {
     );
   }
 
+  public static StreamedRow error(final KsqlErrorMessage errorMessage) {
+    return new StreamedRow(
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(errorMessage),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty()
+    );
+  }
+
   public static StreamedRow finalMessage(final String finalMessage) {
     return new StreamedRow(
         Optional.empty(),


### PR DESCRIPTION
### Description 
This is part of an effort to consolidate endpoints.  What this aims to do is add support for StreamedRow to `/query-stream`.  This should allow a followup change to install the same handler for `/query`.  Then we can support multiple paths under the same handling logic.

Also, this allows handling of http 1.1 requests using `/query-stream`.

### Testing done 
Ran tests and manually tested.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

