### PR TITLE
feat: verify no other query is running before putting into command topic

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -15,8 +15,12 @@
 
 package io.confluent.ksql.rest.server.computation;
 
+import static org.apache.kafka.streams.StreamsConfig.PROCESSING_GUARANTEE_CONFIG;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.config.ConfigItem;
+import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.engine.KsqlPlan;
 import io.confluent.ksql.execution.json.PlanJsonMapper;
 import io.confluent.ksql.parser.tree.AlterSystemProperty;
@@ -33,6 +37,7 @@ import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.common.config.ConfigException;
 
@@ -131,6 +136,17 @@ public final class ValidatedCommandFactory {
           String.format("Failed to set %s to %s. Caused by: "
                   + "Not recognizable as ksql, streams, consumer, or producer property: %s %n",
               propertyName, propertyValue, propertyName), null);
+    }
+
+    // verify that no persistent query is running when attempting to change 'processing.guarantee'
+    final KsqlConfigResolver resolver = new KsqlConfigResolver();
+    final Optional<ConfigItem> resolvedItem = resolver.resolve(propertyName, false);
+    if (resolvedItem.isPresent()
+        && Objects.equals(resolvedItem.get().getPropertyName(), PROCESSING_GUARANTEE_CONFIG)
+        && !context.getPersistentQueries().isEmpty()) {
+      throw new ConfigException(
+          String.format("Failed to set %s to %s. Please terminate all running queries "
+              + "before attempting to set %s", propertyName, propertyValue, propertyName), null);
     }
 
     return Command.of(statement);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
@@ -51,6 +51,8 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.common.config.ConfigException;
@@ -126,6 +128,20 @@ public class ValidatedCommandFactoryTest {
     configuredStatement = configuredStatement("ALTER SYSTEM 'TEST'='TEST';" , alterSystemProperty);
     when(alterSystemProperty.getPropertyName()).thenReturn("TEST");
     when(alterSystemProperty.getPropertyValue()).thenReturn("TEST");
+
+    assertThrows(ConfigException.class,
+        () -> commandFactory.create(configuredStatement, executionContext));
+  }
+
+  @Test
+  public void shouldRaiseExceptionWhenQueryIsRunningAndProcessingGuranteeIsAttemptedToChange() {
+    configuredStatement = configuredStatement("ALTER SYSTEM 'processing.guarantee'='exactly_once';" , alterSystemProperty);
+    when(alterSystemProperty.getPropertyName()).thenReturn("processing.guarantee");
+    when(alterSystemProperty.getPropertyValue()).thenReturn("exactly_once");
+
+    final List<PersistentQueryMetadata> persistentList = new ArrayList<>();
+    persistentList.add(query1);
+    when(executionContext.getPersistentQueries()).thenReturn(persistentList);
 
     assertThrows(ConfigException.class,
         () -> commandFactory.create(configuredStatement, executionContext));


### PR DESCRIPTION
### Description 
We want to make sure that no other query is running before changing `processing.guarantee` with the new `ALTER SYSTEM` query

```
ksql>  alter system 'processing.guarantee'='exactly_once';
Could not write the statement 'alter system 'processing.guarantee'='exactly_once';' into the command topic.
Caused by: Invalid value null for configuration Failed to set
	processing.guarantee to exactly_once. Please terminate all running queries
	before attempting to set processing.guarantee
```

### Testing done 
unit test + manual testing 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")


