### PR TITLE
fix: maybe fix flaky test

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
@@ -75,12 +75,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.reactivestreams.Subscription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConsistencyOffsetVectorFunctionalTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ConsistencyOffsetVectorFunctionalTest.class);
 
   private static final StructuredTypesDataProvider TEST_DATA_PROVIDER = new StructuredTypesDataProvider();
   private static final String TEST_TOPIC = TEST_DATA_PROVIDER.topicName();
@@ -179,7 +175,6 @@ public class ConsistencyOffsetVectorFunctionalTest {
   @Test
   public void shouldRoundTripCVWhenPullQueryOnTableAsync() throws Exception {
     // When
-    LOGGER.info("Run test http2 async");
     final StreamedQueryResult streamedQueryResult = client.streamQuery(
         PULL_QUERY_ON_TABLE,  ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true)).get();
 
@@ -192,7 +187,6 @@ public class ConsistencyOffsetVectorFunctionalTest {
     );
 
     assertThatEventually(streamedQueryResult::isComplete, is(true));
-    LOGGER.info("Received consistency vector = " + ((ClientImpl)client).getSerializedConsistencyVector());
     assertThat(((ClientImpl)client).getSerializedConsistencyVector(), is(notNullValue()));
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();
     verifyConsistencyVector(serializedCV);
@@ -201,7 +195,6 @@ public class ConsistencyOffsetVectorFunctionalTest {
   @Test
   public void shouldRoundTripCVWhenPullQueryOnTableSync() throws Exception {
     // When
-    LOGGER.info("Run test http2 sync");
     final StreamedQueryResult streamedQueryResult = client.streamQuery(
         PULL_QUERY_ON_TABLE,  ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true)).get();
     streamedQueryResult.poll();
@@ -210,7 +203,6 @@ public class ConsistencyOffsetVectorFunctionalTest {
     assertThatEventually(streamedQueryResult::isComplete, is(true));
     assertThatEventually(() -> ((ClientImpl)client).getSerializedConsistencyVector(),
                          is(notNullValue()));
-    LOGGER.info("Received consistency vector = " + ((ClientImpl)client).getSerializedConsistencyVector());
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();
     verifyConsistencyVector(serializedCV);
   }
@@ -218,7 +210,6 @@ public class ConsistencyOffsetVectorFunctionalTest {
   @Test
   public void shouldRoundTripCVWhenExecutePullQuery() throws Exception {
     // When
-    LOGGER.info("Run test http2 execute");
     final BatchedQueryResult batchedQueryResult = client.executeQuery(
         PULL_QUERY_ON_TABLE, ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true));
     final List<Row> rows = batchedQueryResult.get();
@@ -228,7 +219,6 @@ public class ConsistencyOffsetVectorFunctionalTest {
     assertThat(batchedQueryResult.queryID().get(), is(nullValue()));
     assertThatEventually(() -> ((ClientImpl)client).getSerializedConsistencyVector(),
                           is(notNullValue()));
-    LOGGER.info("Received consistency vector = " + ((ClientImpl)client).getSerializedConsistencyVector());
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();
     verifyConsistencyVector(serializedCV);
   }
@@ -236,7 +226,6 @@ public class ConsistencyOffsetVectorFunctionalTest {
   @Test(timeout = 120000L)
   public void shouldRoundTripCVWhenPullQueryHttp1() throws Exception {
     // Given
-    LOGGER.info("Run test http1");
     final KsqlRestClient ksqlRestClient = REST_APP.buildKsqlClient();
     ksqlRestClient.setProperty(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
 
@@ -248,7 +237,6 @@ public class ConsistencyOffsetVectorFunctionalTest {
     // Then
     assertThat(rows, hasSize(3));
     assertThat(rows.get(2).getConsistencyToken().get(), not(Optional.empty()));
-    LOGGER.info("Received consistency vector = " + rows.get(2).getConsistencyToken().get());
     final String serialized = rows.get(2).getConsistencyToken().get().getConsistencyToken();
     verifyConsistencyVector(serialized);
   }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
@@ -179,6 +179,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
   @Test
   public void shouldRoundTripCVWhenPullQueryOnTableAsync() throws Exception {
     // When
+    LOGGER.info("Run test http2 async");
     final StreamedQueryResult streamedQueryResult = client.streamQuery(
         PULL_QUERY_ON_TABLE,  ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true)).get();
 
@@ -200,6 +201,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
   @Test
   public void shouldRoundTripCVWhenPullQueryOnTableSync() throws Exception {
     // When
+    LOGGER.info("Run test http2 sync");
     final StreamedQueryResult streamedQueryResult = client.streamQuery(
         PULL_QUERY_ON_TABLE,  ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true)).get();
     streamedQueryResult.poll();
@@ -208,6 +210,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
     assertThatEventually(streamedQueryResult::isComplete, is(true));
     assertThatEventually(() -> ((ClientImpl)client).getSerializedConsistencyVector(),
                          is(notNullValue()));
+    LOGGER.info("Received consistency vector = " + ((ClientImpl)client).getSerializedConsistencyVector());
     final String serializedCV = ((ClientImpl)client).getSerializedConsistencyVector();
     verifyConsistencyVector(serializedCV);
   }
@@ -215,6 +218,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
   @Test
   public void shouldRoundTripCVWhenExecutePullQuery() throws Exception {
     // When
+    LOGGER.info("Run test http2 execute");
     final BatchedQueryResult batchedQueryResult = client.executeQuery(
         PULL_QUERY_ON_TABLE, ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true));
     final List<Row> rows = batchedQueryResult.get();
@@ -232,6 +236,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
   @Test(timeout = 120000L)
   public void shouldRoundTripCVWhenPullQueryHttp1() throws Exception {
     // Given
+    LOGGER.info("Run test http1");
     final KsqlRestClient ksqlRestClient = REST_APP.buildKsqlClient();
     ksqlRestClient.setProperty(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
 
@@ -243,6 +248,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
     // Then
     assertThat(rows, hasSize(3));
     assertThat(rows.get(2).getConsistencyToken().get(), not(Optional.empty()));
+    LOGGER.info("Received consistency vector = " + rows.get(2).getConsistencyToken().get());
     final String serialized = rows.get(2).getConsistencyToken().get().getConsistencyToken();
     verifyConsistencyVector(serialized);
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/BlockingQueryPublisher.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/BlockingQueryPublisher.java
@@ -29,7 +29,6 @@ import io.vertx.core.Context;
 import io.vertx.core.WorkerExecutor;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QuerySubscriber.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QuerySubscriber.java
@@ -66,10 +66,6 @@ public class QuerySubscriber extends BaseSubscriber<KeyValueMetadata<List<?>, Ge
         queryStreamResponseWriter.writeContinuationToken(new PushContinuationToken(
             row.getRowMetadata().get().getPushOffsetsRange().get().serialize()));
       } else if (row.getRowMetadata().get().getConsistencyOffsetVector().isPresent()) {
-        log.info("Response writer writing consistency vector "
-                     + row.getRowMetadata().get().getConsistencyOffsetVector().get());
-        log.info("Serialized consistency vector "
-                     + row.getRowMetadata().get().getConsistencyOffsetVector().get().serialize());
         queryStreamResponseWriter.writeConsistencyToken(new ConsistencyToken(
             row.getRowMetadata().get().getConsistencyOffsetVector().get().serialize()));
       }


### PR DESCRIPTION
### Description 
I added more logs and made a change to the code that adds the consistency token to the queue. 

The problem stems from the fact that rows are streamed asynchronously and the limit handler is also set asynchronously. Hence there is a race on whether the limit handler is called first or not.

The code path where this was happening before would not be called if the limit handler was called first on an empty queue. So, what might be happening is that we poll the last row of data from the queue but the complete flag has not been set yet hence the consistency token is not added. Then, the limit handler gets called and sets the complete flag and also initiates complete on the subscriber. Only then, can the consistency token be added but we have already completed the response so it is lost.

It is not failing locally because the code path that is followed is that the limit handler is called first and sets the complete flag to true but the queue is not empty. Then, we poll from the queue which makes the queue empty. Now, since the complete flag is true, the consistency token is added to the queue as well. 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

