### PR TITLE
docs: Add http protocol to the default ksql.connect.url value

### DIFF
--- a/docs/concepts/connectors.md
+++ b/docs/concepts/connectors.md
@@ -30,7 +30,7 @@ There are two ways to deploy the ksqlDB-Connect integration:
 
 1.  **External**: If a {{ site.kconnect }} cluster is available, set the
     `ksql.connect.url` property in your ksqlDB Server configuration file.
-    The default value for this is `localhost:8083`.
+    The default value for this is `http://localhost:8083`.
 2.  **Embedded**: ksqlDB can double as a {{ site.kconnect }} server and
     will run a
     [Distributed Mode](https://docs.confluent.io/current/connect/userguide.html#distributed-mode)


### PR DESCRIPTION
### Description 

Default value for `ksql.connect.url` used in the docs - `localhost:8083` is not correct. Setting this value in `ksql-server.properties` leads to the following error:

```
ksql> CREATE SOURCE CONNECTOR `jdbc-connector` WITH(
>  "connector.class"='io.confluent.connect.jdbc.JdbcSourceConnector',
>  "connection.url"='jdbc:postgresql://localhost:5432/user1',
>  "mode"='bulk',
>  "topic.prefix"='jdbc-',
>  "key"='username',
>  "connection.username"='user1');
io.confluent.ksql.util.KsqlServerException: org.apache.hc.client5.http.ClientProtocolException: Target host is not specified
Caused by: org.apache.hc.client5.http.ClientProtocolException: Target host is
	not specified
Caused by: Target host is not specified
```

Instead, the value should be `http://localhost:8083` - the same as the default in the code:

https://github.com/confluentinc/ksql/blob/5c9be20917f1f88b0587310134cc3b48b396e345/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java#L180

### Testing done 

Manual testing.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

