### PR TITLE
chore: get query-specific errors from StreamsException

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -16,8 +16,8 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.query.KafkaStreamsBuilder;
-import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.QueryMetadataImpl.TimeBoundedQueue;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
@@ -37,8 +37,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
   ) {
     super(
         sharedRuntime.getKafkaStreamsBuilder(),
-        getSandboxStreamsProperties(sharedRuntime),
-        new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), 0)
+        getSandboxStreamsProperties(sharedRuntime)
     );
 
     for (BinPackedPersistentQueryMetadataImpl query : sharedRuntime.collocatedQueries.values()) {
@@ -48,13 +47,11 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
 
   public SandboxedSharedKafkaStreamsRuntimeImpl(
       final KafkaStreamsBuilder kafkaStreamsBuilder,
-      final int maxQueryErrorsQueueSize,
       final Map<String, Object> streamsProperties
   ) {
     super(
         kafkaStreamsBuilder,
-        streamsProperties,
-        new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), maxQueryErrorsQueueSize)
+        streamsProperties
     );
   }
 
@@ -74,7 +71,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
 
   @Override
   public void register(
-      final QueryErrorClassifier errorClassifier,
       final BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata,
       final QueryId queryId
   ) {
@@ -99,6 +95,11 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
       final Throwable e
   ) {
     return StreamThreadExceptionResponse.REPLACE_THREAD;
+  }
+
+  @Override
+  public TimeBoundedQueue getNewQueryErrorQueue() {
+    return new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), 0);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -125,6 +125,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     return StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse.REPLACE_THREAD;
   }
 
+  // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   private BinPackedPersistentQueryMetadataImpl parseException(final Throwable e) {
     final TaskId task =
         e instanceof StreamsException && ((StreamsException) e).taskId().isPresent()
@@ -150,6 +151,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
       return null;
     }
   }
+  // CHECKSTYLE_RULES.ON: CyclomaticComplexity
 
   @Override
   public TimeBoundedQueue getNewQueryErrorQueue() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
-import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
@@ -58,8 +57,6 @@ public class BinPackedPersistentQueryMetadataImplTest {
     @Mock
     private Map<String, Object> overrides;
     @Mock
-    private QueryErrorClassifier queryErrorClassifier;
-    @Mock
     private ExecutionStep<?> physicalPlan;
     @Mock
     private ProcessingLogger processingLogger;
@@ -67,8 +64,6 @@ public class BinPackedPersistentQueryMetadataImplTest {
     private Listener listener;
     @Mock
     private SharedKafkaStreamsRuntimeImpl sharedKafkaStreamsRuntimeImpl;
-    @Mock
-    private QueryErrorClassifier classifier;
     @Mock
     private Map<String, Object> streamsProperties;
     @Mock
@@ -95,7 +90,6 @@ public class BinPackedPersistentQueryMetadataImplTest {
             processingLogger,
             Optional.of(sinkDataSource),
             listener,
-            classifier,
             streamsProperties,
             scalablePushRegistry,
             (runtime) -> topology);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -17,9 +17,12 @@ package io.confluent.ksql.util;
 
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
+import io.confluent.ksql.query.QueryError.Type;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.namedtopology.AddNamedTopologyResult;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
@@ -37,6 +40,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,19 +56,29 @@ public class SharedKafkaStreamsRuntimeImplTest {
     @Mock
     private KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper2;
     @Mock
-    private BinPackedPersistentQueryMetadataImpl persistentQueriesInSharedRuntimes;
+    private BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata;
+    @Mock
+    private BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata2;
     @Mock
     private QueryErrorClassifier queryErrorClassifier;
-    @Mock
-    private QueryId queryId;
-    @Mock
-    private QueryId queryId2;
     @Mock
     private NamedTopology namedTopology;
     @Mock
     private AddNamedTopologyResult addNamedTopologyResult;
     @Mock
     private KafkaFuture<Void> future;
+
+    private final QueryId queryId = new QueryId("query-1");
+    private final QueryId queryId2= new QueryId("query-2");
+
+    private final StreamsException query1Exception =
+        new StreamsException("query down!", new TaskId(0, 0, queryId.toString()));
+    private final StreamsException runtimeExceptionWithNoTask =
+        new StreamsException("query down!");
+    private final StreamsException runtimeExceptionWithTaskAndNoTopology =
+        new StreamsException("query down!", new TaskId(0, 0));
+    private final StreamsException runtimeExceptionWithTaskAndUnknownTopology =
+        new StreamsException("query down!", new TaskId(0, 0, "not-a-real-query"));
 
     private SharedKafkaStreamsRuntimeImpl sharedKafkaStreamsRuntimeImpl;
 
@@ -73,22 +87,21 @@ public class SharedKafkaStreamsRuntimeImplTest {
         when(kafkaStreamsBuilder.buildNamedTopologyWrapper(any())).thenReturn(kafkaStreamsNamedTopologyWrapper).thenReturn(kafkaStreamsNamedTopologyWrapper2);
         sharedKafkaStreamsRuntimeImpl = new SharedKafkaStreamsRuntimeImpl(
             kafkaStreamsBuilder,
+            queryErrorClassifier,
             5,
             300_000L,
             streamProps
         );
-        when(queryId.toString()).thenReturn("query 1");
-        when(queryId2.toString()).thenReturn("query 2");
 
         sharedKafkaStreamsRuntimeImpl.markSources(queryId, Collections.singleton(SourceName.of("foo")));
         sharedKafkaStreamsRuntimeImpl.register(
-            queryErrorClassifier,
-            persistentQueriesInSharedRuntimes,
+            binPackedPersistentQueryMetadata,
             queryId);
+
         when(kafkaStreamsNamedTopologyWrapper.getTopologyByName(any())).thenReturn(Optional.empty());
         when(kafkaStreamsNamedTopologyWrapper.addNamedTopology(any())).thenReturn(addNamedTopologyResult);
         when(addNamedTopologyResult.all()).thenReturn(future);
-        when(persistentQueriesInSharedRuntimes.getTopologyCopy(any())).thenReturn(namedTopology);
+        when(binPackedPersistentQueryMetadata.getTopologyCopy(any())).thenReturn(namedTopology);
     }
 
     @Test
@@ -101,15 +114,99 @@ public class SharedKafkaStreamsRuntimeImplTest {
     }
 
     @Test
+    public void shouldAddErrorToQuery1() {
+         when(queryErrorClassifier.classify(query1Exception)).thenReturn(Type.USER);
+
+        //Should not try to add error to query2's queue
+        sharedKafkaStreamsRuntimeImpl.markSources(queryId2, Collections.singleton(SourceName.of("foo2")));
+        sharedKafkaStreamsRuntimeImpl.register(
+            binPackedPersistentQueryMetadata2,
+            queryId2
+        );
+
+        //When:
+        sharedKafkaStreamsRuntimeImpl.start(queryId);
+        sharedKafkaStreamsRuntimeImpl.start(queryId2);
+
+        sharedKafkaStreamsRuntimeImpl.uncaughtHandler(query1Exception);
+
+        //Then:
+        verify(binPackedPersistentQueryMetadata).setQueryError(any());
+        verify(binPackedPersistentQueryMetadata2, never()).setQueryError(any());
+    }
+
+    @Test
+    public void shouldAddErrorWithNoTaskToAllQueries() {
+        when(queryErrorClassifier.classify(runtimeExceptionWithNoTask)).thenReturn(Type.USER);
+
+        sharedKafkaStreamsRuntimeImpl.markSources(queryId2, Collections.singleton(SourceName.of("foo2")));
+        sharedKafkaStreamsRuntimeImpl.register(
+            binPackedPersistentQueryMetadata2,
+            queryId2
+        );
+
+        //When:
+        sharedKafkaStreamsRuntimeImpl.start(queryId);
+        sharedKafkaStreamsRuntimeImpl.start(queryId2);
+
+        sharedKafkaStreamsRuntimeImpl.uncaughtHandler(runtimeExceptionWithNoTask);
+
+        //Then:
+        verify(binPackedPersistentQueryMetadata).setQueryError(any());
+        verify(binPackedPersistentQueryMetadata2).setQueryError(any());
+    }
+
+    @Test
+    public void shouldAddErrorWithTaskAndNoTopologyToAllQueries() {
+        when(queryErrorClassifier.classify(runtimeExceptionWithTaskAndNoTopology)).thenReturn(Type.USER);
+
+        sharedKafkaStreamsRuntimeImpl.markSources(queryId2, Collections.singleton(SourceName.of("foo2")));
+        sharedKafkaStreamsRuntimeImpl.register(
+            binPackedPersistentQueryMetadata2,
+            queryId2
+        );
+
+        //When:
+        sharedKafkaStreamsRuntimeImpl.start(queryId);
+        sharedKafkaStreamsRuntimeImpl.start(queryId2);
+
+        sharedKafkaStreamsRuntimeImpl.uncaughtHandler(runtimeExceptionWithTaskAndNoTopology);
+
+        //Then:
+        verify(binPackedPersistentQueryMetadata).setQueryError(any());
+        verify(binPackedPersistentQueryMetadata2).setQueryError(any());
+    }
+
+    @Test
+    public void shouldAddErrorWithTaskAndUnknownTopologyToAllQueries() {
+        when(queryErrorClassifier.classify(runtimeExceptionWithTaskAndUnknownTopology)).thenReturn(Type.USER);
+
+        sharedKafkaStreamsRuntimeImpl.markSources(queryId2, Collections.singleton(SourceName.of("foo2")));
+        sharedKafkaStreamsRuntimeImpl.register(
+            binPackedPersistentQueryMetadata2,
+            queryId2
+        );
+
+        //When:
+        sharedKafkaStreamsRuntimeImpl.start(queryId);
+        sharedKafkaStreamsRuntimeImpl.start(queryId2);
+
+        sharedKafkaStreamsRuntimeImpl.uncaughtHandler(runtimeExceptionWithTaskAndUnknownTopology);
+
+        //Then:
+        verify(binPackedPersistentQueryMetadata).setQueryError(any());
+        verify(binPackedPersistentQueryMetadata2).setQueryError(any());
+    }
+
+    @Test
     public void shouldNotAddQuery() {
         //Given:
-        when(persistentQueriesInSharedRuntimes.getSourceNames())
+        when(binPackedPersistentQueryMetadata.getSourceNames())
             .thenReturn(Collections.singleton(SourceName.of("foo")));
         //When:
         final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> sharedKafkaStreamsRuntimeImpl.register(
-                queryErrorClassifier,
-                persistentQueriesInSharedRuntimes,
+                binPackedPersistentQueryMetadata,
                 queryId2));
         //Then
         assertThat(e.getMessage(), containsString(": was not reserved on this runtime"));


### PR DESCRIPTION
Now that we have the NamedTopology info in the StreamsException class, we should check whether a given error has originated from a specific query and add it to that query's error queue rather than the runtime error queue instead
