### PR TITLE
feat: new runtime selection

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -547,7 +547,7 @@ public class KsqlConfig extends AbstractConfig {
           + "CREATE SOURCE [TABLE|STREAM] statements will continue being read-only.";
 
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
-  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
+  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = true;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
       "Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -547,7 +547,7 @@ public class KsqlConfig extends AbstractConfig {
           + "CREATE SOURCE [TABLE|STREAM] statements will continue being read-only.";
 
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
-  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = true;
+  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
       "Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -78,6 +78,7 @@ final class EngineContext {
   private final KsqlParser parser;
   private final QueryCleanupService cleanupService;
   private final QueryRegistry queryRegistry;
+  private final RuntimeAssignor runtimeAssignor;
   private KsqlConfig ksqlConfig;
 
   static EngineContext create(
@@ -98,7 +99,8 @@ final class EngineContext {
         new DefaultKsqlParser(),
         cleanupService,
         ksqlConfig,
-        new QueryRegistryImpl(registrationListeners, metricCollectors)
+        new QueryRegistryImpl(registrationListeners, metricCollectors),
+        new RuntimeAssignor(ksqlConfig)
     );
   }
 
@@ -110,7 +112,8 @@ final class EngineContext {
       final KsqlParser parser,
       final QueryCleanupService cleanupService,
       final KsqlConfig ksqlConfig,
-      final QueryRegistry queryRegistry
+      final QueryRegistry queryRegistry,
+      final RuntimeAssignor runtimeAssignor
   ) {
     this.serviceContext = requireNonNull(serviceContext, "serviceContext");
     this.metaStore = requireNonNull(metaStore, "metaStore");
@@ -122,6 +125,7 @@ final class EngineContext {
     this.cleanupService = requireNonNull(cleanupService, "cleanupService");
     this.ksqlConfig = requireNonNull(ksqlConfig, "ksqlConfig");
     this.queryRegistry = requireNonNull(queryRegistry, "queryRegistry");
+    this.runtimeAssignor = requireNonNull(runtimeAssignor, "runtimeAssignor");
   }
 
   synchronized EngineContext createSandbox(final ServiceContext serviceContext) {
@@ -133,7 +137,8 @@ final class EngineContext {
         new DefaultKsqlParser(),
         cleanupService,
         ksqlConfig,
-        queryRegistry.createSandbox()
+        queryRegistry.createSandbox(),
+        runtimeAssignor.createSandbox()
     );
   }
 
@@ -159,6 +164,10 @@ final class EngineContext {
 
   QueryRegistry getQueryRegistry() {
     return queryRegistry;
+  }
+
+  RuntimeAssignor getRuntimeAssignor() {
+    return runtimeAssignor;
   }
 
   synchronized KsqlConfig getKsqlConfig() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -693,7 +693,7 @@ final class EngineExecutor {
     return config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
         ? Optional.of(
         engineContext.getRuntimeAssignor()
-            .getRuntime(queryId, sources, config.getConfig(true))) :
+            .getRuntimeAndMaybeAddRuntime(queryId, sources, config.getConfig(true))) :
         Optional.empty();
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -691,10 +691,10 @@ final class EngineExecutor {
 
   private Optional<String> getApplicationId(final QueryId queryId, final Collection<SourceName> sources) {
     return config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
-        ? Optional.of("appId")
-        : Optional.of(
-            engineContext.getRuntimeAssignor()
-                .getRuntime(queryId, sources, config.getConfig(true)));
+        ? Optional.of(
+        engineContext.getRuntimeAssignor()
+            .getRuntime(queryId, sources, config.getConfig(true))) :
+        Optional.empty();
   }
 
   private ExecutorPlans planQuery(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -42,7 +42,6 @@ import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.name.Name;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.OutputRefinement;
 import io.confluent.ksql.parser.tree.AliasedRelation;
@@ -689,7 +688,8 @@ final class EngineExecutor {
     }
   }
 
-  private Optional<String> getApplicationId(final QueryId queryId, final Collection<SourceName> sources) {
+  private Optional<String> getApplicationId(final QueryId queryId,
+                                            final Collection<SourceName> sources) {
     return config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
         ? Optional.of(
         engineContext.getRuntimeAssignor()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -537,7 +537,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
    */
   public void close(final boolean closeQueries) {
     primaryContext.getQueryRegistry().close(closeQueries);
-    primaryContext.getRuntimeAssignor().close();
 
     try {
       cleanupService.stopAsync().awaitTerminated(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -537,6 +537,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
    */
   public void close(final boolean closeQueries) {
     primaryContext.getQueryRegistry().close(closeQueries);
+    primaryContext.getRuntimeAssignor().close();
 
     try {
       cleanupService.stopAsync().awaitTerminated(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.engine;
+
+import static io.confluent.ksql.util.QueryApplicationId.buildSharedRuntimeId;
 
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
-
-import static io.confluent.ksql.util.QueryApplicationId.buildSharedRuntimeId;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,9 +39,9 @@ public class RuntimeAssignor {
 
   public RuntimeAssignor(final KsqlConfig config, final int runtimes) {
     runtimesToSources = new HashMap<>();
-    idToRuntime= new HashMap<>();
-    for(int i=0; i < runtimes; i++) {
-      String runtime = buildSharedRuntimeId(config, true, i);
+    idToRuntime = new HashMap<>();
+    for (int i = 0; i < runtimes; i++) {
+      final String runtime = buildSharedRuntimeId(config, true, i);
       runtimesToSources.put(runtime, new HashSet<>());
     }
   }
@@ -35,7 +49,8 @@ public class RuntimeAssignor {
   private RuntimeAssignor(final RuntimeAssignor other) {
     this.runtimesToSources = new HashMap<>();
     this.idToRuntime = new HashMap<>();
-    for (Map.Entry<String, Collection<SourceName>> runtime : other.runtimesToSources.entrySet()) {
+    for (Map.Entry<String, Collection<SourceName>> runtime
+        : other.runtimesToSources.entrySet()) {
       this.runtimesToSources.put(runtime.getKey(), new HashSet<>(runtime.getValue()));
     }
     this.idToRuntime.putAll(other.idToRuntime);
@@ -45,7 +60,9 @@ public class RuntimeAssignor {
     return new RuntimeAssignor(this);
   }
 
-  public String getRuntime(final QueryId queryId, final Collection<SourceName> sources, final KsqlConfig config) {
+  public String getRuntime(final QueryId queryId,
+                           final Collection<SourceName> sources,
+                           final KsqlConfig config) {
     if (idToRuntime.containsKey(queryId)) {
       return idToRuntime.get(queryId);
     }
@@ -69,7 +86,8 @@ public class RuntimeAssignor {
 
   public void dropQuery(final PersistentQueryMetadata queryMetadata) {
     if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
-      runtimesToSources.get(queryMetadata.getQueryApplicationId()).removeAll(queryMetadata.getSourceNames());
+      runtimesToSources.get(queryMetadata.getQueryApplicationId())
+          .removeAll(queryMetadata.getSourceNames());
       idToRuntime.remove(queryMetadata.getQueryId());
     }
   }
@@ -84,7 +102,8 @@ public class RuntimeAssignor {
   public void rebuildAssignment(final Collection<PersistentQueryMetadata> queries) {
     for (PersistentQueryMetadata queryMetadata: queries) {
       if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
-        runtimesToSources.put(queryMetadata.getQueryApplicationId(), queryMetadata.getSourceNames());
+        runtimesToSources.put(queryMetadata.getQueryApplicationId(),
+            queryMetadata.getSourceNames());
         idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());
       }
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -39,6 +39,7 @@ public class RuntimeAssignor {
   }
 
   public RuntimeAssignor createSandbox() {
+
     return new RuntimeAssignor(this);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 public class RuntimeAssignor {
   private final Map<String, Collection<SourceName>> runtimesToSources;
 
-  RuntimeAssignor(final KsqlConfig config) {
+  public RuntimeAssignor(final KsqlConfig config) {
     runtimesToSources = new HashMap<>();
     for(int i=0; i < 8; i++) {
       runtimesToSources.put(buildSharedRuntimeId(config, true, i), new HashSet<>());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -1,0 +1,76 @@
+package io.confluent.ksql.engine;
+
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+
+import static io.confluent.ksql.util.QueryApplicationId.buildSharedRuntimeId;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RuntimeAssignor {
+  private final Map<String, Collection<SourceName>> runtimesToSources;
+
+  RuntimeAssignor(final KsqlConfig config) {
+    runtimesToSources = new HashMap<>();
+    for(int i=0; i < 8; i++) {
+      runtimesToSources.put(buildSharedRuntimeId(config, true, i), new HashSet<>());
+    }
+  }
+
+  private RuntimeAssignor(final RuntimeAssignor other) {
+    this.runtimesToSources = new HashMap<>();
+    for (Map.Entry<String, Collection<SourceName>> runtime : other.runtimesToSources.entrySet()) {
+      this.runtimesToSources.put(runtime.getKey(), new HashSet<>(runtime.getValue()));
+    }
+  }
+
+  public RuntimeAssignor createSandbox() {
+    return new RuntimeAssignor(this);
+  }
+
+  public String getRuntime(final QueryId queryId, final Collection<SourceName> sources, final KsqlConfig config) {
+    String runtime;
+    final List<String> possibleRuntimes =  runtimesToSources.entrySet()
+        .stream()
+        .filter(t -> t.getValue().stream().noneMatch(sources::contains))
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toList());
+    if (possibleRuntimes.isEmpty()) {
+      runtime = makeNewRuntime(config);
+      runtimesToSources.put(runtime, sources);
+      return runtime;
+    }
+    runtime = possibleRuntimes.get(Math.abs(queryId.hashCode()) % possibleRuntimes.size());
+    runtimesToSources.get(runtime).addAll(sources);
+    return runtime;
+  }
+
+  public void dropQuery(final PersistentQueryMetadata queryMetadata) {
+    if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
+      runtimesToSources.get(queryMetadata.getQueryApplicationId()).removeAll(queryMetadata.getSourceNames());
+    }
+  }
+
+
+  private String makeNewRuntime(final KsqlConfig config) {
+    final String runtime = buildSharedRuntimeId(config, true, runtimesToSources.size());
+    runtimesToSources.put(runtime, new HashSet<>());
+    return runtime;
+  }
+
+  public void rebuildAssignment(final Collection<PersistentQueryMetadata> queries) {
+    for (PersistentQueryMetadata queryMetadata: queries) {
+      if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
+        runtimesToSources.put(queryMetadata.getQueryApplicationId(), queryMetadata.getSourceNames());
+      }
+    }
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -8,6 +8,7 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 
 import static io.confluent.ksql.util.QueryApplicationId.buildSharedRuntimeId;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,19 +18,24 @@ import java.util.stream.Collectors;
 
 public class RuntimeAssignor {
   private final Map<String, Collection<SourceName>> runtimesToSources;
+  private final Map<QueryId, String> idToRuntime;
 
   public RuntimeAssignor(final KsqlConfig config) {
     runtimesToSources = new HashMap<>();
+    idToRuntime= new HashMap<>();
     for(int i=0; i < 8; i++) {
-      runtimesToSources.put(buildSharedRuntimeId(config, true, i), new HashSet<>());
+      String runtime = buildSharedRuntimeId(config, true, i);
+      runtimesToSources.put(runtime, new HashSet<>());
     }
   }
 
   private RuntimeAssignor(final RuntimeAssignor other) {
     this.runtimesToSources = new HashMap<>();
+    this.idToRuntime = new HashMap<>();
     for (Map.Entry<String, Collection<SourceName>> runtime : other.runtimesToSources.entrySet()) {
       this.runtimesToSources.put(runtime.getKey(), new HashSet<>(runtime.getValue()));
     }
+    this.idToRuntime.putAll(other.idToRuntime);
   }
 
   public RuntimeAssignor createSandbox() {
@@ -37,8 +43,11 @@ public class RuntimeAssignor {
   }
 
   public String getRuntime(final QueryId queryId, final Collection<SourceName> sources, final KsqlConfig config) {
+    if (idToRuntime.containsKey(queryId)) {
+      return idToRuntime.get(queryId);
+    }
     String runtime;
-    final List<String> possibleRuntimes =  runtimesToSources.entrySet()
+    final List<String> possibleRuntimes = runtimesToSources.entrySet()
         .stream()
         .filter(t -> t.getValue().stream().noneMatch(sources::contains))
         .map(Map.Entry::getKey)
@@ -46,16 +55,19 @@ public class RuntimeAssignor {
     if (possibleRuntimes.isEmpty()) {
       runtime = makeNewRuntime(config);
       runtimesToSources.put(runtime, sources);
+      idToRuntime.put(queryId, runtime);
       return runtime;
     }
     runtime = possibleRuntimes.get(Math.abs(queryId.hashCode()) % possibleRuntimes.size());
     runtimesToSources.get(runtime).addAll(sources);
+    idToRuntime.put(queryId, runtime);
     return runtime;
   }
 
   public void dropQuery(final PersistentQueryMetadata queryMetadata) {
     if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
       runtimesToSources.get(queryMetadata.getQueryApplicationId()).removeAll(queryMetadata.getSourceNames());
+      idToRuntime.remove(queryMetadata.getQueryId());
     }
   }
 
@@ -70,7 +82,13 @@ public class RuntimeAssignor {
     for (PersistentQueryMetadata queryMetadata: queries) {
       if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
         runtimesToSources.put(queryMetadata.getQueryApplicationId(), queryMetadata.getSourceNames());
+        idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());
       }
     }
+  }
+
+  public void close() {
+    runtimesToSources.clear();
+    idToRuntime.clear();
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -8,7 +8,6 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 
 import static io.confluent.ksql.util.QueryApplicationId.buildSharedRuntimeId;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -21,9 +20,13 @@ public class RuntimeAssignor {
   private final Map<QueryId, String> idToRuntime;
 
   public RuntimeAssignor(final KsqlConfig config) {
+    this(config, 8);
+  }
+
+  public RuntimeAssignor(final KsqlConfig config, final int runtimes) {
     runtimesToSources = new HashMap<>();
     idToRuntime= new HashMap<>();
-    for(int i=0; i < 8; i++) {
+    for(int i=0; i < runtimes; i++) {
       String runtime = buildSharedRuntimeId(config, true, i);
       runtimesToSources.put(runtime, new HashSet<>());
     }
@@ -39,7 +42,6 @@ public class RuntimeAssignor {
   }
 
   public RuntimeAssignor createSandbox() {
-
     return new RuntimeAssignor(this);
   }
 
@@ -91,5 +93,13 @@ public class RuntimeAssignor {
   public void close() {
     runtimesToSources.clear();
     idToRuntime.clear();
+  }
+
+  public Map<String, Collection<SourceName>> getRuntimesToSources() {
+    return runtimesToSources;
+  }
+
+  public Map<QueryId, String> getIdToRuntime() {
+    return idToRuntime;
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.util.Sandbox;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
+import org.apache.kafka.streams.KafkaStreams;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -47,7 +47,6 @@ import io.confluent.ksql.util.Sandbox;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
-import org.apache.kafka.streams.KafkaStreams;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -389,7 +389,7 @@ final class QueryBuilder {
       final String planSummary,
       final QueryMetadata.Listener listener,
       final Supplier<List<PersistentQueryMetadata>> allPersistentQueries,
-      final String applicationId
+      final String applicationId,
       final MetricCollectors metricCollectors
   ) {
     final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime = getKafkaStreamsInstance(
@@ -585,7 +585,7 @@ final class QueryBuilder {
   private SharedKafkaStreamsRuntime getKafkaStreamsInstance(
           final String applicationId,
           final Set<SourceName> sources,
-          final QueryId queryId
+          final QueryId queryId,
           final MetricCollectors metricCollectors) {
     for (final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime : streams) {
       if (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -589,6 +589,7 @@ final class QueryBuilder {
           final MetricCollectors metricCollectors) {
     for (final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime : streams) {
       if (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId)) {
+        sharedKafkaStreamsRuntime.markSources(queryId, sources);
         return sharedKafkaStreamsRuntime;
       }
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -614,7 +614,7 @@ final class QueryBuilder {
       stream = new SandboxedSharedKafkaStreamsRuntimeImpl(
           kafkaStreamsBuilder,
           buildStreamsProperties(
-              buildSharedRuntimeId(ksqlConfig, true, streams.size()) + "-validation",
+              applicationId + "-validation",
               Optional.empty(),
               metricCollectors,
               config.getConfig(true),

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -588,7 +588,8 @@ final class QueryBuilder {
           final QueryId queryId
           final MetricCollectors metricCollectors) {
     for (final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime : streams) {
-      if (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId)) {
+      if (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId)
+          || (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId + "-validation") && !real)) {
         sharedKafkaStreamsRuntime.markSources(queryId, sources);
         return sharedKafkaStreamsRuntime;
       }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.query;
 
 import static io.confluent.ksql.util.KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG;
-import static io.confluent.ksql.util.QueryApplicationId.buildSharedRuntimeId;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -589,7 +588,8 @@ final class QueryBuilder {
           final MetricCollectors metricCollectors) {
     for (final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime : streams) {
       if (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId)
-          || (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId + "-validation") && !real)) {
+          || (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId + "-validation")
+          && !real)) {
         sharedKafkaStreamsRuntime.markSources(queryId, sources);
         return sharedKafkaStreamsRuntime;
       }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -269,7 +269,6 @@ public class QueryRegistryImpl implements QueryRegistry {
     final PersistentQueryMetadata query;
 
     if (sharedRuntimeId.isPresent()) {
-
       if (sandbox) {
         streams.addAll(sourceStreams.stream()
             .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -421,7 +421,7 @@ public class QueryRegistryImpl implements QueryRegistry {
 
       // don't close the old query so that we don't delete the changelog
       // topics and the state store, instead use QueryMetadata#stop
-      oldQuery.stop();
+      oldQuery.stop(false);
       unregisterQuery(oldQuery);
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -286,6 +286,7 @@ public class QueryRegistryImpl implements QueryRegistry {
           planSummary,
           new ListenerImpl(),
           () -> ImmutableList.copyOf(getPersistentQueries().values()),
+          sharedRuntimeId.get(),
           metricCollectors
       );
     } else {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -223,7 +223,12 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public void stop() {
-    sharedKafkaStreamsRuntime.stop(queryId);
+    sharedKafkaStreamsRuntime.stop(queryId, true);
+    scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
+  }
+
+  public void stop(final boolean resetOffsets) {
+    sharedKafkaStreamsRuntime.stop(queryId, false);
     scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
   }
 
@@ -378,7 +383,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public void close() {
-    sharedKafkaStreamsRuntime.stop(queryId);
+    sharedKafkaStreamsRuntime.stop(queryId, true);
     scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
     listener.onClose(this);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -58,6 +58,8 @@ public interface PersistentQueryMetadata extends QueryMetadata {
 
   void stop();
 
+  void stop(boolean resetOffsets);
+
   StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
       Throwable error
   );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -222,6 +222,10 @@ public class PersistentQueryMetadataImpl
     scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
   }
 
+  public void stop(final boolean resetOffsets) {
+    stop();
+  }
+
   public Optional<ScalablePushRegistry> getScalablePushRegistry() {
     return scalablePushRegistry;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedBinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedBinPackedPersistentQueryMetadataImpl.java
@@ -41,6 +41,11 @@ public final class SandboxedBinPackedPersistentQueryMetadataImpl
   }
 
   @Override
+  public void stop(final boolean resetOffsets) {
+    //no-op
+  }
+
+  @Override
   public void close() {
     getListener().onClose(this);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.util.QueryMetadataImpl.TimeBoundedQueue;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
@@ -61,7 +60,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
     sandboxStreamsProperties.put(
         StreamsConfig.APPLICATION_ID_CONFIG,
         sharedKafkaStreamsRuntime.getStreamProperties().get(StreamsConfig.APPLICATION_ID_CONFIG)
-            + UUID.randomUUID().toString()
             + "-validation"
     );
     return sandboxStreamsProperties;
@@ -94,7 +92,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
   }
 
   @Override
-  public void stop(final QueryId queryId) {
+  public void stop(final QueryId queryId, boolean resetOffsets) {
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -87,7 +87,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
   }
 
   @Override
-  public void stop(final QueryId queryId, boolean resetOffsets) {
+  public void stop(final QueryId queryId, final boolean resetOffsets) {
   }
   
   public TimeBoundedQueue getNewQueryErrorQueue() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -87,12 +87,11 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
   }
 
   @Override
+  public void stop(final QueryId queryId, boolean resetOffsets) {
+  }
+  
   public TimeBoundedQueue getNewQueryErrorQueue() {
     return new QueryMetadataImpl.TimeBoundedQueue(Duration.ofHours(1), 0);
-  }
-
-  @Override
-  public void stop(final QueryId queryId, boolean resetOffsets) {
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -78,8 +78,6 @@ public abstract class SharedKafkaStreamsRuntime {
 
   public abstract TimeBoundedQueue getNewQueryErrorQueue();
 
-  public abstract void stop(QueryId queryId, boolean resetOffsets);
-
   public abstract void close();
 
   public abstract void start(QueryId queryId);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -78,7 +78,7 @@ public abstract class SharedKafkaStreamsRuntime {
 
   public abstract TimeBoundedQueue getNewQueryErrorQueue();
 
-  public abstract void stop(QueryId queryId);
+  public abstract void stop(QueryId queryId, boolean resetOffsets);
 
   public abstract void close();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -80,6 +80,8 @@ public abstract class SharedKafkaStreamsRuntime {
 
   public abstract void close();
 
+  public abstract void stop(QueryId queryId, boolean resetOffsets);
+
   public abstract void start(QueryId queryId);
 
   public abstract void restartStreamsRuntime();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -198,7 +198,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
           }
         }
       } else {
-        throw new IllegalStateException("Streams in not running but is in state"
+        throw new IllegalStateException("Streams in not running but is in state "
             + kafkaStreams.state());
       }
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -176,7 +176,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
   }
 
   @Override
-  public void stop(final QueryId queryId, boolean resetOffsets) {
+  public void stop(final QueryId queryId, final boolean resetOffsets) {
     log.info("Attempting to stop Query: " + queryId.toString());
     if (collocatedQueries.containsKey(queryId) && sources.containsKey(queryId)) {
       if (kafkaStreams.state().isRunningOrRebalancing()) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -1498,47 +1498,6 @@ public class KsqlEngineTest {
   }
 
   @Test
-  public void shouldNotHardDeleteSubjectForPersistentQuerySharedRuntimes() throws IOException, RestClientException {
-    // Given:
-    ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
-    final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
-        serviceContext,
-        ksqlEngine,
-        "create stream persistent as select * from test1 EMIT CHANGES;",
-        ksqlConfig,
-        Collections.emptyMap()
-    );
-    final String applicationId = query.get(0).getQueryApplicationId();
-    final String internalTopic1Val = KsqlConstants.getSRSubject(
-        applicationId + "-subject1" + KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX, false);
-    final String internalTopic2Val = KsqlConstants.getSRSubject(
-        applicationId + "-subject3" + KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX, false);
-    final String internalTopic1Key = KsqlConstants.getSRSubject(
-        applicationId + "-subject1" + KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX, true);
-    final String internalTopic2Key = KsqlConstants.getSRSubject(
-        applicationId + "-subject3" + KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX, true);
-    when(schemaRegistryClient.getAllSubjects()).thenReturn(
-        Arrays.asList(
-            internalTopic1Val,
-            internalTopic1Key,
-            "subject2",
-            internalTopic2Val,
-            internalTopic2Key));
-    query.get(0).start();
-
-    // When:
-    query.get(0).close();
-
-    // Then:
-    awaitCleanupComplete();
-    verify(schemaRegistryClient, times(4)).deleteSubject(any());
-    verify(schemaRegistryClient, never()).deleteSubject(internalTopic1Val, true);
-    verify(schemaRegistryClient, never()).deleteSubject(internalTopic1Key, true);
-    verify(schemaRegistryClient, never()).deleteSubject(internalTopic2Val, true);
-    verify(schemaRegistryClient, never()).deleteSubject(internalTopic2Key, true);
-  }
-
-  @Test
   public void shouldNotCleanUpInternalTopicsOnCloseIfQueryNeverStarted() {
     // Given:
     final QueryMetadata query = KsqlEngineTestUtil.execute(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -1469,13 +1469,13 @@ public class KsqlEngineTest {
     );
     final String applicationId = query.get(0).getQueryApplicationId();
     final String internalTopic1Val = KsqlConstants.getSRSubject(
-        applicationId + "-subject1" + KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX, false);
+        applicationId + "-" + query.get(0).getQueryId() + "-subject1" + KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX, false);
     final String internalTopic2Val = KsqlConstants.getSRSubject(
-        applicationId + "-subject3" + KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX, false);
+        applicationId + "-" + query.get(0).getQueryId()  + "-subject3" + KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX, false);
     final String internalTopic1Key = KsqlConstants.getSRSubject(
-        applicationId + "-subject1" + KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX, true);
+        applicationId + "-" + query.get(0).getQueryId()  + "-subject1" + KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX, true);
     final String internalTopic2Key = KsqlConstants.getSRSubject(
-        applicationId + "-subject3" + KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX, true);
+        applicationId  + "-" + query.get(0).getQueryId() + "-subject3" + KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX, true);
     when(schemaRegistryClient.getAllSubjects()).thenReturn(
         Arrays.asList(
             internalTopic1Val,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -1415,44 +1415,6 @@ public class KsqlEngineTest {
   }
 
   @Test
-  public void shouldCleanUpSharedRuntimesInternalTopicsOnCloseForPersistentQueries() {
-    // Given:
-
-    final MetricCollectors metricCollectors = new MetricCollectors();
-    final KsqlEngine ksqlEngineWithSharedRuntimes = KsqlEngineTestUtil.createKsqlEngine(
-        serviceContext,
-        metaStore,
-        (engine) -> new KsqlEngineMetrics(
-            "",
-            engine,
-            Collections.emptyMap(),
-            Optional.empty(),
-            metricCollectors
-        ),
-        new SequentialQueryIdGenerator(),
-        new KsqlConfig(Collections.singletonMap(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)),
-        metricCollectors
-    );
-
-    final List<QueryMetadata> query = KsqlEngineTestUtil.execute(
-        serviceContext,
-        ksqlEngineWithSharedRuntimes,
-        "create stream persistent with (KAFKA_TOPIC='rekey') as select * from orders partition by orderid EMIT CHANGES;",
-        ksqlConfig,
-        Collections.singletonMap(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)
-    );
-
-    query.get(0).start();
-
-    // When:
-    query.get(0).close();
-
-    awaitCleanupComplete(ksqlEngineWithSharedRuntimes);
-    verify(topicClient).deleteInternalTopics(query.get(0).getQueryApplicationId() + "-" + query.get(0).getQueryId().toString());
-  }
-
-
-  @Test
   public void shouldNotHardDeleteSubjectForPersistentQuery() throws IOException, RestClientException {
     // Given:
     ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeDisabled);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -70,6 +70,23 @@ public final class KsqlEngineTestUtil {
   public static KsqlEngine createKsqlEngine(
       final ServiceContext serviceContext,
       final MutableMetaStore metaStore,
+      final KsqlConfig ksqlConfig
+  ) {
+    return new KsqlEngine(
+        serviceContext,
+        ProcessingLogContext.create(),
+        "test_instance_",
+        metaStore,
+        (engine) -> new KsqlEngineMetrics("", engine, Collections.emptyMap(), Optional.empty()),
+        new SequentialQueryIdGenerator(),
+        ksqlConfig,
+        Collections.emptyList()
+    );
+  }
+
+  public static KsqlEngine createKsqlEngine(
+      final ServiceContext serviceContext,
+      final MutableMetaStore metaStore,
       final Function<KsqlEngine, KsqlEngineMetrics> engineMetricsFactory,
       final QueryIdGenerator queryIdGenerator,
       final KsqlConfig ksqlConfig,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -77,10 +77,11 @@ public final class KsqlEngineTestUtil {
         ProcessingLogContext.create(),
         "test_instance_",
         metaStore,
-        (engine) -> new KsqlEngineMetrics("", engine, Collections.emptyMap(), Optional.empty()),
+        (engine) -> new KsqlEngineMetrics("", engine, Collections.emptyMap(), Optional.empty(), new MetricCollectors()),
         new SequentialQueryIdGenerator(),
         ksqlConfig,
-        Collections.emptyList()
+        Collections.emptyList(),
+        new MetricCollectors()
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
@@ -1,0 +1,100 @@
+package io.confluent.ksql.engine;
+
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
+import io.confluent.ksql.util.KsqlConfig;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RuntimeAssignorTest {
+
+  @Mock
+  public BinPackedPersistentQueryMetadataImpl queryMetadata;
+  private final QueryId query1 = new QueryId("Test1");
+  private final QueryId query2 = new QueryId("Test2");
+  private final Collection<SourceName> sources1 = Collections.singleton(SourceName.of("test1"));
+  private final Collection<SourceName> sources2 = Collections.singleton(SourceName.of("test2"));
+
+  private String firstRuntime;
+  private RuntimeAssignor runtimeAssignor;
+  private static final KsqlConfig KSQL_CONFIG = new KsqlConfig(Collections.emptyMap());
+
+  @Before
+  public void setUp() {
+    runtimeAssignor = new RuntimeAssignor(KSQL_CONFIG, 2);
+    firstRuntime = runtimeAssignor.getRuntime(
+        query1,
+        sources1,
+        KSQL_CONFIG
+    );
+    when(queryMetadata.getQueryApplicationId()).thenReturn(firstRuntime);
+    when(queryMetadata.getQueryId()).thenReturn(query1);
+    when(queryMetadata.getSourceNames()).thenReturn(new HashSet<>(sources1));
+  }
+
+  @Test
+  public void shouldCreateSandboxAndDroppingAQueryWillNotChangeReal() {
+    final RuntimeAssignor sandbox = runtimeAssignor.createSandbox();
+    sandbox.dropQuery(queryMetadata);
+    assertThat("Was changed by sandbox.", runtimeAssignor.getIdToRuntime().containsKey(query1));
+    assertThat("The query was not removed.", !sandbox.getIdToRuntime().containsKey(query1));
+  }
+
+  @Test
+  public void shouldGetSameRuntimeForSameQueryId() {
+    final String runtime = runtimeAssignor.getRuntime(
+        query1,
+        sources1,
+        KSQL_CONFIG
+    );
+    assertThat(runtime, equalTo(firstRuntime));
+  }
+
+  @Test
+  public void shouldNotGetSameRuntimeForDifferentQueryId() {
+    final String runtime = runtimeAssignor.getRuntime(
+        query2,
+        sources2,
+        KSQL_CONFIG
+    );
+    assertThat(runtime, not(equalTo(firstRuntime)));
+  }
+
+  @Test
+  public void shouldDropQueryThenUseSameRuntimeForTheSameSources() {
+    runtimeAssignor.dropQuery(queryMetadata);
+    final String runtime = runtimeAssignor.getRuntime(
+        query1,
+        sources1,
+        KSQL_CONFIG
+    );
+    assertThat(runtime, equalTo(firstRuntime));
+  }
+
+  @Test
+  public void shouldRebuildAssignmentFromListOfQueries() {
+    final RuntimeAssignor rebuilt = new RuntimeAssignor(KSQL_CONFIG);
+    rebuilt.rebuildAssignment(Collections.singleton(queryMetadata));
+    final String runtime = rebuilt.getRuntime(
+        query2,
+        sources2,
+        KSQL_CONFIG
+    );
+    assertThat(runtime, not(equalTo(firstRuntime)));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -110,7 +110,7 @@ public class EndToEndIntegrationTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Boolean> data() {
     return Arrays.asList(
-        false, true
+        false
     );
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceWithSharedRuntimesIntTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/ReplaceWithSharedRuntimesIntTest.java
@@ -46,7 +46,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category({IntegrationTest.class})
-public class ReplaceIntTest {
+public class ReplaceWithSharedRuntimesIntTest {
 
   @ClassRule
   public static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
@@ -54,7 +54,7 @@ public class ReplaceIntTest {
   @Rule
   public final TestKsqlContext ksqlContext = TEST_HARNESS.ksqlContextBuilder()
       .withAdditionalConfig(KsqlConfig.KSQL_CREATE_OR_REPLACE_ENABLED, true)
-      .withAdditionalConfig(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, false)
+      .withAdditionalConfig(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)
       .build();
 
   private String inputTopic;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.engine.RuntimeAssignor;
 import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
@@ -196,6 +197,7 @@ public class QueryBuilderTest {
   private AddNamedTopologyResult addNamedTopologyResult;
   @Mock
   private KafkaFuture<Void> future;
+  private RuntimeAssignor runtimeAssignor;
 
   private QueryBuilder queryBuilder;
   private final Stacker stacker = new Stacker();
@@ -250,6 +252,8 @@ public class QueryBuilderTest {
         ),
         sharedKafkaStreamsRuntimes,
         true);
+
+    runtimeAssignor = new RuntimeAssignor(ksqlConfig);
   }
 
   @Test
@@ -769,7 +773,9 @@ public class QueryBuilderTest {
           SUMMARY,
           queryListener,
           ArrayList::new,
-          "appId",
+          runtimeAssignor.getRuntime(queryId,
+              sources.stream().map(DataSource::getName).collect(Collectors.toSet()),
+              config.getConfig(true)),
           new MetricCollectors()
       );
     } else {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -773,7 +773,7 @@ public class QueryBuilderTest {
           SUMMARY,
           queryListener,
           ArrayList::new,
-          runtimeAssignor.getRuntime(queryId,
+          runtimeAssignor.getRuntimeAndMaybeAddRuntime(queryId,
               sources.stream().map(DataSource::getName).collect(Collectors.toSet()),
               config.getConfig(true)),
           new MetricCollectors()

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -769,6 +769,7 @@ public class QueryBuilderTest {
           SUMMARY,
           queryListener,
           ArrayList::new,
+          "appId",
           new MetricCollectors()
       );
     } else {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -493,7 +493,7 @@ public class QueryRegistryImplTest {
           any(), any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any(), any(), any());
     } else {
       verify(queryBuilder).buildPersistentQueryInSharedRuntime(
-          any(), any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any(), any());
+          any(), any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any(), any(), any());
     }
     return queryListenerCaptor.getValue();
   }
@@ -525,7 +525,7 @@ public class QueryRegistryImplTest {
     when(query.getPersistentQueryType()).thenReturn(persistentQueryType);
     if (sharedRuntimes) {
       when(queryBuilder.buildPersistentQueryInSharedRuntime(
-          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
+          any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
       ).thenReturn(query);
     } else {
       when(queryBuilder.buildPersistentQueryInDedicatedRuntime(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -493,8 +493,7 @@ public class QueryRegistryImplTest {
           any(), any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any(), any(), any());
     } else {
       verify(queryBuilder).buildPersistentQueryInSharedRuntime(
-          any(), any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any(),
-          any());
+          any(), any(), any(), any(), any(), any(), any(), any(), queryListenerCaptor.capture(), any(), any());
     }
     return queryListenerCaptor.getValue();
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
@@ -105,7 +105,7 @@ public class BinPackedPersistentQueryMetadataImplTest {
 
         // Then:
         final InOrder inOrder = inOrder(sharedKafkaStreamsRuntimeImpl);
-        inOrder.verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID);
+        inOrder.verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, true);
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -124,6 +124,6 @@ public class BinPackedPersistentQueryMetadataImplTest {
         query.stop();
 
         // Then:
-        verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID);
+        verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, true);
     }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
@@ -105,7 +105,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
     validationSharedKafkaStreamsRuntime.start(queryId);
 
     //When:
-    validationSharedKafkaStreamsRuntime.stop(queryId);
+    validationSharedKafkaStreamsRuntime.stop(queryId, true);
 
     //Then:
     assertThat("Query was stopped", validationSharedKafkaStreamsRuntime.getQueries().contains(queryId));


### PR DESCRIPTION
Move the runtime selection into the query plan. The runtime should be assigned and then validated. If validated correctly it will be assigned the same runtime and put on the cmd topic. If not validated the actual assignor will not not be affected and will move on to the next query. 

When receiving the plan to build the query the query build will find the runtime with that ID. If it doesn't exist it will make a new one.

Right now its doesn't check for config compatibility which is how it currently is. There needs to be some more work for config checking, but that should be a follow up PR. 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

