### PR TITLE
chore: clarify reasoning behind preventing live updates to `processing.guarantee` config

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -160,10 +160,9 @@ public final class ValidatedCommandFactory {
       LOG.error("Failed to set {} to {} due to the {} persistent queries currently running: {}",
                 propertyName, propertyValue, runningQueries.size(), runningQueries);
       throw new ConfigException(
-          String.format("Unable to set %s to %s due to existing persistent queries. The %s may"
-                            + " not be changed for live queries which have already processed data"
-                            + " under a different %s. To modify the %s you must first terminate"
-                            + " all running queries.",
+          String.format("Unable to set %s to %s, as the %s may not be changed for running persistent"
+                            + " queries which have already processed data under a different %s.To"
+                            + " modify %s you must first terminate all running persistent queries.",
                         propertyName, propertyValue, propertyName, propertyName, propertyName));
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -38,14 +38,13 @@ import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Creates commands that have been validated to successfully execute against
@@ -160,9 +159,10 @@ public final class ValidatedCommandFactory {
       LOG.error("Failed to set {} to {} due to the {} persistent queries currently running: {}",
                 propertyName, propertyValue, runningQueries.size(), runningQueries);
       throw new ConfigException(
-          String.format("Unable to set %s to %s, as the %s may not be changed for running persistent"
-                            + " queries which have already processed data under a different %s.To"
-                            + " modify %s you must first terminate all running persistent queries.",
+          String.format("Unable to set %s to %s, as the %s may not be changed for running"
+                            + " persistent queries which have already processed data under a"
+                            + " different %s. To modify %s you must first terminate all running"
+                            + " persistent queries.",
                         propertyName, propertyValue, propertyName, propertyName, propertyName));
     }
 


### PR DESCRIPTION
We decided to prevent users from modifying the server-level `processing.guarantee` config unless there are no persistent queries running at the time which would be affected by this change, to avoid mixed processing of exactly-once and at-least-once semantics. We should make sure to state clearly the reasoning behind this 