### PR TITLE
fix: use correct runtime to build copy of query's NamedTopology

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -477,28 +477,19 @@ final class QueryBuilder {
         classifier,
         queryOverrides,
         scalablePushRegistry,
-        () -> getNamedTopology(
-            sharedKafkaStreamsRuntime,
+        (builder) -> getNamedTopology(
+            builder,
             queryId,
             applicationId,
-            queryOverrides,
             physicalPlan
         )
     );
   }
 
-  public NamedTopology getNamedTopology(final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime,
+  public NamedTopology getNamedTopology(final NamedTopologyBuilder namedTopologyBuilder,
                                         final QueryId queryId,
                                         final String applicationId,
-                                        final Map<String, Object>  queryOverrides,
                                         final ExecutionStep<?> physicalPlan) {
-    final NamedTopologyBuilder namedTopologyBuilder =
-        ((KafkaStreamsNamedTopologyWrapper) sharedKafkaStreamsRuntime.getKafkaStreams())
-            .newNamedTopologyBuilder(
-                queryId.toString(),
-                PropertiesUtil.asProperties(queryOverrides)
-            );
-
     final RuntimeBuildContext runtimeBuildContext = buildContext(
         applicationId,
         queryId,


### PR DESCRIPTION
When building up a copy of a query's NamedTopology for use when restarting the runtime or validating a new query, we need to make sure to use a NamedTopologyBuilder that corresponds to the correct/new runtime. Otherwise the copied topology will still be tied to the original topology and its runtime.

See https://github.com/confluentinc/ksql/pull/8434/files#r764394827