### PR TITLE
feat: custom auth configs for ksql connector requests

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -811,7 +811,8 @@ public class KsqlConfig extends AbstractConfig {
             false,
             ConfigDef.Importance.LOW,
             "If true, basic auth credentials for connector auth will automatically reload "
-                + "on file change."
+                + "on file change (creation or modification). File deletion is not monitored and "
+                + "old credentials will continue to be used in this case."
         ).define(
             CONNECT_BASIC_AUTH_FAIL_ON_UNREADABLE_CREDENTIALS,
             ConfigDef.Type.BOOLEAN,

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -91,9 +91,31 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String SCHEMA_REGISTRY_URL_PROPERTY = "ksql.schema.registry.url";
 
-  public static final String CONNECT_URL_PROPERTY = "ksql.connect.url";
+  public static final String KSQL_CONNECT_PREFIX = "ksql.connect.";
 
-  public static final String CONNECT_WORKER_CONFIG_FILE_PROPERTY = "ksql.connect.worker.config";
+  public static final String CONNECT_URL_PROPERTY = KSQL_CONNECT_PREFIX + "url";
+
+  public static final String CONNECT_WORKER_CONFIG_FILE_PROPERTY =
+      KSQL_CONNECT_PREFIX + "worker.config";
+
+  public static final String CONNECT_BASIC_AUTH_CREDENTIALS_SOURCE_PROPERTY =
+      KSQL_CONNECT_PREFIX + "basic.auth.credentials.source";
+  public static final String BASIC_AUTH_CREDENTIALS_SOURCE_NONE = "NONE";
+  public static final String BASIC_AUTH_CREDENTIALS_SOURCE_FILE = "FILE";
+  private static final ConfigDef.ValidString BASIC_AUTH_CREDENTIALS_SOURCE_VALIDATOR =
+      ConfigDef.ValidString.in(
+          BASIC_AUTH_CREDENTIALS_SOURCE_NONE,
+          BASIC_AUTH_CREDENTIALS_SOURCE_FILE
+      );
+  public static final String BASIC_AUTH_CREDENTIALS_USERNAME = "username";
+  public static final String BASIC_AUTH_CREDENTIALS_PASSWORD = "password";
+
+  public static final String CONNECT_BASIC_AUTH_CREDENTIALS_FILE_PROPERTY =
+      KSQL_CONNECT_PREFIX + "basic.auth.credentials.file";
+  public static final String CONNECT_BASIC_AUTH_CREDENTIALS_RELOAD_PROPERTY =
+      KSQL_CONNECT_PREFIX + "basic.auth.credentials.reload";
+  public static final String CONNECT_BASIC_AUTH_FAIL_ON_UNREADABLE_CREDENTIALS =
+      KSQL_CONNECT_PREFIX + "basic.auth.credentials.fail.on.unreadable";
 
   public static final String KSQL_ENABLE_UDFS = "ksql.udfs.enabled";
 
@@ -764,6 +786,39 @@ public class KsqlConfig extends AbstractConfig {
                 + "will prevent connect from starting up embedded within KSQL. For more information"
                 + " on configuring connect, see "
                 + "https://docs.confluent.io/current/connect/userguide.html#configuring-workers."
+        ).define(
+            CONNECT_BASIC_AUTH_CREDENTIALS_SOURCE_PROPERTY,
+            ConfigDef.Type.STRING,
+            BASIC_AUTH_CREDENTIALS_SOURCE_NONE,
+            BASIC_AUTH_CREDENTIALS_SOURCE_VALIDATOR,
+            Importance.LOW,
+            "If providing explicit basic auth credentials for ksqlDB to use when sending connector "
+                + "requests, this config specifies how credentials should be loaded. Valid "
+                + "options are 'FILE' in order to specify the username and password in a "
+                + "properties file, or 'NONE' to indicate that custom basic auth should "
+                + "not be used. If 'NONE', ksqlDB will forward the auth header, if present, "
+                + "on the incoming ksql request to Connect."
+        ).define(
+            CONNECT_BASIC_AUTH_CREDENTIALS_FILE_PROPERTY,
+            ConfigDef.Type.STRING,
+            "",
+            Importance.LOW,
+            "If '" + CONNECT_BASIC_AUTH_CREDENTIALS_SOURCE_PROPERTY + "' is set to 'FILE', "
+                + "then this config specifies the path to the credentials file."
+        ).define(
+            CONNECT_BASIC_AUTH_CREDENTIALS_RELOAD_PROPERTY,
+            ConfigDef.Type.BOOLEAN,
+            false,
+            ConfigDef.Importance.LOW,
+            "If true, basic auth credentials for connector auth will automatically reload "
+                + "on file change."
+        ).define(
+            CONNECT_BASIC_AUTH_FAIL_ON_UNREADABLE_CREDENTIALS,
+            ConfigDef.Type.BOOLEAN,
+            true,
+            ConfigDef.Importance.LOW,
+            "If true, failure to load basic auth credentials for connector auth will result "
+                + "in an error. If false, failure will result in a warn log and empty credentials."
         ).define(
             KSQL_ENABLE_UDFS,
             ConfigDef.Type.BOOLEAN,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClientFactory.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import io.confluent.ksql.services.ConnectClient.ConnectClientFactory;
+import io.confluent.ksql.util.FileWatcher;
+import io.confluent.ksql.util.KsqlConfig;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultConnectClientFactory implements ConnectClientFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(DefaultConnectClientFactory.class);
+
+  private final KsqlConfig ksqlConfig;
+  private Optional<String> connectAuthHeader;
+  private FileWatcher credentialsFileWatcher;
+
+  public DefaultConnectClientFactory(
+      final KsqlConfig ksqlConfig
+  ) {
+    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
+  }
+
+  @Override
+  public DefaultConnectClient get(final Optional<String> ksqlAuthHeader) {
+    if (connectAuthHeader == null) {
+      connectAuthHeader = buildAuthHeader();
+    }
+
+    return new DefaultConnectClient(
+        ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
+        // if no explicit header specified, then forward incoming request header
+        connectAuthHeader.isPresent() ? connectAuthHeader : ksqlAuthHeader
+    );
+  }
+
+  @Override
+  public void close() {
+    if (credentialsFileWatcher != null) {
+      credentialsFileWatcher.shutdown();
+    }
+  }
+
+  private Optional<String> buildAuthHeader() {
+    // custom basic auth credentials
+    if (ksqlConfig.getString(KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_SOURCE_PROPERTY)
+        .equalsIgnoreCase(KsqlConfig.BASIC_AUTH_CREDENTIALS_SOURCE_FILE)) {
+      final String credentialsFile =
+          ksqlConfig.getString(KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_FILE_PROPERTY);
+      final boolean failOnUnreadableCreds =
+          ksqlConfig.getBoolean(KsqlConfig.CONNECT_BASIC_AUTH_FAIL_ON_UNREADABLE_CREDENTIALS);
+
+      if (ksqlConfig.getBoolean(KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_RELOAD_PROPERTY)) {
+        startBasicAuthFileWatcher(credentialsFile, failOnUnreadableCreds);
+      }
+
+      return buildBasicAuthHeader(credentialsFile, failOnUnreadableCreds);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private void startBasicAuthFileWatcher(
+      final String filePath,
+      final boolean failOnUnreadableCreds
+  ) {
+    try {
+      credentialsFileWatcher = new FileWatcher(Paths.get(filePath), () -> {
+        connectAuthHeader = buildBasicAuthHeader(filePath, failOnUnreadableCreds);
+      });
+      credentialsFileWatcher.start();
+      log.info("Enabled automatic connector credentials reload for location: " + filePath);
+    } catch (java.io.IOException e) {
+      log.error("Failed to enable automatic connector credentials reload.");
+    }
+  }
+
+  private static Optional<String> buildBasicAuthHeader(
+      final String credentialsPath,
+      final boolean failOnUnreadableCredentials
+  ) {
+    if (credentialsPath == null || credentialsPath.isEmpty()) {
+      throw new ConfigException(String.format("'%s' cannot be empty if '%s' is set to '%s'",
+          KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_FILE_PROPERTY,
+          KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_SOURCE_PROPERTY,
+          KsqlConfig.BASIC_AUTH_CREDENTIALS_SOURCE_FILE));
+    }
+
+    final Properties credentials = new Properties();
+    try {
+      credentials.load(new FileInputStream(credentialsPath));
+
+      if (credentials.containsKey(KsqlConfig.BASIC_AUTH_CREDENTIALS_USERNAME)
+          && credentials.containsKey(KsqlConfig.BASIC_AUTH_CREDENTIALS_PASSWORD)) {
+        final String userInfo = credentials.getProperty(KsqlConfig.BASIC_AUTH_CREDENTIALS_USERNAME)
+            + ":" + credentials.getProperty(KsqlConfig.BASIC_AUTH_CREDENTIALS_PASSWORD);
+        return Optional.of("Basic " + Base64.getEncoder()
+            .encodeToString(userInfo.getBytes(Charset.defaultCharset())));
+      } else {
+        if (failOnUnreadableCredentials) {
+          throw new ConfigException(
+              "Provided credentials file doesn't provide username and password");
+        } else {
+          log.warn("Provided credentials file doesn't provide username and password");
+          return Optional.empty();
+        }
+      }
+    } catch (IOException e) {
+      if (failOnUnreadableCredentials) {
+        throw new ConfigException(e.getMessage());
+      } else {
+        log.warn("Failed to load credentials file: " + e.getMessage());
+        return Optional.empty();
+      }
+    }
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClientFactory.java
@@ -35,7 +35,7 @@ public class DefaultConnectClientFactory implements ConnectClientFactory {
   private static final Logger log = LoggerFactory.getLogger(DefaultConnectClientFactory.class);
 
   private final KsqlConfig ksqlConfig;
-  private Optional<String> connectAuthHeader;
+  private volatile Optional<String> connectAuthHeader;
   private FileWatcher credentialsFileWatcher;
 
   public DefaultConnectClientFactory(
@@ -45,7 +45,7 @@ public class DefaultConnectClientFactory implements ConnectClientFactory {
   }
 
   @Override
-  public DefaultConnectClient get(final Optional<String> ksqlAuthHeader) {
+  public synchronized DefaultConnectClient get(final Optional<String> ksqlAuthHeader) {
     if (connectAuthHeader == null) {
       connectAuthHeader = buildAuthHeader();
     }
@@ -58,7 +58,7 @@ public class DefaultConnectClientFactory implements ConnectClientFactory {
   }
 
   @Override
-  public void close() {
+  public synchronized void close() {
     if (credentialsFileWatcher != null) {
       credentialsFileWatcher.shutdown();
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClientFactory.java
@@ -110,8 +110,10 @@ public class DefaultConnectClientFactory implements ConnectClientFactory {
     }
 
     final Properties credentials = new Properties();
+    FileInputStream inputStream = null;
     try {
-      credentials.load(new FileInputStream(credentialsPath));
+      inputStream = new FileInputStream(credentialsPath);
+      credentials.load(inputStream);
 
       if (credentials.containsKey(KsqlConfig.BASIC_AUTH_CREDENTIALS_USERNAME)
           && credentials.containsKey(KsqlConfig.BASIC_AUTH_CREDENTIALS_PASSWORD)) {
@@ -134,6 +136,14 @@ public class DefaultConnectClientFactory implements ConnectClientFactory {
       } else {
         log.warn("Failed to load credentials file: " + e.getMessage());
         return Optional.empty();
+      }
+    } finally {
+      if (inputStream != null) {
+        try {
+          inputStream.close();
+        } catch (IOException e) {
+          log.error("Failed to close credentials input stream: " + e.getMessage());
+        }
       }
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -40,8 +40,7 @@ public final class ServiceContextFactory {
         new KsqlSchemaRegistryClientFactory(
             ksqlConfig,
             Collections.emptyMap())::get,
-        () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
-            Optional.empty()),
+        () -> new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty()),
         ksqlClientSupplier
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/FileWatcher.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/FileWatcher.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.api.server;
+package io.confluent.ksql.util;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/FileWatcher.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/FileWatcher.java
@@ -33,7 +33,8 @@ import org.slf4j.LoggerFactory;
 // https://gist.github.com/danielflower/f54c2fe42d32356301c68860a4ab21ed
 // https://github.com/confluentinc/rest-utils/blob/master/core/src/main/java/io/confluent/rest/FileWatcher.java
 /**
- * Watches a file and calls a callback when it is changed.
+ * Watches a file and calls a callback when it is changed. Only file creation and modification
+ * are watched for; deletion has no effect.
  */
 public class FileWatcher extends Thread {
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
 import io.confluent.ksql.services.DefaultConnectClient;
+import io.confluent.ksql.services.DefaultConnectClientFactory;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClientImpl;
 import io.confluent.ksql.services.ServiceContext;
@@ -59,9 +60,7 @@ public final class KsqlContextTestUtil {
         adminClient,
         kafkaTopicClient,
         () -> schemaRegistryClient,
-        new DefaultConnectClient(
-            ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
-            Optional.empty())
+        new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty())
     );
 
     final String metricsPrefix = "instance-" + COUNTER.getAndIncrement() + "-";

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientFactoryTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.test.util.KsqlTestFolder;
+import io.confluent.ksql.util.KsqlConfig;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.util.Base64;
+import java.util.Optional;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultConnectClientFactoryTest {
+
+  private static final String USERNAME = "fred";
+  private static final String PASSWORD = "pass";
+  private static final String EXPECTED_HEADER = expectedBasicAuthHeader(USERNAME, PASSWORD);
+
+  @Rule
+  public TemporaryFolder folder = KsqlTestFolder.temporaryFolder();
+
+  @Mock
+  private KsqlConfig config;
+
+  private String credentialsPath;
+
+  private DefaultConnectClientFactory connectClientFactory;
+
+  @Before
+  public void setUp() {
+    credentialsPath = folder.getRoot().getPath() + "/connect_credentials.properties";
+
+    when(config.getString(KsqlConfig.CONNECT_URL_PROPERTY)).thenReturn("http://localhost:8034");
+    when(config.getString(KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_SOURCE_PROPERTY)).thenReturn("NONE");
+
+    connectClientFactory = new DefaultConnectClientFactory(config);
+  }
+
+  @Test
+  public void shouldBuildWithoutAuthHeader() {
+    // When:
+    final DefaultConnectClient connectClient = connectClientFactory.get(Optional.empty());
+
+    // Then:
+    assertThat(connectClient.getAuthHeader(), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldBuildAuthHeader() throws Exception {
+    // Given:
+    givenCustomBasicAuthHeader();
+    givenValidCredentialsFile();
+
+    // When:
+    final DefaultConnectClient connectClient = connectClientFactory.get(Optional.empty());
+
+    // Then:
+    assertThat(connectClient.getAuthHeader(), is(Optional.of(EXPECTED_HEADER)));
+  }
+
+  @Test
+  public void shouldBuildAuthHeaderOnlyOnce() throws Exception {
+    // Given:
+    givenCustomBasicAuthHeader();
+    givenValidCredentialsFile();
+
+    // When: get() is called twice
+    connectClientFactory.get(Optional.empty());
+    connectClientFactory.get(Optional.empty());
+
+    // Then: only loaded the credentials once -- ideally we'd check the number of times the file
+    //       was read but this is an acceptable proxy for this unit test
+    verify(config, times(1)).getString(KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_FILE_PROPERTY);
+  }
+
+  @Test
+  public void shouldUseKsqlAuthHeaderIfNoAuthHeaderPresent() {
+    // When:
+    final DefaultConnectClient connectClient =
+        connectClientFactory.get(Optional.of("some ksql request header"));
+
+    // Then:
+    assertThat(connectClient.getAuthHeader(), is(Optional.of("some ksql request header")));
+  }
+
+  @Test
+  public void shouldFailOnUnreadableCredentials() throws Exception {
+    // Given:
+    givenCustomBasicAuthHeader(true);
+    givenInvalidCredentialsFiles();
+
+    // When:
+    final Exception e = assertThrows(
+        ConfigException.class,
+        () -> connectClientFactory.get(Optional.empty()));
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("Provided credentials file doesn't provide username and password"));
+  }
+
+  @Test
+  public void shouldNotFailOnUnreadableCredentialsIfConfigured() throws Exception {
+    // Given:
+    givenCustomBasicAuthHeader(false);
+    givenInvalidCredentialsFiles();
+
+    // When:
+    final DefaultConnectClient connectClient = connectClientFactory.get(Optional.empty());
+
+    // Then:
+    assertThat(connectClient.getAuthHeader(), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldFailOnMissingCredentials() {
+    // Given:
+    givenCustomBasicAuthHeader(true);
+    // no credentials file present
+
+    // When:
+    final Exception e = assertThrows(
+        ConfigException.class,
+        () -> connectClientFactory.get(Optional.empty()));
+
+    // Then:
+    assertThat(e.getMessage(),
+        containsString("No such file or directory"));
+  }
+
+  @Test
+  public void shouldNotFailOnMissingCredentialsIfConfigured() {
+    // Given:
+    givenCustomBasicAuthHeader(false);
+    // no credentials file present
+
+    // When:
+    final DefaultConnectClient connectClient = connectClientFactory.get(Optional.empty());
+
+    // Then:
+    assertThat(connectClient.getAuthHeader(), is(Optional.empty()));
+  }
+
+  private void givenCustomBasicAuthHeader() {
+    givenCustomBasicAuthHeader(true);
+  }
+
+  private void givenCustomBasicAuthHeader(final boolean failOnUnreadableCreds) {
+    when(config.getString(KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_SOURCE_PROPERTY)).thenReturn("FILE");
+    when(config.getString(KsqlConfig.CONNECT_BASIC_AUTH_CREDENTIALS_FILE_PROPERTY)).thenReturn(credentialsPath);
+    when(config.getBoolean(KsqlConfig.CONNECT_BASIC_AUTH_FAIL_ON_UNREADABLE_CREDENTIALS)).thenReturn(failOnUnreadableCreds);
+  }
+
+  private void givenValidCredentialsFile() throws Exception {
+    final String content = String.format("username=%s\npassword=%s", USERNAME, PASSWORD);
+    createCredentialsFile(content);
+  }
+
+  private void givenInvalidCredentialsFiles() throws Exception {
+    createCredentialsFile("malformed credentials content");
+  }
+
+  private void createCredentialsFile(final String content) throws IOException {
+    assertThat(new File(credentialsPath).createNewFile(), is(true));
+    PrintWriter out = new PrintWriter(credentialsPath, Charset.defaultCharset().name());
+    out.println(content);
+    out.close();
+  }
+  
+  private static String expectedBasicAuthHeader(final String username, final String password) {
+    final String userInfo = username + ":" + password;
+    return "Basic " + Base64.getEncoder()
+        .encodeToString(userInfo.getBytes(Charset.defaultCharset()));
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientFactoryTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientFactoryTest.java
@@ -239,7 +239,7 @@ public class DefaultConnectClientFactoryTest {
   }
 
   private void givenValidCredentialsFile() throws Exception {
-    final String content = String.format("username=%s\npassword=%s", USERNAME, PASSWORD);
+    final String content = String.format("username=%s%npassword=%s", USERNAME, PASSWORD);
     createCredentialsFile(content, true);
   }
 
@@ -248,7 +248,7 @@ public class DefaultConnectClientFactoryTest {
   }
 
   private void writeNewCredentialsFile() throws Exception {
-    final String content = String.format("username=%s\npassword=%s", OTHER_USERNAME, OTHER_PASSWORD);
+    final String content = String.format("username=%s%npassword=%s", OTHER_USERNAME, OTHER_PASSWORD);
     createCredentialsFile(content, false);
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.metastore.model.MetaStoreMatchers.OptionalMatchers;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -45,7 +46,10 @@ import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class DefaultConnectClientTest {
 
   private static final ObjectMapper MAPPER = ConnectJsonMapper.INSTANCE.get();
@@ -83,18 +87,29 @@ public class DefaultConnectClientTest {
           .dynamicPort()
   );
 
+  @Parameterized.Parameters(name = "{1}")
+  public static Collection<String[]> pathPrefixes() {
+    return ImmutableList.of(new String[]{"", "no path prefix"}, new String[]{"/some/path/prefix", "with path prefix"});
+  }
+
+  private final String pathPrefix;
+
   private ConnectClient client;
+
+  public DefaultConnectClientTest(final String pathPrefix, final String testName) {
+    this.pathPrefix = pathPrefix;
+  }
 
   @Before
   public void setup() {
-    client = new DefaultConnectClient("http://localhost:" + wireMockRule.port(), Optional.of(AUTH_HEADER));
+    client = new DefaultConnectClient("http://localhost:" + wireMockRule.port() + pathPrefix, Optional.of(AUTH_HEADER));
   }
 
   @Test
   public void testCreate() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.post(WireMock.urlEqualTo("/connectors"))
+        WireMock.post(WireMock.urlEqualTo(pathPrefix + "/connectors"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_CREATED)
@@ -114,7 +129,7 @@ public class DefaultConnectClientTest {
   public void testCreateWithError() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.post(WireMock.urlEqualTo("/connectors"))
+        WireMock.post(WireMock.urlEqualTo(pathPrefix + "/connectors"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)
@@ -134,7 +149,7 @@ public class DefaultConnectClientTest {
   public void testList() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.get(WireMock.urlEqualTo("/connectors"))
+        WireMock.get(WireMock.urlEqualTo(pathPrefix + "/connectors"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_OK)
@@ -153,7 +168,7 @@ public class DefaultConnectClientTest {
   public void testListPlugins() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.get(WireMock.urlEqualTo("/connector-plugins"))
+        WireMock.get(WireMock.urlEqualTo(pathPrefix + "/connector-plugins"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_OK)
@@ -172,7 +187,7 @@ public class DefaultConnectClientTest {
   public void testDescribe() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.get(WireMock.urlEqualTo("/connectors/foo"))
+        WireMock.get(WireMock.urlEqualTo(pathPrefix + "/connectors/foo"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_OK)
@@ -191,7 +206,7 @@ public class DefaultConnectClientTest {
   public void testStatus() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.get(WireMock.urlEqualTo("/connectors/foo/status"))
+        WireMock.get(WireMock.urlEqualTo(pathPrefix + "/connectors/foo/status"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_OK)
@@ -218,7 +233,7 @@ public class DefaultConnectClientTest {
   public void testDelete() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.delete(WireMock.urlEqualTo("/connectors/foo"))
+        WireMock.delete(WireMock.urlEqualTo(pathPrefix + "/connectors/foo"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_NO_CONTENT))
@@ -236,7 +251,7 @@ public class DefaultConnectClientTest {
   public void testTopics() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.get(WireMock.urlEqualTo("/connectors/foo/topics"))
+        WireMock.get(WireMock.urlEqualTo(pathPrefix + "/connectors/foo/topics"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_OK)
@@ -259,7 +274,7 @@ public class DefaultConnectClientTest {
   public void testListShouldRetryOnFailure() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(
-        WireMock.get(WireMock.urlEqualTo("/connectors"))
+        WireMock.get(WireMock.urlEqualTo(pathPrefix + "/connectors"))
             .withHeader(AUTHORIZATION.toString(), new EqualToPattern(AUTH_HEADER))
             .willReturn(WireMock.aResponse()
                 .withStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -108,9 +108,7 @@ public final class TestServiceContext {
         adminClient,
         new KafkaTopicClientImpl(() -> adminClient),
         srClientFactory,
-        new DefaultConnectClient(
-            ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
-            Optional.empty()),
+        new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty()),
         new KafkaConsumerGroupClientImpl(() -> adminClient)
     );
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/FileWatcherTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/FileWatcherTest.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.api.server;
+package io.confluent.ksql.util;
 
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
-import io.confluent.ksql.api.server.FileWatcher.Callback;
+import io.confluent.ksql.util.FileWatcher.Callback;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/services/ConnectClient.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/services/ConnectClient.java
@@ -122,4 +122,10 @@ public interface ConnectClient {
     }
   }
 
+  interface ConnectClientFactory {
+    ConnectClient get(Optional<String> authHeader);
+
+    default void close() {}
+  }
+
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KsqlSecurityContextProvider.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/KsqlSecurityContextProvider.java
@@ -21,4 +21,6 @@ import io.confluent.ksql.security.KsqlSecurityContext;
 public interface KsqlSecurityContextProvider {
 
   KsqlSecurityContext provide(ApiSecurityContext apiSecurityContext);
+
+  default void close() {}
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.rest.entity.PushQueryId;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.security.KsqlSecurityExtension;
+import io.confluent.ksql.util.FileWatcher;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.VertxCompletableFuture;
 import io.confluent.ksql.util.VertxSslOptionsFactory;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.rest.server.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.rest.client.KsqlClient;
-import io.confluent.ksql.services.DefaultConnectClient;
+import io.confluent.ksql.services.ConnectClient.ConnectClientFactory;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.util.KsqlConfig;
@@ -37,6 +37,7 @@ public final class RestServiceContextFactory {
         KsqlConfig config,
         Optional<String> authHeader,
         Supplier<SchemaRegistryClient> srClientFactory,
+        ConnectClientFactory connectClientFactory,
         KsqlClient sharedClient
     );
   }
@@ -48,6 +49,7 @@ public final class RestServiceContextFactory {
         Optional<String> authHeader,
         KafkaClientSupplier kafkaClientSupplier,
         Supplier<SchemaRegistryClient> srClientFactory,
+        ConnectClientFactory connectClientFactory,
         KsqlClient sharedClient
     );
   }
@@ -56,6 +58,7 @@ public final class RestServiceContextFactory {
       final KsqlConfig ksqlConfig,
       final Optional<String> authHeader,
       final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
+      final ConnectClientFactory connectClientFactory,
       final KsqlClient sharedClient
   ) {
     return create(
@@ -63,6 +66,7 @@ public final class RestServiceContextFactory {
         authHeader,
         new DefaultKafkaClientSupplier(),
         schemaRegistryClientFactory,
+        connectClientFactory,
         sharedClient
     );
   }
@@ -72,14 +76,14 @@ public final class RestServiceContextFactory {
       final Optional<String> authHeader,
       final KafkaClientSupplier kafkaClientSupplier,
       final Supplier<SchemaRegistryClient> srClientFactory,
+      final ConnectClientFactory connectClientFactory,
       final KsqlClient sharedClient
   ) {
     return ServiceContextFactory.create(
         ksqlConfig,
         kafkaClientSupplier,
         srClientFactory,
-        () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
-            authHeader),
+        () -> connectClientFactory.get(authHeader),
         () -> new DefaultKsqlClient(authHeader, sharedClient)
     );
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProviderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProviderTest.java
@@ -77,7 +77,7 @@ public class DefaultKsqlSecurityContextProviderTest {
         userServiceContextFactory,
         ksqlConfig,
         () -> schemaRegistryClientFactory,
-        (authHeader) -> connectClient, // TODO: fix
+        (authHeader) -> connectClient,
         ksqlClient
     );
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -330,6 +330,7 @@ public class TestKsqlRestApp extends ExternalResource {
           3,
           serviceContext.get(),
           () -> serviceContext.get().getSchemaRegistryClient(),
+          (authHeader) -> serviceContext.get().getConnectClient(),
           vertx,
           InternalKsqlClientFactory.createInternalClient(
               PropertiesUtil.toMapStrings(ksqlRestConfig.originals()),


### PR DESCRIPTION
### Description 

This PR broadens the types of Connect deployments that ksqlDB's connector integration can work with. Specifically, this PR:
* adds new configs for specifying custom HTTP basic auth credentials to be sent with ksql connector requests. If not specified, then ksqlDB will continue to forward the incoming request auth header as it does today.
* adds support for automatically reloading file-based basic auth credentials (see above), if configured. This functionality is off by default in order to avoid the background thread that monitors for file changes.
* adds a configuration to specify whether missing/malformed credentials (see above) should result in an error or not. By default, an error will be thrown, but this PR adds a config to control this behavior to support use cases where, e.g., the credentials file may not exist at first but will be created after the ksqlDB server has already started.
* switches the Connect API paths to be relative rather than absolute, to support integrating with Connect deployments where the raw endpoints are nested under other paths.

### Testing done 

Unit tests + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

