### PR TITLE
fix: clean up transient queries when using shared runtimes

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -607,8 +607,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     ) {
       final String applicationId = query.getQueryApplicationId();
       Optional<String> topologyName = Optional.empty();
-      if (ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED) &&
-          !(query instanceof TransientQueryMetadata)) {
+      if (ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
+          && !(query instanceof TransientQueryMetadata)) {
         topologyName = Optional.of(query.getQueryId().toString());
       }
       if (query.hasEverBeenStarted()) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -607,7 +607,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     ) {
       final String applicationId = query.getQueryApplicationId();
       Optional<String> topologyName = Optional.empty();
-      if (ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+      if (ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED) &&
+          !(query instanceof TransientQueryMetadata)) {
         topologyName = Optional.of(query.getQueryId().toString());
       }
       if (query.hasEverBeenStarted()) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
@@ -114,6 +114,9 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
       pathName = topologyName
           .map(s -> stateDir + "/" + appId + "/__" + s + "__")
           .orElse(stateDir + "/" + appId);
+      if (isTransient && topologyName.isPresent()) {
+        throw new IllegalArgumentException("Transient Queries can not have named topologies");
+      }
     }
 
     public String getAppId() {
@@ -145,7 +148,7 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
 
       tryRun(() -> serviceContext.getTopicClient().deleteInternalTopics(queryTopicPrefix),
           "internal topics");
-      if (!topologyName.isPresent()) {
+      if (!topologyName.isPresent() || isTransient) {
         tryRun(
             () -> serviceContext
                 .getConsumerGroupClient()


### PR DESCRIPTION
we shouldn't be trying to clean up named topologies for transient queries when shared runtimes are on. 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

