### PR TITLE
feat: Allow to plug-in custom error handling for Connect server errors

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -130,6 +130,12 @@ public class KsqlConfig extends AbstractConfig {
       "Custom extension to allow for more fine-grained control of connector requests made by "
           + "ksqlDB. Extensions should implement the ConnectRequestHeadersExtension interface.";
 
+  public static final String KSQL_CONNECT_SERVER_ERROR_HANDLER =
+      KSQL_CONNECT_PREFIX + "error.handler";
+  public static final String KSQL_CONNECT_SERVER_ERROR_HANDLER_DEFAULT = null;
+  private static final String KSQL_CONNECT_SERVER_ERROR_HANDLER_DOC =
+      "A class that allows the ksqlDB server to customize error handling from connector requests.";
+
   public static final String KSQL_ENABLE_UDFS = "ksql.udfs.enabled";
 
   public static final String KSQL_EXT_DIR = "ksql.extension.dir";
@@ -1329,6 +1335,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_HEADERS_COLUMNS_ENABLED_DEFAULT,
             Importance.LOW,
             KSQL_HEADERS_COLUMNS_ENABLED_DOC
+        )
+        .define(
+            KSQL_CONNECT_SERVER_ERROR_HANDLER,
+            Type.CLASS,
+            KSQL_CONNECT_SERVER_ERROR_HANDLER_DEFAULT,
+            Importance.LOW,
+            KSQL_CONNECT_SERVER_ERROR_HANDLER_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -71,6 +71,8 @@ import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.InteractiveStatementExecutor;
 import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
+import io.confluent.ksql.rest.server.execution.ConnectServerErrors;
+import io.confluent.ksql.rest.server.execution.DefaultConnectServerErrors;
 import io.confluent.ksql.rest.server.query.QueryExecutor;
 import io.confluent.ksql.rest.server.resources.ClusterStatusResource;
 import io.confluent.ksql.rest.server.resources.HealthCheckResource;
@@ -807,6 +809,8 @@ public final class KsqlRestApplication implements Executable {
         ErrorMessages.class
     ));
 
+    final ConnectServerErrors connectErrorHandler = loadConnectErrorHandler(ksqlConfig);
+
     final Optional<LagReportingAgent> lagReportingAgent =
         initializeLagReportingAgent(restConfig, ksqlEngine, serviceContext);
     final Optional<HeartbeatAgent> heartbeatAgent =
@@ -925,6 +929,7 @@ public final class KsqlRestApplication implements Executable {
         versionChecker::updateLastRequestTime,
         authorizationValidator,
         errorHandler,
+        connectErrorHandler,
         denyListPropertyValidator
     );
 
@@ -1101,6 +1106,15 @@ public final class KsqlRestApplication implements Executable {
         securityHandlerPlugin.configure(ksqlRestConfig.originals())
     );
     return authenticationPlugin;
+  }
+
+  private static ConnectServerErrors loadConnectErrorHandler(
+      final KsqlConfig ksqlConfig) {
+    return Optional.ofNullable(
+        ksqlConfig.getConfiguredInstance(
+            KsqlConfig.KSQL_CONNECT_SERVER_ERROR_HANDLER,
+            ConnectServerErrors.class
+        )).orElse(new DefaultConnectServerErrors());
   }
 
   private void displayWelcomeMessage() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -40,11 +40,13 @@ import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 
 public final class ConnectExecutor {
+  private final ConnectServerErrors connectErrorHandler;
 
-  private ConnectExecutor() {
+  ConnectExecutor(final ConnectServerErrors connectErrorHandler) {
+    this.connectErrorHandler = connectErrorHandler;
   }
 
-  public static StatementExecutorResponse execute(
+  public StatementExecutorResponse execute(
       final ConfiguredStatement<CreateConnector> statement,
       final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -90,8 +92,7 @@ public final class ConnectExecutor {
       }
     }
 
-    return StatementExecutorResponse.handled(response.error()
-        .map(err -> new ErrorEntity(statement.getStatementText(), err)));
+    return StatementExecutorResponse.handled(connectErrorHandler.handle(statement, response));
   }
 
   private static List<String> validate(final CreateConnector createConnector,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectServerErrors.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectServerErrors.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
+
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Optional;
+
+/**
+ * An interface that allows to plug-in custom error handling for Connect server errors, such as 403
+ * Forbidden or 401 Unauthorized.
+ */
+public interface ConnectServerErrors {
+
+  /**
+   * Handles error response for a create connector request. This method dispatches to specific
+   * methods based on error codes.
+   *
+   * @param statement the executed statement
+   * @param response the failed response
+   * @return the optional {@link KsqlEntity} that represents server error
+   */
+  default Optional<KsqlEntity> handle(
+      final ConfiguredStatement<? extends Statement> statement,
+      final ConnectResponse<?> response) {
+    if (response.httpCode() == FORBIDDEN.code()) {
+      return handleForbidden(statement, response);
+    } else if (response.httpCode() == UNAUTHORIZED.code()) {
+      return handleUnauthorized(statement, response);
+    } else {
+      return handleDefault(statement, response);
+    }
+  }
+
+  /**
+   * This method allows altering error response on 403 Forbidden.
+   *
+   * @param statement the executed statement
+   * @param response the failed response
+   * @return the optional {@code KsqlEntity} that represents server error
+   */
+  Optional<KsqlEntity> handleForbidden(
+      ConfiguredStatement<? extends Statement> statement,
+      ConnectResponse<?> response);
+
+  /**
+   * This method allows altering error response on 401 Unauthorized.
+   *
+   * @param statement the executed statement
+   * @param response the failed response
+   * @return the optional {@code KsqlEntity} that represents server error
+   */
+  Optional<KsqlEntity> handleUnauthorized(
+      ConfiguredStatement<? extends Statement> statement,
+      ConnectResponse<?> response);
+
+  /**
+   * This method is a fall-back for errors that are not handled by the error-specific methods.
+   *
+   * @param statement the executed statement
+   * @param response the failed response
+   * @return the optional {@code KsqlEntity} that represents server error
+   */
+  Optional<KsqlEntity> handleDefault(
+      ConfiguredStatement<? extends Statement> statement,
+      ConnectResponse<?> response);
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -15,8 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
-import com.google.common.collect.ImmutableMap;
-import io.confluent.ksql.KsqlExecutionContext;
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DefineVariable;
 import io.confluent.ksql.parser.tree.DescribeConnector;
@@ -42,91 +41,161 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UndefineVariable;
 import io.confluent.ksql.parser.tree.UnsetProperty;
-import io.confluent.ksql.rest.SessionProperties;
-import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
- * A suite of {@code StatementExecutor}s that do not need to be distributed.
- * Each handles a corresponding {@code Class<? extends Statement>} and is
- * assumed that the {@code ConfiguredStatement} that is passed in matches the
- * expected class.
+ * A suite of {@link StatementExecutor}s that do not need to be distributed. Each handles a
+ * corresponding {@code Class<? extends Statement>} and is assumed that the {@link
+ * ConfiguredStatement} that is passed in matches the expected class.
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
-public enum CustomExecutors {
+public class CustomExecutors {
 
-  LIST_TOPICS(ListTopics.class, ListTopicsExecutor::execute),
-  LIST_STREAMS(ListStreams.class, ListSourceExecutor::streams),
-  LIST_TABLES(ListTables.class, ListSourceExecutor::tables),
-  DESCRIBE_STREAMS(DescribeStreams.class, ListSourceExecutor::describeStreams),
-  DESCRIBE_TABLES(DescribeTables.class, ListSourceExecutor::describeTables),
-  LIST_FUNCTIONS(ListFunctions.class, ListFunctionsExecutor::execute),
-  LIST_QUERIES(ListQueries.class, ListQueriesExecutor::execute),
-  LIST_PROPERTIES(ListProperties.class, ListPropertiesExecutor::execute),
-  LIST_CONNECTORS(ListConnectors.class, ListConnectorsExecutor::execute),
-  LIST_CONNECTOR_PLUGINS(ListConnectorPlugins.class, ListConnectorPluginsExecutor::execute),
-  LIST_TYPES(ListTypes.class, ListTypesExecutor::execute),
-  LIST_VARIABLES(ListVariables.class, ListVariablesExecutor::execute),
+  @SuppressWarnings({"checkstyle:AbbreviationAsWordInName", "checkstyle:MemberName"})
+  public final Map<Class<? extends Statement>, StatementExecutor<?>> EXECUTOR_MAP;
 
-  SHOW_COLUMNS(ShowColumns.class, ListSourceExecutor::columns),
-  EXPLAIN(Explain.class, ExplainExecutor::execute),
-  DESCRIBE_FUNCTION(DescribeFunction.class, DescribeFunctionExecutor::execute),
-  SET_PROPERTY(SetProperty.class, PropertyExecutor::set),
-  UNSET_PROPERTY(UnsetProperty.class, PropertyExecutor::unset),
-  DEFINE_VARIABLE(DefineVariable.class, VariableExecutor::set),
-  UNDEFINE_VARIABLE(UndefineVariable.class, VariableExecutor::unset),
-  INSERT_VALUES(InsertValues.class, insertValuesExecutor()),
-  CREATE_CONNECTOR(CreateConnector.class, ConnectExecutor::execute),
-  DROP_CONNECTOR(DropConnector.class, DropConnectorExecutor::execute),
-  DESCRIBE_CONNECTOR(DescribeConnector.class, new DescribeConnectorExecutor()::execute),
-  TERMINATE_QUERY(TerminateQuery.class, TerminateQueryExecutor::execute)
-  ;
+  public CustomExecutors(final ConnectServerErrors connectErrorHandler) {
+    Objects.requireNonNull(connectErrorHandler, "connectErrorHandler");
 
-  public static final Map<Class<? extends Statement>, StatementExecutor<?>> EXECUTOR_MAP =
-      ImmutableMap.copyOf(
-          EnumSet.allOf(CustomExecutors.class)
-              .stream()
-              .collect(Collectors.toMap(
-                  CustomExecutors::getStatementClass,
-                  CustomExecutors::getExecutor))
-      );
-
-  private final Class<? extends Statement> statementClass;
-  private final StatementExecutor executor;
-
-  <T extends Statement> CustomExecutors(
-      final Class<T> statementClass,
-      final StatementExecutor<? super T> executor
-  ) {
-    this.statementClass = Objects.requireNonNull(statementClass, "statementClass");
-    this.executor = Objects.requireNonNull(executor, "executor");
+    EXECUTOR_MAP = new HashMap<Class<? extends Statement>, StatementExecutor<?>>() {{
+        put(ListTopics.class,
+            (StatementExecutor<ListTopics>) ListTopicsExecutor::execute);
+        put(ListStreams.class,
+            (StatementExecutor<ListStreams>) ListSourceExecutor::streams);
+        put(ListTables.class,
+            (StatementExecutor<ListTables>) ListSourceExecutor::tables);
+        put(DescribeStreams.class,
+            (StatementExecutor<DescribeStreams>) ListSourceExecutor::describeStreams);
+        put(DescribeTables.class,
+            (StatementExecutor<DescribeTables>) ListSourceExecutor::describeTables);
+        put(ListFunctions.class,
+            (StatementExecutor<ListFunctions>) ListFunctionsExecutor::execute);
+        put(ListQueries.class,
+            (StatementExecutor<ListQueries>) ListQueriesExecutor::execute);
+        put(ListProperties.class,
+            (StatementExecutor<ListProperties>) ListPropertiesExecutor::execute);
+        put(ListConnectors.class,
+            (StatementExecutor<ListConnectors>)
+                new ListConnectorsExecutor(connectErrorHandler)::execute);
+        put(ListConnectorPlugins.class,
+            (StatementExecutor<ListConnectorPlugins>)
+                new ListConnectorPluginsExecutor(connectErrorHandler)::execute);
+        put(ListTypes.class,
+            (StatementExecutor<ListTypes>) ListTypesExecutor::execute);
+        put(ListVariables.class,
+            (StatementExecutor<ListVariables>) ListVariablesExecutor::execute);
+        put(ShowColumns.class,
+            (StatementExecutor<ShowColumns>) ListSourceExecutor::columns);
+        put(Explain.class,
+            (StatementExecutor<Explain>) ExplainExecutor::execute);
+        put(DescribeFunction.class,
+            (StatementExecutor<DescribeFunction>) DescribeFunctionExecutor::execute);
+        put(SetProperty.class,
+            (StatementExecutor<SetProperty>) PropertyExecutor::set);
+        put(UnsetProperty.class, (StatementExecutor<UnsetProperty>) PropertyExecutor::unset);
+        put(DefineVariable.class, (StatementExecutor<DefineVariable>) VariableExecutor::set);
+        put(UndefineVariable.class, (StatementExecutor<UndefineVariable>) VariableExecutor::unset);
+        put(InsertValues.class, insertValuesExecutor());
+        put(CreateConnector.class,
+            (StatementExecutor<CreateConnector>) new ConnectExecutor(connectErrorHandler)::execute);
+        put(DropConnector.class,
+            (StatementExecutor<DropConnector>)
+                new DropConnectorExecutor(connectErrorHandler)::execute);
+        put(DescribeConnector.class,
+            (StatementExecutor<DescribeConnector>)
+                new DescribeConnectorExecutor(connectErrorHandler)::execute);
+        put(TerminateQuery.class,
+            (StatementExecutor<TerminateQuery>) TerminateQueryExecutor::execute);
+      }};
   }
 
-  private Class<? extends Statement> getStatementClass() {
-    return statementClass;
+  @VisibleForTesting
+  StatementExecutor<Explain> explain() {
+    return (StatementExecutor<Explain>) EXECUTOR_MAP.get(Explain.class);
   }
 
-  private StatementExecutor<?> getExecutor() {
-    return this::execute;
+  @VisibleForTesting
+  StatementExecutor<ListTopics> listTopics() {
+    return (StatementExecutor<ListTopics>) EXECUTOR_MAP.get(ListTopics.class);
   }
 
-  public StatementExecutorResponse execute(
-      final ConfiguredStatement<?> statement,
-      final SessionProperties sessionProperties,
-      final KsqlExecutionContext executionCtx,
-      final ServiceContext serviceCtx
-  ) {
-    return executor.execute(
-        statement,
-        sessionProperties,
-        executionCtx,
-        serviceCtx
-    );
+  @VisibleForTesting
+  StatementExecutor<TerminateQuery> terminateQuery() {
+    return (StatementExecutor<TerminateQuery>) EXECUTOR_MAP.get(TerminateQuery.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<DefineVariable> defineVariable() {
+    return (StatementExecutor<DefineVariable>) EXECUTOR_MAP.get(DefineVariable.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<UndefineVariable> undefineVariable() {
+    return (StatementExecutor<UndefineVariable>) EXECUTOR_MAP.get(UndefineVariable.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<SetProperty> setProperty() {
+    return (StatementExecutor<SetProperty>) EXECUTOR_MAP.get(SetProperty.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<UnsetProperty> unsetProperty() {
+    return (StatementExecutor<UnsetProperty>) EXECUTOR_MAP.get(UnsetProperty.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<ListProperties> listProperties() {
+    return (StatementExecutor<ListProperties>) EXECUTOR_MAP.get(ListProperties.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<ListStreams> listStreams() {
+    return (StatementExecutor<ListStreams>) EXECUTOR_MAP.get(ListStreams.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<DescribeStreams> describeStreams() {
+    return (StatementExecutor<DescribeStreams>) EXECUTOR_MAP.get(DescribeStreams.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<ListTables> listTables() {
+    return (StatementExecutor<ListTables>) EXECUTOR_MAP.get(ListTables.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<DescribeTables> describeTables() {
+    return (StatementExecutor<DescribeTables>) EXECUTOR_MAP.get(DescribeTables.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<ShowColumns> showColumns() {
+    return (StatementExecutor<ShowColumns>) EXECUTOR_MAP.get(ShowColumns.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<ListFunctions> listFunctions() {
+    return (StatementExecutor<ListFunctions>) EXECUTOR_MAP.get(ListFunctions.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<DescribeFunction> describeFunction() {
+    return (StatementExecutor<DescribeFunction>) EXECUTOR_MAP.get(DescribeFunction.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<ListQueries> listQueries() {
+    return (StatementExecutor<ListQueries>) EXECUTOR_MAP.get(ListQueries.class);
+  }
+
+  @VisibleForTesting
+  StatementExecutor<ListVariables> listVariables() {
+    return (StatementExecutor<ListVariables>) EXECUTOR_MAP.get(ListVariables.class);
   }
 
   private static StatementExecutor insertValuesExecutor() {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DefaultConnectServerErrors.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DefaultConnectServerErrors.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.entity.ErrorEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Optional;
+
+public class DefaultConnectServerErrors implements ConnectServerErrors {
+
+  @Override
+  public Optional<KsqlEntity> handleForbidden(
+      final ConfiguredStatement<? extends Statement> statement,
+      final ConnectResponse<?> response) {
+    return handleDefault(statement, response);
+  }
+
+  @Override
+  public Optional<KsqlEntity> handleUnauthorized(
+      final ConfiguredStatement<? extends Statement> statement,
+      final ConnectResponse<?> response) {
+    return handleDefault(statement, response);
+  }
+
+  @Override
+  public Optional<KsqlEntity> handleDefault(
+      final ConfiguredStatement<? extends Statement> statement,
+      final ConnectResponse<?> response) {
+    return response.error().map(err -> new ErrorEntity(statement.getStatementText(), err));
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.DropConnector;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.DropConnectorEntity;
-import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.WarningEntity;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
@@ -28,12 +27,13 @@ import java.util.Optional;
 import org.apache.hc.core5.http.HttpStatus;
 
 public final class DropConnectorExecutor {
+  private final ConnectServerErrors connectErrorHandler;
 
-  private DropConnectorExecutor() {
-
+  DropConnectorExecutor(final ConnectServerErrors connectErrorHandler) {
+    this.connectErrorHandler = connectErrorHandler;
   }
 
-  public static StatementExecutorResponse execute(
+  public StatementExecutorResponse execute(
       final ConfiguredStatement<DropConnector> statement,
       final SessionProperties sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -50,8 +50,8 @@ public final class DropConnectorExecutor {
             new WarningEntity(statement.getStatementText(),
                 "Connector '" + connectorName + "' does not exist.")));
       } else {
-        return StatementExecutorResponse.handled(Optional.of(
-            new ErrorEntity(statement.getStatementText(), response.error().get())));
+        return StatementExecutorResponse.handled(connectErrorHandler.handle(
+            statement, response));
       }
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.rest.server.ServerUtil;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.DistributingExecutor;
 import io.confluent.ksql.rest.server.computation.ValidatedCommandFactory;
+import io.confluent.ksql.rest.server.execution.ConnectServerErrors;
 import io.confluent.ksql.rest.server.execution.CustomExecutors;
 import io.confluent.ksql.rest.server.execution.DefaultCommandQueueSync;
 import io.confluent.ksql.rest.server.execution.RequestHandler;
@@ -111,6 +112,7 @@ public class KsqlResource implements KsqlConfigurable {
   private final Errors errorHandler;
   private KsqlHostInfo localHost;
   private URL localUrl;
+  private final CustomExecutors customExecutors;
 
   public KsqlResource(
       final KsqlEngine ksqlEngine,
@@ -119,6 +121,7 @@ public class KsqlResource implements KsqlConfigurable {
       final ActivenessRegistrar activenessRegistrar,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
+      final ConnectServerErrors connectErrorHandler,
       final DenyListPropertyValidator denyListPropertyValidator
   ) {
     this(
@@ -129,6 +132,7 @@ public class KsqlResource implements KsqlConfigurable {
         Injectors.DEFAULT,
         authorizationValidator,
         errorHandler,
+        connectErrorHandler,
         denyListPropertyValidator,
         commandRunner::getCommandRunnerDegradedWarning
     );
@@ -142,6 +146,7 @@ public class KsqlResource implements KsqlConfigurable {
       final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory,
       final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final Errors errorHandler,
+      final ConnectServerErrors connectErrorHandler,
       final DenyListPropertyValidator denyListPropertyValidator,
       final Supplier<String> commandRunnerWarning
   ) {
@@ -159,6 +164,8 @@ public class KsqlResource implements KsqlConfigurable {
         Objects.requireNonNull(denyListPropertyValidator, "denyListPropertyValidator");
     this.commandRunnerWarning =
         Objects.requireNonNull(commandRunnerWarning, "commandRunnerWarning");
+    this.customExecutors = new CustomExecutors(Objects.requireNonNull(connectErrorHandler,
+        "connectErrorHandler"));
   }
 
   @Override
@@ -187,7 +194,7 @@ public class KsqlResource implements KsqlConfigurable {
     );
 
     this.handler = new RequestHandler(
-        CustomExecutors.EXECUTOR_MAP,
+        customExecutors.EXECUTOR_MAP,
         new DistributingExecutor(
             config,
             commandRunner.getCommandQueue(),
@@ -201,7 +208,7 @@ public class KsqlResource implements KsqlConfigurable {
         ksqlEngine,
         new DefaultCommandQueueSync(
             commandRunner.getCommandQueue(),
-            KsqlResource::shouldSynchronize,
+            this::shouldSynchronize,
             distributedCmdResponseTimeout
         )
     );
@@ -338,10 +345,10 @@ public class KsqlResource implements KsqlConfigurable {
     }
   }
 
-  private static boolean shouldSynchronize(final Class<? extends Statement> statementClass) {
+  private boolean shouldSynchronize(final Class<? extends Statement> statementClass) {
     return !SYNC_BLACKLIST.contains(statementClass)
         // we never need to synchronize distributed statements
-        && CustomExecutors.EXECUTOR_MAP.containsKey(statementClass);
+        && customExecutors.EXECUTOR_MAP.containsKey(statementClass);
   }
 
   private static void ensureValidPatterns(final List<String> deleteTopicList) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.parser.tree.UndefineVariable;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.SessionProperties;
+import io.confluent.ksql.rest.server.execution.DefaultConnectServerErrors;
 import io.confluent.ksql.rest.server.execution.DescribeConnectorExecutor;
 import io.confluent.ksql.rest.server.execution.DescribeFunctionExecutor;
 import io.confluent.ksql.rest.server.execution.ExplainExecutor;
@@ -99,7 +100,8 @@ public enum CustomValidators {
   SHOW_COLUMNS(ShowColumns.class, ListSourceExecutor::columns),
   EXPLAIN(Explain.class, ExplainExecutor::execute),
   DESCRIBE_FUNCTION(DescribeFunction.class, DescribeFunctionExecutor::execute),
-  DESCRIBE_CONNECTOR(DescribeConnector.class, new DescribeConnectorExecutor()::execute),
+  DESCRIBE_CONNECTOR(DescribeConnector.class,
+      new DescribeConnectorExecutor(new DefaultConnectServerErrors())::execute),
   SET_PROPERTY(SetProperty.class, PropertyExecutor::set),
   UNSET_PROPERTY(UnsetProperty.class, PropertyExecutor::unset),
   DEFINE_VARIABLE(DefineVariable.class, VariableExecutor::set),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.SystemColumns;
@@ -183,7 +184,7 @@ public class TemporaryEngine extends ExternalResource {
         .preconditionTopicExists(name, 1, (short) 1, Collections.emptyMap());
   }
 
-  public ConfiguredStatement<?> configure(final String sql) {
+  public ConfiguredStatement<? extends Statement> configure(final String sql) {
     return ConfiguredStatement.of(getEngine().prepare(new DefaultKsqlParser().parse(sql).get(0)),
         SessionConfig.of(ksqlConfig, ImmutableMap.of()));
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -48,6 +48,7 @@ import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.server.execution.DefaultConnectServerErrors;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
@@ -254,6 +255,7 @@ public class RecoveryTest {
           ()->{},
           Optional.of((sc, metastore, statement) -> { }),
           errorHandler,
+          new DefaultConnectServerErrors(),
           denyListPropertyValidator
       );
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CONNECT_SERVER_ERROR_HANDLER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
@@ -87,6 +88,9 @@ public class ConnectExecutorTest {
           CREATE_DUPLICATE_CONNECTOR), SessionConfig.of(CONFIG, ImmutableMap.of())
       );
 
+  private static final ConnectExecutor EXECUTOR =
+      new ConnectExecutor(new DefaultConnectServerErrors());
+
   @Mock
   private ServiceContext serviceContext;
   @Mock
@@ -105,8 +109,10 @@ public class ConnectExecutorTest {
     givenCreationSuccess();
 
     // When:
-    ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext);
+    EXECUTOR.execute(CREATE_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext);
 
     // Then:
     verify(connectClient).create(eq("foo"),
@@ -120,8 +126,10 @@ public class ConnectExecutorTest {
     givenCreationSuccess();
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(CREATE_CONNECTOR_CONFIGURED,
+        mock(SessionProperties.class),
+        null,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -135,9 +143,10 @@ public class ConnectExecutorTest {
     givenCreationError();
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null,
-            serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(CREATE_CONNECTOR_CONFIGURED,
+        mock(SessionProperties.class),
+        null,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -151,9 +160,10 @@ public class ConnectExecutorTest {
     givenCreationSuccess();
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null,
-            serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(CREATE_CONNECTOR_CONFIGURED,
+        mock(SessionProperties.class),
+        null,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -170,9 +180,10 @@ public class ConnectExecutorTest {
     givenConnectorExists();
 
     //When
-    final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_DUPLICATE_CONNECTOR_CONFIGURED,
-            mock(SessionProperties.class), null, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(CREATE_DUPLICATE_CONNECTOR_CONFIGURED,
+        mock(SessionProperties.class),
+        null,
+        serviceContext).getEntity();
     //Then
     assertThat("Expected non-empty response", entity.isPresent());
     assertThat(entity.get(), instanceOf(WarningEntity.class));
@@ -187,8 +198,10 @@ public class ConnectExecutorTest {
             ConnectResponse.failure("Connector foo already exists", HttpStatus.SC_CONFLICT));
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(CREATE_CONNECTOR_CONFIGURED,
+        mock(SessionProperties.class),
+        null,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -207,9 +220,10 @@ public class ConnectExecutorTest {
         createConnectorMissingType), SessionConfig.of(CONFIG, ImmutableMap.of()));
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(createConnectorMissingTypeConfigured, mock(SessionProperties.class),
-            null, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(createConnectorMissingTypeConfigured,
+        mock(SessionProperties.class),
+        null,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -232,15 +246,85 @@ public class ConnectExecutorTest {
 
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(createConnectorEmptyTypeConfigured, mock(SessionProperties.class),
-            null, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(createConnectorEmptyTypeConfigured,
+        mock(SessionProperties.class),
+        null,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
     assertThat(entity.get(), instanceOf(ErrorEntity.class));
     final String expectedError = "Validation error: Connector type cannot be empty";
     assertThat(((ErrorEntity) entity.get()).getErrorMessage(), is(expectedError));
+  }
+
+  @Test
+  public void shouldReturnPluggableForbiddenError() {
+    //Given:
+    givenValidationSuccess();
+    when(connectClient.create(anyString(), anyMap()))
+        .thenReturn(
+            ConnectResponse.failure("FORBIDDEN", HttpStatus.SC_FORBIDDEN));
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+
+    // When:
+    final Optional<KsqlEntity> entity = new ConnectExecutor(connectErrorHandler)
+        .execute(CREATE_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.FORBIDDEN_ERR));
+  }
+
+  @Test
+  public void shouldReturnPluggableUnauthorizedError() {
+    //Given:
+    givenValidationSuccess();
+    when(connectClient.create(anyString(), anyMap()))
+        .thenReturn(
+            ConnectResponse.failure("UNAUTHORIZED", HttpStatus.SC_UNAUTHORIZED));
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+
+    // When:
+    final Optional<KsqlEntity> entity = new ConnectExecutor(connectErrorHandler)
+        .execute(CREATE_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.UNAUTHORIZED_ERR));
+  }
+
+  @Test
+  public void shouldReturnDefaultPluggableErrorOnUnknownCode() {
+    //Given:
+    givenValidationSuccess();
+    when(connectClient.create(anyString(), anyMap()))
+        .thenReturn(
+            ConnectResponse.failure("NOT ACCEPTABLE", HttpStatus.SC_NOT_ACCEPTABLE));
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+
+    // When:
+    final Optional<KsqlEntity> entity = new ConnectExecutor(connectErrorHandler)
+        .execute(CREATE_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.DEFAULT_ERR));
   }
 
   private void givenCreationSuccess() {
@@ -266,7 +350,7 @@ public class ConnectExecutorTest {
   private void givenValidationError() {
     final ConfigInfo configInfo1  = new ConfigInfo(new ConfigKeyInfo("name", "STRING",
         true, null, "HIGH", "docs",
-            "Common", 1, "MEDIUM", "Connector name",
+        "Common", 1, "MEDIUM", "Connector name",
         ImmutableList.of()),
         new ConfigValueInfo("name", null, ImmutableList.of(), ImmutableList.of(
             "Name is missing"), true));
@@ -309,5 +393,13 @@ public class ConnectExecutorTest {
     when(connectClient.connectors())
         .thenReturn(ConnectResponse.success(
             Arrays.asList("foo", "bar"), HttpStatus.SC_OK));
+  }
+
+  private ConnectServerErrors givenCustomConnectErrorHandler() {
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of(
+        KSQL_CONNECT_SERVER_ERROR_HANDLER, DummyConnectServerErrors.class));
+    return config.getConfiguredInstance(
+        KSQL_CONNECT_SERVER_ERROR_HANDLER,
+        ConnectServerErrors.class);
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
@@ -20,12 +20,14 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import io.confluent.ksql.parser.tree.DescribeFunction;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ArgumentInfo;
 import io.confluent.ksql.rest.entity.FunctionDescriptionList;
 import io.confluent.ksql.rest.entity.FunctionInfo;
 import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.server.TemporaryEngine;
+import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Arrays;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -37,14 +39,17 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DescribeFunctionExecutorTest {
 
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors());
+
   @Rule public TemporaryEngine engine = new TemporaryEngine();
 
   @Test
   public void shouldDescribeUDF() {
     // When:
     final FunctionDescriptionList functionList = (FunctionDescriptionList)
-        CustomExecutors.DESCRIBE_FUNCTION.execute(
-        engine.configure(
+        CUSTOM_EXECUTORS.describeFunction().execute(
+            (ConfiguredStatement<DescribeFunction>) engine.configure(
                 "DESCRIBE FUNCTION TEST_UDF_1;"),
             mock(SessionProperties.class),
             engine.getEngine(),
@@ -70,8 +75,8 @@ public class DescribeFunctionExecutorTest {
   public void shouldDescribeUDAF() {
     // When:
     final FunctionDescriptionList functionList = (FunctionDescriptionList)
-        CustomExecutors.DESCRIBE_FUNCTION.execute(
-            engine.configure("DESCRIBE FUNCTION MAX;"),
+        CUSTOM_EXECUTORS.describeFunction().execute(
+            (ConfiguredStatement<DescribeFunction>) engine.configure("DESCRIBE FUNCTION MAX;"),
             mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
@@ -96,8 +101,9 @@ public class DescribeFunctionExecutorTest {
   public void shouldDescribeUDTF() {
     // When:
     final FunctionDescriptionList functionList = (FunctionDescriptionList)
-        CustomExecutors.DESCRIBE_FUNCTION.execute(
-            engine.configure("DESCRIBE FUNCTION TEST_UDTF1;"),
+        CUSTOM_EXECUTORS.describeFunction().execute(
+            (ConfiguredStatement<DescribeFunction>)
+                engine.configure("DESCRIBE FUNCTION TEST_UDTF1;"),
             mock(SessionProperties.class),
             engine.getEngine(),
             engine.getServiceContext()
@@ -119,13 +125,13 @@ public class DescribeFunctionExecutorTest {
 
     assertThat(functionList.getFunctions(), hasSize(2));
 
-    FunctionInfo expected1 = new FunctionInfo(
+    final FunctionInfo expected1 = new FunctionInfo(
         Arrays.asList(new ArgumentInfo("foo", "INT", "", false)),
         "INT", "test_udtf1 int");
 
     assertTrue(functionList.getFunctions().contains(expected1));
 
-    FunctionInfo expected2 = new FunctionInfo(
+    final FunctionInfo expected2 = new FunctionInfo(
         Arrays.asList(new ArgumentInfo("foo", "DOUBLE", "", false)),
         "DOUBLE", "test_udtf1 double");
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutorTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CONNECT_SERVER_ERROR_HANDLER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -64,6 +65,8 @@ public class DropConnectorExecutorTest {
           "DROP CONNECTOR \"foo\"",
           DROP_CONNECTOR_IF_EXISTS), SessionConfig.of(CONFIG, ImmutableMap.of())
       );
+  private static final DropConnectorExecutor EXECUTOR = new DropConnectorExecutor(
+      new DefaultConnectServerErrors());
 
   @Mock
   private ServiceContext serviceContext;
@@ -83,7 +86,10 @@ public class DropConnectorExecutorTest {
         .thenReturn(ConnectResponse.success("foo", HttpStatus.SC_OK));
 
     // When:
-    DropConnectorExecutor.execute(DROP_CONNECTOR_CONFIGURED, mock(SessionProperties.class),null, serviceContext);
+    EXECUTOR.execute(DROP_CONNECTOR_CONFIGURED,
+        mock(SessionProperties.class),
+        null,
+        serviceContext);
 
     // Then:
     verify(connectClient).delete("foo");
@@ -96,8 +102,10 @@ public class DropConnectorExecutorTest {
         .thenReturn(ConnectResponse.success("foo", HttpStatus.SC_OK));
 
     // When:
-    final Optional<KsqlEntity> response = DropConnectorExecutor
-        .execute(DROP_CONNECTOR_CONFIGURED, mock(SessionProperties.class),null, serviceContext).getEntity();
+    final Optional<KsqlEntity> response = EXECUTOR.execute(DROP_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
 
     // Then:
     assertThat("expected response", response.isPresent());
@@ -111,10 +119,15 @@ public class DropConnectorExecutorTest {
         .thenReturn(ConnectResponse.failure("Danger Mouse!", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
-    final Optional<KsqlEntity> entity = DropConnectorExecutor
-        .execute(DROP_CONNECTOR_CONFIGURED, mock(SessionProperties.class), null, serviceContext).getEntity();
-    final Optional<KsqlEntity> entityIfExists = DropConnectorExecutor
-            .execute(DROP_CONNECTOR_IF_EXISTS_CONFIGURED, mock(SessionProperties.class), null, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(DROP_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+    final Optional<KsqlEntity> entityIfExists = EXECUTOR
+            .execute(DROP_CONNECTOR_IF_EXISTS_CONFIGURED,
+                mock(SessionProperties.class),
+                null,
+                serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -130,11 +143,87 @@ public class DropConnectorExecutorTest {
             .thenReturn(ConnectResponse.failure("Danger Mouse!", HttpStatus.SC_NOT_FOUND));
 
     // When:
-    final Optional<KsqlEntity> entity = DropConnectorExecutor
-            .execute(DROP_CONNECTOR_IF_EXISTS_CONFIGURED, mock(SessionProperties.class), null, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(DROP_CONNECTOR_IF_EXISTS_CONFIGURED,
+        mock(SessionProperties.class),
+        null,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
     assertThat(entity.get(), instanceOf(WarningEntity.class));
+  }
+
+  @Test
+  public void shouldReturnPluggableForbiddenError() {
+    //Given:
+    when(connectClient.delete(anyString()))
+        .thenReturn(
+            ConnectResponse.failure("FORBIDDEN", HttpStatus.SC_FORBIDDEN));
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+
+    // When:
+    final Optional<KsqlEntity> entity = new DropConnectorExecutor(connectErrorHandler)
+        .execute(DROP_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.FORBIDDEN_ERR));
+  }
+
+  @Test
+  public void shouldReturnPluggableUnauthorizedError() {
+    //Given:
+    when(connectClient.delete(anyString()))
+        .thenReturn(
+            ConnectResponse.failure("UNAUTHORIZED", HttpStatus.SC_UNAUTHORIZED));
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+
+    // When:
+    final Optional<KsqlEntity> entity = new DropConnectorExecutor(connectErrorHandler)
+        .execute(DROP_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.UNAUTHORIZED_ERR));
+  }
+
+  @Test
+  public void shouldReturnDefaultPluggableErrorOnUnknownCode() {
+    //Given:
+    when(connectClient.delete(anyString()))
+        .thenReturn(
+            ConnectResponse.failure("NOT ACCEPTABLE", HttpStatus.SC_NOT_ACCEPTABLE));
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+
+    // When:
+    final Optional<KsqlEntity> entity = new DropConnectorExecutor(connectErrorHandler)
+        .execute(DROP_CONNECTOR_CONFIGURED,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.DEFAULT_ERR));
+  }
+
+  private ConnectServerErrors givenCustomConnectErrorHandler() {
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of(
+        KSQL_CONNECT_SERVER_ERROR_HANDLER, DummyConnectServerErrors.class));
+    return config.getConfiguredInstance(
+        KSQL_CONNECT_SERVER_ERROR_HANDLER,
+        ConnectServerErrors.class);
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DummyConnectServerErrors.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DummyConnectServerErrors.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.entity.ErrorEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Optional;
+
+public class DummyConnectServerErrors implements ConnectServerErrors {
+
+  static final String FORBIDDEN_ERR = "FORBIDDEN";
+  static final String UNAUTHORIZED_ERR = "UNAUTHORIZED";
+  static final String DEFAULT_ERR = "DEFAULT";
+
+  @Override
+  public Optional<KsqlEntity> handleForbidden(
+      final ConfiguredStatement<? extends Statement> statement,
+      final ConnectResponse<?> response) {
+    return Optional.of(new ErrorEntity(statement.getStatementText(), FORBIDDEN_ERR));
+  }
+
+  @Override
+  public Optional<KsqlEntity> handleUnauthorized(
+      final ConfiguredStatement<? extends Statement> statement,
+      final ConnectResponse<?> response) {
+    return Optional.of(new ErrorEntity(statement.getStatementText(), UNAUTHORIZED_ERR));
+  }
+
+  @Override
+  public Optional<KsqlEntity> handleDefault(
+      final ConfiguredStatement<? extends Statement> statement,
+      final ConnectResponse<?> response) {
+    return Optional.of(new ErrorEntity(statement.getStatementText(), DEFAULT_ERR));
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorPluginsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorPluginsTest.java
@@ -23,9 +23,11 @@ import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.tree.ListConnectorPlugins;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ConnectorPluginsList;
+import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.SimpleConnectorPluginInfo;
 import io.confluent.ksql.services.ConnectClient;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
@@ -41,8 +43,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Arrays;
 import java.util.Optional;
 
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CONNECT_SERVER_ERROR_HANDLER;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,6 +60,9 @@ public class ListConnectorPluginsTest {
         ConnectorType.SOURCE,
         "2.1"
     );
+
+    private static final ListConnectorPluginsExecutor EXECUTOR =
+        new ListConnectorPluginsExecutor(new DefaultConnectServerErrors());
 
     @Mock
     private KsqlExecutionContext engine;
@@ -81,8 +90,10 @@ public class ListConnectorPluginsTest {
                 SessionConfig.of(ksqlConfig, ImmutableMap.of()));
 
         // When:
-        final Optional<KsqlEntity> entity = ListConnectorPluginsExecutor
-            .execute(statement, mock(SessionProperties.class), engine, serviceContext).getEntity();
+        final Optional<KsqlEntity> entity = EXECUTOR.execute(statement,
+            mock(SessionProperties.class),
+            engine,
+            serviceContext).getEntity();
 
         // Then:
         assertThat("expected response!", entity.isPresent());
@@ -98,5 +109,91 @@ public class ListConnectorPluginsTest {
                     "2.1")
             )
         )));
+    }
+
+    @Test
+    public void shouldReturnPluggableForbiddenError() {
+        //Given:
+        when(connectClient.connectorPlugins())
+            .thenReturn(
+                ConnectResponse.failure("FORBIDDEN", HttpStatus.SC_FORBIDDEN));
+
+        final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+        final ConfiguredStatement<ListConnectorPlugins> statement = ConfiguredStatement
+            .of(KsqlParser.PreparedStatement.of("", new ListConnectorPlugins(Optional.empty())),
+                SessionConfig.of(new KsqlConfig(ImmutableMap.of()), ImmutableMap.of()));
+
+        // When:
+        final Optional<KsqlEntity> entity = new ListConnectorPluginsExecutor(connectErrorHandler)
+            .execute(statement,
+                mock(SessionProperties.class),
+                null,
+                serviceContext).getEntity();
+
+        // Then:
+        assertThat("Expected non-empty response", entity.isPresent());
+        assertThat(entity.get(), instanceOf(ErrorEntity.class));
+        assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+            is(DummyConnectServerErrors.FORBIDDEN_ERR));
+    }
+
+    @Test
+    public void shouldReturnPluggableUnauthorizedError() {
+        //Given:
+        when(connectClient.connectorPlugins())
+            .thenReturn(
+                ConnectResponse.failure("UNAUTHORIZED", HttpStatus.SC_UNAUTHORIZED));
+
+        final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+        final ConfiguredStatement<ListConnectorPlugins> statement = ConfiguredStatement
+            .of(KsqlParser.PreparedStatement.of("", new ListConnectorPlugins(Optional.empty())),
+                SessionConfig.of(new KsqlConfig(ImmutableMap.of()), ImmutableMap.of()));
+
+        // When:
+        final Optional<KsqlEntity> entity = new ListConnectorPluginsExecutor(connectErrorHandler)
+            .execute(statement,
+                mock(SessionProperties.class),
+                null,
+                serviceContext).getEntity();
+
+        // Then:
+        assertThat("Expected non-empty response", entity.isPresent());
+        assertThat(entity.get(), instanceOf(ErrorEntity.class));
+        assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+            is(DummyConnectServerErrors.UNAUTHORIZED_ERR));
+    }
+
+    @Test
+    public void shouldReturnDefaultPluggableErrorOnUnknownCode() {
+        //Given:
+        when(connectClient.connectorPlugins())
+            .thenReturn(
+                ConnectResponse.failure("NOT ACCEPTABLE", HttpStatus.SC_NOT_ACCEPTABLE));
+
+        final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+        final ConfiguredStatement<ListConnectorPlugins> statement = ConfiguredStatement
+            .of(KsqlParser.PreparedStatement.of("", new ListConnectorPlugins(Optional.empty())),
+                SessionConfig.of(new KsqlConfig(ImmutableMap.of()), ImmutableMap.of()));
+
+        // When:
+        final Optional<KsqlEntity> entity = new ListConnectorPluginsExecutor(connectErrorHandler)
+            .execute(statement,
+                mock(SessionProperties.class),
+                null,
+                serviceContext).getEntity();
+
+        // Then:
+        assertThat("Expected non-empty response", entity.isPresent());
+        assertThat(entity.get(), instanceOf(ErrorEntity.class));
+        assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+            is(DummyConnectServerErrors.DEFAULT_ERR));
+    }
+
+    private ConnectServerErrors givenCustomConnectErrorHandler() {
+        final KsqlConfig config = new KsqlConfig(ImmutableMap.of(
+            KSQL_CONNECT_SERVER_ERROR_HANDLER, DummyConnectServerErrors.class));
+        return config.getConfiguredInstance(
+            KSQL_CONNECT_SERVER_ERROR_HANDLER,
+            ConnectServerErrors.class);
     }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
@@ -15,7 +15,9 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import static io.confluent.ksql.util.KsqlConfig.KSQL_CONNECT_SERVER_ERROR_HANDLER;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -29,6 +31,7 @@ import io.confluent.ksql.parser.tree.ListConnectors;
 import io.confluent.ksql.parser.tree.ListConnectors.Scope;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.ConnectorList;
+import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.SimpleConnectorInfo;
@@ -84,6 +87,9 @@ public class ListConnectorsExecutorTest {
       ConnectorType.SOURCE
   );
 
+  private static final ListConnectorsExecutor EXECUTOR = new ListConnectorsExecutor(
+      new DefaultConnectServerErrors());
+
   @Mock
   private KsqlExecutionContext engine;
   @Mock
@@ -113,8 +119,10 @@ public class ListConnectorsExecutorTest {
             SessionConfig.of(ksqlConfig, ImmutableMap.of()));
 
     // When:
-    final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, mock(SessionProperties.class), engine, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(statement,
+        mock(SessionProperties.class),
+        engine,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -142,8 +150,10 @@ public class ListConnectorsExecutorTest {
             SessionConfig.of(ksqlConfig, ImmutableMap.of()));
 
     // When:
-    final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, mock(SessionProperties.class), engine, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(statement,
+        mock(SessionProperties.class),
+        engine,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -170,8 +180,10 @@ public class ListConnectorsExecutorTest {
         );
 
     // When:
-    final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, mock(SessionProperties.class), engine, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(statement,
+        mock(SessionProperties.class),
+        engine,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -195,8 +207,10 @@ public class ListConnectorsExecutorTest {
         );
 
     // When:
-    final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, mock(SessionProperties.class), engine, serviceContext).getEntity();
+    final Optional<KsqlEntity> entity = EXECUTOR.execute(statement,
+        mock(SessionProperties.class),
+        engine,
+        serviceContext).getEntity();
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -210,6 +224,92 @@ public class ListConnectorsExecutorTest {
             new SimpleConnectorInfo("connector2", ConnectorType.UNKNOWN, null, null)
         )
     )));
+  }
+
+  @Test
+  public void shouldReturnPluggableForbiddenError() {
+    //Given:
+    when(connectClient.connectors())
+        .thenReturn(
+            ConnectResponse.failure("FORBIDDEN", HttpStatus.SC_FORBIDDEN));
+
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+    final ConfiguredStatement<ListConnectors> statement = ConfiguredStatement
+        .of(PreparedStatement.of("", new ListConnectors(Optional.empty(), Scope.ALL)),
+            SessionConfig.of(new KsqlConfig(ImmutableMap.of()), ImmutableMap.of()));
+
+    // When:
+    final Optional<KsqlEntity> entity = new ListConnectorsExecutor(connectErrorHandler)
+        .execute(statement,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.FORBIDDEN_ERR));
+  }
+
+  @Test
+  public void shouldReturnPluggableUnauthorizedError() {
+    //Given:
+    when(connectClient.connectors())
+        .thenReturn(
+            ConnectResponse.failure("UNAUTHORIZED", HttpStatus.SC_UNAUTHORIZED));
+
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+    final ConfiguredStatement<ListConnectors> statement = ConfiguredStatement
+        .of(PreparedStatement.of("", new ListConnectors(Optional.empty(), Scope.ALL)),
+            SessionConfig.of(new KsqlConfig(ImmutableMap.of()), ImmutableMap.of()));
+
+    // When:
+    final Optional<KsqlEntity> entity = new ListConnectorsExecutor(connectErrorHandler)
+        .execute(statement,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.UNAUTHORIZED_ERR));
+  }
+
+  @Test
+  public void shouldReturnDefaultPluggableErrorOnUnknownCode() {
+    //Given:
+    when(connectClient.connectors())
+        .thenReturn(
+            ConnectResponse.failure("NOT ACCEPTABLE", HttpStatus.SC_NOT_ACCEPTABLE));
+
+    final ConnectServerErrors connectErrorHandler = givenCustomConnectErrorHandler();
+    final ConfiguredStatement<ListConnectors> statement = ConfiguredStatement
+        .of(PreparedStatement.of("", new ListConnectors(Optional.empty(), Scope.ALL)),
+            SessionConfig.of(new KsqlConfig(ImmutableMap.of()), ImmutableMap.of()));
+
+    // When:
+    final Optional<KsqlEntity> entity = new ListConnectorsExecutor(connectErrorHandler)
+        .execute(statement,
+            mock(SessionProperties.class),
+            null,
+            serviceContext).getEntity();
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(((ErrorEntity) entity.get()).getErrorMessage(),
+        is(DummyConnectServerErrors.DEFAULT_ERR));
+  }
+
+  private ConnectServerErrors givenCustomConnectErrorHandler() {
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of(
+        KSQL_CONNECT_SERVER_ERROR_HANDLER, DummyConnectServerErrors.class));
+    return config.getConfiguredInstance(
+        KSQL_CONNECT_SERVER_ERROR_HANDLER,
+        ConnectServerErrors.class);
   }
 
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
@@ -20,11 +20,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.parser.tree.ListFunctions;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.FunctionNameList;
 import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.entity.SimpleFunctionInfo;
 import io.confluent.ksql.rest.server.TemporaryEngine;
+import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Collection;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,14 +36,17 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ListFunctionsExecutorTest {
 
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors());
+
   @Rule public final TemporaryEngine engine = new TemporaryEngine();
 
   @Test
   public void shouldListFunctions() {
 
     // When:
-    final FunctionNameList functionList = (FunctionNameList) CustomExecutors.LIST_FUNCTIONS.execute(
-        engine.configure("LIST FUNCTIONS;"),
+    final FunctionNameList functionList = (FunctionNameList) CUSTOM_EXECUTORS.listFunctions().execute(
+        (ConfiguredStatement<ListFunctions>) engine.configure("LIST FUNCTIONS;"),
         mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -26,10 +26,12 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.parser.tree.ListProperties;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.rest.server.TemporaryEngine;
+import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import java.io.File;
@@ -39,10 +41,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,6 +52,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ListPropertiesExecutorTest {
+
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors()
+  );
 
   @Rule
   public final TemporaryEngine engine = new TemporaryEngine();
@@ -70,8 +73,8 @@ public class ListPropertiesExecutorTest {
   @Test
   public void shouldContainAllowField() {
     // When:
-    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
-        engine.configure("LIST PROPERTIES;"),
+    final PropertiesList properties = (PropertiesList) CUSTOM_EXECUTORS.listProperties().execute(
+        (ConfiguredStatement<ListProperties>) engine.configure("LIST PROPERTIES;"),
         mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
@@ -85,8 +88,8 @@ public class ListPropertiesExecutorTest {
   @Test
   public void shouldContainLevelField() {
     // When:
-    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
-        engine.configure("LIST PROPERTIES;"),
+    final PropertiesList properties = (PropertiesList) CUSTOM_EXECUTORS.listProperties().execute(
+        (ConfiguredStatement<ListProperties>) engine.configure("LIST PROPERTIES;"),
         mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
@@ -100,8 +103,8 @@ public class ListPropertiesExecutorTest {
   @Test
   public void shouldListProperties() {
     // When:
-    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
-        engine.configure("LIST PROPERTIES;"),
+    final PropertiesList properties = (PropertiesList) CUSTOM_EXECUTORS.listProperties().execute(
+        (ConfiguredStatement<ListProperties>) engine.configure("LIST PROPERTIES;"),
         mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
@@ -117,8 +120,8 @@ public class ListPropertiesExecutorTest {
   @Test
   public void shouldListPropertiesWithOverrides() {
     // When:
-    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
-        engine.configure("LIST PROPERTIES;")
+    final PropertiesList properties = (PropertiesList) CUSTOM_EXECUTORS.listProperties().execute(
+        (ConfiguredStatement<ListProperties>) engine.configure("LIST PROPERTIES;")
             .withConfigOverrides(ImmutableMap.of("ksql.streams.auto.offset.reset", "latest")),
         mock(SessionProperties.class),
         engine.getEngine(),
@@ -135,8 +138,8 @@ public class ListPropertiesExecutorTest {
   @Test
   public void shouldNotListSslProperties() {
     // When:
-    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
-        engine.configure("LIST PROPERTIES;"),
+    final PropertiesList properties = (PropertiesList) CUSTOM_EXECUTORS.listProperties().execute(
+        (ConfiguredStatement<ListProperties>) engine.configure("LIST PROPERTIES;"),
         mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
@@ -151,8 +154,8 @@ public class ListPropertiesExecutorTest {
   @Test
   public void shouldListUnresolvedStreamsTopicProperties() {
     // When:
-    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
-        engine.configure("LIST PROPERTIES;")
+    final PropertiesList properties = (PropertiesList) CUSTOM_EXECUTORS.listProperties().execute(
+        (ConfiguredStatement<ListProperties>) engine.configure("LIST PROPERTIES;")
             .withConfig(new KsqlConfig(ImmutableMap.of(
                 "ksql.streams.topic.min.insync.replicas", "2"))),
         mock(SessionProperties.class),
@@ -181,8 +184,8 @@ public class ListPropertiesExecutorTest {
     );
 
     // When:
-    final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
-        engine.configure("LIST PROPERTIES;")
+    final PropertiesList properties = (PropertiesList) CUSTOM_EXECUTORS.listProperties().execute(
+        (ConfiguredStatement<ListProperties>) engine.configure("LIST PROPERTIES;")
             .withConfig(new KsqlConfig(ImmutableMap.of(
                 "ksql.connect.worker.config", connectPropsFile))),
         mock(SessionProperties.class),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.ListQueries;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.client.KsqlRestClientException;
@@ -78,6 +79,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ListQueriesExecutorTest {
 
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors());
   private static final HostInfo REMOTE_HOST = new HostInfo("otherhost", 1234);
   private static final HostInfo LOCAL_HOST = new HostInfo("HOST", 444);
   private static final KsqlHostInfoEntity LOCAL_KSQL_HOST_INFO_ENTITY =
@@ -127,8 +130,8 @@ public class ListQueriesExecutorTest {
   @Test
   public void shouldListQueriesEmpty() {
     // When
-    final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
-        engine.configure("SHOW QUERIES;"),
+    final Queries queries = (Queries) CUSTOM_EXECUTORS.listQueries().execute(
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES;"),
         mock(SessionProperties.class),
         engine.getEngine(),
         engine.getServiceContext()
@@ -140,7 +143,8 @@ public class ListQueriesExecutorTest {
   @Test
   public void shouldListQueriesBasic() {
     // Given
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
 
     final KsqlEngine engine = mock(KsqlEngine.class);
@@ -148,7 +152,7 @@ public class ListQueriesExecutorTest {
     queryStatusCount.updateStatusCount(RUNNING_QUERY_STATE, 1);
 
     // When
-    final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
+    final Queries queries = (Queries) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -162,7 +166,8 @@ public class ListQueriesExecutorTest {
   public void shouldScatterGatherAndMergeShowQueries() {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES;");
     final PersistentQueryMetadata localMetadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
     final PersistentQueryMetadata remoteMetadata = givenPersistentQuery("id", ERROR_QUERY_STATE);
 
@@ -183,7 +188,7 @@ public class ListQueriesExecutorTest {
     queryStatusCount.updateStatusCount(ERROR_QUERY_STATE, 1);
 
     // When
-    final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
+    final Queries queries = (Queries) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -198,7 +203,8 @@ public class ListQueriesExecutorTest {
   public void shouldNotMergeDifferentRunningQueries() {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES;");
     final PersistentQueryMetadata localMetadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
     final PersistentQueryMetadata remoteMetadata = givenPersistentQuery("different Id", RUNNING_QUERY_STATE);
 
@@ -216,7 +222,7 @@ public class ListQueriesExecutorTest {
     queryStatusCount.updateStatusCount(RUNNING_QUERY_STATE, 1);
 
     // When
-    final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
+    final Queries queries = (Queries) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -234,7 +240,8 @@ public class ListQueriesExecutorTest {
   public void shouldIncludeUnresponsiveIfShowQueriesFutureThrowsException() {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
 
     final KsqlEngine engine = mock(KsqlEngine.class);
@@ -247,7 +254,7 @@ public class ListQueriesExecutorTest {
     queryStatusCount.updateStatusCount(KsqlQueryStatus.UNRESPONSIVE, 1);
 
     // When
-    final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
+    final Queries queries = (Queries) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -262,7 +269,8 @@ public class ListQueriesExecutorTest {
   public void shouldIncludeUnresponsiveIfShowQueriesErrorResponse() {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
 
     final KsqlEngine engine = mock(KsqlEngine.class);
@@ -275,7 +283,7 @@ public class ListQueriesExecutorTest {
     queryStatusCount.updateStatusCount(KsqlQueryStatus.UNRESPONSIVE, 1);
 
     // When
-    final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
+    final Queries queries = (Queries) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -289,14 +297,15 @@ public class ListQueriesExecutorTest {
   @Test
   public void shouldListQueriesExtended() {
     // Given
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES EXTENDED;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES EXTENDED;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id", KafkaStreams.State.CREATED);
 
     final KsqlEngine engine = mock(KsqlEngine.class);
     when(engine.getAllLiveQueries()).thenReturn(ImmutableList.of(metadata));
 
     // When
-    final QueryDescriptionList queries = (QueryDescriptionList) CustomExecutors.LIST_QUERIES.execute(
+    final QueryDescriptionList queries = (QueryDescriptionList) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -312,7 +321,8 @@ public class ListQueriesExecutorTest {
   public void shouldScatterGatherAndMergeShowQueriesExtended() {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES EXTENDED;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES EXTENDED;");
     
     final StreamsTaskMetadata localTaskMetadata = mock(StreamsTaskMetadata.class);
     final StreamsTaskMetadata remoteTaskMetadata = mock(StreamsTaskMetadata.class);
@@ -337,7 +347,7 @@ public class ListQueriesExecutorTest {
     mergedMap.put(LOCAL_KSQL_HOST_INFO_ENTITY, KsqlQueryStatus.RUNNING);
 
     // When
-    final QueryDescriptionList queries = (QueryDescriptionList) CustomExecutors.LIST_QUERIES.execute(
+    final QueryDescriptionList queries = (QueryDescriptionList) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -355,7 +365,8 @@ public class ListQueriesExecutorTest {
   public void shouldNotMergeDifferentQueryDescriptions() {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES EXTENDED;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES EXTENDED;");
     final PersistentQueryMetadata localMetadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
     final PersistentQueryMetadata remoteMetadata = givenPersistentQuery("different id", ERROR_QUERY_STATE);
 
@@ -374,7 +385,7 @@ public class ListQueriesExecutorTest {
     when(response.getResponse()).thenReturn(ksqlEntityList);
 
     // When
-    final QueryDescriptionList queries = (QueryDescriptionList) CustomExecutors.LIST_QUERIES.execute(
+    final QueryDescriptionList queries = (QueryDescriptionList) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -392,7 +403,8 @@ public class ListQueriesExecutorTest {
   public void shouldIncludeUnresponsiveIfShowQueriesExtendedFutureThrowsException() {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES EXTENDED;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES EXTENDED;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
 
     final KsqlEngine engine = mock(KsqlEngine.class);
@@ -408,7 +420,7 @@ public class ListQueriesExecutorTest {
     map.put(REMOTE_KSQL_HOST_INFO_ENTITY, KsqlQueryStatus.UNRESPONSIVE);
 
     // When
-    final QueryDescriptionList queries = (QueryDescriptionList) CustomExecutors.LIST_QUERIES.execute(
+    final QueryDescriptionList queries = (QueryDescriptionList) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,
@@ -424,7 +436,8 @@ public class ListQueriesExecutorTest {
   public void shouldIncludeUnresponsiveIfShowQueriesExtendedErrorResponse() {
     // Given
     when(sessionProperties.getInternalRequest()).thenReturn(false);
-    final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES EXTENDED;");
+    final ConfiguredStatement<ListQueries> showQueries =
+        (ConfiguredStatement<ListQueries>) engine.configure("SHOW QUERIES EXTENDED;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id", RUNNING_QUERY_STATE);
 
     final KsqlEngine engine = mock(KsqlEngine.class);
@@ -439,7 +452,7 @@ public class ListQueriesExecutorTest {
     map.put(REMOTE_KSQL_HOST_INFO_ENTITY, KsqlQueryStatus.UNRESPONSIVE);
 
     // When
-    final QueryDescriptionList queries = (QueryDescriptionList) CustomExecutors.LIST_QUERIES.execute(
+    final QueryDescriptionList queries = (QueryDescriptionList) CUSTOM_EXECUTORS.listQueries().execute(
         showQueries,
         sessionProperties,
         engine,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -39,6 +39,10 @@ import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.DescribeStreams;
+import io.confluent.ksql.parser.tree.DescribeTables;
+import io.confluent.ksql.parser.tree.ListStreams;
+import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -79,6 +83,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ListSourceExecutorTest {
 
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors());
+
   EasyRandom objectMother = new EasyRandom();
 
   @Rule
@@ -109,8 +116,8 @@ public class ListSourceExecutorTest {
 
     // When:
     final StreamsList descriptionList = (StreamsList)
-        CustomExecutors.LIST_STREAMS.execute(
-            engine.configure("SHOW STREAMS;"),
+        CUSTOM_EXECUTORS.listStreams().execute(
+            (ConfiguredStatement<ListStreams>) engine.configure("SHOW STREAMS;"),
             SESSION_PROPERTIES,
             engine.getEngine(),
             engine.getServiceContext()
@@ -145,8 +152,8 @@ public class ListSourceExecutorTest {
 
     // When:
     final SourceDescriptionList descriptionList = (SourceDescriptionList)
-        CustomExecutors.LIST_STREAMS.execute(
-            engine.configure("SHOW STREAMS EXTENDED;"),
+        CUSTOM_EXECUTORS.listStreams().execute(
+            (ConfiguredStatement<ListStreams>) engine.configure("SHOW STREAMS EXTENDED;"),
             SESSION_PROPERTIES,
             engine.getEngine(),
             engine.getServiceContext()
@@ -187,8 +194,8 @@ public class ListSourceExecutorTest {
 
     // When:
     final SourceDescriptionList descriptionList = (SourceDescriptionList)
-        CustomExecutors.DESCRIBE_STREAMS.execute(
-            engine.configure("DESCRIBE STREAMS;"),
+        CUSTOM_EXECUTORS.describeStreams().execute(
+            (ConfiguredStatement<DescribeStreams>) engine.configure("DESCRIBE STREAMS;"),
             SESSION_PROPERTIES,
             engine.getEngine(),
             engine.getServiceContext()
@@ -228,8 +235,8 @@ public class ListSourceExecutorTest {
 
     // When:
     final TablesList descriptionList = (TablesList)
-        CustomExecutors.LIST_TABLES.execute(
-            engine.configure("LIST TABLES;"),
+        CUSTOM_EXECUTORS.listTables().execute(
+            (ConfiguredStatement<ListTables>) engine.configure("LIST TABLES;"),
             SESSION_PROPERTIES,
             engine.getEngine(),
             engine.getServiceContext()
@@ -264,8 +271,8 @@ public class ListSourceExecutorTest {
 
     // When:
     final SourceDescriptionList descriptionList = (SourceDescriptionList)
-        CustomExecutors.LIST_TABLES.execute(
-            engine.configure("LIST TABLES EXTENDED;"),
+        CUSTOM_EXECUTORS.listTables().execute(
+            (ConfiguredStatement<ListTables>) engine.configure("LIST TABLES EXTENDED;"),
             SESSION_PROPERTIES,
             engine.getEngine(),
             engine.getServiceContext()
@@ -307,8 +314,8 @@ public class ListSourceExecutorTest {
 
     // When:
     final SourceDescriptionList descriptionList = (SourceDescriptionList)
-        CustomExecutors.DESCRIBE_TABLES.execute(
-            engine.configure("DESCRIBE TABLES;"),
+        CUSTOM_EXECUTORS.describeTables().execute(
+            (ConfiguredStatement<DescribeTables>) engine.configure("DESCRIBE TABLES;"),
             SESSION_PROPERTIES,
             engine.getEngine(),
             engine.getServiceContext()
@@ -353,7 +360,7 @@ public class ListSourceExecutorTest {
 
     // When:
     final SourceDescriptionEntity sourceDescription = (SourceDescriptionEntity)
-        CustomExecutors.SHOW_COLUMNS.execute(
+        CUSTOM_EXECUTORS.showColumns().execute(
             ConfiguredStatement.of(PreparedStatement.of(
                 "DESCRIBE SINK;",
                 new ShowColumns(SourceName.of("SINK"), false)),
@@ -396,8 +403,8 @@ public class ListSourceExecutorTest {
     // When:
     final Exception e = assertThrows(
         KsqlStatementException.class,
-        () -> CustomExecutors.SHOW_COLUMNS.execute(
-            engine.configure("DESCRIBE S;"),
+        () -> CUSTOM_EXECUTORS.showColumns().execute(
+            (ConfiguredStatement<ShowColumns>) engine.configure("DESCRIBE S;"),
             SESSION_PROPERTIES,
             engine.getEngine(),
             engine.getServiceContext()
@@ -423,8 +430,8 @@ public class ListSourceExecutorTest {
     );
 
     // When:
-    CustomExecutors.LIST_STREAMS.execute(
-        engine.configure("SHOW STREAMS;"),
+    CUSTOM_EXECUTORS.listStreams().execute(
+        (ConfiguredStatement<ListStreams>) engine.configure("SHOW STREAMS;"),
         SESSION_PROPERTIES,
         engine.getEngine(),
         serviceContext
@@ -482,8 +489,8 @@ public class ListSourceExecutorTest {
     serviceContext.getTopicClient().deleteTopics(ImmutableList.of("stream1", "stream2"));
 
     // When:
-    final KsqlEntity entity = CustomExecutors.LIST_STREAMS.execute(
-        engine.configure("SHOW STREAMS EXTENDED;"),
+    final KsqlEntity entity = CUSTOM_EXECUTORS.listStreams().execute(
+        (ConfiguredStatement<ListStreams>) engine.configure("SHOW STREAMS EXTENDED;"),
         SESSION_PROPERTIES,
         engine.getEngine(),
         serviceContext
@@ -502,8 +509,8 @@ public class ListSourceExecutorTest {
     serviceContext.getTopicClient().deleteTopics(ImmutableList.of("table1", "table2"));
 
     // When:
-    final KsqlEntity entity = CustomExecutors.LIST_TABLES.execute(
-        engine.configure("SHOW TABLES EXTENDED;"),
+    final KsqlEntity entity = CUSTOM_EXECUTORS.listTables().execute(
+        (ConfiguredStatement<ListTables>) engine.configure("SHOW TABLES EXTENDED;"),
         SESSION_PROPERTIES,
         engine.getEngine(),
         serviceContext
@@ -521,8 +528,8 @@ public class ListSourceExecutorTest {
     serviceContext.getTopicClient().deleteTopics(ImmutableList.of("STREAM1"));
 
     // When:
-    final KsqlEntity entity = CustomExecutors.SHOW_COLUMNS.execute(
-        engine.configure("DESCRIBE STREAM1 EXTENDED;"),
+    final KsqlEntity entity = CUSTOM_EXECUTORS.showColumns().execute(
+        (ConfiguredStatement<ShowColumns>) engine.configure("DESCRIBE STREAM1 EXTENDED;"),
         SESSION_PROPERTIES,
         engine.getEngine(),
         serviceContext

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.parser.tree.ListTopics;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KafkaTopicInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicInfoExtended;
@@ -29,6 +30,7 @@ import io.confluent.ksql.rest.entity.KafkaTopicsListExtended;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Collection;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
@@ -43,6 +45,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ListTopicsExecutorTest {
+
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors());
 
   @Rule public final TemporaryEngine engine = new TemporaryEngine();
   @Mock
@@ -70,8 +75,8 @@ public class ListTopicsExecutorTest {
 
     // When:
     final KafkaTopicsList topicsList =
-        (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
-            engine.configure("LIST TOPICS;"),
+        (KafkaTopicsList) CUSTOM_EXECUTORS.listTopics().execute(
+            (ConfiguredStatement<ListTopics>) engine.configure("LIST TOPICS;"),
             mock(SessionProperties.class),
             engine.getEngine(),
             serviceContext
@@ -93,8 +98,8 @@ public class ListTopicsExecutorTest {
 
     // When:
     final KafkaTopicsList topicsList =
-        (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
-            engine.configure("LIST ALL TOPICS;"),
+        (KafkaTopicsList) CUSTOM_EXECUTORS.listTopics().execute(
+            (ConfiguredStatement<ListTopics>) engine.configure("LIST ALL TOPICS;"),
             mock(SessionProperties.class),
             engine.getEngine(),
             serviceContext
@@ -116,8 +121,8 @@ public class ListTopicsExecutorTest {
 
     // When:
     final KafkaTopicsList topicsList =
-        (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
-            engine.configure("LIST TOPICS;"),
+        (KafkaTopicsList) CUSTOM_EXECUTORS.listTopics().execute(
+            (ConfiguredStatement<ListTopics>) engine.configure("LIST TOPICS;"),
             mock(SessionProperties.class),
             engine.getEngine(),
             serviceContext
@@ -145,8 +150,8 @@ public class ListTopicsExecutorTest {
 
     // When:
     final KafkaTopicsListExtended topicsList =
-        (KafkaTopicsListExtended) CustomExecutors.LIST_TOPICS.execute(
-            engine.configure("LIST TOPICS EXTENDED;"),
+        (KafkaTopicsListExtended) CUSTOM_EXECUTORS.listTopics().execute(
+            (ConfiguredStatement<ListTopics>) engine.configure("LIST TOPICS EXTENDED;"),
             mock(SessionProperties.class),
             engine.getEngine(),
             serviceContext

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListVariablesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListVariablesExecutorTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.parser.tree.ListVariables;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.VariablesList;
@@ -37,6 +38,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ListVariablesExecutorTest {
   private SessionProperties sessionProperties;
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors());
 
   @Before
   public void setup() {
@@ -45,10 +48,10 @@ public class ListVariablesExecutorTest {
   }
 
   private Optional<KsqlEntity> executeListVariables(final String sql) {
-    final ConfiguredStatement<?> configuredStatement = mock(ConfiguredStatement.class);
+    final ConfiguredStatement<ListVariables> configuredStatement = mock(ConfiguredStatement.class);
     when(configuredStatement.getStatementText()).thenReturn(sql);
 
-    return CustomExecutors.LIST_VARIABLES.execute(
+    return CUSTOM_EXECUTORS.listVariables().execute(
         configuredStatement,
         sessionProperties,
         null,

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
@@ -22,8 +22,11 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 
+import io.confluent.ksql.parser.tree.SetProperty;
+import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.server.TemporaryEngine;
+import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlHostInfo;
 import java.net.URL;
 import java.util.Collections;
@@ -38,6 +41,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PropertyExecutorTest {
 
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors());
+
   @Rule public final TemporaryEngine engine = new TemporaryEngine();
 
   @Test
@@ -48,8 +54,9 @@ public class PropertyExecutorTest {
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
-    CustomExecutors.SET_PROPERTY.execute(
-        engine.configure("SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'none';"),
+    CUSTOM_EXECUTORS.setProperty().execute(
+        (ConfiguredStatement<SetProperty>) engine.configure(
+            "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'none';"),
         sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()
@@ -72,8 +79,9 @@ public class PropertyExecutorTest {
     final Map<String, Object> properties = sessionProperties.getMutableScopedProperties();
 
     // When:
-    CustomExecutors.UNSET_PROPERTY.execute(
-        engine.configure("UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';"),
+    CUSTOM_EXECUTORS.unsetProperty().execute(
+        (ConfiguredStatement<UnsetProperty>) engine.configure(
+            "UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';"),
         sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/VariableExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/VariableExecutorTest.java
@@ -23,10 +23,13 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import io.confluent.ksql.parser.exception.ParseFailedException;
+import io.confluent.ksql.parser.tree.DefineVariable;
+import io.confluent.ksql.parser.tree.UndefineVariable;
 import io.confluent.ksql.rest.SessionProperties;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.WarningEntity;
 import io.confluent.ksql.rest.server.TemporaryEngine;
+import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlHostInfo;
 import java.net.URL;
 import java.util.Arrays;
@@ -42,6 +45,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VariableExecutorTest {
+  private static final CustomExecutors CUSTOM_EXECUTORS = new CustomExecutors(
+      new DefaultConnectServerErrors());
+
   @Rule
   public final TemporaryEngine engine = new TemporaryEngine();
 
@@ -54,8 +60,8 @@ public class VariableExecutorTest {
   }
 
   private void executeDefineVariable(final String sql) {
-    final Optional<KsqlEntity> response = CustomExecutors.DEFINE_VARIABLE.execute(
-        engine.configure(sql),
+    final Optional<KsqlEntity> response = CUSTOM_EXECUTORS.defineVariable().execute(
+        (ConfiguredStatement<DefineVariable>) engine.configure(sql),
         sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()
@@ -64,8 +70,8 @@ public class VariableExecutorTest {
   }
 
   private Optional<KsqlEntity> executeUndefineVariable(final String sql) {
-    return CustomExecutors.UNDEFINE_VARIABLE.execute(
-        engine.configure(sql),
+    return CUSTOM_EXECUTORS.undefineVariable().execute(
+        (ConfiguredStatement<UndefineVariable>) engine.configure(sql),
         sessionProperties,
         engine.getEngine(),
         engine.getServiceContext()

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -142,6 +142,7 @@ import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStatusFuture;
 import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
+import io.confluent.ksql.rest.server.execution.ConnectServerErrors;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.rest.util.TerminateCluster;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -312,6 +313,8 @@ public class KsqlResourceTest {
   @Mock
   private Errors errorsHandler;
   @Mock
+  private ConnectServerErrors connectErrorHandler;
+  @Mock
   private DenyListPropertyValidator denyListPropertyValidator;
   @Mock
   private Supplier<String> commandRunnerWarning;
@@ -443,6 +446,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
+        connectErrorHandler,
         denyListPropertyValidator,
         commandRunnerWarning
     );
@@ -475,6 +479,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
+        connectErrorHandler,
         denyListPropertyValidator,
         commandRunnerWarning
     );
@@ -2504,6 +2509,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
+        connectErrorHandler,
         denyListPropertyValidator,
         commandRunnerWarning
     );
@@ -2598,6 +2604,7 @@ public class KsqlResourceTest {
             new TopicDeleteInjector(ec, sc)),
         Optional.of(authorizationValidator),
         errorsHandler,
+        connectErrorHandler,
         denyListPropertyValidator,
         commandRunnerWarning
     );


### PR DESCRIPTION
### Description 

This patch enables pluggable error handling for ksqlDB <-> Connect integration. Specifically, it allows to customize behaviour on `UNAUTHORIZED` and `FORBIDDEN` server errors.

The patch introduces new configuration option -  `ksql.connect.error.handler` that allows to override `DefaultConnectServerErrors` by implementing `ConnectServerErrors` interface. The latter allows to return `Optional<KsqlEntity>` for a specific error code. Currently, the interface has custom handlers for the 2 codes mentioned above - 401 and 403 as well as a fall-back handler for other errors. In the future we can extend this interface with more handlers for specific errors.

Specifically, I made the following changes:
* `ConnectExecutor`, `DescribeConnectExecutor`, `DropConnectExecutor`, `ListConnectorPluginsExecutor`, `ListConnectorsExecutor`  have an immutable error handler as part of their state.
* For the executors mentioned in the previous point, `execute` is an instance method now.
* `CustomExecutors` is a class now rather than an `enum` of static methods.

The first 2 changes follow one another. As we change executors' behavior based on the loaded plugin, the best place to store it is in their state.

I considered an alternative, adding the error handler to a static method signature, but concluded that it is suboptimal because:

* it is a "garbage argument" for all but 5 executors - the chances are slim that other executors will ever use it.
* With the project's tendency to plugin custom behavior, there is a good chance that some other executor might need a similar extension, and we'll have to add another such argument.

### Testing done 

I added new cases to all changed executors' test suites that check server errors are handled by the actual handler supplied in the passed `KsqlConfig`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

