### PR TITLE
feat: restart runtime after alter system query

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -64,6 +64,7 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
+import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
 import io.confluent.ksql.util.StreamPullQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
@@ -211,6 +212,10 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
   public boolean hasActiveQueries() {
     return !primaryContext.getQueryRegistry().getPersistentQueries().isEmpty();
+  }
+
+  public void restartStreamsRuntime() {
+    primaryContext.getQueryRegistry().restartStreamsRuntime();
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -64,7 +64,6 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
-import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
 import io.confluent.ksql.util.StreamPullQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
@@ -215,7 +214,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   }
 
   public void restartStreamsRuntime() {
-    primaryContext.getQueryRegistry().restartStreamsRuntime();
+    final KsqlConfig config = primaryContext.getKsqlConfig();
+    primaryContext.getQueryRegistry().restartStreamsRuntime(config);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -604,19 +604,9 @@ final class QueryBuilder {
     );
   }
 
-  private Map<String, Object> buildStreamsProperties(
-      final String applicationId,
-      final QueryId queryId
+  public static Map<String, Object> updateListProperties(
+      final Map<String, Object> newStreamsProperties
   ) {
-    final Map<String, Object> newStreamsProperties
-        = new HashMap<>(config.getConfig(true).getKsqlStreamConfigProps(applicationId));
-    newStreamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
-    final ProcessingLogger logger
-        = processingLogContext.getLoggerFactory().getLogger(queryId.toString());
-    newStreamsProperties.put(
-        ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER,
-        logger);
-
     updateListProperty(
         newStreamsProperties,
         StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
@@ -638,6 +628,22 @@ final class QueryBuilder {
         StorageUtilizationMetricsReporter.class.getName()
     );
     return newStreamsProperties;
+  }
+
+  private Map<String, Object> buildStreamsProperties(
+      final String applicationId,
+      final QueryId queryId
+  ) {
+    final Map<String, Object> newStreamsProperties
+        = new HashMap<>(config.getConfig(true).getKsqlStreamConfigProps(applicationId));
+    newStreamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+    final ProcessingLogger logger
+        = processingLogContext.getLoggerFactory().getLogger(queryId.toString());
+    newStreamsProperties.put(
+        ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER,
+        logger);
+
+    return updateListProperties(newStreamsProperties);
   }
 
   private static Optional<QueryErrorClassifier> buildConfiguredClassifiers(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
@@ -25,10 +25,10 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
-import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.List;
 import java.util.Map;
@@ -169,7 +169,7 @@ public interface QueryRegistry {
   /**
    * Restarts the streams runtimes
    */
-  void restartStreamsRuntime();
+  void restartStreamsRuntime(KsqlConfig config);
 
   /**
    * Get all insert queries that write into or read from a given source.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.List;
 import java.util.Map;
@@ -164,6 +165,11 @@ public interface QueryRegistry {
    * @return the query started by the C(S|T)AS that created sourceName
    */
   Optional<QueryMetadata> getCreateAsQuery(SourceName sourceName);
+
+  /**
+   * Restarts the streams runtimes
+   */
+  void restartStreamsRuntime();
 
   /**
    * Get all insert queries that write into or read from a given source.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.engine.QueryEventListener;
 import io.confluent.ksql.execution.plan.ExecutionStep;
@@ -219,6 +220,13 @@ public class QueryRegistryImpl implements QueryRegistry {
     // nor will it count against the push query limit.
     notifyCreate(serviceContext, metaStore, query);
     return query;
+  }
+
+  @Override
+  public void restartStreamsRuntime() {
+    for (SharedKafkaStreamsRuntime stream : streams) {
+      stream.restartStreamsRuntime();
+    };
   }
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -118,6 +118,10 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
   }
 
   @Override
+  public void overrideStreamsProperties(final Map<String, Object> newStreamsProperties) {
+  }
+
+  @Override
   public void restartStreamsRuntime() {
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -44,7 +44,7 @@ public abstract class SharedKafkaStreamsRuntime {
 
   protected final KafkaStreamsBuilder kafkaStreamsBuilder;
   protected KafkaStreamsNamedTopologyWrapper kafkaStreams;
-  protected final ImmutableMap<String, Object> streamsProperties;
+  protected ImmutableMap<String, Object> streamsProperties;
   protected final Map<QueryId, BinPackedPersistentQueryMetadataImpl> collocatedQueries;
   protected final Map<QueryId, Set<SourceName>> sources;
 
@@ -155,4 +155,6 @@ public abstract class SharedKafkaStreamsRuntime {
   public String getApplicationId() {
     return getStreamProperties().get(StreamsConfig.APPLICATION_ID_CONFIG).toString();
   }
+
+  public abstract void overrideStreamsProperties(Map<String, Object> newStreamsProperties);
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.util;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryErrorClassifier;
@@ -216,6 +218,17 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     } else {
       throw new IllegalArgumentException("query: " + queryId + " not added to runtime");
     }
+  }
+
+  @Override
+  public void overrideStreamsProperties(final Map<String, Object> newProperties) {
+    // cannot override logger
+    newProperties.put(
+        ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER,
+        streamsProperties.get(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER)
+    );
+
+    streamsProperties = ImmutableMap.copyOf(newProperties);
   }
 
   @Override

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -290,6 +291,7 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
       final String propertyName = alterSystemQuery.getStatement().getPropertyName();
       final String propertyValue = alterSystemQuery.getStatement().getPropertyValue();
       ksqlEngine.alterSystemProperty(propertyName, propertyValue);
+      ksqlEngine.restartStreamsRuntime();
 
       final String successMessage = String.format("System property %s was set to %s.",
           propertyName, propertyValue);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -40,7 +40,6 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
-import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;


### PR DESCRIPTION
### Description 
Once the system configs are altered we need to restart the runtimes to pick up the change. This PR is dependend on https://github.com/confluentinc/ksql/pull/8434

### Testing done 
unit tests 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

