### PR TITLE
chore: exclude dependency to log4j2

### DIFF
--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 import static io.confluent.ksql.parser.SqlBaseParser.DecimalLiteralContext;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.base.Strings;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
@@ -45,7 +46,6 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.commons.lang3.text.translate.LookupTranslator;
-import org.apache.logging.log4j.util.Strings;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class ParserUtil {
@@ -256,7 +256,7 @@ public final class ParserUtil {
     } else if (context.HEADERS() != null) {
       builder = builder.headers();
     } else if (context.HEADER() != null) {
-      builder = builder.header(Strings.trimToNull(unquote(context.STRING().getText(), "'")));
+      builder = builder.header(Strings.emptyToNull(unquote(context.STRING().getText(), "'")));
     }
 
     return builder.build();

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -256,7 +256,8 @@ public final class ParserUtil {
     } else if (context.HEADERS() != null) {
       builder = builder.headers();
     } else if (context.HEADER() != null) {
-      builder = builder.header(Strings.emptyToNull(unquote(context.STRING().getText(), "'")));
+      builder =
+          builder.header(Strings.emptyToNull(unquote(context.STRING().getText(), "'").trim()));
     }
 
     return builder.build();

--- a/pom.xml
+++ b/pom.xml
@@ -632,6 +632,16 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+             </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Description 

ksql has a dependency to log4j2 although it uses log4j1 for
logging. The dependency to log4j2 comes transitively from
confluent-log4j.

This PR excludes the log4j2 dependency from confluent-log4j.

### Testing done 


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

