### PR TITLE
feat: throw exception if feature flag is off

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -136,6 +136,12 @@ public final class ValidatedCommandFactory {
     final String propertyName = alterSystemProperty.getPropertyName();
     final String propertyValue = alterSystemProperty.getPropertyValue();
 
+    // raise exception if feature flag is set
+    if (!context.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+      throw new KsqlServerException("Cannot alter system configs "
+          + "when KSQL_SHARED_RUNTIME_ENABLED is turned off.");
+    }
+
     // validate
     context.alterSystemProperty(propertyName, propertyValue);
     if (!Property.isEditable(propertyName)) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactoryTest.java
@@ -119,8 +119,20 @@ public class ValidatedCommandFactoryTest {
     configuredStatement = configuredStatement("ALTER SYSTEM 'ksql.streams.upgrade.from'='TEST';" , alterSystemProperty);
     when(alterSystemProperty.getPropertyName()).thenReturn("ksql.streams.upgrade.from");
     when(alterSystemProperty.getPropertyValue()).thenReturn("TEST");
+    when(config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(true);
 
     commandFactory.create(configuredStatement, executionContext);
+  }
+
+  @Test
+  public void shouldRaiseExceptionWhenFeatureFlagIsTurnedOff() {
+    configuredStatement = configuredStatement("ALTER SYSTEM 'ksql.streams.upgrade.from'='TEST';" , alterSystemProperty);
+    when(alterSystemProperty.getPropertyName()).thenReturn("ksql.streams.upgrade.from");
+    when(alterSystemProperty.getPropertyValue()).thenReturn("TEST");
+    when(config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(false);
+
+    assertThrows(KsqlServerException.class,
+        () -> commandFactory.create(configuredStatement, executionContext));
   }
 
   @Test
@@ -128,6 +140,7 @@ public class ValidatedCommandFactoryTest {
     configuredStatement = configuredStatement("ALTER SYSTEM 'TEST'='TEST';" , alterSystemProperty);
     when(alterSystemProperty.getPropertyName()).thenReturn("TEST");
     when(alterSystemProperty.getPropertyValue()).thenReturn("TEST");
+    when(config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(true);
 
     assertThrows(ConfigException.class,
         () -> commandFactory.create(configuredStatement, executionContext));
@@ -138,6 +151,7 @@ public class ValidatedCommandFactoryTest {
     configuredStatement = configuredStatement("ALTER SYSTEM 'processing.guarantee'='exactly_once';" , alterSystemProperty);
     when(alterSystemProperty.getPropertyName()).thenReturn("processing.guarantee");
     when(alterSystemProperty.getPropertyValue()).thenReturn("exactly_once");
+    when(config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(true);
 
     final List<PersistentQueryMetadata> persistentList = new ArrayList<>();
     persistentList.add(query1);


### PR DESCRIPTION
### Description 
The `Alter System` work work as expected in the old runtime. We want to disallow this if the feature flag is not set.

### Testing done 
Existing tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

