### PR TITLE
fix: close all runtimes in sandbox

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -173,7 +173,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
     if (getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
       result.getQuery().map(QueryMetadata::getKafkaStreams).ifPresent(streams -> streams.close());
     } else {
-      engineContext.getQueryRegistry().getPersistentQueries().values().stream().map(QueryMetadata::getKafkaStreams).forEach(KafkaStreams::close);
+      engineContext.getQueryRegistry().closeRuntimes();
     }
     return result;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -47,7 +47,6 @@ import io.confluent.ksql.util.Sandbox;
 import io.confluent.ksql.util.ScalablePushQueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.vertx.core.Context;
-import org.apache.kafka.streams.KafkaStreams;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -169,7 +169,7 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
     ).execute(ksqlPlan.getPlan());
 
     // Having a streams running in a sandboxed environment is not necessary
-    if (getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+    if (!getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
       result.getQuery().map(QueryMetadata::getKafkaStreams).ifPresent(streams -> streams.close());
     } else {
       engineContext.getQueryRegistry().closeRuntimes();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -67,6 +67,7 @@ import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.PushQueryMetadata.ResultType;
 import io.confluent.ksql.util.QueryApplicationId;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.SandboxedBinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.SandboxedSharedKafkaStreamsRuntimeImpl;
 import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
 import io.confluent.ksql.util.SharedKafkaStreamsRuntimeImpl;
@@ -462,7 +463,7 @@ final class QueryBuilder {
         serviceContext
     );
 
-    return new BinPackedPersistentQueryMetadataImpl(
+    final BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata = new BinPackedPersistentQueryMetadataImpl(
         persistentQueryType,
         statementText,
         querySchema,
@@ -489,6 +490,11 @@ final class QueryBuilder {
             physicalPlan
         )
     );
+    if (real) {
+      return binPackedPersistentQueryMetadata;
+    } else {
+      return SandboxedBinPackedPersistentQueryMetadataImpl.of(binPackedPersistentQueryMetadata, listener);
+    }
   }
 
   public NamedTopology getNamedTopology(final SharedKafkaStreamsRuntime sharedRuntime,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -463,7 +463,8 @@ final class QueryBuilder {
         serviceContext
     );
 
-    final BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata = new BinPackedPersistentQueryMetadataImpl(
+    final BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata
+        = new BinPackedPersistentQueryMetadataImpl(
         persistentQueryType,
         statementText,
         querySchema,
@@ -493,7 +494,9 @@ final class QueryBuilder {
     if (real) {
       return binPackedPersistentQueryMetadata;
     } else {
-      return SandboxedBinPackedPersistentQueryMetadataImpl.of(binPackedPersistentQueryMetadata, listener);
+      return SandboxedBinPackedPersistentQueryMetadataImpl.of(
+          binPackedPersistentQueryMetadata,
+          listener);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -465,31 +465,31 @@ final class QueryBuilder {
 
     final BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata
         = new BinPackedPersistentQueryMetadataImpl(
-        persistentQueryType,
-        statementText,
-        querySchema,
-        sources.stream().map(DataSource::getName).collect(Collectors.toSet()),
-        planSummary,
-        applicationId,
-        topology,
-        sharedKafkaStreamsRuntime,
-        runtimeBuildContext.getSchemas(),
-        config.getOverrides(),
-        queryId,
-        materializationProviderBuilder,
-        physicalPlan,
-        getUncaughtExceptionProcessingLogger(queryId),
-        sinkDataSource,
-        listener,
-        queryOverrides,
-        scalablePushRegistry,
-        (streamsRuntime) -> getNamedTopology(
-            streamsRuntime,
-            queryId,
+            persistentQueryType,
+            statementText,
+            querySchema,
+            sources.stream().map(DataSource::getName).collect(Collectors.toSet()),
+            planSummary,
             applicationId,
+            topology,
+            sharedKafkaStreamsRuntime,
+            runtimeBuildContext.getSchemas(),
+            config.getOverrides(),
+            queryId,
+            materializationProviderBuilder,
+            physicalPlan,
+            getUncaughtExceptionProcessingLogger(queryId),
+            sinkDataSource,
+            listener,
             queryOverrides,
-            physicalPlan
-        )
+            scalablePushRegistry,
+            (streamsRuntime) -> getNamedTopology(
+                streamsRuntime,
+                queryId,
+                applicationId,
+                queryOverrides,
+                physicalPlan
+            )
     );
     if (real) {
       return binPackedPersistentQueryMetadata;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
@@ -196,4 +196,9 @@ public interface QueryRegistry {
    *                        will be stopped by calling stop(). Transient queries are always closed.
    */
   void close(boolean closePersistent);
+
+  /**
+   * Close all shared runtimes in this registry
+   */
+  void closeRuntimes();
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -277,7 +277,7 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     if (sharedRuntimeId.isPresent()) {
 
-      if(sandbox) {
+      if (sandbox) {
         streams.addAll(sourceStreams.stream()
             .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)
             .collect(Collectors.toList()));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -379,6 +379,11 @@ public class QueryRegistryImpl implements QueryRegistry {
         unregisterQuery(queryMetadata);
       }
     }
+    closeRuntimes();
+  }
+
+  @Override
+  public void closeRuntimes() {
     for (SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime : streams) {
       sharedKafkaStreamsRuntime.close();
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -132,9 +132,9 @@ public class QueryRegistryImpl implements QueryRegistry {
         .filter(Optional::isPresent)
         .map(Optional::get)
         .collect(Collectors.toList());
-    sourceStreams.addAll(original.streams.stream()
-        .collect(Collectors.toList()));
     this.metricCollectors = original.metricCollectors;
+    sourceStreams.addAll(original.streams);
+
     sandbox = true;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -132,8 +132,8 @@ public class QueryRegistryImpl implements QueryRegistry {
         .filter(Optional::isPresent)
         .map(Optional::get)
         .collect(Collectors.toList());
-    this.metricCollectors = original.metricCollectors;
     sourceStreams.addAll(original.streams);
+    this.metricCollectors = original.metricCollectors;
 
     sandbox = true;
   }


### PR DESCRIPTION
this is about cleaning up the validation runtimes. when creating the sandbox there was some issues where the runtimes would get made at creation but the sandbox execution context doesn’t get cleaned up. Now I don’t make the validation runtimes until a query is issued. And ensue that all the runtimes get cleaned up.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

