### PR TITLE
chore: Clean up build

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -46,18 +47,14 @@ public class ConsumerCollector implements MetricCollector, ConsumerInterceptor<O
   public static final String CONSUMER_TOTAL_BYTES = "consumer-total-bytes";
   public static final String CONSUMER_ALL_TOTAL_BYTES_SUM = "consumer-all-total-bytes-sum";
   public static final String CONSUMER_COLLECTOR_METRICS_GROUP_NAME = "consumer-metrics";
-  private static final Sensor totalBytesSum;
 
+  private Sensor totalBytesSum;
   private final Map<String, TopicSensors<ConsumerRecord<Object, Object>>> topicSensors =
       new HashMap<>();
   private Metrics metrics;
   private String id;
   private String groupId;
   private Time time;
-
-  static {
-    totalBytesSum = configureTotalBytesSum(MetricCollectors.getMetrics());
-  }
 
   public void configure(final Map<String, ?> map) {
     String id = (String) map.get(ConsumerConfig.GROUP_ID_CONFIG);
@@ -67,20 +64,19 @@ public class ConsumerCollector implements MetricCollector, ConsumerInterceptor<O
     if (id == null) {
       id = (String) map.get(ConsumerConfig.CLIENT_ID_CONFIG);
     }
-    if (id.contains("")) {
-      configure(
-          MetricCollectors.getMetrics(),
-          MetricCollectors.addCollector(id, this),
-          MetricCollectors.getTime()
-      );
-    }
+    configure(
+        MetricCollectors.getMetrics(),
+        MetricCollectors.addCollector(id, this),
+        MetricCollectors.getTime()
+    );
   }
 
-  ConsumerCollector configure(final Metrics metrics, final String id, final Time time) {
+  void configure(final Metrics metrics, final String id, final Time time) {
+    totalBytesSum = idempotentlyConfigureTotalBytesSum(metrics);
+
     this.id = id;
     this.metrics = metrics;
     this.time = time;
-    return this;
   }
 
   @Override
@@ -206,7 +202,7 @@ public class ConsumerCollector implements MetricCollector, ConsumerInterceptor<O
     return getClass().getSimpleName() + " id:" + this.id + " " + topicSensors.keySet();
   }
 
-  private static Sensor configureTotalBytesSum(final Metrics metrics) {
+  private static Sensor idempotentlyConfigureTotalBytesSum(final Metrics metrics) {
     final String description = "The total number of bytes consumed across all consumers";
     final Sensor sensor = metrics.sensor(CONSUMER_ALL_TOTAL_BYTES_SUM);
     sensor.add(

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/CompatibleElement.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/CompatibleElement.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * Interface get a set of incompatible elements for an object
  * @see CompatibleSet
  */
-public interface CompatibleElement<T extends CompatibleElement> {
+public interface CompatibleElement<T extends CompatibleElement<T>> {
 
   Set<T> getIncompatibleWith();
 }

--- a/ksqldb-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
@@ -27,14 +27,19 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class ConsumerCollectorTest {
 
@@ -42,16 +47,17 @@ public class ConsumerCollectorTest {
 
   @Test
   public void shouldDisplayRateThroughput() {
+    final Metrics metrics = new Metrics();
 
-    final ConsumerCollector collector = new ConsumerCollector();//
-    collector.configure(new Metrics(), "group", new SystemTime());
+    final ConsumerCollector collector = new ConsumerCollector();
+    collector.configure(metrics, "group", new SystemTime());
 
-    for (int i = 0; i < 100; i++){
+    for (int i = 0; i < 100; i++) {
 
       final Map<TopicPartition, List<ConsumerRecord<Object, Object>>> records = ImmutableMap.of(
-              new TopicPartition(TEST_TOPIC, 1), Arrays.asList(
-                      new ConsumerRecord<>(TEST_TOPIC, 1, i, 1L, TimestampType.CREATE_TIME, 10, 10,
-                          "key", "1234567890", new RecordHeaders(), Optional.empty())) );
+          new TopicPartition(TEST_TOPIC, 1), Arrays.asList(
+              new ConsumerRecord<>(TEST_TOPIC, 1, i, 1L, TimestampType.CREATE_TIME, 10, 10,
+                  "key", "1234567890", new RecordHeaders(), Optional.empty())));
       final ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);
 
       collector.onConsume(consumerRecords);
@@ -60,17 +66,18 @@ public class ConsumerCollectorTest {
     final Collection<TopicSensors.Stat> stats = collector.stats(TEST_TOPIC, false);
     assertNotNull(stats);
 
-    assertThat( stats.toString(), containsString("name=consumer-messages-per-sec,"));
-    assertThat( stats.toString(), containsString("total-messages, value=100.0"));
+    assertThat(stats.toString(), containsString("name=consumer-messages-per-sec,"));
+    assertThat(stats.toString(), containsString("total-messages, value=100.0"));
   }
 
   @Test
   public void shouldDisplayByteThroughputAcrossAllTopics() {
+    final Metrics metrics = new Metrics();
 
     final ConsumerCollector collector = new ConsumerCollector();
-    collector.configure(new Metrics(), "group", new SystemTime());
+    collector.configure(metrics, "group", new SystemTime());
 
-    for (int i = 0; i < 100; i++){
+    for (int i = 0; i < 100; i++) {
 
       final Map<TopicPartition, List<ConsumerRecord<Object, Object>>> records1 = ImmutableMap.of(
           new TopicPartition(TEST_TOPIC, 1), Collections.singletonList(
@@ -89,7 +96,6 @@ public class ConsumerCollectorTest {
       collector.onConsume(consumerRecords2);
     }
 
-    final Metrics metrics = MetricCollectors.getMetrics();
     assertThat(Double.parseDouble(metrics.metric(metrics.metricName(
         ConsumerCollector.CONSUMER_ALL_TOTAL_BYTES_SUM,
         ConsumerCollector.CONSUMER_COLLECTOR_METRICS_GROUP_NAME)

--- a/ksqldb-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
@@ -27,9 +27,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.Test;
@@ -48,7 +50,8 @@ public class ConsumerCollectorTest {
 
       final Map<TopicPartition, List<ConsumerRecord<Object, Object>>> records = ImmutableMap.of(
               new TopicPartition(TEST_TOPIC, 1), Arrays.asList(
-                      new ConsumerRecord<>(TEST_TOPIC, 1, i, 1L, TimestampType.CREATE_TIME, 1L, 10, 10, "key", "1234567890")) );
+                      new ConsumerRecord<>(TEST_TOPIC, 1, i, 1L, TimestampType.CREATE_TIME, 10, 10,
+                          "key", "1234567890", new RecordHeaders(), Optional.empty())) );
       final ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);
 
       collector.onConsume(consumerRecords);
@@ -71,13 +74,13 @@ public class ConsumerCollectorTest {
 
       final Map<TopicPartition, List<ConsumerRecord<Object, Object>>> records1 = ImmutableMap.of(
           new TopicPartition(TEST_TOPIC, 1), Collections.singletonList(
-              new ConsumerRecord<>(TEST_TOPIC, 1, i, 1L, TimestampType.CREATE_TIME, 1L, 10, 10,
-                  "key", "1234567890")));
+              new ConsumerRecord<>(TEST_TOPIC, 1, i, 1L, TimestampType.CREATE_TIME, 10, 10,
+                  "key", "1234567890", new RecordHeaders(), Optional.empty())));
 
       final Map<TopicPartition, List<ConsumerRecord<Object, Object>>> records2 = ImmutableMap.of(
           new TopicPartition(TEST_TOPIC, 1), Collections.singletonList(
-              new ConsumerRecord<>(TEST_TOPIC, 1, i, 1L, TimestampType.CREATE_TIME, 1L, 10, 10,
-                  "key", "1234567890")));
+              new ConsumerRecord<>(TEST_TOPIC, 1, i, 1L, TimestampType.CREATE_TIME, 10, 10,
+                  "key", "1234567890", new RecordHeaders(), Optional.empty())));
 
       final ConsumerRecords<Object, Object> consumerRecords1 = new ConsumerRecords<>(records1);
       final ConsumerRecords<Object, Object> consumerRecords2 = new ConsumerRecords<>(records2);

--- a/ksqldb-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
@@ -35,12 +35,14 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.After;
@@ -97,7 +99,8 @@ public class MetricCollectorsTest {
 
     final Map<TopicPartition, List<ConsumerRecord<Object, Object>>> records = ImmutableMap.of(
             new TopicPartition(TEST_TOPIC, 1), Arrays.asList(
-                    new ConsumerRecord<>(TEST_TOPIC, 1, 1, 1L, TimestampType.CREATE_TIME, 1L, 10, 10, "key", "1234567890")) );
+                    new ConsumerRecord<>(TEST_TOPIC, 1, 1, 1L, TimestampType.CREATE_TIME, 10, 10,
+                        "key", "1234567890", new RecordHeaders(), Optional.empty())) );
     final ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);
 
 
@@ -152,7 +155,8 @@ public class MetricCollectorsTest {
     final List<ConsumerRecord<Object, Object>> recordList = new ArrayList<>();
     for (int i = 0; i < 500; i++) {
       recordList.add(new ConsumerRecord<>(TEST_TOPIC, 1, 1, 1L, TimestampType
-          .CREATE_TIME, 1L, 10, 10, "key", "1234567890"));
+                .CREATE_TIME, 10, 10,
+          "key", "1234567890", new RecordHeaders(), Optional.empty()));
     }
     records.put(new TopicPartition(TEST_TOPIC, 1), recordList);
     final ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);
@@ -175,7 +179,8 @@ public class MetricCollectorsTest {
     final List<ConsumerRecord<Object, Object>> recordList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       recordList.add(new ConsumerRecord<>(TEST_TOPIC, 1, 1, 1L, TimestampType
-          .CREATE_TIME, 1L, 10, 10,"key", "1234567890"));
+                .CREATE_TIME, 10, 10,
+          "key", "1234567890", new RecordHeaders(), Optional.empty()));
     }
     records.put(new TopicPartition(TEST_TOPIC, 1), recordList);
     final ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);
@@ -197,7 +202,8 @@ public class MetricCollectorsTest {
     int totalSz = 0;
     for (int i = 0; i < 10; i++) {
       recordList.add(new ConsumerRecord<>(TEST_TOPIC, 1, 1, 1L, TimestampType
-          .CREATE_TIME, 1L, 5 + i, 10 + i, "key", "1234567890"));
+                .CREATE_TIME, 5 + i, 10 + i,
+          "key", "1234567890", new RecordHeaders(), Optional.empty()));
       totalSz += 15 + 2 * i;
     }
     records.put(new TopicPartition(TEST_TOPIC, 1), recordList);
@@ -223,7 +229,8 @@ public class MetricCollectorsTest {
     final List<ConsumerRecord<Object, Object>> recordList = new ArrayList<>();
     for (int i = 0; i < 500; i++) {
       recordList.add(new ConsumerRecord<>(TEST_TOPIC, 1, 1, 1L, TimestampType
-          .CREATE_TIME, 1L, 10, 10, "key", "1234567890"));
+                .CREATE_TIME, 10, 10,
+          "key", "1234567890", new RecordHeaders(), Optional.empty()));
     }
     records.put(new TopicPartition(TEST_TOPIC, 1), recordList);
     final ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);
@@ -267,7 +274,8 @@ public class MetricCollectorsTest {
     final List<ConsumerRecord<Object, Object>> recordList = new ArrayList<>();
     for (int i = 0; i < 500; i++) {
       recordList.add(new ConsumerRecord<>(TEST_TOPIC, 1, 1, 1L, TimestampType
-          .CREATE_TIME, 1L, 10, 10, "key", "1234567890"));
+                .CREATE_TIME, 10, 10,
+          "key", "1234567890", new RecordHeaders(), Optional.empty()));
     }
     records.put(new TopicPartition(TEST_TOPIC, 1), recordList);
     final ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -47,6 +47,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.MeasurableStat;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -322,7 +323,8 @@ public class KsqlEngineMetricsTest {
     final List<ConsumerRecord<Object, Object>> recordList = new ArrayList<>();
     for (int i = 0; i < numMessages; i++) {
       recordList.add(new ConsumerRecord<>("foo", 1, 1, 1L, TimestampType
-          .CREATE_TIME, 1L, 10, 10, "key", "1234567890"));
+                .CREATE_TIME, 10, 10,
+          "key", "1234567890", new RecordHeaders(), Optional.empty()));
     }
     records.put(new TopicPartition("foo", 1), recordList);
     final ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -325,7 +325,7 @@ class KafkaEmbedded {
   public Map<String, Integer> getPartitionCount(final Collection<String> topics) {
     try (AdminClient adminClient = adminClient()) {
       final DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(topics);
-      final Map<String, TopicDescription> topicDescriptionMap = describeTopicsResult.all().get();
+      final Map<String, TopicDescription> topicDescriptionMap = describeTopicsResult.allTopicNames().get();
       return topicDescriptionMap
           .entrySet()
           .stream()

--- a/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksqldb-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -325,7 +325,8 @@ class KafkaEmbedded {
   public Map<String, Integer> getPartitionCount(final Collection<String> topics) {
     try (AdminClient adminClient = adminClient()) {
       final DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(topics);
-      final Map<String, TopicDescription> topicDescriptionMap = describeTopicsResult.allTopicNames().get();
+      final Map<String, TopicDescription> topicDescriptionMap =
+          describeTopicsResult.allTopicNames().get();
       return topicDescriptionMap
           .entrySet()
           .stream()


### PR DESCRIPTION
* Fix deprecation warnings
* Fix ConsumerCollectorTest fails for some people in Maven

I think the failure is because Maven chooses to run the tests in a different
order for some people, which causes the validations not to work due to the
way that ConsumerCollector creates one of the metrics in a static initialization
block.

It looks like it was written that way because we wanted to have a unique sensor
across all interceptors. One way to do that is to pass it in
to all instances via the config map in `configure`. Another way is to simply leverage
the fact that sensor creation and metric registration are idempotent in the Metrics
library. Note: they weren't idempotent at the time this class was written.

In this PR, I went with the latter because it keeps the sensor definition local to
the class.

I also cleaned up some synchronization that is also no longer necessary, given
the idempotence of registration.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

