### PR TITLE
chore: improve error message on unknown PARTITION BY column

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/InvalidColumnException.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/InvalidColumnException.java
@@ -17,8 +17,12 @@ package io.confluent.ksql.util;
 
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.parser.NodeLocation;
+import java.util.Objects;
 
 public class InvalidColumnException extends KsqlException {
+
+  private final ColumnReferenceExp column;
+  private final String prefix;
 
   public InvalidColumnException(
       final ColumnReferenceExp column,
@@ -33,6 +37,16 @@ public class InvalidColumnException extends KsqlException {
       final String message
   ) {
     super(buildMessage(prefix, column, message));
+    this.column = Objects.requireNonNull(column, "column");
+    this.prefix = Objects.requireNonNull(prefix, "prefix");
+  }
+
+  public ColumnReferenceExp getColumnExp() {
+    return column;
+  }
+
+  public String getPrefix() {
+    return prefix;
   }
 
   private static String buildMessage(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/UnknownColumnException.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/UnknownColumnException.java
@@ -24,6 +24,14 @@ public class UnknownColumnException extends InvalidColumnException  {
   }
 
   public UnknownColumnException(final String prefix, final ColumnReferenceExp column) {
-    super(prefix, column, "cannot be resolved.");
+    this(prefix, column, "cannot be resolved.");
+  }
+
+  public UnknownColumnException(
+      final String prefix,
+      final ColumnReferenceExp column,
+      final String message
+  ) {
+    super(prefix, column, message);
   }
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/partition-by.json
@@ -1444,6 +1444,17 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "PARTITION BY requires at least one expression"
       }
+    },
+    {
+      "name": "partition by output col should give good error message",
+      "statements": [
+        "CREATE STREAM INPUT (NAME STRING, ID INT, AGE INT) with (kafka_topic='input', format='JSON');",
+        "CREATE STREAM OUTPUT AS select ID, AGE, NAME AS something from INPUT partition by something;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "PARTITION BY column 'SOMETHING' cannot be resolved. 'SOMETHING' must be a column in the source schema since PARTITION BY is applied on the input."
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 
it seems that users are generally confused by the behavior of `PARTITION BY` (that it functions on source columns, no sink columns). While I admit to that having been a questionable decision to begin with (see discussion on https://github.com/confluentinc/ksql/issues/2701) we're kinda stuck with it - so may as well build the explanation into the product.

### Testing done 

QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

