### PR TITLE
fix: explicitly set confluent log4j version to 1.2.17-cp5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,16 +632,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-             </exclusions>
+            <version>1.2.17-cp5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
There is a security vulnerability with log4j versions prior to 2.15.0, we dont use it for logging but it did show up in the jars so here  we bump the confluent patch of log4j which removes any transitive dependencies on log4j 2.10. Note that trying to exclude does not work since the exclusion logic is not recursive. 

