### PR TITLE
docs: fix link to 0.22 announcement post

### DIFF
--- a/docs/operate-and-deploy/changelog.md
+++ b/docs/operate-and-deploy/changelog.md
@@ -9,7 +9,7 @@ keywords: ksqldb, changelog
 Version 0.22.0
 --------------
 
-- [Announcing ksqlDB 0.22.0](https://www.confluent.io/blog/announcing-ksqldb-0-22-new-features-major-upgrades/)
+- [Announcing ksqlDB 0.22.0](https://www.confluent.io/blog/ksqldb-0-22-new-features-major-upgrades/)
 - [ksqlDB v0.22.0 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0220-2021-11-03)
 
 Version 0.21.0


### PR DESCRIPTION
Corrects link on this page: https://docs.ksqldb.io/en/latest/operate-and-deploy/changelog/