### PR TITLE
fix: disallow persistent query limit clause

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-limit-clause.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-limit-clause.json
@@ -483,6 +483,28 @@
       "expectedError": {
         "message": "line 1:36: mismatched input 'heh' expecting {'-', INTEGER_VALUE, DECIMAL_VALUE, FLOATING_POINT_VALUE}"
       }
+    },
+    {
+      "name": "error on limit clause in persistent queries - CTAS",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM riderLocations (profileId VARCHAR, latitude DOUBLE, longitude DOUBLE) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE TABLE currentLocation AS SELECT profileId, LATEST_BY_OFFSET(latitude) AS la, LATEST_BY_OFFSET(longitude) AS lo FROM riderlocations GROUP BY profileId LIMIT 5;"
+      ],
+      "expectedError": {
+        "message": "CREATE TABLE AS SELECT statements don't support LIMIT clause."
+      }
+    },
+    {
+      "name": "error on limit clause in persistent queries - CSAS",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM riderLocations (profileId VARCHAR, latitude DOUBLE, longitude DOUBLE) WITH (kafka_topic='test_topic', value_format='{FORMAT}');",
+        "CREATE STREAM currentLocation AS SELECT * FROM riderlocations LIMIT 5;"
+      ],
+      "expectedError": {
+        "message": "CREATE STREAM AS SELECT statements don't support LIMIT clause."
+      }
     }
   ]
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -899,4 +899,38 @@ public class AstBuilderTest {
     assertThat(column.getConstraints(),
         is((new ColumnConstraints.Builder()).header("h1").build()));
   }
+
+  @Test
+  public void shouldFailOnPersistentQueryLimitClauseStream() {
+    // Given:
+    final SingleStatementContext stmt
+            = givenQuery("CREATE STREAM X AS SELECT * FROM TEST1 LIMIT 5;");
+
+    // Then:
+    Exception exception = assertThrows(KsqlException.class, () -> {
+      builder.buildStatement(stmt);
+    });
+
+    String expectedMessage = "CREATE STREAM AS SELECT statements don't support LIMIT clause.";
+    String actualMessage = exception.getMessage();
+
+    assertEquals(expectedMessage, actualMessage);
+  }
+
+  @Test
+  public void shouldFailOnPersistentQueryLimitClauseTable() {
+    // Given:
+    final SingleStatementContext stmt
+            = givenQuery("CREATE TABLE X AS SELECT * FROM TEST1 LIMIT 5;");
+
+    // Then:
+    Exception exception = assertThrows(KsqlException.class, () -> {
+      builder.buildStatement(stmt);
+    });
+
+    String expectedMessage = "CREATE TABLE AS SELECT statements don't support LIMIT clause.";
+    String actualMessage = exception.getMessage();
+
+    assertEquals(expectedMessage, actualMessage);
+  }
 }


### PR DESCRIPTION
### Description 
Disallows persistent query limit clause. Throws an error message saying `CREATE STREAM/TABLE AS SELECT statements don't support LIMIT clause.` for `CSAS/CTAS` statements

### Testing done 
unit tests
Rest query validation tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

