### PR TITLE
fix: Prevents internal http2 requests from having shared connections closed

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -383,7 +383,7 @@ public class KsqlRestConfig extends AbstractConfig {
 
   public static final String KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG
       = "ksql.internal.http2.max.pool.size";
-  public static final int KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT = 1000;
+  public static final int KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT = 3000;
   public static final String KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DOC =
       "The maximum connection pool size used by Vertx for http2 internal connections";
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -381,6 +381,12 @@ public class KsqlRestConfig extends AbstractConfig {
           + " otherwise be verbose. Note that this works on the entire URI, respecting the "
           + KSQL_ENDPOINT_LOGGING_LOG_QUERIES_CONFIG + " configuration";
 
+  public static final String KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG
+      = "ksql.internal.http2.max.pool.size";
+  public static final int KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT = 1000;
+  public static final String KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DOC =
+      "The maximum connection pool size used by Vertx for http2 internal connections";
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -722,6 +728,12 @@ public class KsqlRestConfig extends AbstractConfig {
             KSQL_ENDPOINT_LOGGING_LOG_QUERIES_DEFAULT,
             Importance.LOW,
             KSQL_ENDPOINT_LOGGING_LOG_QUERIES_DOC
+        ).define(
+            KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG,
+            Type.INT,
+            KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT,
+            Importance.LOW,
+            KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DOC
         );
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactory.java
@@ -105,12 +105,16 @@ public final class InternalKsqlClientFactory {
     final String size = clientProps.get(
         KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG);
     int sizeInt;
-    try {
-      sizeInt = Integer.parseInt(size);
-    } catch (NumberFormatException e) {
-      LOG.error("Bad int passed in for " + KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG
-              + ", using 1000", e);
-      sizeInt = 1000;
+    if (size != null) {
+      try {
+        sizeInt = Integer.parseInt(size);
+      } catch (NumberFormatException e) {
+        LOG.error("Bad int passed in for " + KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG
+            + ", using " + KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT, e);
+        sizeInt = KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT;
+      }
+    } else {
+      sizeInt = KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT;
     }
     return new HttpClientOptions()
         // At the moment, we cannot asynchronously end long-running queries in http2, in a way that

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactoryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/InternalKsqlClientFactoryTest.java
@@ -1,0 +1,86 @@
+package io.confluent.ksql.rest.server.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.client.KsqlClient;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.net.SocketAddress;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InternalKsqlClientFactoryTest {
+
+  @Mock
+  private Vertx vertx;
+  @Mock
+  private HttpClient httpClient;
+  @Captor
+  private ArgumentCaptor<HttpClientOptions> options;
+
+  @Before
+  public void setUp() {
+    when(vertx.createHttpClient(options.capture())).thenReturn(httpClient);
+  }
+
+  @Test
+  public void shouldCreateClient() {
+    // When:
+    KsqlClient client = InternalKsqlClientFactory.createInternalClient(
+        ImmutableMap.of(), SocketAddress::inetSocketAddress,
+        vertx);
+
+    // Then:
+    assertThat(client, notNullValue());
+  }
+
+  @Test
+  public void shouldCreateClient_http2() {
+    // When:
+    KsqlClient client = InternalKsqlClientFactory.createInternalClient(
+        ImmutableMap.of(
+            KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG, "1234"
+        ), SocketAddress::inetSocketAddress,
+        vertx);
+    List<HttpClientOptions> optionsList = options.getAllValues();
+
+
+    // Then:
+    assertThat(client, notNullValue());
+    assertThat(optionsList.size(), is(4));
+    HttpClientOptions sslOptions = optionsList.get(2);
+    assertThat(sslOptions.getHttp2MaxPoolSize(), is(1234));
+  }
+
+  @Test
+  public void shouldCreateClient_http2_badPoolSize() {
+    // When:
+    KsqlClient client = InternalKsqlClientFactory.createInternalClient(
+        ImmutableMap.of(
+            KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_CONFIG, "abc"
+        ), SocketAddress::inetSocketAddress,
+        vertx);
+    List<HttpClientOptions> optionsList = options.getAllValues();
+
+
+    // Then:
+    assertThat(client, notNullValue());
+    assertThat(optionsList.size(), is(4));
+    HttpClientOptions sslOptions = optionsList.get(2);
+    assertThat(sslOptions.getHttp2MaxPoolSize(),
+        is(KsqlRestConfig.KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT));
+  }
+}


### PR DESCRIPTION
### Description 
Related to #8505.  Since we currently close connections upon being finished with a request, this disables multiplexing so that shared connections are not closed, affecting other requests.

### Testing done 
Ran locally.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

