### PR TITLE
fix: invoke per-query listeners upon state change in shared runtime

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -236,11 +236,6 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   }
 
   @Override
-  public Optional<MaterializationProvider> getMaterializationProvider() {
-    return materializationProvider;
-  }
-
-  @Override
   public Optional<ScalablePushRegistry> getScalablePushRegistry() {
     return scalablePushRegistry;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
@@ -128,7 +129,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.resultSchema = requireNonNull(schema, "schema");
     this.materializationProviderBuilder =
         requireNonNull(materializationProviderBuilder, "materializationProviderBuilder");
-    this.listener = requireNonNull(listener, "listener");
+    this.listener = new QueryListenerWrapper(listener, scalablePushRegistry);
     this.namedTopologyBuilder = requireNonNull(namedTopologyBuilder, "namedTopologyBuilder");
     this.queryErrors = sharedKafkaStreamsRuntime.getNewQueryErrorQueue();
     this.materializationProvider = materializationProviderBuilder
@@ -161,7 +162,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.physicalPlan = original.physicalPlan;
     this.resultSchema = original.resultSchema;
     this.materializationProviderBuilder = original.materializationProviderBuilder;
-    this.listener = requireNonNull(listener, "listen");
+    this.listener = requireNonNull(listener, "listener");
     this.queryErrors = sharedKafkaStreamsRuntime.getNewQueryErrorQueue();
     this.materializationProvider = original.materializationProvider;
     this.scalablePushRegistry = original.scalablePushRegistry;
@@ -374,6 +375,10 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public KafkaStreams getKafkaStreams() {
     return sharedKafkaStreamsRuntime.getKafkaStreams();
+  }
+
+  public void onStateChange(final State newState, final State oldState) {
+    listener.onStateChange(this, newState, oldState);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
-import io.confluent.ksql.execution.streams.materialization.MaterializationProvider;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
@@ -29,7 +28,6 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
 import java.util.Optional;
-
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -64,8 +64,6 @@ public interface PersistentQueryMetadata extends QueryMetadata {
       Throwable error
   );
 
-  Optional<MaterializationProvider>  getMaterializationProvider();
-
   Optional<ScalablePushRegistry> getScalablePushRegistry();
 
   final class QueryListenerWrapper implements Listener {
@@ -85,9 +83,8 @@ public interface PersistentQueryMetadata extends QueryMetadata {
     }
 
     @Override
-    public void onStateChange(final QueryMetadata queryMetadata, final State before,
-                              final State after) {
-      this.listener.onStateChange(queryMetadata, before, after);
+    public void onStateChange(final QueryMetadata query, final State old, final State newState) {
+      this.listener.onStateChange(query, old, newState);
     }
 
     @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -200,11 +200,6 @@ public class PersistentQueryMetadataImpl
   }
 
   @VisibleForTesting
-  public Optional<MaterializationProvider> getMaterializationProvider() {
-    return materializationProvider;
-  }
-
-  @VisibleForTesting
   public ProcessingLogger getProcessingLogger() {
     return processingLogger;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -31,7 +31,6 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.physical.scalablepush.ScalablePushRegistry;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.MaterializationProviderBuilderFactory;
-import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -41,7 +40,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 
@@ -233,32 +231,4 @@ public class PersistentQueryMetadataImpl
     return scalablePushRegistry;
   }
 
-  private static final class QueryListenerWrapper implements Listener {
-    private final Listener listener;
-    private final Optional<ScalablePushRegistry> scalablePushRegistry;
-
-    private QueryListenerWrapper(final Listener listener,
-        final Optional<ScalablePushRegistry> scalablePushRegistry) {
-      this.listener = listener;
-      this.scalablePushRegistry = scalablePushRegistry;
-    }
-
-    @Override
-    public void onError(final QueryMetadata queryMetadata, final QueryError error) {
-      this.listener.onError(queryMetadata, error);
-      scalablePushRegistry.ifPresent(ScalablePushRegistry::onError);
-    }
-
-    @Override
-    public void onStateChange(final QueryMetadata queryMetadata, final State before,
-        final State after) {
-      this.listener.onStateChange(queryMetadata, before, after);
-    }
-
-    @Override
-    public void onClose(final QueryMetadata queryMetadata) {
-      this.listener.onClose(queryMetadata);
-      scalablePushRegistry.ifPresent(ScalablePushRegistry::cleanup);
-    }
-  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
-import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,13 +86,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
     }
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
     log.debug("mapping {}", collocatedQueries);
-  }
-
-  @Override
-  public StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
-      final Throwable e
-  ) {
-    return StreamThreadExceptionResponse.REPLACE_THREAD;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -33,7 +33,6 @@ import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +55,6 @@ public abstract class SharedKafkaStreamsRuntime {
     this.streamsProperties = ImmutableMap.copyOf(streamsProperties);
     this.collocatedQueries = new ConcurrentHashMap<>();
     this.sources = new ConcurrentHashMap<>();
-    kafkaStreams.setUncaughtExceptionHandler(this::uncaughtHandler);
   }
 
   public void markSources(final QueryId queryId, final Set<SourceName> sourceNames) {
@@ -72,10 +70,6 @@ public abstract class SharedKafkaStreamsRuntime {
   public abstract void register(
       BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata,
       QueryId queryId
-  );
-
-  public abstract StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
-      Throwable e
   );
 
   public boolean isError(final QueryId queryId) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -29,9 +29,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;


### PR DESCRIPTION
Fix for the query-level metrics such as [Query Status](https://ccloud-production.datadoghq.com/dashboard/m59-7gm-x4j/ksql-node-health?fullscreen_end_ts=1639468089988&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1636876089988&fullscreen_widget=8638173689799481&from_ts=1636876064877&to_ts=1639468064877&live=true) which aren't coming through due to the fact that we aren't registering a `StateListener` on the shared `KafkaStreams` runtime. This patch sets a `StateListener` that loops over all queries in the runtime and invokes the `#onStateChange` callback on their individual query listeners.

Also includes a miscellaneous set of minor fixes/cleanups in the BinPackedPersistentQueryMetadataImpl and SharedKafkaStreamsRuntime interface/subclasses