### PR TITLE
fix: refactoring properties replacement before restarting runtime

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -223,7 +223,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
   public void updateStreamsPropertiesAndRestartRuntime() {
     final KsqlConfig config = primaryContext.getKsqlConfig();
-    primaryContext.getQueryRegistry().updateStreamsPropertiesAndRestartRuntime(config);
+    final ProcessingLogContext logContext = primaryContext.getProcessingLogContext();
+    primaryContext.getQueryRegistry().updateStreamsPropertiesAndRestartRuntime(config, logContext);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -221,9 +221,9 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     return !primaryContext.getQueryRegistry().getPersistentQueries().isEmpty();
   }
 
-  public void restartStreamsRuntime() {
+  public void updateStreamsPropertiesAndRestartRuntime() {
     final KsqlConfig config = primaryContext.getKsqlConfig();
-    primaryContext.getQueryRegistry().restartStreamsRuntime(config);
+    primaryContext.getQueryRegistry().updateStreamsPropertiesAndRestartRuntime(config);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -625,7 +625,9 @@ final class QueryBuilder {
   }
 
   public static void updateListProperties(
-      final Map<String, Object> newStreamsProperties
+      final Map<String, Object> newStreamsProperties,
+      final MetricCollectors metricCollectors,
+      final String applicationId
   ) {
     updateListProperty(
         newStreamsProperties,
@@ -647,6 +649,17 @@ final class QueryBuilder {
         StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG,
         StorageUtilizationMetricsReporter.class.getName()
     );
+
+    // Passing shared state into managed components
+    newStreamsProperties.put(KsqlConfig.KSQL_INTERNAL_METRIC_COLLECTORS_CONFIG, metricCollectors);
+    newStreamsProperties.put(
+        KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG,
+        metricCollectors.getMetrics()
+    );
+    newStreamsProperties.put(
+        KsqlConfig.KSQL_INTERNAL_STREAMS_ERROR_COLLECTOR_CONFIG,
+        StreamsErrorCollector.create(applicationId, metricCollectors)
+    );
   }
 
   private Map<String, Object> buildStreamsProperties(
@@ -663,18 +676,7 @@ final class QueryBuilder {
         ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER,
         logger);
 
-    updateListProperties(newStreamsProperties);
-
-    // Passing shared state into managed components
-    newStreamsProperties.put(KsqlConfig.KSQL_INTERNAL_METRIC_COLLECTORS_CONFIG, metricCollectors);
-    newStreamsProperties.put(
-        KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG,
-        metricCollectors.getMetrics()
-    );
-    newStreamsProperties.put(
-        KsqlConfig.KSQL_INTERNAL_STREAMS_ERROR_COLLECTOR_CONFIG,
-        StreamsErrorCollector.create(applicationId, metricCollectors)
-    );
+    updateListProperties(newStreamsProperties, metricCollectors, applicationId);
 
     return newStreamsProperties;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
@@ -167,9 +167,9 @@ public interface QueryRegistry {
   Optional<QueryMetadata> getCreateAsQuery(SourceName sourceName);
 
   /**
-   * Restarts the streams runtimes
+   * Updates streams properties and restarts the streams runtimes
    */
-  void restartStreamsRuntime(KsqlConfig config);
+  void updateStreamsPropertiesAndRestartRuntime(KsqlConfig config);
 
   /**
    * Get all insert queries that write into or read from a given source.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistry.java
@@ -169,7 +169,7 @@ public interface QueryRegistry {
   /**
    * Updates streams properties and restarts the streams runtimes
    */
-  void updateStreamsPropertiesAndRestartRuntime(KsqlConfig config);
+  void updateStreamsPropertiesAndRestartRuntime(KsqlConfig config, ProcessingLogContext logContext);
 
   /**
    * Get all insert queries that write into or read from a given source.

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -232,17 +232,9 @@ public class QueryRegistryImpl implements QueryRegistry {
   }
 
   @Override
-  public void restartStreamsRuntime(final KsqlConfig config) {
+  public void updateStreamsPropertiesAndRestartRuntime(final KsqlConfig config) {
     for (SharedKafkaStreamsRuntime stream : streams) {
-      // get kafka streams properties
-      final String applicationId = stream.getApplicationId();
-      final Map<String, Object> newStreamsProperties =
-          new HashMap<>(config.getKsqlStreamConfigProps(applicationId));
-      newStreamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
-      QueryBuilder.updateListProperties(newStreamsProperties);
-      stream.overrideStreamsProperties(newStreamsProperties);
-
-      // restart runtime
+      updateStreamsProperties(stream, config);
       stream.restartStreamsRuntime();
     }
   }
@@ -382,6 +374,19 @@ public class QueryRegistryImpl implements QueryRegistry {
     for (SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime : streams) {
       sharedKafkaStreamsRuntime.close();
     }
+  }
+
+  private void updateStreamsProperties(
+      final SharedKafkaStreamsRuntime stream,
+      final KsqlConfig config
+  ) {
+    final String applicationId = stream.getApplicationId();
+    final Map<String, Object> newStreamsProperties =
+        new HashMap<>(config.getKsqlStreamConfigProps(applicationId));
+    newStreamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+    QueryBuilder
+        .updateListProperties(newStreamsProperties, metricCollectors, stream.getApplicationId());
+    stream.overrideStreamsProperties(newStreamsProperties);
   }
 
   private void registerPersistentQuery(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.util;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryError;
 import io.confluent.ksql.query.QueryErrorClassifier;
@@ -222,12 +221,6 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void overrideStreamsProperties(final Map<String, Object> newProperties) {
-    // cannot override logger
-    newProperties.put(
-        ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER,
-        streamsProperties.get(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER)
-    );
-
     streamsProperties = ImmutableMap.copyOf(newProperties);
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -108,32 +108,18 @@ public class SharedKafkaStreamsRuntimeImplTest {
     }
 
     @Test
-    public void overrideStreamsPropertiesShouldReplacePropertiesExceptLoggerAndSharedStates() {
+    public void overrideStreamsPropertiesShouldReplaceProperties() {
         // Given:
-        final Map<String, Object> oldProps = new HashMap<>();
-        oldProps.put(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER, "TestLogger");
-
-        final SharedKafkaStreamsRuntime streams = new SharedKafkaStreamsRuntimeImpl(
-           kafkaStreamsBuilder,
-           queryErrorClassifier,
-           5,
-           300_000L,
-           oldProps
-        );
-
         final Map<String, Object> newProps = new HashMap<>();
         newProps.put("Test", "Test");
 
         // When:
-        streams.overrideStreamsProperties(newProps);
+        sharedKafkaStreamsRuntimeImpl.overrideStreamsProperties(newProps);
 
         // Then:
-        final Map<String, Object> properties = streams.streamsProperties;
+        final Map<String, Object> properties = sharedKafkaStreamsRuntimeImpl.streamsProperties;
         assertThat(properties.get("Test"), equalTo("Test"));
-        assertThat(properties.get(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER),
-            equalTo("TestLogger"));
-
-        assertThat(properties.size(), equalTo(2));
+        assertThat(properties.size(), equalTo(1));
     }
 
     @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -108,29 +108,31 @@ public class SharedKafkaStreamsRuntimeImplTest {
     }
 
     @Test
-    public void overrideStreamsPropertiesShouldReplaceStreamsPropertiesExceptLogger() {
+    public void overrideStreamsPropertiesShouldReplacePropertiesExceptLoggerAndSharedStates() {
         // Given:
-        final Map<String, Object> oldProperties = new HashMap<>();
-        oldProperties.put(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER, "TestLogger");
-       final SharedKafkaStreamsRuntime streams = new SharedKafkaStreamsRuntimeImpl(
+        final Map<String, Object> oldProps = new HashMap<>();
+        oldProps.put(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER, "TestLogger");
+
+        final SharedKafkaStreamsRuntime streams = new SharedKafkaStreamsRuntimeImpl(
            kafkaStreamsBuilder,
            queryErrorClassifier,
            5,
            300_000L,
-           oldProperties
+           oldProps
         );
 
-        final Map<String, Object> newProperties = new HashMap<>();
-        newProperties.put("Test", "Test");
+        final Map<String, Object> newProps = new HashMap<>();
+        newProps.put("Test", "Test");
 
         // When:
-        streams.overrideStreamsProperties(newProperties);
+        streams.overrideStreamsProperties(newProps);
 
         // Then:
         final Map<String, Object> properties = streams.streamsProperties;
         assertThat(properties.get("Test"), equalTo("Test"));
         assertThat(properties.get(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER),
             equalTo("TestLogger"));
+
         assertThat(properties.size(), equalTo(2));
     }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -290,7 +290,7 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
       final String propertyName = alterSystemQuery.getStatement().getPropertyName();
       final String propertyValue = alterSystemQuery.getStatement().getPropertyValue();
       ksqlEngine.alterSystemProperty(propertyName, propertyValue);
-      ksqlEngine.restartStreamsRuntime();
+      ksqlEngine.updateStreamsPropertiesAndRestartRuntime();
 
       final String successMessage = String.format("System property %s was set to %s.",
           propertyName, propertyValue);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -345,7 +345,7 @@ public class InteractiveStatementExecutorTest {
     handleStatement(statementExecutorWithMocks, alterSystemCommand, COMMAND_ID, Optional.empty(), 0L);
 
     // Then:
-    verify(mockEngine).restartStreamsRuntime();
+    verify(mockEngine).updateStreamsPropertiesAndRestartRuntime();
   }
 
   @Test


### PR DESCRIPTION
### Description 
After https://github.com/confluentinc/ksql/pull/8498 we needed to do some refactoring for the restart runtime.

### Testing done 
Unit tests

### Open questions 
- Is there any way we can do an end to end test to verify this works?

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

