### PR TITLE
fix: Streams overrides bugfix

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1341,12 +1341,12 @@ public class KsqlConfig extends AbstractConfig {
   }
   // CHECKSTYLE_RULES.ON: MethodLength
 
-  public Map<String, Object> originalsWithPrefixOverride(String prefix) {
+  public Map<String, Object> originalsWithPrefixOverride(final String prefix) {
     final Map<String, Object> originals = originals();
-    Map<String, Object> result = new HashMap<>(originals);
+    final Map<String, Object> result = new HashMap<>(originals);
     for (Map.Entry<String, ?> entry : originals.entrySet()) {
       if (entry.getKey().startsWith(prefix) && entry.getKey().length() > prefix.length()) {
-        String keyWithNoPrefix = entry.getKey().substring(prefix.length());
+        final String keyWithNoPrefix = entry.getKey().substring(prefix.length());
         result.put(keyWithNoPrefix, entry.getValue());
       }
     }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1341,6 +1341,18 @@ public class KsqlConfig extends AbstractConfig {
   }
   // CHECKSTYLE_RULES.ON: MethodLength
 
+  public Map<String, Object> originalsWithPrefixOverride(String prefix) {
+    final Map<String, Object> originals = originals();
+    Map<String, Object> result = new HashMap<>(originals);
+    for (Map.Entry<String, ?> entry : originals.entrySet()) {
+      if (entry.getKey().startsWith(prefix) && entry.getKey().length() > prefix.length()) {
+        String keyWithNoPrefix = entry.getKey().substring(prefix.length());
+        result.put(keyWithNoPrefix, entry.getValue());
+      }
+    }
+    return result;
+  }
+
   private static final class ConfigValue {
     final ConfigItem configItem;
     final String key;
@@ -1429,7 +1441,8 @@ public class KsqlConfig extends AbstractConfig {
             config.name,
             generation == ConfigGeneration.CURRENT
                 ? config.defaultValueCurrent : config.defaultValueLegacy));
-    this.ksqlStreamConfigProps = buildStreamingConfig(streamsConfigDefaults, originals());
+    this.ksqlStreamConfigProps = buildStreamingConfig(streamsConfigDefaults,
+            originalsWithPrefixOverride(KSQL_STREAMS_PREFIX));
   }
 
   private static Set<String> streamTopicConfigNames() {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1343,14 +1343,29 @@ public class KsqlConfig extends AbstractConfig {
 
   public Map<String, Object> originalsWithPrefixOverride(final String prefix) {
     final Map<String, Object> originals = originals();
-    final Map<String, Object> result = new HashMap<>(originals);
+    final Map<String, Object> result = new HashMap<>();
+    // first we iterate over the originals and we add only the entries without the prefix
     for (Map.Entry<String, ?> entry : originals.entrySet()) {
-      if (entry.getKey().startsWith(prefix) && entry.getKey().length() > prefix.length()) {
-        final String keyWithNoPrefix = entry.getKey().substring(prefix.length());
-        result.put(keyWithNoPrefix, entry.getValue());
+      if (!isKeyPrefixed(entry.getKey(), prefix)) {
+        result.put(entry.getKey(), entry.getValue());
       }
     }
+    // then we add only prefixed entries with dropped prefix
+    for (Map.Entry<String, ?> entry : originals.entrySet()) {
+      if (isKeyPrefixed(entry.getKey(), prefix)) {
+        result.put(entry.getKey().substring(prefix.length()), entry.getValue());
+      }
+    }
+    // two iterations are necessary to avoid a situation where the unprefixed value
+    // is handled after the prefixed one, because we do not control the order in which
+    // the entries are presented from the originals map
     return result;
+  }
+
+  private boolean isKeyPrefixed(final String key, final String prefix) {
+    Objects.requireNonNull(key);
+    Objects.requireNonNull(prefix);
+    return key.startsWith(prefix) && key.length() > prefix.length();
   }
 
   private static final class ConfigValue {

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -259,6 +259,21 @@ public class KsqlConfigTest {
   }
 
   @Test
+  public void shouldOverrideStreamsConfigProperties() {
+    Map<String, Object> originals = new HashMap<>();
+    originals.put(KsqlConfig.KSQL_STREAMS_PREFIX + SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+            "kafka.jks");
+    originals.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+            "https.jks");
+
+    final KsqlConfig ksqlConfig = new KsqlConfig(originals);
+
+    assertThat(ksqlConfig.getKsqlStreamConfigProps().
+            get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG), equalTo("kafka.jks"));
+
+  }
+
+  @Test
   public void shouldSetMonitoringInterceptorConfigProperties() {
     final KsqlConfig ksqlConfig = new KsqlConfig(Collections.singletonMap(
         "confluent.monitoring.interceptor.topic", "foo"));


### PR DESCRIPTION
### Description 
The bugfix introduces a helper method **originalsWithPrefixOverride** similar to existing **valuesWithPrefixOverride**. Contrary to the latter it does not limit the result to defined configuration entries. The new method is used instead of **originals** to provide the values for Kafka configuration in KsqlConfig.

### Testing done 
Unit test added to KsqlConfigTest failing in unmodified class.