### PR TITLE
fix: Consider topics created by join operations internal

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -27,6 +27,11 @@ public final class KsqlConstants {
   public static final String STREAMS_CHANGELOG_TOPIC_SUFFIX = "-changelog";
   public static final String STREAMS_REPARTITION_TOPIC_SUFFIX = "-repartition";
 
+  public static final String STREAMS_JOIN_REGISTRATION_TOPIC_PATTERN =
+      ".+-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-\\d+-topic";
+  public static final String STREAMS_JOIN_RESPONSE_TOPIC_PATTERN =
+      ".+-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-\\d+-topic";
+
   private static final String SCHEMA_REGISTRY_KEY_SUFFIX = "-key";
   private static final String SCHEMA_REGISTRY_VALUE_SUFFIX = "-value";
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -325,6 +325,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
         }
       }
       if (!internalTopics.isEmpty()) {
+        Collections.sort(internalTopics); // prevents flaky tests
         deleteTopics(internalTopics);
       }
     } catch (final Exception e) {
@@ -371,9 +372,12 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   }
 
   private static boolean isInternalTopic(final String topicName, final String applicationId) {
-    return topicName.startsWith(applicationId + "-")
-        && (topicName.endsWith(KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX)
-        || topicName.endsWith(KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX));
+    final boolean prefixMatches = topicName.startsWith(applicationId + "-");
+    final boolean suffixMatches = topicName.endsWith(KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX)
+        || topicName.endsWith(KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX)
+        || topicName.matches(KsqlConstants.STREAMS_JOIN_REGISTRATION_TOPIC_PATTERN)
+        || topicName.matches(KsqlConstants.STREAMS_JOIN_RESPONSE_TOPIC_PATTERN);
+    return prefixMatches && suffixMatches;
   }
 
   private void validateTopicProperties(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -447,12 +447,27 @@ public class KafkaTopicClientImplTest {
   public void shouldDeleteInternalTopics() {
     // Given:
     final String applicationId = "whatEva";
-    final String internalTopic1 = applicationId + "-something-repartition";
-    final String internalTopic2 = applicationId + "-someting-changelog";
+    final String internalTopic1 = applicationId
+        + "-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-0000000012-topic";
+    final String internalTopic2 = applicationId
+        + "-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-0000000012-topic";
+    final String internalTopic3 = applicationId + "-something-changelog";
+    final String internalTopic4 = applicationId + "-something-repartition";
+    // the next four topics are not prefixed with the application id, so they are not internal
+    final String customTopic1 = "what-KTABLE-FK-JOIN-SUBSCRIPTION-REGISTRATION-0000000012-topic";
+    final String customTopic2 = "eva-KTABLE-FK-JOIN-SUBSCRIPTION-RESPONSE-0000000012-topic";
+    final String customTopic3 = "-something-changelog";
+    final String customTopic4 = "-something-repartition";
 
     givenTopicExists("topic1", 1, 1);
     givenTopicExists(internalTopic1, 1, 1);
     givenTopicExists(internalTopic2, 1, 1);
+    givenTopicExists(internalTopic3, 1, 1);
+    givenTopicExists(internalTopic4, 1, 1);
+    givenTopicExists(customTopic1, 1, 1);
+    givenTopicExists(customTopic2, 1, 1);
+    givenTopicExists(customTopic3, 1, 1);
+    givenTopicExists(customTopic4, 1, 1);
     givenTopicExists("topic2", 1, 1);
 
     // When:
@@ -460,7 +475,7 @@ public class KafkaTopicClientImplTest {
 
     // Then:
     verify(adminClient).deleteTopics(ImmutableList.of(
-        internalTopic1, internalTopic2
+        internalTopic1, internalTopic2, internalTopic3, internalTopic4
     ));
   }
 


### PR DESCRIPTION
### Description 

Fixes #8456.

Ideally, we should probably rely on a standard predicate in KStreams, but given this issue is a release blocker, we can probably introduce this predicate to KStreams and update ksql's dependency in follow-up PRs.

### Testing done 

* Added a unit test
* Double-checked that ksqlDB's classification of internal topics matches [KStreams' one](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/tools/StreamsResetter.java#L683-L690).

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

