### PR TITLE
fix: Restore runtime assignor

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -129,6 +129,7 @@ final class EngineContext {
   }
 
   synchronized EngineContext createSandbox(final ServiceContext serviceContext) {
+    this.runtimeAssignor.rebuildAssignment(queryRegistry.getPersistentQueries().values());
     return new EngineContext(
         SandboxedServiceContext.create(serviceContext),
         processingLogContext,


### PR DESCRIPTION
If the validation node goes down or needs to replay the cmd topic we need to pick up the running queries from cmd topic an put them in the assignor. This will make sure that the runtime assignor will always be in sync with the runtimes using the Engine Context. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

