### PR TITLE
fix: header column names must be unique

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/headers.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/headers.json
@@ -178,6 +178,16 @@
         "type": "io.confluent.ksql.util.KsqlException",
         "message": "Cannot insert into SOURCE1 because it has header columns"
       }
+    },
+    {
+      "name": "should reject sources with value and header columns sharing name",
+      "statements": [
+        "CREATE STREAM SOURCE1 (K STRING KEY, K BYTES HEADER('abc'), V BIGINT) WITH (kafka_topic='stream-source', value_format='json');"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Header columns cannot share names with key or value columns. Found header column with non-unique name: K"
+      }
     }
   ]
 }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -322,8 +322,8 @@ public class AstBuilder {
           .filter(tableElement -> tableElement.getConstraints().isHeaders())
           .forEach(tableElement -> {
             if (nonHeaders.contains(tableElement.getName())) {
-              throw new KsqlException("Header columns must have unique names. "
-                  + "Found header column with non-unique name: "
+              throw new KsqlException("Header columns cannot share names with key or value "
+                  + "columns. Found header column with non-unique name: "
                   + tableElement.getName().text());
             }
           });

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -872,6 +872,21 @@ public class AstBuilderTest {
   }
 
   @Test
+  public void shouldThrowOnSharedKeyHeaderColumnName() {
+    // Given:
+    final SingleStatementContext stmt
+        = givenQuery("CREATE STREAM INPUT (K BIGINT KEY, K BYTES HEADER('abc')) WITH (kafka_topic='input',value_format='JSON');");
+
+    // When:
+    final KsqlException e = assertThrows(KsqlException.class, () -> {
+      builder.buildStatement(stmt);
+    });
+
+    // Then:
+    assertThat(e.getMessage(), is("Header columns cannot share names with key or value columns. Found header column with non-unique name: K"));
+  }
+
+  @Test
   public void shouldSupportHeadersColumns() {
     // Given:
     final SingleStatementContext stmt


### PR DESCRIPTION
### Description 
Headers columns cannot have the same name as another value or key column, because that introduces ambiguities in some parts of the code. Internally, headers are treated very similarly to pseudocolumns, so this is similar to not being able to have key/value columns named `ROWOFFSET`.

### Testing done 
QTT + unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

