### PR TITLE
fix: only use uuid as alter system command id

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
@@ -149,7 +149,7 @@ public class CommandIdAssigner {
   private static CommandId getAlterSystemCommandId(final AlterSystemProperty alterSystemProperty) {
     return new CommandId(
         Type.CLUSTER,
-        String.format("%s: %s", UUID.randomUUID(), alterSystemProperty.toString()),
+        UUID.randomUUID().toString(),
         Action.ALTER
     );
   }


### PR DESCRIPTION
### Description 
The command id for the `alter system` query was using a uuid plus the query in string form. This was leading to the server to crash as the `/` is not allowed as a command id due to the following line `final String[] splitOnSlash = fromString.split("/", 3);`. 

This changes the command id to only use a random uuid as originally planned. 


### Testing done 
manual testing 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

