### PR TITLE
feat: don't book keep sources in runtime as well

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -430,8 +430,7 @@ final class QueryBuilder {
         valueFormat.getFeatures()
     );
 
-    final NamedTopologyBuilder namedTopologyBuilder =
-        ((KafkaStreamsNamedTopologyWrapper) sharedKafkaStreamsRuntime.getKafkaStreams())
+    final NamedTopologyBuilder namedTopologyBuilder = sharedKafkaStreamsRuntime.getKafkaStreams()
             .newNamedTopologyBuilder(
                 queryId.toString(),
                 PropertiesUtil.asProperties(queryOverrides)
@@ -590,7 +589,6 @@ final class QueryBuilder {
       if (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId)
           || (sharedKafkaStreamsRuntime.getApplicationId().equals(applicationId + "-validation")
           && !real)) {
-        sharedKafkaStreamsRuntime.markSources(queryId, sources);
         return sharedKafkaStreamsRuntime;
       }
     }
@@ -623,7 +621,6 @@ final class QueryBuilder {
       );
     }
     streams.add(stream);
-    stream.markSources(queryId, sources);
     return stream;
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -91,7 +91,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
-import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopologyBuilder;
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.QueryMetadataImpl.TimeBoundedQueue;
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.streams.StreamsConfig;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -70,18 +70,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
       final BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata,
       final QueryId queryId
   ) {
-    if (!sources.containsKey(queryId)) {
-      if (sources
-          .values()
-          .stream()
-          .flatMap(Collection::stream)
-          .anyMatch(t -> binpackedPersistentQueryMetadata.getSourceNames().contains(t))) {
-        throw new IllegalArgumentException(
-            queryId.toString() + ": was not reserved on this runtime");
-      } else {
-        sources.put(queryId, binpackedPersistentQueryMetadata.getSourceNames());
-      }
-    }
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
     log.debug("mapping {}", collocatedQueries);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.QueryMetadataImpl.TimeBoundedQueue;
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -65,18 +65,6 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
       final BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata,
       final QueryId queryId
   ) {
-    if (!sources.containsKey(queryId)) {
-      if (sources
-          .values()
-          .stream()
-          .flatMap(Collection::stream)
-          .anyMatch(t -> binpackedPersistentQueryMetadata.getSourceNames().contains(t))) {
-        throw new IllegalArgumentException(
-            queryId.toString() + ": was not reserved on this runtime");
-      } else {
-        sources.put(queryId, binpackedPersistentQueryMetadata.getSourceNames());
-      }
-    }
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
     log.info("mapping {}", collocatedQueries);
   }
@@ -178,7 +166,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
   @Override
   public void stop(final QueryId queryId, final boolean resetOffsets) {
     log.info("Attempting to stop Query: " + queryId.toString());
-    if (collocatedQueries.containsKey(queryId) && sources.containsKey(queryId)) {
+    if (collocatedQueries.containsKey(queryId)) {
       if (kafkaStreams.state().isRunningOrRebalancing()) {
         try {
           kafkaStreams.removeNamedTopology(queryId.toString(), resetOffsets)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
@@ -85,20 +85,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
   }
 
   @Test
-  public void shouldNotAddQuery() {
-    //Given:
-    when(binPackedPersistentQueryMetadata.getSourceNames())
-        .thenReturn(Collections.singleton(SourceName.of("foo")));
-    //When:
-    final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> validationSharedKafkaStreamsRuntime.register(
-            binPackedPersistentQueryMetadata,
-            queryId2));
-    //Then
-    assertThat(e.getMessage(), containsString(": was not reserved on this runtime"));
-  }
-
-  @Test
   public void shouldNotStopQuery() {
     //Given:
     validationSharedKafkaStreamsRuntime.start(queryId);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
@@ -70,7 +70,6 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
     when(queryId.toString()).thenReturn("query 1");
     when(queryId2.toString()).thenReturn("query 2");
 
-    validationSharedKafkaStreamsRuntime.markSources(queryId, Collections.singleton(SourceName.of("foo")));
     validationSharedKafkaStreamsRuntime.register(
         binPackedPersistentQueryMetadata,
         queryId);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -219,20 +219,6 @@ public class SharedKafkaStreamsRuntimeImplTest {
     }
 
     @Test
-    public void shouldNotAddQuery() {
-        //Given:
-        when(binPackedPersistentQueryMetadata.getSourceNames())
-            .thenReturn(Collections.singleton(SourceName.of("foo")));
-        //When:
-        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-            () -> sharedKafkaStreamsRuntimeImpl.register(
-                binPackedPersistentQueryMetadata,
-                queryId2));
-        //Then
-        assertThat(e.getMessage(), containsString(": was not reserved on this runtime"));
-    }
-
-    @Test
     public void shouldCloseRuntime() {
         //When:
         sharedKafkaStreamsRuntimeImpl.close();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -96,7 +96,6 @@ public class SharedKafkaStreamsRuntimeImplTest {
             streamProps
         );
 
-        sharedKafkaStreamsRuntimeImpl.markSources(queryId, Collections.singleton(SourceName.of("foo")));
         sharedKafkaStreamsRuntimeImpl.register(
             binPackedPersistentQueryMetadata,
             queryId);
@@ -136,7 +135,6 @@ public class SharedKafkaStreamsRuntimeImplTest {
          when(queryErrorClassifier.classify(query1Exception)).thenReturn(Type.USER);
 
         //Should not try to add error to query2's queue
-        sharedKafkaStreamsRuntimeImpl.markSources(queryId2, Collections.singleton(SourceName.of("foo2")));
         sharedKafkaStreamsRuntimeImpl.register(
             binPackedPersistentQueryMetadata2,
             queryId2
@@ -157,7 +155,6 @@ public class SharedKafkaStreamsRuntimeImplTest {
     public void shouldAddErrorWithNoTaskToAllQueries() {
         when(queryErrorClassifier.classify(runtimeExceptionWithNoTask)).thenReturn(Type.USER);
 
-        sharedKafkaStreamsRuntimeImpl.markSources(queryId2, Collections.singleton(SourceName.of("foo2")));
         sharedKafkaStreamsRuntimeImpl.register(
             binPackedPersistentQueryMetadata2,
             queryId2
@@ -178,7 +175,6 @@ public class SharedKafkaStreamsRuntimeImplTest {
     public void shouldAddErrorWithTaskAndNoTopologyToAllQueries() {
         when(queryErrorClassifier.classify(runtimeExceptionWithTaskAndNoTopology)).thenReturn(Type.USER);
 
-        sharedKafkaStreamsRuntimeImpl.markSources(queryId2, Collections.singleton(SourceName.of("foo2")));
         sharedKafkaStreamsRuntimeImpl.register(
             binPackedPersistentQueryMetadata2,
             queryId2
@@ -199,7 +195,6 @@ public class SharedKafkaStreamsRuntimeImplTest {
     public void shouldAddErrorWithTaskAndUnknownTopologyToAllQueries() {
         when(queryErrorClassifier.classify(runtimeExceptionWithTaskAndUnknownTopology)).thenReturn(Type.USER);
 
-        sharedKafkaStreamsRuntimeImpl.markSources(queryId2, Collections.singleton(SourceName.of("foo2")));
         sharedKafkaStreamsRuntimeImpl.register(
             binPackedPersistentQueryMetadata2,
             queryId2


### PR DESCRIPTION
Now that we have the runtime assignor we don't need to keep checking the sources in the runtime. There will not be queries assigned to `SharedKafkaStreamRuntime` with the same sources. If by some bug there is the add will fail.
 
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

