### PR TITLE
chore: display error with workaround when CREATE OR REPLACE fails due to overlapping sources

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -120,8 +120,10 @@ public class RuntimeAssignor {
   public void rebuildAssignment(final Collection<PersistentQueryMetadata> queries) {
     for (PersistentQueryMetadata queryMetadata: queries) {
       if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
-        runtimesToSources.put(queryMetadata.getQueryApplicationId(),
-            queryMetadata.getSourceNames());
+        runtimesToSources.put(
+            queryMetadata.getQueryApplicationId(),
+            new HashSet<>(queryMetadata.getSourceNames())
+        );
         idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());
       }
     }


### PR DESCRIPTION
A limitation in V1 of the query scaling engine will prevent users from issuing CREATE OR REPLACE commands that update the source topics of a query if those topics happen to already be consumed by another query in the same runtime. This should be a very rare case but if a user does hit it, we should make sure to explain why this failed and suggest a workaround for updating the query in the error message.
