### PR TITLE
fix: Allow disabling Scalable Push Query ALOS to be set via config

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryConfigRoutingOptions.java
@@ -92,6 +92,6 @@ public class PushQueryConfigRoutingOptions implements PushRoutingOptions {
     if (configOverrides.containsKey(KsqlConfig.KSQL_QUERY_PUSH_V2_ALOS_ENABLED)) {
       return (Boolean) configOverrides.get(KsqlConfig.KSQL_QUERY_PUSH_V2_ALOS_ENABLED);
     }
-    return KsqlConfig.KSQL_QUERY_PUSH_V2_ALOS_ENABLED_DEFAULT;
+    return ksqlConfig.getBoolean(KsqlConfig.KSQL_QUERY_PUSH_V2_ALOS_ENABLED);
   }
 }


### PR DESCRIPTION
### Description 
Allows scalable push queries to be set via sercer config, not just via the request.

### Testing done 
Tested the change manually and ran tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

