### PR TITLE
fix: make adding to pull query queue threadsafe

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/PullQueryQueue.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/PullQueryQueue.java
@@ -217,7 +217,7 @@ public class PullQueryQueue implements BlockingRowQueue {
    * Enqueues a row on the queue.  Blocks until the row can be accepted.
    * @param row The row to enqueue.
    */
-  public boolean acceptRow(final PullQueryRow row) {
+  public synchronized boolean acceptRow(final PullQueryRow row) {
     try {
       if (row == null) {
         return false;


### PR DESCRIPTION
### Description 
fixes https://github.com/confluentinc/ksql/issues/8517 by making adding rows to pull query queue threadsafe


### Testing done 
I ran `io.confluent.ksql.rest.integration.PullQueryLimitHARoutingTest.shouldReturnLimitRowsMultiHostSetupTable` locally ~90 times and it never failed. Before this fix, it used to fail before ~25 runs

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

