### PR TITLE
fix: variable substitution with CREATE CONNECTOR in migrations tool

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -221,7 +221,7 @@ public final class CommandParser {
       case INSERT_VALUES:
         return getInsertValuesStatement(sql, variables);
       case CREATE_CONNECTOR:
-        return getCreateConnectorStatement(sql);
+        return getCreateConnectorStatement(sql, variables);
       case DROP_CONNECTOR:
         return getDropConnectorStatement(sql);
       case STATEMENT:
@@ -262,11 +262,18 @@ public final class CommandParser {
             .map(ColumnName::text).collect(Collectors.toList()));
   }
 
-  private static SqlCreateConnectorStatement getCreateConnectorStatement(final String sql) {
+  private static SqlCreateConnectorStatement getCreateConnectorStatement(
+      final String sql,
+      final Map<String, String> variables
+  ) {
     final CreateConnector createConnector;
     try {
+      final String substituted = VariableSubstitutor.substitute(
+          KSQL_PARSER.parse(sql).get(0),
+          variables
+      );
       createConnector = (CreateConnector) new AstBuilder(TypeRegistry.EMPTY)
-          .buildStatement(KSQL_PARSER.parse(sql).get(0).getStatement());
+          .buildStatement(KSQL_PARSER.parse(substituted).get(0).getStatement());
     } catch (ParseFailedException e) {
       throw new MigrationException(String.format(
           "Failed to parse CREATE CONNECTOR statement. Statement: %s. Reason: %s",

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -228,7 +228,8 @@ public class MigrationsTest {
         "CREATE STREAM ${streamName} (A STRING) WITH (KAFKA_TOPIC='FOO', PARTITIONS=1, VALUE_FORMAT='JSON');\n" +
             "-- let's create some connectors!!!\n" +
             "CREATE SOURCE CONNECTOR C WITH ('connector.class'='org.apache.kafka.connect.tools.MockSourceConnector');\n" +
-            "CREATE SINK CONNECTOR D WITH ('connector.class'='org.apache.kafka.connect.tools.MockSinkConnector', 'topics'='d');\n" +
+            "DEFINE connectorName = 'D';" +
+            "CREATE SINK CONNECTOR ${connectorName} WITH ('connector.class'='org.apache.kafka.connect.tools.MockSinkConnector', 'topics'='d');\n" +
             "CREATE TABLE blue (ID BIGINT PRIMARY KEY, A STRING, H BYTES HEADER('a')) WITH (KAFKA_TOPIC='blue', PARTITIONS=1, VALUE_FORMAT='DELIMITED');" +
             "DROP TABLE blue;" +
             "DEFINE onlyDefinedInFile1 = 'nope';"
@@ -251,7 +252,8 @@ public class MigrationsTest {
             "CREATE STREAM `bar` AS SELECT CONCAT(A, 'woo''hoo') AS A FROM FOO;" +
             "UnSET 'ksql.output.topic.name.prefix';" +
             "CREATE STREAM CAR AS SELECT * FROM FOO;" +
-            "DROP CONNECTOR D;" +
+            "DEFINE connectorName = 'D';" +
+            "DROP CONNECTOR ${connectorName};" +
             "INSERT INTO `bar` SELECT A FROM CAR;" +
             "CREATE TYPE ADDRESS AS STRUCT<number INTEGER, street VARCHAR, city VARCHAR>;" +
             "DEFINE suffix = 'OMES';" +

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -361,6 +361,35 @@ public class CommandParserTest {
   }
 
   @Test
+  public void shouldParseCreateConnectorStatementWithVariables() {
+    // Given:
+    final String createConnector = "CREATE SOURCE CONNECTOR ${name} WITH(\n"
+        + "    \"connector.class\"='io.confluent.connect.jdbc.JdbcSourceConnector',\n"
+        + "    \"connection.url\"=${url},\n"
+        + "    \"mode\"='bulk',\n"
+        + "    \"topic.prefix\"='jdbc-',\n"
+        + "    \"table.whitelist\"='users',\n"
+        + "    \"key\"='username');";
+
+    // When:
+    List<SqlCommand> commands = parse(createConnector, ImmutableMap.of("url", "'jdbc:postgresql://localhost:5432/my.db'", "name", "`jdbc_connector`"));
+
+    // Then:
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0), instanceOf(SqlCreateConnectorStatement.class));
+    assertThat(commands.get(0).getCommand(), is(createConnector));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getName(), is("`jdbc_connector`"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).isSource(), is(true));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().size(), is(6));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("connector.class"), is("io.confluent.connect.jdbc.JdbcSourceConnector"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("connection.url"), is("jdbc:postgresql://localhost:5432/my.db"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("mode"), is("bulk"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("topic.prefix"), is("jdbc-"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("table.whitelist"), is("users"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("key"), is("username"));
+  }
+
+  @Test
   public void shouldParseDropConnectorStatement() {
     // Given:
     final String dropConnector = "DRoP CONNEcTOR `jdbc-connector` ;"; // The space at the end is to make sure that the regex doesn't capture it as a part of the name


### PR DESCRIPTION
### Description 
Fixes bug in migrations tool where using variable substitution for `CREATE CONNECTOR` statements fail. This is what happens when you try something like `CREATE SOURCE CONNECTOR ${name} WITH ...`:

```
Exception in thread "main" java.lang.UnsupportedOperationException: not yet implemented
        at io.confluent.ksql.parser.AstBuilder$Visitor.aggregateResult(AstBuilder.java:1339)
        at io.confluent.ksql.parser.AstBuilder$Visitor.aggregateResult(AstBuilder.java:218)
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visitChildren(AbstractParseTreeVisitor.java:47)
        at io.confluent.ksql.parser.SqlBaseBaseVisitor.visitVariableLiteral(SqlBaseBaseVisitor.java:958)
        at io.confluent.ksql.parser.SqlBaseParser$VariableLiteralContext.accept(SqlBaseParser.java:8224)
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
        at io.confluent.ksql.parser.AstBuilder$Visitor.processTableProperties(AstBuilder.java:269)
        at io.confluent.ksql.parser.AstBuilder$Visitor.visitCreateConnector(AstBuilder.java:348)
        at io.confluent.ksql.parser.AstBuilder$Visitor.visitCreateConnector(AstBuilder.java:218)
        at io.confluent.ksql.parser.SqlBaseParser$CreateConnectorContext.accept(SqlBaseParser.java:817)
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
        at io.confluent.ksql.parser.AstBuilder$Visitor.visitSingleStatement(AstBuilder.java:247)
        at io.confluent.ksql.parser.AstBuilder$Visitor.visitSingleStatement(AstBuilder.java:218)
        at io.confluent.ksql.parser.SqlBaseParser$SingleStatementContext.accept(SqlBaseParser.java:365)
        at org.antlr.v4.runtime.tree.AbstractParseTreeVisitor.visit(AbstractParseTreeVisitor.java:18)
        at io.confluent.ksql.parser.AstBuilder.build(AstBuilder.java:214)
        at io.confluent.ksql.parser.AstBuilder.buildStatement(AstBuilder.java:195)
        at io.confluent.ksql.tools.migrations.util.CommandParser.getCreateConnectorStatement(CommandParser.java:269)
        at io.confluent.ksql.tools.migrations.util.CommandParser.transformToSqlCommand(CommandParser.java:224)
        at io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand.executeCommands(ApplyMigrationCommand.java:361)
        at io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand.executeCommands(ApplyMigrationCommand.java:332)
        at io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand.applyMigration(ApplyMigrationCommand.java:306)
        at io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand.apply(ApplyMigrationCommand.java:221)
        at io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand.command(ApplyMigrationCommand.java:186)
        at io.confluent.ksql.tools.migrations.commands.ApplyMigrationCommand.command(ApplyMigrationCommand.java:148)
        at io.confluent.ksql.tools.migrations.commands.BaseCommand.runCommand(BaseCommand.java:85)
        at io.confluent.ksql.tools.migrations.Migrations.main(Migrations.java:103)

```
The fix is to substitute all the variables before [this line](https://github.com/confluentinc/ksql/blob/136c18309e6b5942a57847e4c4362abfd4cb0a9f/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java#L269).

### Testing done 
Unit + integration tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

