### PR TITLE
feat: add max task usage and num stateful tasks metrics

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -51,7 +51,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   private static final String METRIC_GROUP = "ksqldb_utilization";
 
   private Map<String, Map<String, TaskStorageMetric>> metricsSeen;
-  private static Metrics metricRegistry;
+  private Metrics metricRegistry;
   private static Map<String, String> customTags = new HashMap<>();
   private static AtomicInteger numberStatefulTasks = new AtomicInteger(0);
 
@@ -109,7 +109,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     );
     metricRegistry.addMetric(
         maxTaskPerNode,
-        (Gauge<BigInteger>) (config, now) -> (getMaxTaskUsage())
+        (Gauge<BigInteger>) (config, now) -> (getMaxTaskUsage(metricRegistry))
     );
     metricRegistry.addMetric(
         numStatefulTasks,
@@ -244,10 +244,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     return queryMetricSum;
   }
   
-  public static synchronized BigInteger getMaxTaskUsage() {
-    if (metricRegistry == null) {
-      return BigInteger.ZERO;
-    }
+  public static synchronized BigInteger getMaxTaskUsage(final Metrics metricRegistry) {
     final Collection<KafkaMetric> taskMetrics = metricRegistry
         .metrics()
         .entrySet()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -53,7 +53,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   private Map<String, Map<String, TaskStorageMetric>> metricsSeen;
   private static Metrics metricRegistry;
   private static Map<String, String> customTags = new HashMap<>();
-  private static AtomicInteger numberStatefulTasks;
+  private static AtomicInteger numberStatefulTasks = new AtomicInteger(0);
 
   public StorageUtilizationMetricsReporter() {
   }
@@ -68,7 +68,6 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
         map.get(KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG)
     );
     this.metricsSeen = new HashMap<>();
-    this.numberStatefulTasks = new AtomicInteger(0);
   }
 
   public static void configureShared(
@@ -114,7 +113,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     );
     metricRegistry.addMetric(
         numStatefulTasks,
-        (Gauge<Integer>) (config, now) -> (numberStatefulTasks!= null ? numberStatefulTasks.get() : 0)
+        (Gauge<Integer>) (config, now) -> (numberStatefulTasks.get())
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -114,7 +114,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     );
     metricRegistry.addMetric(
         numStatefulTasks,
-        (Gauge<AtomicInteger>) (config, now) -> (numberStatefulTasks)
+        (Gauge<Integer>) (config, now) -> (numberStatefulTasks.get())
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -84,7 +84,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     final MetricName nodePct =
         metricRegistry.metricName("storage_utilization", METRIC_GROUP, customTags);
     final MetricName maxTaskPerNode = 
-      metricRegistry.metricName("max_task_storage_used_bytes", METRIC_GROUP, customTags);
+        metricRegistry.metricName("max_task_storage_used_bytes", METRIC_GROUP, customTags);
 
     metricRegistry.addMetric(
         nodeAvailable,
@@ -105,8 +105,8 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
             / (double) baseDir.getTotalSpace())
     );
     metricRegistry.addMetric(
-      maxTaskPerNode,
-      (Gauge<BigInteger>) (config, now) -> (getMaxTaskUsage())
+        maxTaskPerNode,
+        (Gauge<BigInteger>) (config, now) -> (getMaxTaskUsage())
     );
   }
 
@@ -236,14 +236,17 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   }
   
   public static synchronized BigInteger getMaxTaskUsage() {
-    Collection<KafkaMetric> taskMetrics = metricRegistry
-      .metrics()
-      .entrySet()
-      .stream()
-      .filter(e -> e.getKey().name().contains("task_storage_used_bytes"))
-      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-      .values();
-    Optional<BigInteger> maxOfTaskMetrics = taskMetrics.stream().map(e -> (BigInteger) e.metricValue()).reduce(BigInteger::max);
+    final Collection<KafkaMetric> taskMetrics = metricRegistry
+        .metrics()
+        .entrySet()
+        .stream()
+        .filter(e -> e.getKey().name().contains("task_storage_used_bytes"))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+        .values();
+    final Optional<BigInteger> maxOfTaskMetrics = taskMetrics
+        .stream()
+        .map(e -> (BigInteger) e.metricValue())
+        .reduce(BigInteger::max);
     return maxOfTaskMetrics.orElse(BigInteger.ZERO);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -114,7 +114,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     );
     metricRegistry.addMetric(
         numStatefulTasks,
-        (Gauge<Integer>) (config, now) -> (numberStatefulTasks.get())
+        (Gauge<Integer>) (config, now) -> (numberStatefulTasks!= null ? numberStatefulTasks.get() : 0)
     );
   }
 
@@ -246,6 +246,9 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   }
   
   public static synchronized BigInteger getMaxTaskUsage() {
+    if (metricRegistry == null) {
+      return BigInteger.ZERO;
+    }
     final Collection<KafkaMetric> taskMetrics = metricRegistry
         .metrics()
         .entrySet()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -49,6 +49,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   private static final Logger LOGGER
       = LoggerFactory.getLogger(StorageUtilizationMetricsReporter.class);
   private static final String METRIC_GROUP = "ksqldb_utilization";
+  private static final String TASK_STORAGE_USED_BYTES = "task_storage_used_bytes";
 
   private Map<String, Map<String, TaskStorageMetric>> metricsSeen;
   private Metrics metricRegistry;
@@ -194,7 +195,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
       // create a new task level metric to track state store storage usage
       newMetric = new TaskStorageMetric(
         metricRegistry.metricName(
-          "task_storage_used_bytes",
+          TASK_STORAGE_USED_BYTES,
           METRIC_GROUP,
           taskMetricTags
         ));
@@ -249,7 +250,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
         .metrics()
         .entrySet()
         .stream()
-        .filter(e -> e.getKey().name().contains("task_storage_used_bytes"))
+        .filter(e -> e.getKey().name().contains(TASK_STORAGE_USED_BYTES))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
         .values();
     final Optional<BigInteger> maxOfTaskMetrics = taskMetrics

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -96,7 +96,7 @@ public class StorageUtilizationMetricsReporterTest {
     final Gauge<?> maxTaskUsageGauge = verifyAndGetRegisteredMetric("max_task_storage_used_bytes", BASE_TAGS);
     final Object maxTaskUsageValue = maxTaskUsageGauge.value(null, 0);
     final Gauge<?> numStatefulTasksGauge = verifyAndGetRegisteredMetric("num_stateful_tasks", BASE_TAGS);
-    final AtomicInteger numStatefulTasksValue = (AtomicInteger) numStatefulTasksGauge.value(null, 0);
+    final Object numStatefulTasksValue = numStatefulTasksGauge.value(null, 0);
     
     // Then:
     assertThat((Long) storageFreeValue, greaterThan(0L));
@@ -104,7 +104,7 @@ public class StorageUtilizationMetricsReporterTest {
     assertThat((Long) storageUsedValue, greaterThan(0L));
     assertThat((Double) pctUsedValue, greaterThan(0.0));
     assertThat((BigInteger) maxTaskUsageValue, greaterThanOrEqualTo(BigInteger.ZERO));
-    assertEquals(numStatefulTasksValue.intValue(), 0);
+    assertEquals((int) numStatefulTasksValue, 0);
   }
 
   @Test
@@ -316,8 +316,8 @@ public class StorageUtilizationMetricsReporterTest {
     );
     
     // Then:
-    final AtomicInteger numStatefulTasksValue = (AtomicInteger) numStatefulTasksGauge.value(null, 0);
-    assertEquals(numStatefulTasksValue.intValue(), 2);
+    final Object numStatefulTasksValue = numStatefulTasksGauge.value(null, 0);
+    assertEquals((int) numStatefulTasksValue, 2);
   }
 
   private KafkaMetric mockMetric(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -104,7 +104,7 @@ public class StorageUtilizationMetricsReporterTest {
     assertThat((Long) storageUsedValue, greaterThan(0L));
     assertThat((Double) pctUsedValue, greaterThan(0.0));
     assertThat((BigInteger) maxTaskUsageValue, greaterThanOrEqualTo(BigInteger.ZERO));
-    assertEquals((int) numStatefulTasksValue, 0);
+    assertEquals(numStatefulTasksValue, 7);
   }
 
   @Test
@@ -290,7 +290,7 @@ public class StorageUtilizationMetricsReporterTest {
     listener.metricChange(m2);
     
     // Then:
-    BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage();
+    BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage(metrics);
     assertTrue(maxVal.equals(BigInteger.valueOf(5)));
   }
 
@@ -302,7 +302,7 @@ public class StorageUtilizationMetricsReporterTest {
     // When:
 
     // Then:
-    BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage();
+    BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage(metrics);
     assertTrue(maxVal.equals(BigInteger.valueOf(0)));
   }
   

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -293,6 +293,18 @@ public class StorageUtilizationMetricsReporterTest {
     BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage();
     assertTrue(maxVal.equals(BigInteger.valueOf(5)));
   }
+
+  @Test
+  public void shouldRecordMaxTaskUsageWithNoTasks() {
+    // Given:
+    when(metrics.metrics()).thenReturn(Collections.EMPTY_MAP);
+
+    // When:
+
+    // Then:
+    BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage();
+    assertTrue(maxVal.equals(BigInteger.valueOf(0)));
+  }
   
   @Test
   public void shouldRecordNumStatefulTasks() {


### PR DESCRIPTION
### Description 
We're adding a metric (`max_task_storage_used_bytes`) that takes the maximum task disk usage on a node and emits that. This allows users to see the maximum disk space a single task is taking up without having to filter through all the task metrics on their side.

We're also adding a metric `num_stateful_tasks` that records the number of stateful tasks on a node. These two metrics combined will allow users to better understand their task work distribution and understand how to tune their system for their needs. 

### Testing done 
unit tests, tested on jconsole

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

