### PR TITLE
fix: SandboxKafkaTopicClient should use default replication factor if applicable

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
@@ -44,7 +44,7 @@ public final class SandboxedServiceContext implements ServiceContext {
 
     final KafkaClientSupplier kafkaClientSupplier = new SandboxedKafkaClientSupplier();
     final KafkaTopicClient kafkaTopicClient = SandboxedKafkaTopicClient
-        .createProxy(serviceContext.getTopicClient());
+        .createProxy(serviceContext.getTopicClient(), serviceContext::getAdminClient);
     final SchemaRegistryClient schemaRegistryClient =
         SandboxedSchemaRegistryClient.createProxy(serviceContext.getSchemaRegistryClient());
     final ConnectClient connectClient = SandboxConnectClient.createProxy();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/FakeKafkaClientSupplier.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/FakeKafkaClientSupplier.java
@@ -31,7 +31,7 @@ public class FakeKafkaClientSupplier implements KafkaClientSupplier {
 
   @Override
   public Admin getAdmin(final Map<String, Object> config) {
-    final Node node = new Node(1, "localhost", 1234);
+    final Node node = new Node(0, "localhost", 1234);
     return new MockAdminClient(Collections.singletonList(node), node);
   }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -591,6 +591,7 @@ public class RecoveryTest {
   @Before
   public void setUp() {
     topicClient.preconditionTopicExists("A");
+    topicClient.preconditionTopicExists("B");
     topicClient.preconditionTopicExists("command_topic");
   }
 
@@ -638,8 +639,6 @@ public class RecoveryTest {
     shouldRecover(commands);
   }
 
-
-  @Ignore // this test fails until https://github.com/apache/kafka/pull/11648 in available
   @Test
   public void shouldRecoverInsertIntos() {
     server1.submitCommands(
@@ -650,7 +649,6 @@ public class RecoveryTest {
     shouldRecover(commands);
   }
 
-  @Ignore // this test fails until https://github.com/apache/kafka/pull/11648 in available
   @Test
   public void shouldRecoverInsertIntosWithCustomQueryId() {
     server1.submitCommands(
@@ -661,7 +659,6 @@ public class RecoveryTest {
     shouldRecover(commands);
   }
 
-  @Ignore // this test fails until https://github.com/apache/kafka/pull/11648 in available
   @Test
   public void shouldRecoverInsertIntosRecreates() {
     server1.submitCommands(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -80,6 +80,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 
@@ -638,6 +639,7 @@ public class RecoveryTest {
   }
 
 
+  @Ignore // this test fails until https://github.com/apache/kafka/pull/11648 in available
   @Test
   public void shouldRecoverInsertIntos() {
     server1.submitCommands(
@@ -648,6 +650,7 @@ public class RecoveryTest {
     shouldRecover(commands);
   }
 
+  @Ignore // this test fails until https://github.com/apache/kafka/pull/11648 in available
   @Test
   public void shouldRecoverInsertIntosWithCustomQueryId() {
     server1.submitCommands(
@@ -658,6 +661,7 @@ public class RecoveryTest {
     shouldRecover(commands);
   }
 
+  @Ignore // this test fails until https://github.com/apache/kafka/pull/11648 in available
   @Test
   public void shouldRecoverInsertIntosRecreates() {
     server1.submitCommands(


### PR DESCRIPTION
If replication factor `-1` is used (implying to use the broker default) the
SandboxKafkaTopicClient created a mocked topic with replication factor 0
instead of using the broker default.

If multiple statement are submitted as once (ie, via a file), later
statement could inherit the incorrect replication factor and thus fail,
which fails all statements in the file.

Closes #4800