### PR TITLE
feat: add support for connect specific https configs

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -119,6 +119,11 @@ public class KsqlConfig extends AbstractConfig {
   public static final String BASIC_AUTH_CREDENTIALS_USERNAME = "username";
   public static final String BASIC_AUTH_CREDENTIALS_PASSWORD = "password";
 
+  public static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG =
+      SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG;
+  public static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_HTTPS = "https";
+  public static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_NONE = "none";
+
   public static final String CONNECT_BASIC_AUTH_CREDENTIALS_FILE_PROPERTY =
       KSQL_CONNECT_PREFIX + "basic.auth.credentials.file";
   public static final String CONNECT_BASIC_AUTH_CREDENTIALS_RELOAD_PROPERTY =

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 
@@ -93,7 +94,9 @@ public final class TestServiceContext {
         new DefaultConnectClient(
             "http://localhost:8083",
             Optional.empty(),
-            Collections.emptyMap()),
+            Collections.emptyMap(),
+            Optional.empty(),
+            false),
         consumerGroupClient
     );
   }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -84,6 +84,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -574,7 +575,9 @@ public class TestExecutor implements Closeable {
         () -> new DefaultConnectClient(
             "http://localhost:8083",
             Optional.empty(),
-            Collections.emptyMap()),
+            Collections.emptyMap(),
+            Optional.empty(),
+            false),
         DisabledKsqlClient::instance,
         new StubKafkaConsumerGroupClient()
     );

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -84,7 +84,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.kstream.Windowed;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestRestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestRestServiceContextFactory.java
@@ -10,6 +10,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 
 public class TestRestServiceContextFactory {
@@ -44,8 +45,12 @@ public class TestRestServiceContextFactory {
           ksqlConfig,
           kafkaClientSupplier,
           srClientFactory,
-          () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
-              authHeader, Collections.emptyMap()),
+          () -> new DefaultConnectClient(
+              ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
+              authHeader,
+              Collections.emptyMap(),
+              Optional.empty(),
+              false),
           () -> ksqlClientFactory.create(authHeader, sharedClient)
       );
     };


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/6631.

This PR adds support for TLS configs to configure ksqlDB requests to an external Connect deployment. Configs prefixed with `ksql.connect.` are applied only to ksqlDB's Connect client. Non-prefixed configs are also applied to ksqlDB's Connect client by default, similar to how ksqlDB handles its Schema Registry TLS configs today.

Example configs:
```
ksql.connect.url=https://localhost:8443
ksql.connect.ssl.truststore.location=/path/to/client.truststore.jks
ksql.connect.ssl.truststore.password=<some password here>
ksql.connect.ssl.truststore.type=JKS
ksql.connect.ssl.endpoint.identification.algorithm=none
```

### Testing done 

I wanted to add an integration test but hit a few dead ends trying to configure an embedded Connect with custom TLS configs. Open to ideas if anyone has any, else I think the change is minor enough that I feel good about the unit tests plus my manual test coverage.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

