### PR TITLE
test: add more logging to flaky stream insert test

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedInsertsStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedInsertsStreamResponseWriter.java
@@ -22,6 +22,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import java.util.Objects;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Writes the inserts response stream in delimited format.
@@ -37,14 +40,17 @@ import java.util.Objects;
  */
 public class DelimitedInsertsStreamResponseWriter implements InsertsStreamResponseWriter {
 
+  private static final Logger LOG = LoggerFactory.getLogger(DelimitedInsertsStreamResponseWriter.class);
   private static final Buffer ACK_RESPONSE_LINE = new JsonObject().put("status", "ok").toBuffer()
       .appendString("\n");
 
   private final HttpServerResponse response;
+  private final UUID uuid;
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
-  public DelimitedInsertsStreamResponseWriter(final HttpServerResponse response) {
+  public DelimitedInsertsStreamResponseWriter(final HttpServerResponse response, final UUID uuid) {
     this.response = Objects.requireNonNull(response);
+    this.uuid = uuid;
   }
 
   @Override
@@ -61,6 +67,7 @@ public class DelimitedInsertsStreamResponseWriter implements InsertsStreamRespon
 
   @Override
   public void end() {
+    LOG.debug("({}) Ending response for insert stream", uuid);
     response.end();
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedInsertsStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/DelimitedInsertsStreamResponseWriter.java
@@ -40,7 +40,8 @@ import org.slf4j.LoggerFactory;
  */
 public class DelimitedInsertsStreamResponseWriter implements InsertsStreamResponseWriter {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DelimitedInsertsStreamResponseWriter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(
+      DelimitedInsertsStreamResponseWriter.class);
   private static final Buffer ACK_RESPONSE_LINE = new JsonObject().put("status", "ok").toBuffer()
       .appendString("\n");
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/InsertsStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/InsertsStreamHandler.java
@@ -35,6 +35,7 @@ import io.vertx.core.parsetools.RecordParser;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,7 @@ import org.slf4j.LoggerFactory;
  */
 public class InsertsStreamHandler implements Handler<RoutingContext> {
 
-  private static final Logger log = LoggerFactory.getLogger(InsertsStreamHandler.class);
+  private static final Logger LOG = LoggerFactory.getLogger(InsertsStreamHandler.class);
 
   private final Context ctx;
   private final Endpoints endpoints;
@@ -65,7 +66,6 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
 
   @Override
   public void handle(final RoutingContext routingContext) {
-
     if (!checkHttp2(routingContext)) {
       return;
     }
@@ -83,6 +83,7 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
     private final RoutingContext routingContext;
     private final RecordParser recordParser;
     private final InsertsStreamResponseWriter insertsStreamResponseWriter;
+    private final UUID uuid; // used to correlate logs
     private boolean hasReadArguments;
     private BufferedPublisher<JsonObject> publisher;
     private long rowsReceived;
@@ -96,18 +97,19 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
         final RecordParser recordParser) {
       this.routingContext = Objects.requireNonNull(routingContext);
       this.recordParser = Objects.requireNonNull(recordParser);
+      this.uuid = UUID.randomUUID();
       final String contentType = routingContext.getAcceptableContentType();
       if (DELIMITED_CONTENT_TYPE.equals(contentType) || contentType == null) {
         // Default
         insertsStreamResponseWriter =
-            new DelimitedInsertsStreamResponseWriter(routingContext.response());
+            new DelimitedInsertsStreamResponseWriter(routingContext.response(), uuid);
       } else {
         insertsStreamResponseWriter = new JsonInsertsStreamResponseWriter(
-            routingContext.response());
+            routingContext.response(), uuid);
       }
     }
 
-    public void handleBodyBuffer(final Buffer buff) {
+    private void handleBodyBuffer(final Buffer buff) {
 
       if (responseEnded) {
         // Ignore further buffers from request if response has been written (most probably due
@@ -130,6 +132,8 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
         return;
       }
 
+      LOG.debug("({}) Processed insert stream args: {}", uuid, insertsStreamArgs.get());
+
       routingContext.response().endHandler(v -> handleResponseEnd());
 
       acksSubscriber = new AcksSubscriber(ctx, routingContext.response(),
@@ -145,6 +149,8 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
 
             // This forces response headers to be written so we know we send a 200 OK
             // This is important if we subsequently find an error in the stream
+            LOG.debug(
+                "({}) Acknowledging insert stream in subscriber after creating publisher.", uuid);
             routingContext.response().write("");
 
             publisher.subscribe(insertsSubscriber);
@@ -162,11 +168,14 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
       final JsonObject row;
       try {
         row = new JsonObject(buff);
+        LOG.debug("({}) Handling insert stream row: {}", uuid, row);
       } catch (DecodeException e) {
         final InsertError errorResponse = new InsertError(
             seq,
             ERROR_CODE_BAD_REQUEST,
             "Invalid JSON in inserts stream");
+        LOG.warn("({}) Failed to process row at sequence {} ({})",
+            uuid, sendSequence, buff.toString(), e);
         insertsStreamResponseWriter.writeError(errorResponse).end();
         acksSubscriber.cancel();
         return;
@@ -174,6 +183,8 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
 
       final boolean bufferFull = publisher.accept(row);
       if (bufferFull && !paused) {
+        LOG.debug("({}) Buffer is full after processing {} records. Pausing the parser",
+            uuid, sendSequence);
         recordParser.pause();
         publisher.drainHandler(this::publisherReceptive);
         paused = true;
@@ -182,11 +193,18 @@ public class InsertsStreamHandler implements Handler<RoutingContext> {
     }
 
     private void publisherReceptive() {
+      LOG.debug("({}) Resuming record parser after draining publisher.", uuid);
       paused = false;
       recordParser.resume();
     }
 
-    public void handleBodyEnd(final Void v) {
+    private void handleBodyEnd(final Void v) {
+      LOG.debug("({}) Completed reading the request, ending the response. "
+              + "Completing Publisher: {}, Closing Publisher: {}",
+          uuid,
+          publisher != null,
+          acksSubscriber == null);
+
       if (publisher != null) {
         publisher.complete();
         if (acksSubscriber == null) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonInsertsStreamResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonInsertsStreamResponseWriter.java
@@ -21,6 +21,9 @@ import io.confluent.ksql.rest.entity.InsertError;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
 import java.util.Objects;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Writes the inserts response stream in JSON format.
@@ -36,12 +39,16 @@ import java.util.Objects;
  */
 public class JsonInsertsStreamResponseWriter implements InsertsStreamResponseWriter {
 
+  private static final Logger LOG = LoggerFactory.getLogger(JsonInsertsStreamResponseWriter.class);
+
   protected final HttpServerResponse response;
+  private final UUID uuid;
   private boolean dataWritten;
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP2")
-  public JsonInsertsStreamResponseWriter(final HttpServerResponse response) {
+  public JsonInsertsStreamResponseWriter(final HttpServerResponse response, final UUID uuid) {
     this.response = Objects.requireNonNull(response);
+    this.uuid = uuid;
   }
 
   @Override
@@ -58,6 +65,7 @@ public class JsonInsertsStreamResponseWriter implements InsertsStreamResponseWri
 
   @Override
   public void end() {
+    LOG.debug("({}) Ending response for insert stream. Data written: {}", uuid, dataWritten);
     if (!dataWritten) {
       response.write("[]").end();
     } else {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/ApiTest.java
@@ -802,7 +802,7 @@ public class ApiTest extends BaseApiTest {
     // Then
     HttpResponse<Buffer> response = requestFuture.get();
     JsonArray jsonArray = new JsonArray(response.body());
-    assertThat(jsonArray.size(), is(DEFAULT_JSON_ROWS.size()));
+    assertThat(jsonArray.size(), is(DEFAULT_INSERT_ROWS.size()));
     for (int i = 0; i < jsonArray.size(); i++) {
       final JsonObject ackLine = new JsonObject().put("status", "ok").put("seq", i);
       assertThat(jsonArray.getJsonObject(i), is(ackLine));
@@ -895,7 +895,7 @@ public class ApiTest extends BaseApiTest {
 
   private static List<JsonObject> generateInsertRows() {
     List<JsonObject> rows = new ArrayList<>();
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 3; i++) {
       JsonObject row = new JsonObject()
           .put("f_str", "foo" + i)
           .put("f_int", i)

--- a/ksqldb-test-util/src/main/resources/log4j.properties
+++ b/ksqldb-test-util/src/main/resources/log4j.properties
@@ -18,6 +18,9 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
+# help debug a flaky test
+log4j.logger.io.confluent.ksql.api.server=DEBUG
+
 # Disable INFO and WARN logs from Config classes, which log out their config on each creation
 # and warnings for any unknown config:
 log4j.logger.io.confluent.connect.avro.AvroConverterConfig=ERROR


### PR DESCRIPTION
### Description 

the `shouldStreamInserts` test is flaky (see https://jenkins.confluent.io/job/confluentinc/job/ksql/job/master/9268/testReport/junit/io.confluent.ksql.api/TlsTest/shouldStreamInserts/) and we added some logging in #8092 to help this and now I see that it's timing out in the insert part itself (never getting a response) so I've added logging to help dig into that...

looks like this is going to be a multi-step debugging process!

**NOTE**: I've also changed our test configuration logging for the `io.confluent.ksql.api.server` package to `DEBUG` because some of the logging that I added was in production code

### Testing done 

Ran the test and saw the logs

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

