### PR TITLE
fix: Fix DROP STREAM IF EXISTS DELETE TOPIC

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
@@ -114,7 +114,7 @@ public class TopicDeleteInjector implements Injector {
       } catch (final Exception e) {
         throw new KsqlException(e);
       }
-    } else if (dropStatement.getIfExists()) {
+    } else if (!dropStatement.getIfExists()) {
       throw new KsqlException("Could not find source to delete topic for: " + statement);
     }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/topic/TopicDeleteInjectorTest.java
@@ -203,7 +203,7 @@ public class TopicDeleteInjectorTest {
   public void shouldThrowExceptionIfSourceDoesNotExist() {
     // Given:
     final ConfiguredStatement<DropStream> dropStatement = givenStatement(
-        "DROP SOMETHING", new DropStream(SourceName.of("SOMETHING_ELSE"), true, true));
+        "DROP SOMETHING", new DropStream(SourceName.of("SOMETHING_ELSE"), false, true));
 
     // When:
     final Exception e = assertThrows(
@@ -213,6 +213,16 @@ public class TopicDeleteInjectorTest {
 
     // Then:
     assertThat(e.getMessage(), containsString("Could not find source to delete topic for"));
+  }
+
+  @Test
+  public void shouldNotThrowIfStatementHasIfExistsAndSourceDoesNotExist() {
+    // Given:
+    final ConfiguredStatement<DropStream> dropStatement = givenStatement(
+        "DROP SOMETHING", new DropStream(SourceName.of("SOMETHING_ELSE"), true, true));
+
+    // When:
+    deleteInjector.inject(dropStatement);
   }
 
   @Test


### PR DESCRIPTION
### Description 

This PR fixes https://github.com/confluentinc/ksql/issues/8548.

### Testing done 

I added a new unit test and checked manually that `DROP STREAM IF EXISTS DELETE TOPIC` works as expected now.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

