### PR TITLE
fix: make writes to the backup file atomic

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
@@ -98,12 +98,12 @@ public final class BackupReplayFile implements Closeable {
       final File file,
       final Filesystem filesystem
   ) throws IOException {
-    final FileOutputStream writer = createWriter(file, filesystem);
-    writer.write(record.key());
-    writer.write(KEY_VALUE_SEPARATOR_BYTES);
-    writer.write(record.value());
-    writer.write(NEW_LINE_SEPARATOR_BYTES);
-    writer.close();
+    try (final FileOutputStream writer = createWriter(file, filesystem)) {
+      writer.write(record.key());
+      writer.write(KEY_VALUE_SEPARATOR_BYTES);
+      writer.write(record.value());
+      writer.write(NEW_LINE_SEPARATOR_BYTES);
+    }
   }
 
   public void write(final ConsumerRecord<byte[], byte[]> record) throws IOException {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
@@ -24,7 +24,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -167,7 +166,7 @@ public final class BackupReplayFile implements Closeable {
 
   @VisibleForTesting
   interface Filesystem {
-    FileOutputStream outputStream(final File file, final boolean append)
+    FileOutputStream outputStream(File file, boolean append)
         throws FileNotFoundException;
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import java.io.Closeable;
@@ -23,7 +24,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.CopyOption;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -35,6 +39,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 public final class BackupReplayFile implements Closeable {
   private static final String KEY_VALUE_SEPARATOR_STR = ":";
   private static final String NEW_LINE_SEPARATOR_STR = "\n";
+  private static final String TMP_SUFFIX = ".tmp";
+  private static final String DIRTY_SUFFIX = ".dirty";
 
   private static final byte[] KEY_VALUE_SEPARATOR_BYTES =
       KEY_VALUE_SEPARATOR_STR.getBytes(StandardCharsets.UTF_8);
@@ -42,29 +48,34 @@ public final class BackupReplayFile implements Closeable {
       NEW_LINE_SEPARATOR_STR.getBytes(StandardCharsets.UTF_8);
 
   private final File file;
-  private final FileOutputStream writer;
+  private final boolean writable;
+  private final Filesystem filesystem;
 
-  public static BackupReplayFile readOnly(final File file) {
-    return new BackupReplayFile(file, false);
+  public static BackupReplayFile readOnly(final File file) throws IOException {
+    return new BackupReplayFile(file, false, filesystemImpl());
   }
 
-  public static BackupReplayFile writable(final File file) {
-    return new BackupReplayFile(file, true);
+  public static BackupReplayFile writable(final File file) throws IOException {
+    return new BackupReplayFile(file, true, filesystemImpl());
   }
 
-  private BackupReplayFile(final File file, final boolean write) {
+  @VisibleForTesting
+  BackupReplayFile(
+      final File file,
+      final boolean write,
+      final Filesystem filesystem
+  ) throws IOException {
     this.file = Objects.requireNonNull(file, "file");
-
+    this.filesystem = Objects.requireNonNull(filesystem, "filesystem");
+    this.writable = write;
     if (write) {
-      this.writer = createWriter(file);
-    } else {
-      this.writer = null;
+      initDirtyCopy();
     }
   }
 
-  private static FileOutputStream createWriter(final File file) {
+  private static FileOutputStream createWriter(final File file, final Filesystem filesystem) {
     try {
-      return new FileOutputStream(file, true);
+      return filesystem.outputStream(file, true);
     } catch (final FileNotFoundException e) {
       throw new KsqlException(
           String.format("Failed to create/open replay file: %s", file.getAbsolutePath()), e);
@@ -79,16 +90,39 @@ public final class BackupReplayFile implements Closeable {
     return file.getAbsolutePath();
   }
 
-  public void write(final ConsumerRecord<byte[], byte[]> record) throws IOException {
-    if (writer == null) {
-      throw new IOException("Write permission denied.");
-    }
-
+  private static void appendRecordToFile(
+      final ConsumerRecord<byte[], byte[]> record,
+      final File file,
+      final Filesystem filesystem
+  ) throws IOException {
+    final FileOutputStream writer = createWriter(file, filesystem);
     writer.write(record.key());
     writer.write(KEY_VALUE_SEPARATOR_BYTES);
     writer.write(record.value());
     writer.write(NEW_LINE_SEPARATOR_BYTES);
-    writer.flush();
+    writer.close();
+  }
+
+  public void write(final ConsumerRecord<byte[], byte[]> record) throws IOException {
+    if (!writable) {
+      throw new IOException("Write permission denied.");
+    }
+    final File dirty = dirty(file);
+    final File tmp = tmp(file);
+    // first write to the dirty copy
+    appendRecordToFile(record, dirty, filesystem);
+    // atomically rename the dirty copy to the "live" copy while copying the live copy to
+    // the "dirty" copy via a temporary hard link
+    Files.createLink(tmp.toPath(), file.toPath());
+    Files.move(
+        dirty.toPath(),
+        file.toPath(),
+        StandardCopyOption.REPLACE_EXISTING,
+        StandardCopyOption.ATOMIC_MOVE
+    );
+    Files.move(tmp.toPath(), dirty.toPath());
+    // keep the dirty copy in sync with the live copy, which now has the write
+    appendRecordToFile(record, dirty, filesystem);
   }
 
   public List<Pair<byte[], byte[]>> readRecords() throws IOException {
@@ -107,9 +141,33 @@ public final class BackupReplayFile implements Closeable {
   }
 
   @Override
-  public void close() throws IOException {
-    if (writer != null) {
-      writer.close();
+  public void close() {
+  }
+
+  private void initDirtyCopy() throws IOException {
+    final Path dirtyFile = dirty(file).toPath();
+    Files.deleteIfExists(dirtyFile);
+    Files.deleteIfExists(tmp(file).toPath());
+    if (file.exists()) {
+      Files.copy(file.toPath(), dirty(file).toPath(), StandardCopyOption.REPLACE_EXISTING);
     }
+  }
+
+  private File dirty(final File file) {
+    return new File(file.getPath() + DIRTY_SUFFIX);
+  }
+
+  private File tmp(final File file) {
+    return new File(file.getPath() + TMP_SUFFIX);
+  }
+
+  private static Filesystem filesystemImpl() {
+    return FileOutputStream::new;
+  }
+
+  @VisibleForTesting
+  interface Filesystem {
+    FileOutputStream outputStream(final File file, final boolean append)
+        throws FileNotFoundException;
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/BackupReplayFile.java
@@ -98,7 +98,7 @@ public final class BackupReplayFile implements Closeable {
       final File file,
       final Filesystem filesystem
   ) throws IOException {
-    try (final FileOutputStream writer = createWriter(file, filesystem)) {
+    try (FileOutputStream writer = createWriter(file, filesystem)) {
       writer.write(record.key());
       writer.write(KEY_VALUE_SEPARATOR_BYTES);
       writer.write(record.value());

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopicBackupImpl.java
@@ -89,7 +89,11 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
       LOG.warn("Failed to read the latest backup from {}. Continue with a new file. Error = {}",
           replayFile.getPath(), e.getMessage());
 
-      replayFile = newReplayFile();
+      try {
+        replayFile = newReplayFile();
+      } catch (final IOException ee) {
+        throw new RuntimeException(ee);
+      }
       latestReplay = Collections.emptyList();
     }
 
@@ -105,12 +109,7 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
 
   @Override
   public void close() {
-    try {
-      replayFile.close();
-    } catch (final IOException e) {
-      LOG.warn("Failed closing the backup file {}. Error = {}",
-          replayFile.getPath(), e.getMessage());
-    }
+    replayFile.close();
   }
 
   @VisibleForTesting
@@ -180,18 +179,25 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
 
   @VisibleForTesting
   BackupReplayFile openOrCreateReplayFile() {
-    return latestReplayFile()
-        .orElseGet(this::newReplayFile);
+    try {
+      final Optional<BackupReplayFile> backupReplayFile = latestReplayFile();
+      if (backupReplayFile.isPresent()) {
+        return backupReplayFile.get();
+      }
+      return newReplayFile();
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  private BackupReplayFile newReplayFile() {
+  private BackupReplayFile newReplayFile() throws IOException {
     return BackupReplayFile.writable(Paths.get(
         backupLocation.getAbsolutePath(),
         String.format("%s%s_%s", PREFIX, topicName, ticker.get())
     ).toFile());
   }
 
-  private Optional<BackupReplayFile> latestReplayFile() {
+  private Optional<BackupReplayFile> latestReplayFile() throws IOException {
     final String prefixFilename = String.format("%s%s_", PREFIX, topicName);
     final File[] files = backupLocation.listFiles(
         (f, name) -> name.toLowerCase().startsWith(prefixFilename));
@@ -216,8 +222,10 @@ public class CommandTopicBackupImpl implements CommandTopicBackup {
       }
     }
 
-    return Optional.ofNullable(latestBakFile)
-        .map(BackupReplayFile::writable);
+    if (latestBakFile != null) {
+      return Optional.of(BackupReplayFile.writable(latestBakFile));
+    }
+    return Optional.empty();
   }
 
   private static void ensureDirectoryExists(final File backupsDir) {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
@@ -17,22 +17,31 @@ package io.confluent.ksql.rest.server;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.rest.server.BackupReplayFile.Filesystem;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.Pair;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -45,11 +54,16 @@ public class BackupReplayFileTest {
 
   private BackupReplayFile replayFile;
   private File internalReplayFile;
+  @Mock
+  private Filesystem filesystem;
 
   @Before
   public void setup() throws IOException {
     internalReplayFile = backupLocation.newFile(REPLAY_FILE_NAME);
-    replayFile = BackupReplayFile.writable(internalReplayFile);
+    replayFile = new BackupReplayFile(internalReplayFile, true, filesystem);
+    when(filesystem.outputStream(any(File.class), anyBoolean())).thenAnswer(
+        i -> new FileOutputStream((File) i.getArgument(0), i.getArgument(1))
+    );
   }
 
   @Test
@@ -69,6 +83,62 @@ public class BackupReplayFileTest {
 
     // When
     replayFile.write(record);
+
+    // Then
+    final List<String> commands = Files.readAllLines(internalReplayFile.toPath());
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0), is(
+        "\"stream/stream1/create\"" + KEY_VALUE_SEPARATOR
+            + "{\"statement\":\"CREATE STREAM stream1 (id INT) WITH (kafka_topic='stream1')\""
+            + ",\"streamsProperties\":{},\"originalProperties\":{},\"plan\":null}"
+    ));
+  }
+
+  @Test
+  public void shouldWriteMultipleRecords() throws IOException {
+    // Given
+    final ConsumerRecord<byte[], byte[]> record1= newStreamRecord("stream1");
+    final ConsumerRecord<byte[], byte[]> record2 = newStreamRecord("stream2");
+
+    // When
+    replayFile.write(record1);
+    replayFile.write(record2);
+
+    // Then
+    final List<String> commands = Files.readAllLines(internalReplayFile.toPath());
+    assertThat(commands.size(), is(2));
+    assertThat(commands.get(0), is(
+        "\"stream/stream1/create\"" + KEY_VALUE_SEPARATOR
+            + "{\"statement\":\"CREATE STREAM stream1 (id INT) WITH (kafka_topic='stream1')\""
+            + ",\"streamsProperties\":{},\"originalProperties\":{},\"plan\":null}"
+    ));
+    assertThat(commands.get(1), is(
+        "\"stream/stream2/create\"" + KEY_VALUE_SEPARATOR
+            + "{\"statement\":\"CREATE STREAM stream2 (id INT) WITH (kafka_topic='stream2')\""
+            + ",\"streamsProperties\":{},\"originalProperties\":{},\"plan\":null}"
+    ));
+  }
+
+  @Test
+  public void shouldPreserveBackupOnWriteFailure() throws IOException {
+    // Given
+    final ConsumerRecord<byte[], byte[]> record = newStreamRecord("stream1");
+    replayFile.write(record);
+    when(filesystem.outputStream(any(), anyBoolean()))
+        .thenAnswer(i -> {
+          final FileOutputStream stream
+              = new FileOutputStream((File) i.getArgument(0), i.getArgument(1));
+          final FileOutputStream spy = Mockito.spy(stream);
+          doCallRealMethod().doThrow(new IOException("")).when(spy).write(any(byte[].class));
+          return spy;
+        });
+
+    // When/Then:
+    try {
+      replayFile.write(record);
+      Assert.fail("should throw IO exception");
+    } catch (final IOException e) {
+    }
 
     // Then
     final List<String> commands = Files.readAllLines(internalReplayFile.toPath());

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
@@ -122,6 +122,10 @@ public class BackupReplayFileTest {
   }
 
   @Test
+  @SuppressFBWarnings(
+      value = "OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE",
+      justification = "stream is closed by consumer of mock (BackupReplayFile)"
+  )
   public void shouldPreserveBackupOnWriteFailure() throws IOException {
     // Given
     final ConsumerRecord<byte[], byte[]> record = newStreamRecord("stream1");

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/BackupReplayFileTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.rest.server.BackupReplayFile.Filesystem;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.Pair;
@@ -121,6 +122,10 @@ public class BackupReplayFileTest {
   }
 
   @Test
+  @SuppressFBWarnings(
+      value = "OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE",
+      justification = "stream is closed explicitly in test"
+  )
   public void shouldPreserveBackupOnWriteFailure() throws IOException {
     // Given
     final ConsumerRecord<byte[], byte[]> record = newStreamRecord("stream1");


### PR DESCRIPTION
This patch makes writes to the backup file atomic. Writing a record now will either
complete in full, or not at all. This is achieved by writing the record to a dirty
copy, and then renaming the dirty copy to the live backup file. To maintain the dirty
copy without creating a new copy on each write, we create a temporary hardlink to
the live copy before renaming the dirty copy, and then rename the link to the dirty
copy. Finally, the write appends the record to the dirty copy (which was the old
live copy) to keep it in sync