### PR TITLE
fix: Make JaasPrincipal public

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
@@ -24,13 +24,17 @@ import java.util.Objects;
 
 /**
  * Principal implementation created when authenticating with the JaasAuthProvider
+ * <p>
+ *  This class and its constructor are public to make them accessible from pluggable security
+ *  extensions.
+ * </p>
  */
-class JaasPrincipal implements KsqlPrincipal {
+public class JaasPrincipal implements KsqlPrincipal {
 
   private final String name;
   private final String token;
 
-  JaasPrincipal(final String name, final String password) {
+  public JaasPrincipal(final String name, final String password) {
     this.name = Objects.requireNonNull(name, "name");
     this.token = createToken(name, Objects.requireNonNull(password));
   }


### PR DESCRIPTION
### Description 

`JaasPrincipal` public should be public to make it accessible from pluggable security extensions.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

