### PR TITLE
chore: expose original principal from DefaultKsqlPrincipal (MINOR)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
@@ -37,4 +37,8 @@ public class DefaultKsqlPrincipal implements KsqlPrincipal {
   public Map<String, Object> getUserProperties() {
     return Collections.emptyMap();
   }
+
+  public Principal getOriginalPrincipal() {
+    return principal;
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
@@ -20,6 +20,11 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * A {@link KsqlPrincipal} implementation that wraps another {@code Principal}.
+ * If the wrapped principal is a KsqlPrincipal, then its user properties are
+ * passed through. Otherwise, an empty map is returned.
+ */
 public class DefaultKsqlPrincipal implements KsqlPrincipal {
 
   private final Principal principal;
@@ -35,9 +40,17 @@ public class DefaultKsqlPrincipal implements KsqlPrincipal {
 
   @Override
   public Map<String, Object> getUserProperties() {
-    return Collections.emptyMap();
+    if (principal instanceof KsqlPrincipal) {
+      return ((KsqlPrincipal) principal).getUserProperties();
+    } else {
+      return Collections.emptyMap();
+    }
   }
 
+  /**
+   * Exposes the wrapped principal so custom extensions can access the original
+   * principal. This is part of the public API and should not be removed.
+   */
   public Principal getOriginalPrincipal() {
     return principal;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlPrincipal.java
@@ -31,9 +31,4 @@ public interface KsqlPrincipal extends Principal {
     return Collections.emptyMap();
   }
 
-  static KsqlPrincipal from(final Principal principal) {
-    return principal instanceof KsqlPrincipal
-        ? (KsqlPrincipal) principal
-        : new DefaultKsqlPrincipal(principal);
-  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/security/DefaultKsqlPrincipalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/security/DefaultKsqlPrincipalTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.security;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultKsqlPrincipalTest {
+
+  private static final String KSQL_PRINCIPAL_NAME = "ksql_principal";
+  private static final String OTHER_PRINCIPAL_NAME = "other_principal";
+  private static final Map<String, Object> USER_PROPERTIES = ImmutableMap.of("prop", "val");
+
+  @Mock
+  private KsqlPrincipal ksqlPrincipal;
+  @Mock
+  private Principal otherPrincipal;
+
+  private DefaultKsqlPrincipal wrappedKsqlPrincipal;
+  private DefaultKsqlPrincipal wrappedOtherPrincipal;
+
+  @Before
+  public void setUp() {
+    when(ksqlPrincipal.getName()).thenReturn(KSQL_PRINCIPAL_NAME);
+    when(ksqlPrincipal.getUserProperties()).thenReturn(USER_PROPERTIES);
+    when(otherPrincipal.getName()).thenReturn(OTHER_PRINCIPAL_NAME);
+
+    wrappedKsqlPrincipal = new DefaultKsqlPrincipal(ksqlPrincipal);
+    wrappedOtherPrincipal = new DefaultKsqlPrincipal(otherPrincipal);
+  }
+
+  @Test
+  public void shouldReturnName() {
+    assertThat(wrappedKsqlPrincipal.getName(), is(KSQL_PRINCIPAL_NAME));
+    assertThat(wrappedOtherPrincipal.getName(), is(OTHER_PRINCIPAL_NAME));
+  }
+
+  @Test
+  public void shouldReturnUserProperties() {
+    assertThat(wrappedKsqlPrincipal.getUserProperties(), is(USER_PROPERTIES));
+    assertThat(wrappedOtherPrincipal.getUserProperties(), is(Collections.emptyMap()));
+  }
+
+  @Test
+  public void shouldReturnOriginalPrincipal() {
+    assertThat(wrappedKsqlPrincipal.getOriginalPrincipal(), is(ksqlPrincipal));
+    assertThat(wrappedOtherPrincipal.getOriginalPrincipal(), is(otherPrincipal));
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPlugin.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPlugin.java
@@ -33,10 +33,10 @@ public interface AuthenticationPlugin {
    * Handle authentication for the request. The plugin implementation should not end the response in
    * case of failure. ksqlDB will end the response appropriately in case of failure.
    *
-   * <p>If the returned Principal is an instance of
-   * {@link io.confluent.ksql.security.KsqlPrincipal}, then the principal will be passed
-   * through directly to the ksqlDB engine, rather than being wrapped within another
-   * {@code KsqlPrincipal}.
+   * <p>The returned Principal will be wrapped in a
+   * {@link io.confluent.ksql.security.DefaultKsqlPrincipal}, before being passed
+   * to the ksqlDB engine, as the engine operates on
+   * {@link io.confluent.ksql.security.KsqlPrincipal}s rather than raw {@code Principal}s.
    *
    * @param routingContext The routing context
    * @param workerExecutor The worker executor

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
@@ -25,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.api.server.KsqlApiException;
 import io.confluent.ksql.api.server.Server;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.security.DefaultKsqlPrincipal;
 import io.confluent.ksql.security.KsqlPrincipal;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -104,7 +105,7 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
 
     AuthPluginUser(final Principal principal) {
       Objects.requireNonNull(principal);
-      this.principal = KsqlPrincipal.from(principal);
+      this.principal = new DefaultKsqlPrincipal(principal);
     }
 
     @SuppressWarnings("deprecation")

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/SystemAuthenticationHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/SystemAuthenticationHandler.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.auth;
 
+import io.confluent.ksql.security.DefaultKsqlPrincipal;
 import io.confluent.ksql.security.KsqlPrincipal;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -64,9 +65,9 @@ public class SystemAuthenticationHandler implements Handler<RoutingContext> {
 
     SystemUser(final Principal principal) {
       Objects.requireNonNull(principal);
-      this.principal = principal instanceof KsqlPrincipal
-          ? (KsqlPrincipal) principal
-          : KsqlPrincipal.from(principal);
+      this.principal = principal instanceof DefaultKsqlPrincipal
+          ? (DefaultKsqlPrincipal) principal
+          : new DefaultKsqlPrincipal(principal);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
### Description 

Minor change to expose the original Principal wrapped inside DefaultKsqlPrincipal, so that custom extensions can access the original principal even after wrapping. This PR also updates the existing code to always wrap the original principal in DefaultKsqlPrincipal, and have DefaultKsqlPrincipal pass through the custom properties of the original principal, even if the original principal is a KsqlPrincipal. This change is made because otherwise we'd have two patterns for custom extensions to access original principals:
* have the original principal implement KsqlPrincipal (comes at no cost since KsqlPrincipal has a default implementation for the only method beyond the Principal interface that it extends), which causes the original principal to be passed through (throughout the ksql engine) directly, or
* do not implement KsqlPrincipal, which means the original principal will be wrapped in DefaultKsqlPrincipal. Then access the original principal from the new `getOriginalPrincipal()` method added in this PR.

To avoid confusion from having multiple patterns, this PR removes the first one by always wrapping the incoming Principal in a DefaultKsqlPrincipal.

This change needs to be backported to 7.1.x since that's where DefaultKsqlPrincipal was first introduced.

### Testing done 

Unit tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

