### PR TITLE
fix: use topology-specific IQ APIs

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
@@ -59,7 +59,7 @@ public class AllHostsLocator implements PushLocator {
     }
 
     return currentQueries.stream()
-        .map(QueryMetadata::getAllMetadata)
+        .map(QueryMetadata::getAllStreamsHostMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
         .filter(streamsMetadata -> !(streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)))

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
@@ -62,7 +62,6 @@ public class AllHostsLocator implements PushLocator {
         .map(QueryMetadata::getAllStreamsHostMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
-        .filter(streamsMetadata -> !(streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)))
         .map(StreamsMetadata::hostInfo)
         .map(hi -> new Node(isLocalhost(hi), buildLocation(hi)))
         .distinct()

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -140,7 +140,6 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.scalablePushRegistry = requireNonNull(scalablePushRegistry, "scalablePushRegistry");
   }
 
-
   // for creating sandbox instances
   protected BinPackedPersistentQueryMetadataImpl(
           final BinPackedPersistentQueryMetadataImpl original,
@@ -309,7 +308,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public Collection<StreamsMetadata> getAllMetadata() {
     try {
-      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.allMetadata());
+      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.streamsMetadataForQuery(queryId));
     } catch (IllegalStateException e) {
       LOG.error(e.getMessage());
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -251,7 +251,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public Set<StreamsTaskMetadata> getTaskMetadata() {
-    return sharedKafkaStreamsRuntime.getTaskMetadata();
+    return sharedKafkaStreamsRuntime.getAllTaskMetadataForQuery(queryId);
   }
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "overriddenProperties is immutable")
@@ -302,13 +302,13 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLags() {
-    return sharedKafkaStreamsRuntime.allLocalStorePartitionLags(queryId);
+    return sharedKafkaStreamsRuntime.getAllLocalStorePartitionLagsForQuery(queryId);
   }
 
   @Override
-  public Collection<StreamsMetadata> getAllMetadata() {
+  public Collection<StreamsMetadata> getAllStreamsHostMetadata() {
     try {
-      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.streamsMetadataForQuery(queryId));
+      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.getAllStreamsClientsMetadataForQuery(queryId));
     } catch (IllegalStateException e) {
       LOG.error(e.getMessage());
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -308,7 +308,8 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public Collection<StreamsMetadata> getAllStreamsHostMetadata() {
     try {
-      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.getAllStreamsClientsMetadataForQuery(queryId));
+      return ImmutableList.copyOf(
+          sharedKafkaStreamsRuntime.getAllStreamsClientsMetadataForQuery(queryId));
     } catch (IllegalStateException e) {
       LOG.error(e.getMessage());
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -51,7 +51,7 @@ public interface QueryMetadata {
 
   Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLags();
 
-  Collection<StreamsMetadata> getAllMetadata();
+  Collection<StreamsMetadata> getAllStreamsHostMetadata();
 
   Map<String, Object> getStreamsProperties();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -259,7 +259,7 @@ public class QueryMetadataImpl implements QueryMetadata {
     }
   }
 
-  public Collection<StreamsMetadata> getAllMetadata() {
+  public Collection<StreamsMetadata> getAllStreamsHostMetadata() {
     try {
       return ImmutableList.copyOf(kafkaStreams.metadataForAllStreamsClients());
     } catch (IllegalStateException e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -83,8 +83,8 @@ public abstract class SharedKafkaStreamsRuntime {
     return kafkaStreams.state();
   }
 
-  public Collection<StreamsMetadata> allMetadata() {
-    return kafkaStreams.metadataForAllStreamsClients();
+  public Collection<StreamsMetadata> streamsMetadataForQuery(final QueryId queryId) {
+    return kafkaStreams.streamsMetadataForTopology(queryId.toString());
   }
 
   public Set<StreamsTaskMetadata> getTaskMetadata() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -34,8 +34,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
-import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +96,8 @@ public abstract class SharedKafkaStreamsRuntime {
         .collect(Collectors.toSet());
   }
 
-  public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLagsForQuery(final QueryId queryId) {
+  public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLagsForQuery(
+      final QueryId queryId) {
     try {
       return kafkaStreams.allLocalStorePartitionLagsForTopology(queryId.toString());
     } catch (IllegalStateException | StreamsException e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -34,6 +34,8 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,9 +90,10 @@ public abstract class SharedKafkaStreamsRuntime {
   }
 
   public Set<StreamsTaskMetadata> getAllTaskMetadataForQuery(final QueryId queryId) {
-    return kafkaStreams.metadataForLocalThreads(queryId.toString())
+    return kafkaStreams.metadataForLocalThreads()
         .stream()
         .flatMap(t -> t.activeTasks().stream())
+        .filter(m -> queryId.toString().equals(m.taskId().topologyName()))
         .map(StreamsTaskMetadata::fromStreamsTaskMetadata)
         .collect(Collectors.toSet());
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -83,19 +83,19 @@ public abstract class SharedKafkaStreamsRuntime {
     return kafkaStreams.state();
   }
 
-  public Collection<StreamsMetadata> streamsMetadataForQuery(final QueryId queryId) {
-    return kafkaStreams.streamsMetadataForTopology(queryId.toString());
+  public Collection<StreamsMetadata> getAllStreamsClientsMetadataForQuery(final QueryId queryId) {
+    return kafkaStreams.allStreamsClientsMetadataForTopology(queryId.toString());
   }
 
-  public Set<StreamsTaskMetadata> getTaskMetadata() {
-    return kafkaStreams.metadataForLocalThreads()
+  public Set<StreamsTaskMetadata> getAllTaskMetadataForQuery(final QueryId queryId) {
+    return kafkaStreams.metadataForLocalThreads(queryId.toString())
         .stream()
         .flatMap(t -> t.activeTasks().stream())
         .map(StreamsTaskMetadata::fromStreamsTaskMetadata)
         .collect(Collectors.toSet());
   }
 
-  public Map<String, Map<Integer, LagInfo>> allLocalStorePartitionLags(final QueryId queryId) {
+  public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLagsForQuery(final QueryId queryId) {
     try {
       return kafkaStreams.allLocalStorePartitionLagsForTopology(queryId.toString());
     } catch (IllegalStateException | StreamsException e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -25,8 +25,6 @@ import io.confluent.ksql.util.QueryMetadataImpl.TimeBoundedQueue;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -173,20 +171,14 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
         try {
           kafkaStreams.removeNamedTopology(queryId.toString(), resetOffsets)
               .all()
-              .get(shutdownTimeout, TimeUnit.SECONDS);
+              .get();
           if (resetOffsets) {
             kafkaStreams.cleanUpNamedTopology(queryId.toString());
           }
-        } catch (final TimeoutException | ExecutionException | InterruptedException e) {
+        } catch (ExecutionException | InterruptedException e) {
           log.error(String.format(
               "Failed to close query %s within the allotted timeout %s due to",
               queryId, shutdownTimeout), e);
-          if (e instanceof TimeoutException) {
-            log.warn(
-                "Query {} has not terminated even after trying to remove the topology. "
-                    + "This may happen when streams threads are hung. State is {}",
-                queryId, kafkaStreams.state());
-          }
         }
       } else {
         throw new IllegalStateException("Streams in not running but is in state "
@@ -209,8 +201,8 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
         try {
           kafkaStreams.addNamedTopology(collocatedQueries.get(queryId).getTopology())
               .all()
-              .get(shutdownTimeout, TimeUnit.SECONDS);
-        } catch (final TimeoutException | ExecutionException | InterruptedException e) {
+              .get();
+        } catch (ExecutionException | InterruptedException e) {
           log.error("Failed to start query {} within the allotted timeout {} due to",
               queryId,
               shutdownTimeout,
@@ -236,7 +228,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void restartStreamsRuntime() {
-    log.info("Restarting runtime {}", getApplicationId();
+    log.info("Restarting runtime {}", getApplicationId());
     final KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper = kafkaStreamsBuilder
         .buildNamedTopologyWrapper(streamsProperties);
     kafkaStreams.close();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocatorTest.java
@@ -9,6 +9,7 @@ import io.confluent.ksql.physical.scalablepush.locator.PushLocator.KsqlNode;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.state.HostInfo;
@@ -16,8 +17,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static org.apache.kafka.streams.state.internals.StreamsMetadataImpl.NOT_AVAILABLE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AllHostsLocatorTest {
@@ -43,7 +42,7 @@ public class AllHostsLocatorTest {
     when(metadata1.getAllStreamsHostMetadata())
         .thenReturn(ImmutableList.of(streamsMetadata1, streamsMetadata2));
     when(metadata2.getAllStreamsHostMetadata())
-        .thenReturn(ImmutableList.of(streamsMetadata3, NOT_AVAILABLE));
+        .thenReturn(Collections.emptyList());
     when(streamsMetadata1.hostInfo())
         .thenReturn(new HostInfo("abc", 101), new HostInfo("localhost", 8088));
     when(streamsMetadata2.hostInfo()).thenReturn(new HostInfo("localhost", 8088));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocatorTest.java
@@ -11,7 +11,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import org.apache.kafka.streams.StreamsMetadata;
-import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.state.HostInfo;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,9 +40,9 @@ public class AllHostsLocatorTest {
         () -> ImmutableList.of(metadata1, metadata2),
         new URL("http://localhost:8088")
     );
-    when(metadata1.getAllMetadata())
+    when(metadata1.getAllStreamsHostMetadata())
         .thenReturn(ImmutableList.of(streamsMetadata1, streamsMetadata2));
-    when(metadata2.getAllMetadata())
+    when(metadata2.getAllStreamsHostMetadata())
         .thenReturn(ImmutableList.of(streamsMetadata3, NOT_AVAILABLE));
     when(streamsMetadata1.hostInfo())
         .thenReturn(new HostInfo("abc", 101), new HostInfo("localhost", 8088));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.util;
 
-import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryError.Type;
 import io.confluent.ksql.query.QueryErrorClassifier;
@@ -34,11 +32,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -213,7 +209,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
     
     @Test
     public void allLocalStorePartitionLagsCallsTopologyMethod() {
-        sharedKafkaStreamsRuntimeImpl.allLocalStorePartitionLags(queryId);
+        sharedKafkaStreamsRuntimeImpl.getAllLocalStorePartitionLagsForQuery(queryId);
         verify(kafkaStreamsNamedTopologyWrapper)
             .allLocalStorePartitionLagsForTopology("query-1");
     }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 
 /**
  * Endpoint that reports the view of the cluster that this server has.
@@ -103,8 +102,7 @@ public class ClusterStatusResource {
     final Map<String, ActiveStandbyEntity> perQueryMap = new HashMap<>();
     for (PersistentQueryMetadata persistentQueryMetadata: engine.getPersistentQueries()) {
       for (StreamsMetadata streamsMetadata: persistentQueryMetadata.getAllStreamsHostMetadata()) {
-        if (streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)
-            || !streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
+        if (!streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
           continue;
         }
         final QueryIdAndStreamsMetadata queryIdAndStreamsMetadata = new QueryIdAndStreamsMetadata(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
@@ -102,7 +102,7 @@ public class ClusterStatusResource {
   ) {
     final Map<String, ActiveStandbyEntity> perQueryMap = new HashMap<>();
     for (PersistentQueryMetadata persistentQueryMetadata: engine.getPersistentQueries()) {
-      for (StreamsMetadata streamsMetadata: persistentQueryMetadata.getAllMetadata()) {
+      for (StreamsMetadata streamsMetadata: persistentQueryMetadata.getAllStreamsHostMetadata()) {
         if (streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)
             || !streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
           continue;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -40,7 +40,7 @@ public final class DiscoverRemoteHostsUtil {
     return currentQueries.stream()
         // required filter else QueryMetadata.getAllMetadata() throws
         .filter(q -> q.getState().isRunningOrRebalancing())
-        .map(QueryMetadata::getAllMetadata)
+        .map(QueryMetadata::getAllStreamsHostMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
         .filter(streamsMetadata -> !(streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)))

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 
 public final class DiscoverRemoteHostsUtil {
 
@@ -43,7 +42,6 @@ public final class DiscoverRemoteHostsUtil {
         .map(QueryMetadata::getAllStreamsHostMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
-        .filter(streamsMetadata -> !(streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)))
         .map(StreamsMetadata::hostInfo)
         .filter(hostInfo -> !(hostInfo.host().equals(localHost.host())
             && hostInfo.port() == (localHost.port())))

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/HeartbeatAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/HeartbeatAgentTest.java
@@ -98,10 +98,10 @@ public class HeartbeatAgentTest {
     heartbeatAgent.setHostsStatus(hostsStatus);
     when(ksqlEngine.getPersistentQueries()).thenReturn(ImmutableList.of(query0, query1));
 
-    when(query0.getAllMetadata()).thenReturn(allMetadata0);
+    when(query0.getAllStreamsHostMetadata()).thenReturn(allMetadata0);
     when(streamsMetadata0.hostInfo()).thenReturn(localHostInfo);
 
-    when(query1.getAllMetadata()).thenReturn(allMetadata1);
+    when(query1.getAllStreamsHostMetadata()).thenReturn(allMetadata1);
     when(streamsMetadata1.hostInfo()).thenReturn(remoteHostInfo);
 
     DiscoverClusterService discoverService = heartbeatAgent.new DiscoverClusterService();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -522,7 +522,7 @@ public class ListQueriesExecutorTest {
     final List<StreamsMetadata> streamsData = new ArrayList<>();
     streamsData.add(localStreamsMetadata);
     streamsData.add(remoteStreamsMetadata);
-    when(metadata.getAllMetadata()).thenReturn(streamsData);
+    when(metadata.getAllStreamsHostMetadata()).thenReturn(streamsData);
   }
 
   public static RunningQuery persistentQueryMetadataToRunningQuery(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtilTest.java
@@ -52,7 +52,7 @@ public class DiscoverRemoteHostsUtilTest {
   @Before
   public void setUp() {
     when(runningQuery.getState()).thenReturn(State.RUNNING);
-    when(runningQuery.getAllMetadata()).thenReturn(Collections.singleton(streamsMetadata));
+    when(runningQuery.getAllStreamsHostMetadata()).thenReturn(Collections.singleton(streamsMetadata));
     when(notRunningQuery.getState()).thenReturn(State.CREATED);
     when(streamsMetadata.hostInfo()).thenReturn(OTHER_HOST_INFO);
   }
@@ -68,7 +68,7 @@ public class DiscoverRemoteHostsUtilTest {
     // Then:
     assertThat(info, contains(OTHER_HOST_INFO));
 
-    verify(notRunningQuery, never()).getAllMetadata();
+    verify(notRunningQuery, never()).getAllStreamsHostMetadata();
   }
 
 }


### PR DESCRIPTION
Found two more instances of IQ APIs that need to be updated to fetch metadata for specific queries within the shared runtime:

1. Instead of returning `kafkaStreams.metadataForAllClients()`, the bin-packed persistent queries' `allMetadata` method should return only the query-specific results from (new API) `KafkaStreamsNamedTopologyWrapper#streamsMetadataForTopology`
2. We seem to have lost the `.partition()` specification when constructing the named topology version of the `StoreQueryParameters`, we needed to add this to the  `NamedTopologyStoreQueryParameter` class on the Streams side and then invoke that in ksql

Blocked on https://github.com/apache/kafka/pull/11609

