### PR TITLE
feat: migrate java client to use application/vnd.ksql.v1+json

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.client.impl;
 
 import static io.confluent.ksql.api.client.impl.DdlDmlRequestValidators.validateExecuteStatementRequest;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static io.netty.handler.codec.http.HttpHeaderNames.AUTHORIZATION;
 import static io.netty.handler.codec.http.HttpHeaderNames.USER_AGENT;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
@@ -37,6 +38,7 @@ import io.confluent.ksql.api.client.StreamedQueryResult;
 import io.confluent.ksql.api.client.TableInfo;
 import io.confluent.ksql.api.client.TopicInfo;
 import io.confluent.ksql.api.client.exception.KsqlClientException;
+import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.util.AppInfo;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
@@ -613,6 +615,9 @@ public class ClientImpl implements Client {
     if (clientOptions.isUseBasicAuth()) {
       request = configureBasicAuth(request);
     }
+    if (path.equals(QUERY_STREAM_ENDPOINT)) {
+      request = configureAcceptTypeToLatestMediaType(request);
+    }
     if (clientOptions.getRequestHeaders() != null) {
       for (final Entry<String, String> entry : clientOptions.getRequestHeaders().entrySet()) {
         request.putHeader(entry.getKey(), entry.getValue());
@@ -628,6 +633,10 @@ public class ClientImpl implements Client {
 
   private HttpClientRequest configureBasicAuth(final HttpClientRequest request) {
     return request.putHeader(AUTHORIZATION.toString(), basicAuthHeader);
+  }
+
+  private HttpClientRequest configureAcceptTypeToLatestMediaType(final HttpClientRequest request) {
+    return request.putHeader(ACCEPT.toString(), KsqlMediaType.LATEST_FORMAT.mediaType());
   }
 
   private HttpClientRequest configureUserAgent(final HttpClientRequest request) {

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/QueryResponseHandler.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/QueryResponseHandler.java
@@ -15,12 +15,17 @@
 
 package io.confluent.ksql.api.client.impl;
 
+import static io.confluent.ksql.util.BytesUtils.toJsonMsg;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.api.client.util.JsonMapper;
+import io.confluent.ksql.api.client.util.RowUtil;
 import io.confluent.ksql.rest.entity.QueryResponseMetadata;
 import io.vertx.core.Context;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.parsetools.RecordParser;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 abstract class QueryResponseHandler<T extends CompletableFuture<?>> extends ResponseHandler<T> {
@@ -35,10 +40,14 @@ abstract class QueryResponseHandler<T extends CompletableFuture<?>> extends Resp
 
   @Override
   protected void doHandleBodyBuffer(final Buffer buff) {
+    final Buffer strippedValidJson = toJsonMsg(buff, true);
+
     if (!hasReadArguments) {
-      handleArgs(buff);
+      handleArgs(strippedValidJson);
     } else {
-      handleRow(buff);
+      if (!Objects.equals(strippedValidJson.toString(), "")) {
+        handleRow(strippedValidJson);
+      }
     }
   }
 
@@ -59,10 +68,16 @@ abstract class QueryResponseHandler<T extends CompletableFuture<?>> extends Resp
 
   private void handleArgs(final Buffer buff) {
     hasReadArguments = true;
-
     final QueryResponseMetadata queryResponseMetadata;
     try {
-      queryResponseMetadata = JSON_MAPPER.readValue(buff.getBytes(), QueryResponseMetadata.class);
+      final Object header = buff.toJsonObject().getMap().get("header");
+      final String queryId = (String) ((Map<?, ?>) header).get("queryId");
+      final String schema = (String) ((Map<?, ?>) header).get("schema");
+      queryResponseMetadata =
+              new QueryResponseMetadata(queryId,
+                      RowUtil.colNamesFromSchema(schema),
+                      RowUtil.colTypesFromSchema(schema),
+                      null);
     } catch (Exception e) {
       cf.completeExceptionally(e);
       return;

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/StreamQueryResponseHandler.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/StreamQueryResponseHandler.java
@@ -25,6 +25,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.parsetools.RecordParser;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -83,44 +84,43 @@ public class StreamQueryResponseHandler
     if (queryResult == null) {
       throw new IllegalStateException("handleRow called before metadata processed");
     }
-    final Object json = buff.toJson();
+
     final Row row;
-    if (json instanceof JsonArray) {
-      row = new RowImpl(
-          queryResult.columnNames(),
-          queryResult.columnTypes(),
-          (JsonArray) json,
-          columnNameToIndex
-      );
-      final boolean full = queryResult.accept(row);
-      if (full && !paused) {
-        recordParser.pause();
-        queryResult.drainHandler(this::publisherReceptive);
-        paused = true;
+    final JsonObject jsonObject = buff.toJsonObject();
+
+    if (!jsonObject.containsKey("finalMessage")) {
+      if (jsonObject.containsKey("row")) {
+        row = new RowImpl(
+            queryResult.columnNames(),
+            queryResult.columnTypes(),
+            new JsonArray((List)((Map<?, ?>) jsonObject.getMap().get("row")).get("columns")),
+            columnNameToIndex
+        );
+        final boolean full = queryResult.accept(row);
+        if (full && !paused) {
+          recordParser.pause();
+          queryResult.drainHandler(this::publisherReceptive);
+          paused = true;
+        }
+      } else if (jsonObject.getMap() != null) {
+        if (jsonObject.getMap().containsKey("consistencyToken")) {
+          LOG.info("Response contains consistency vector " + jsonObject);
+          serializedConsistencyVector.set((String) jsonObject.getMap().get("consistencyToken"));
+        }
+        if (jsonObject.getMap().containsKey("continuationToken")) {
+          LOG.info("Response contains continuation token " + jsonObject);
+          continuationToken.set(
+                  (String) ((Map<?, ?>) jsonObject.getMap()
+                          .get("continuationToken"))
+                          .get("continuationToken"));
+        }
+        if (jsonObject.getMap().containsKey("errorMessage")) {
+          queryResult.handleError(new KsqlException(
+                  (String) ((Map<?, ?>) jsonObject.getMap().get("errorMessage")).get("message")));
+        }
+      } else {
+        throw new RuntimeException("Could not decode JSON: " + jsonObject);
       }
-    } else if (json instanceof JsonObject) {
-      final JsonObject jsonObject = (JsonObject) json;
-      // This is the serialized consistency vector
-      // Don't add it to the publisher's buffer since the user should not see it
-      if (jsonObject.getMap() != null && jsonObject.getMap().containsKey("consistencyToken")) {
-        LOG.info("Response contains consistency vector " + jsonObject);
-        serializedConsistencyVector.set((String) ((JsonObject) json).getMap().get(
-            "consistencyToken"));
-      }
-      if (jsonObject.getMap() != null && jsonObject.getMap().containsKey("continuationToken")) {
-        LOG.info("Response contains continuation token " + jsonObject);
-        continuationToken.set((String) ((JsonObject) json).getMap().get(
-                "continuationToken"));
-      }
-      if (!(jsonObject.getMap() != null && jsonObject.getMap().containsKey("consistencyToken"))
-          && !(jsonObject.getMap() != null && jsonObject.getMap().containsKey("continuationToken"))
-      ) {
-        queryResult.handleError(new KsqlException(
-            jsonObject.getString("message")
-        ));
-      }
-    } else {
-      throw new RuntimeException("Could not decode JSON: " + json);
     }
   }
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientImplTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.client.impl;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static io.netty.handler.codec.http.HttpHeaderNames.USER_AGENT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.ClientOptions;
+import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
@@ -62,7 +64,7 @@ public class ClientImplTest {
   }
 
   @Test
-  public void shouldSetUserAgent() {
+  public void shouldSetUserAgentAndAcceptHeaders() {
     // Given
     Vertx vertx = Mockito.mock(Vertx.class);
     HttpClient httpClient = Mockito.mock(HttpClient.class);
@@ -83,10 +85,14 @@ public class ClientImplTest {
     // Then
     Client client = Client.create(OPTIONS_1, vertx);
     client.streamQuery("SELECT * from STREAM1 EMIT CHANGES;");
-    assertThat(headers.size(), is(1));
+    assertThat(headers.size(), is(2));
     assertThat(headers.containsKey(USER_AGENT.toString()), is(true));
     assertThat(headers.get(USER_AGENT.toString()).matches("ksqlDB Java Client v\\d\\.\\d\\.\\d.*"),
         is(true));
+
+    assertThat(headers.containsKey(ACCEPT.toString()), is(true));
+    assertThat(headers.get(ACCEPT.toString()).equals(KsqlMediaType.LATEST_FORMAT.mediaType()),
+            is(true));
   }
 
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/util/RowUtilTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/util/RowUtilTest.java
@@ -67,4 +67,84 @@ public class RowUtilTest {
             "TIME"
     ));
   }
+
+  @Test
+  public void shouldGetColumnNamesFromSchema() {
+    // Given
+    final String schema = "`K` STRUCT<`F1` ARRAY<STRING>>, "
+            + "`STR` STRING, "
+            + "`LONG` BIGINT, "
+            + "`DEC` DECIMAL(4, 2),"
+            + "`BYTES_` BYTES, "
+            + "`ARRAY` ARRAY<STRING>, "
+            + "`MAP` MAP<STRING, STRING>, "
+            + "`STRUCT` STRUCT<`F1` INTEGER>, "
+            + "`COMPLEX` STRUCT<`DECIMAL` DECIMAL(2, 1), `STRUCT` STRUCT<`F1` STRING, `F2` INTEGER>, `ARRAY_ARRAY` ARRAY<ARRAY<STRING>>, `ARRAY_STRUCT` ARRAY<STRUCT<`F1` STRING>>, `ARRAY_MAP` ARRAY<MAP<STRING, INTEGER>>, `MAP_ARRAY` MAP<STRING, ARRAY<STRING>>, `MAP_MAP` MAP<STRING, MAP<STRING, INTEGER>>, `MAP_STRUCT` MAP<STRING, STRUCT<`F1` STRING>>>, "
+            + "`TIMESTAMP` TIMESTAMP, "
+            + "`DATE` DATE, "
+            + "`TIME` TIME, "
+            + "`HEAD` BYTES";
+
+    // When
+    final List<String> columnNames = RowUtil.colNamesFromSchema(schema);
+
+    // Then
+    assertThat(
+            columnNames,
+            contains(
+                    "K",
+                    "STR",
+                    "LONG",
+                    "DEC",
+                    "BYTES_",
+                    "ARRAY",
+                    "MAP",
+                    "STRUCT",
+                    "COMPLEX",
+                    "TIMESTAMP",
+                    "DATE",
+                    "TIME",
+                    "HEAD"
+            ));
+  }
+
+  @Test
+  public void shouldGetColumnTypesFromSchema() {
+    // Given
+    final String schema = "`K` STRUCT<`F1` ARRAY<STRING>>, "
+            + "`STR` STRING, "
+            + "`LONG` BIGINT, "
+            + "`DEC` DECIMAL(4, 2),"
+            + "`BYTES_` BYTES, "
+            + "`ARRAY` ARRAY<STRING>, "
+            + "`MAP` MAP<STRING, STRING>, "
+            + "`STRUCT` STRUCT<`F1` INTEGER>, "
+            + "`COMPLEX` STRUCT<`DECIMAL` DECIMAL(2, 1), `STRUCT` STRUCT<`F1` STRING, `F2` INTEGER>, `ARRAY_ARRAY` ARRAY<ARRAY<STRING>>, `ARRAY_STRUCT` ARRAY<STRUCT<`F1` STRING>>, `ARRAY_MAP` ARRAY<MAP<STRING, INTEGER>>, `MAP_ARRAY` MAP<STRING, ARRAY<STRING>>, `MAP_MAP` MAP<STRING, MAP<STRING, INTEGER>>, `MAP_STRUCT` MAP<STRING, STRUCT<`F1` STRING>>>, "
+            + "`TIMESTAMP` TIMESTAMP, "
+            + "`DATE` DATE, "
+            + "`TIME` TIME, "
+            + "`HEAD` BYTES";
+
+    // When
+    final List<String> columnTypes = RowUtil.colTypesFromSchema(schema);
+
+    // Then
+    assertThat(
+            columnTypes,
+            contains(
+                    "STRUCT<F1 ARRAY<STRING>>",
+                    "STRING",
+                    "BIGINT",
+                    "DECIMAL(4, 2)",
+                    "BYTES",
+                    "ARRAY<STRING>",
+                    "MAP<STRING, STRING>",
+                    "STRUCT<F1 INTEGER>",
+                    "STRUCT<DECIMAL DECIMAL(2, 1), STRUCT STRUCT<F1 STRING, F2 INTEGER>, ARRAY_ARRAY ARRAY<ARRAY<STRING>>, ARRAY_STRUCT ARRAY<STRUCT<F1 STRING>>, ARRAY_MAP ARRAY<MAP<STRING, INTEGER>>, MAP_ARRAY MAP<STRING, ARRAY<STRING>>, MAP_MAP MAP<STRING, MAP<STRING, INTEGER>>, MAP_STRUCT MAP<STRING, STRUCT<F1 STRING>>>",
+                    "TIMESTAMP",
+                    "DATE",
+                    "TIME",
+                    "BYTES"
+            ));
+  }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/BytesUtils.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.util;
 
 import com.google.common.collect.ImmutableMap;
+import io.vertx.core.buffer.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -120,6 +121,24 @@ public final class BytesUtils {
 
   public static byte[] getByteArray(final ByteBuffer buffer, final int start, final int end) {
     return Arrays.copyOfRange(getByteArray(buffer), start, end);
+  }
+
+  public static Buffer toJsonMsg(final Buffer responseLine, final boolean stripArray) {
+
+    int start = 0;
+    int end = responseLine.length() - 1;
+    if (stripArray) {
+      if (responseLine.getByte(0) == (byte) '[') {
+        start = 1;
+      }
+      if (responseLine.getByte(end) == (byte) ']') {
+        end -= 1;
+      }
+    }
+    if (end > 0 && responseLine.getByte(end) == (byte) ',') {
+      end -= 1;
+    }
+    return responseLine.slice(start, end + 1);
   }
 
   public static List<byte[]> split(final byte[] b, final byte[] delim) {

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlTargetUtil.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.client;
 
 import static io.confluent.ksql.rest.client.KsqlClientUtil.deserialize;
+import static io.confluent.ksql.util.BytesUtils.toJsonMsg;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Streams;
@@ -55,7 +56,7 @@ public final class KsqlTargetUtil {
           || (i < buff.length() && buff.getByte(i) == (byte) '\n')) {
         if (begin != i) { // Ignore random newlines - the server can send these
           final Buffer sliced = buff.slice(begin, i);
-          final Buffer tidied = StreamPublisher.toJsonMsg(sliced, true);
+          final Buffer tidied = toJsonMsg(sliced, true);
           if (tidied.length() > 0) {
             final StreamedRow row = deserialize(tidied, StreamedRow.class);
             rows.add(row);

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/StreamPublisher.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/StreamPublisher.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.rest.client;
 
+import static io.confluent.ksql.util.BytesUtils.toJsonMsg;
+
 import io.confluent.ksql.reactive.BufferedPublisher;
 import io.vertx.core.Context;
 import io.vertx.core.buffer.Buffer;
@@ -27,24 +29,6 @@ public class StreamPublisher<T> extends BufferedPublisher<T> {
 
   private final HttpClientResponse response;
   private boolean drainHandlerSet;
-
-  public static Buffer toJsonMsg(final Buffer responseLine, final boolean stripArray) {
-
-    int start = 0;
-    int end = responseLine.length() - 1;
-    if (stripArray) {
-      if (responseLine.getByte(0) == (byte) '[') {
-        start = 1;
-      }
-      if (responseLine.getByte(end) == (byte) ']') {
-        end -= 1;
-      }
-    }
-    if (end > 0 && responseLine.getByte(end) == (byte) ',') {
-      end -= 1;
-    }
-    return responseLine.slice(start, end + 1);
-  }
 
   StreamPublisher(final Context context, final HttpClientResponse response,
       final Function<Buffer, T> mapper,


### PR DESCRIPTION
### Description 
Migrate the java client to use `application/vnd.ksql.v1+json` format when hitting the `/query-stream` endpoint without breaking backward compatibility

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

