### PR TITLE
feat: Change API to return Position from Streams

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedTableLookupOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedTableLookupOperator.java
@@ -119,7 +119,7 @@ public class KeyedTableLookupOperator
     if (keyConstraintKey.getOperator() == ConstraintOperator.EQUAL) {
       return mat.nonWindowed()
         .get(ksqlKey.getKey(), nextLocation.getPartition())
-        .getRowIterator().get();
+        .getRowIterator();
     } else if (keyConstraintKey.getOperator() == ConstraintOperator.GREATER_THAN
         || keyConstraintKey.getOperator() == ConstraintOperator.GREATER_THAN_OR_EQUAL) {
       //Underlying store will always return keys inclusive the endpoints
@@ -128,7 +128,7 @@ public class KeyedTableLookupOperator
       final GenericKey toKey = null;
       return mat.nonWindowed()
           .get(nextLocation.getPartition(), fromKey, toKey)
-          .getRowIterator().get();
+          .getRowIterator();
     } else if (keyConstraintKey.getOperator() == ConstraintOperator.LESS_THAN
         || keyConstraintKey.getOperator() == ConstraintOperator.LESS_THAN_OR_EQUAL) {
       //Underlying store will always return keys inclusive the endpoints
@@ -137,7 +137,7 @@ public class KeyedTableLookupOperator
       final GenericKey toKey = keyConstraintKey.getKey();
       return mat.nonWindowed()
           .get(nextLocation.getPartition(), fromKey, toKey)
-          .getRowIterator().get();
+          .getRowIterator();
     } else {
       throw new IllegalStateException(String.format("Invalid comparator type "
         + keyConstraintKey.getOperator()));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperator.java
@@ -78,7 +78,7 @@ public class KeyedWindowedTableLookupOperator
             nextLocation.getPartition(),
             windowBounds.getMergedStart(),
             windowBounds.getMergedEnd())
-            .iterator();
+            .getRowIterator().get();
       }
     }
   }
@@ -106,7 +106,7 @@ public class KeyedWindowedTableLookupOperator
           nextLocation.getPartition(),
           windowBounds.getMergedStart(),
           windowBounds.getMergedEnd())
-          .iterator();
+          .getRowIterator().get();
     }
     returnedRows++;
     final WindowedRow row = resultIterator.next();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperator.java
@@ -78,7 +78,7 @@ public class KeyedWindowedTableLookupOperator
             nextLocation.getPartition(),
             windowBounds.getMergedStart(),
             windowBounds.getMergedEnd())
-            .getRowIterator().get();
+            .getRowIterator();
       }
     }
   }
@@ -106,7 +106,7 @@ public class KeyedWindowedTableLookupOperator
           nextLocation.getPartition(),
           windowBounds.getMergedStart(),
           windowBounds.getMergedEnd())
-          .getRowIterator().get();
+          .getRowIterator();
     }
     returnedRows++;
     final WindowedRow row = resultIterator.next();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/TableScanOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/TableScanOperator.java
@@ -67,7 +67,8 @@ public class TableScanOperator extends AbstractPhysicalOperator
         throw new IllegalStateException("Table scans should not be done with keys");
       }
       resultIterator = mat.nonWindowed()
-          .get(nextLocation.getPartition());
+          .get(nextLocation.getPartition())
+          .getRowIterator().get();
     }
   }
 
@@ -89,7 +90,8 @@ public class TableScanOperator extends AbstractPhysicalOperator
         throw new IllegalStateException("Table scans should not be done with keys");
       }
       resultIterator = mat.nonWindowed()
-          .get(nextLocation.getPartition());
+          .get(nextLocation.getPartition())
+          .getRowIterator().get();
     }
 
     returnedRows++;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/TableScanOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/TableScanOperator.java
@@ -68,7 +68,7 @@ public class TableScanOperator extends AbstractPhysicalOperator
       }
       resultIterator = mat.nonWindowed()
           .get(nextLocation.getPartition())
-          .getRowIterator().get();
+          .getRowIterator();
     }
   }
 
@@ -91,7 +91,7 @@ public class TableScanOperator extends AbstractPhysicalOperator
       }
       resultIterator = mat.nonWindowed()
           .get(nextLocation.getPartition())
-          .getRowIterator().get();
+          .getRowIterator();
     }
 
     returnedRows++;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WindowedTableScanOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WindowedTableScanOperator.java
@@ -69,7 +69,7 @@ public class WindowedTableScanOperator extends AbstractPhysicalOperator
       }
       resultIterator = mat.windowed()
           .get(nextLocation.getPartition(), Range.all(), Range.all())
-          .getRowIterator().get();
+          .getRowIterator();
     }
   }
 
@@ -92,7 +92,7 @@ public class WindowedTableScanOperator extends AbstractPhysicalOperator
       }
       resultIterator = mat.windowed()
           .get(nextLocation.getPartition(), Range.all(), Range.all())
-          .getRowIterator().get();
+          .getRowIterator();
     }
 
     returnedRows++;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WindowedTableScanOperator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/pull/operators/WindowedTableScanOperator.java
@@ -68,7 +68,8 @@ public class WindowedTableScanOperator extends AbstractPhysicalOperator
         throw new IllegalStateException("Table scans should not be done with keys");
       }
       resultIterator = mat.windowed()
-          .get(nextLocation.getPartition(), Range.all(), Range.all());
+          .get(nextLocation.getPartition(), Range.all(), Range.all())
+          .getRowIterator().get();
     }
   }
 
@@ -90,7 +91,8 @@ public class WindowedTableScanOperator extends AbstractPhysicalOperator
         throw new IllegalStateException("Table scans should not be done with keys");
       }
       resultIterator = mat.windowed()
-          .get(nextLocation.getPartition(), Range.all(), Range.all());
+          .get(nextLocation.getPartition(), Range.all(), Range.all())
+          .getRowIterator().get();
     }
 
     returnedRows++;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -26,17 +26,18 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.google.common.collect.Range;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.Window;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.MaterializedTable;
 import io.confluent.ksql.execution.streams.materialization.MaterializedWindowedTable;
 import io.confluent.ksql.execution.streams.materialization.Row;
-import io.confluent.ksql.Window;
 import io.confluent.ksql.execution.streams.materialization.WindowedRow;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
@@ -58,6 +59,7 @@ import io.confluent.ksql.util.UserDataProvider;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,6 +70,7 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.commons.compress.utils.Lists;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -231,10 +234,15 @@ public class KsMaterializationFunctionalTest {
     rows.forEach((rowKey, value) -> {
       final GenericKey key = genericKey(rowKey);
 
-      final Optional<Row> row = withRetry(() -> table.get(key, PARTITION));
-      assertThat(row.map(Row::schema), is(Optional.of(schema)));
-      assertThat(row.map(Row::key), is(Optional.of(key)));
-      assertThat(row.map(Row::value), is(Optional.of(value)));
+      final Optional<Iterator<Row>> rowIterator =
+          withRetry(() -> table.get(key, PARTITION).getRowIterator());
+
+      assertThat(rowIterator.get(), not(Optional.empty()));
+      assertThat(rowIterator.get().hasNext(), is(true));
+      final Row row = rowIterator.get().next();
+      assertThat(row.schema(), is(schema));
+      assertThat(row.key(), is(key));
+      assertThat(row.value(), is(value));
     });
 
     final GenericKey key = genericKey("Won't find me");
@@ -264,11 +272,16 @@ public class KsMaterializationFunctionalTest {
 
     rows.forEach((rowKey, value) -> {
       final GenericKey key = genericKey(rowKey);
+      final Optional<Iterator<Row>> rowIterator =
+          withRetry(() -> table.get(key, PARTITION).getRowIterator());
 
-      final Optional<Row> row = withRetry(() -> table.get(key, PARTITION));
-      assertThat(row.map(Row::schema), is(Optional.of(schema)));
-      assertThat(row.map(Row::key), is(Optional.of(key)));
-      assertThat(row.map(Row::value), is(Optional.of(value)));
+      assertThat(rowIterator.get(), not(Optional.empty()));
+      assertThat(rowIterator.get().hasNext(), is(true));
+      final Row row = rowIterator.get().next();
+      assertThat(row.schema(), is(schema));
+      assertThat(row.key(), is(key));
+      assertThat(row.value(), is(value));
+
     });
 
     final GenericKey key = genericKey("Won't find me");
@@ -303,7 +316,8 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> Lists.newArrayList(
+              table.get(key, PARTITION, Range.singleton(w.start()), Range.all()).getRowIterator().get()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -312,18 +326,19 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> Lists.newArrayList(
+              table.get(key, PARTITION, Range.all(), Range.singleton(w.end())).getRowIterator().get()));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
-      final List<WindowedRow> resultFromRange = withRetry(() -> withRetry(() -> table
+      final List<WindowedRow> resultFromRange = withRetry(() -> withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all())));
+              Range.all()).getRowIterator().get())));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
-      final List<WindowedRow> resultPast = withRetry(() -> table
+      final List<WindowedRow> resultPast = withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              Range.all()).getRowIterator().get()));
       assertThat("past start", resultPast, is(empty())
       );
     });
@@ -358,7 +373,8 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> Lists.newArrayList(
+              table.get(key, PARTITION, Range.singleton(w.start()), Range.all()).getRowIterator().get()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -367,18 +383,19 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> Lists.newArrayList(
+              table.get(key, PARTITION, Range.all(), Range.singleton(w.end())).getRowIterator().get()));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
-      final List<WindowedRow> resultFromRange = withRetry(() -> table
-          .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+      final List<WindowedRow> resultFromRange = withRetry(() -> Lists.newArrayList(
+          table.get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
+              Range.all()).getRowIterator().get()));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
-      final List<WindowedRow> resultPast = withRetry(() -> table
+      final List<WindowedRow> resultPast = withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              Range.all()).getRowIterator().get()));
 
       assertThat("past start", resultPast, is(empty()));
     });
@@ -412,7 +429,8 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(k.key());
 
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, PARTITION, Range.singleton(w.start()), Range.all()));
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION, Range.singleton(w.start())
+              , Range.all()).getRowIterator().get()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -421,17 +439,18 @@ public class KsMaterializationFunctionalTest {
       assertThat(resultAtWindowStart.get(0).value(), is(v));
 
       final List<WindowedRow> resultAtWindowEnd =
-          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.singleton(w.end())));
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION, Range.all(),
+                                                       Range.singleton(w.end())).getRowIterator().get()));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
-      final List<WindowedRow> resultFromRange = withRetry(() -> table
+      final List<WindowedRow> resultFromRange = withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              Range.all()).getRowIterator().get()));
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
-      final List<WindowedRow> resultPast = withRetry(() -> table
+      final List<WindowedRow> resultPast = withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()));
+              Range.all()).getRowIterator().get()));
       assertThat("past start", resultPast, is(empty()));
     });
   }
@@ -561,10 +580,12 @@ public class KsMaterializationFunctionalTest {
     rows.forEach((rowKey, value) -> {
       final GenericKey key = genericKey(rowKey);
 
-      final Optional<Row> row = withRetry(() -> table.get(key, PARTITION));
-      assertThat(row.map(Row::schema), is(Optional.of(schema)));
-      assertThat(row.map(Row::key), is(Optional.of(key)));
-      assertThat(row.map(Row::value), is(Optional.of(value)));
+      final List<Row> rowList =
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator().get()));
+      assertThat(rowList.size(), is(1));
+      assertThat(rowList.get(0).schema(), is(schema));
+      assertThat(rowList.get(0).key(), is(key));
+      assertThat(rowList.get(0).value(), is(value));
     });
   }
 
@@ -595,10 +616,12 @@ public class KsMaterializationFunctionalTest {
     rows.forEach((rowKey, value) -> {
       final GenericKey key = genericKey(rowKey);
 
-      final Optional<Row> row = withRetry(() -> table.get(key, PARTITION));
-      assertThat(row.map(Row::schema), is(Optional.of(schema)));
-      assertThat(row.map(Row::key), is(Optional.of(key)));
-      assertThat(row.map(Row::value), is(Optional.of(value)));
+      final List<Row> rowList =
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator().get()));
+      assertThat(rowList.size(), is(1));
+      assertThat(rowList.get(0).schema(), is(schema));
+      assertThat(rowList.get(0).key(), is(key));
+      assertThat(rowList.get(0).value(), is(value));
     });
   }
 
@@ -633,18 +656,21 @@ public class KsMaterializationFunctionalTest {
       // Rows passing the HAVING clause:
       final GenericKey key = genericKey(rowKey);
 
-      final Optional<Row> row = withRetry(() -> table.get(key, PARTITION));
-      assertThat(row.map(Row::schema), is(Optional.of(schema)));
-      assertThat(row.map(Row::key), is(Optional.of(key)));
-      assertThat(row.map(Row::value), is(Optional.of(value)));
+      final List<Row> rowList =
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator().get()));
+      assertThat(rowList.size(), is(1));
+      assertThat(rowList.get(0).schema(), is(schema));
+      assertThat(rowList.get(0).key(), is(key));
+      assertThat(rowList.get(0).value(), is(value));
     });
 
     USER_DATA_PROVIDER.data().entries().stream()
         .filter(e -> !rows.containsKey(e.getKey().get(0)))
         .forEach(e -> {
           // Rows filtered by the HAVING clause:
-          final Optional<Row> row = withRetry(() -> table.get(e.getKey(), PARTITION));
-          assertThat(row, is(Optional.empty()));
+          final List<Row> rowList =
+              withRetry(() -> Lists.newArrayList(table.get(e.getKey(), PARTITION).getRowIterator().get()));
+          assertThat(rowList.isEmpty(), is(true));
         });
   }
 
@@ -656,7 +682,7 @@ public class KsMaterializationFunctionalTest {
     rows.forEach(record -> {
       final GenericKey key = genericKey(record.key().key());
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> table.get(key, PARTITION, Range.all(), Range.all()));
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION, Range.all(), Range.all()).getRowIterator().get()));
 
       assertThat("Should have fewer windows retained",
           resultAtWindowStart,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -234,12 +234,12 @@ public class KsMaterializationFunctionalTest {
     rows.forEach((rowKey, value) -> {
       final GenericKey key = genericKey(rowKey);
 
-      final Optional<Iterator<Row>> rowIterator =
+      final Iterator<Row> rowIterator =
           withRetry(() -> table.get(key, PARTITION).getRowIterator());
 
-      assertThat(rowIterator.get(), not(Optional.empty()));
-      assertThat(rowIterator.get().hasNext(), is(true));
-      final Row row = rowIterator.get().next();
+      
+      assertThat(rowIterator.hasNext(), is(true));
+      final Row row = rowIterator.next();
       assertThat(row.schema(), is(schema));
       assertThat(row.key(), is(key));
       assertThat(row.value(), is(value));
@@ -272,12 +272,12 @@ public class KsMaterializationFunctionalTest {
 
     rows.forEach((rowKey, value) -> {
       final GenericKey key = genericKey(rowKey);
-      final Optional<Iterator<Row>> rowIterator =
+      final Iterator<Row> rowIterator =
           withRetry(() -> table.get(key, PARTITION).getRowIterator());
 
-      assertThat(rowIterator.get(), not(Optional.empty()));
-      assertThat(rowIterator.get().hasNext(), is(true));
-      final Row row = rowIterator.get().next();
+      
+      assertThat(rowIterator.hasNext(), is(true));
+      final Row row = rowIterator.next();
       assertThat(row.schema(), is(schema));
       assertThat(row.key(), is(key));
       assertThat(row.value(), is(value));
@@ -317,7 +317,7 @@ public class KsMaterializationFunctionalTest {
 
       final List<WindowedRow> resultAtWindowStart =
           withRetry(() -> Lists.newArrayList(
-              table.get(key, PARTITION, Range.singleton(w.start()), Range.all()).getRowIterator().get()));
+              table.get(key, PARTITION, Range.singleton(w.start()), Range.all()).getRowIterator()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -327,18 +327,18 @@ public class KsMaterializationFunctionalTest {
 
       final List<WindowedRow> resultAtWindowEnd =
           withRetry(() -> Lists.newArrayList(
-              table.get(key, PARTITION, Range.all(), Range.singleton(w.end())).getRowIterator().get()));
+              table.get(key, PARTITION, Range.all(), Range.singleton(w.end())).getRowIterator()));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all()).getRowIterator().get())));
+              Range.all()).getRowIterator())));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()).getRowIterator().get()));
+              Range.all()).getRowIterator()));
       assertThat("past start", resultPast, is(empty())
       );
     });
@@ -374,7 +374,7 @@ public class KsMaterializationFunctionalTest {
 
       final List<WindowedRow> resultAtWindowStart =
           withRetry(() -> Lists.newArrayList(
-              table.get(key, PARTITION, Range.singleton(w.start()), Range.all()).getRowIterator().get()));
+              table.get(key, PARTITION, Range.singleton(w.start()), Range.all()).getRowIterator()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -384,18 +384,18 @@ public class KsMaterializationFunctionalTest {
 
       final List<WindowedRow> resultAtWindowEnd =
           withRetry(() -> Lists.newArrayList(
-              table.get(key, PARTITION, Range.all(), Range.singleton(w.end())).getRowIterator().get()));
+              table.get(key, PARTITION, Range.all(), Range.singleton(w.end())).getRowIterator()));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> Lists.newArrayList(
           table.get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all()).getRowIterator().get()));
+              Range.all()).getRowIterator()));
 
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()).getRowIterator().get()));
+              Range.all()).getRowIterator()));
 
       assertThat("past start", resultPast, is(empty()));
     });
@@ -430,7 +430,7 @@ public class KsMaterializationFunctionalTest {
 
       final List<WindowedRow> resultAtWindowStart =
           withRetry(() -> Lists.newArrayList(table.get(key, PARTITION, Range.singleton(w.start())
-              , Range.all()).getRowIterator().get()));
+              , Range.all()).getRowIterator()));
 
       assertThat("at exact window start", resultAtWindowStart, hasSize(1));
       assertThat(resultAtWindowStart.get(0).schema(), is(schema));
@@ -440,17 +440,17 @@ public class KsMaterializationFunctionalTest {
 
       final List<WindowedRow> resultAtWindowEnd =
           withRetry(() -> Lists.newArrayList(table.get(key, PARTITION, Range.all(),
-                                                       Range.singleton(w.end())).getRowIterator().get()));
+                                                       Range.singleton(w.end())).getRowIterator()));
       assertThat("at exact window end", resultAtWindowEnd, hasSize(1));
 
       final List<WindowedRow> resultFromRange = withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().minusMillis(1), w.start().plusMillis(1)),
-              Range.all()).getRowIterator().get()));
+              Range.all()).getRowIterator()));
       assertThat("range including window start", resultFromRange, is(resultAtWindowStart));
 
       final List<WindowedRow> resultPast = withRetry(() -> Lists.newArrayList(table
           .get(key, PARTITION, Range.closed(w.start().plusMillis(1), w.start().plusMillis(1)),
-              Range.all()).getRowIterator().get()));
+              Range.all()).getRowIterator()));
       assertThat("past start", resultPast, is(empty()));
     });
   }
@@ -581,7 +581,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(rowKey);
 
       final List<Row> rowList =
-          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator().get()));
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator()));
       assertThat(rowList.size(), is(1));
       assertThat(rowList.get(0).schema(), is(schema));
       assertThat(rowList.get(0).key(), is(key));
@@ -617,7 +617,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(rowKey);
 
       final List<Row> rowList =
-          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator().get()));
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator()));
       assertThat(rowList.size(), is(1));
       assertThat(rowList.get(0).schema(), is(schema));
       assertThat(rowList.get(0).key(), is(key));
@@ -657,7 +657,7 @@ public class KsMaterializationFunctionalTest {
       final GenericKey key = genericKey(rowKey);
 
       final List<Row> rowList =
-          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator().get()));
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION).getRowIterator()));
       assertThat(rowList.size(), is(1));
       assertThat(rowList.get(0).schema(), is(schema));
       assertThat(rowList.get(0).key(), is(key));
@@ -669,7 +669,7 @@ public class KsMaterializationFunctionalTest {
         .forEach(e -> {
           // Rows filtered by the HAVING clause:
           final List<Row> rowList =
-              withRetry(() -> Lists.newArrayList(table.get(e.getKey(), PARTITION).getRowIterator().get()));
+              withRetry(() -> Lists.newArrayList(table.get(e.getKey(), PARTITION).getRowIterator()));
           assertThat(rowList.isEmpty(), is(true));
         });
   }
@@ -682,7 +682,7 @@ public class KsMaterializationFunctionalTest {
     rows.forEach(record -> {
       final GenericKey key = genericKey(record.key().key());
       final List<WindowedRow> resultAtWindowStart =
-          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION, Range.all(), Range.all()).getRowIterator().get()));
+          withRetry(() -> Lists.newArrayList(table.get(key, PARTITION, Range.all(), Range.all()).getRowIterator()));
 
       assertThat("Should have fewer windows retained",
           resultAtWindowStart,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.google.common.collect.Range;
@@ -246,7 +245,8 @@ public class KsMaterializationFunctionalTest {
     });
 
     final GenericKey key = genericKey("Won't find me");
-    assertThat("unknown key", withRetry(() -> table.get(key, PARTITION)), is(Optional.empty()));
+    assertThat("unknown key", withRetry(() -> table.get(key, PARTITION).getRowIterator().hasNext()),
+               is(false));
   }
 
   @Test
@@ -285,7 +285,8 @@ public class KsMaterializationFunctionalTest {
     });
 
     final GenericKey key = genericKey("Won't find me");
-    assertThat("unknown key", withRetry(() -> table.get(key, PARTITION)), is(Optional.empty()));
+    assertThat("unknown key", withRetry(() -> table.get(key, PARTITION)).getRowIterator().hasNext(),
+               is(false));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/KeyedTableLookupOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/KeyedTableLookupOperatorTest.java
@@ -23,19 +23,19 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.GenericKey;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlNode;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlPartitionLocation;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.MaterializedTable;
 import io.confluent.ksql.execution.streams.materialization.Row;
 import io.confluent.ksql.execution.streams.materialization.ks.KsLocator;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializedQueryResult;
 import io.confluent.ksql.physical.common.QueryRow;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.KeyConstraint;
 import io.confluent.ksql.planner.plan.KeyConstraint.ConstraintOperator;
+import io.confluent.ksql.util.IteratorUtil;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
@@ -112,10 +112,14 @@ public class KeyedTableLookupOperatorTest {
 
     final KeyedTableLookupOperator lookupOperator = new KeyedTableLookupOperator(materialization, logicalNode);
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
-    when(materialization.nonWindowed().get(GKEY1, 1)).thenReturn(Optional.of(ROW1));
-    when(materialization.nonWindowed().get(GKEY2, 2)).thenReturn(Optional.empty());
-    when(materialization.nonWindowed().get(GKEY3, 3)).thenReturn(Optional.of(ROW3));
-    when(materialization.nonWindowed().get(GKEY4, 3)).thenReturn(Optional.of(ROW4));
+    when(materialization.nonWindowed().get(GKEY1, 1)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW1)));
+    when(materialization.nonWindowed().get(GKEY2, 2)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of()));
+    when(materialization.nonWindowed().get(GKEY3, 3)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW3)));
+    when(materialization.nonWindowed().get(GKEY4, 3)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW4)));
 
 
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);
@@ -140,9 +144,12 @@ public class KeyedTableLookupOperatorTest {
 
     final KeyedTableLookupOperator lookupOperator = new KeyedTableLookupOperator(materialization, logicalNode);
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
-    when(materialization.nonWindowed().get(GKEY1, 1)).thenReturn(Optional.of(ROW1));
-    when(materialization.nonWindowed().get(GKEY3, 3)).thenReturn(Optional.of(ROW3));
-    when(materialization.nonWindowed().get(GKEY4, 3)).thenReturn(Optional.of(ROW4));
+    when(materialization.nonWindowed().get(GKEY1, 1)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW1)));
+    when(materialization.nonWindowed().get(GKEY3, 3)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW3)));
+    when(materialization.nonWindowed().get(GKEY4, 3)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW4)));
     lookupOperator.setPartitionLocations(multipleKeysPartitionLocations);
     lookupOperator.open();
 
@@ -164,7 +171,8 @@ public class KeyedTableLookupOperatorTest {
 
     final KeyedTableLookupOperator lookupOperator = new KeyedTableLookupOperator(materialization, logicalNode);
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
-    when(materialization.nonWindowed().get(1,null, GKEY3)).thenReturn(Arrays.asList(ROW1, ROW3).iterator());
+    when(materialization.nonWindowed().get(1,null, GKEY3)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW1, ROW3)));
 
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);
     lookupOperator.open();
@@ -188,8 +196,10 @@ public class KeyedTableLookupOperatorTest {
 
     final KeyedTableLookupOperator lookupOperator = new KeyedTableLookupOperator(materialization, logicalNode);
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
-    when(materialization.nonWindowed().get(1,null, GKEY2)).thenReturn(Arrays.asList(ROW1).iterator());
-    when(materialization.nonWindowed().get(3,null, GKEY3)).thenReturn(Arrays.asList(ROW3).iterator());
+    when(materialization.nonWindowed().get(1,null, GKEY2)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW1)));
+    when(materialization.nonWindowed().get(3,null, GKEY3)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW3)));
 
     lookupOperator.setPartitionLocations(multipleKeysPartitionLocations);
     lookupOperator.open();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/KeyedTableLookupOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/KeyedTableLookupOperatorTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.planner.plan.KeyConstraint;
 import io.confluent.ksql.planner.plan.KeyConstraint.ConstraintOperator;
 import io.confluent.ksql.util.IteratorUtil;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
@@ -146,6 +147,8 @@ public class KeyedTableLookupOperatorTest {
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
     when(materialization.nonWindowed().get(GKEY1, 1)).thenReturn(
         KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW1)));
+    when(materialization.nonWindowed().get(GKEY2, 1)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Collections.emptyIterator()));
     when(materialization.nonWindowed().get(GKEY3, 3)).thenReturn(
         KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW3)));
     when(materialization.nonWindowed().get(GKEY4, 3)).thenReturn(
@@ -171,8 +174,14 @@ public class KeyedTableLookupOperatorTest {
 
     final KeyedTableLookupOperator lookupOperator = new KeyedTableLookupOperator(materialization, logicalNode);
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
+    when(materialization.nonWindowed().get(GKEY1, 1)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Collections.emptyIterator()));
+    when(materialization.nonWindowed().get(GKEY2, 2)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Collections.emptyIterator()));
     when(materialization.nonWindowed().get(1,null, GKEY3)).thenReturn(
         KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW1, ROW3)));
+    when(materialization.nonWindowed().get(GKEY4, 3)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Collections.emptyIterator()));
 
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);
     lookupOperator.open();
@@ -196,10 +205,14 @@ public class KeyedTableLookupOperatorTest {
 
     final KeyedTableLookupOperator lookupOperator = new KeyedTableLookupOperator(materialization, logicalNode);
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
+    when(materialization.nonWindowed().get(GKEY1, 1)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Collections.emptyIterator()));
     when(materialization.nonWindowed().get(1,null, GKEY2)).thenReturn(
         KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW1)));
     when(materialization.nonWindowed().get(3,null, GKEY3)).thenReturn(
         KsMaterializedQueryResult.rowIterator(IteratorUtil.of(ROW3)));
+    when(materialization.nonWindowed().get(GKEY4, 3)).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Collections.emptyIterator()));
 
     lookupOperator.setPartitionLocations(multipleKeysPartitionLocations);
     lookupOperator.open();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/KeyedWindowedTableLookupOperatorTest.java
@@ -24,20 +24,20 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import io.confluent.ksql.GenericKey;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlNode;
 import io.confluent.ksql.execution.streams.materialization.Locator.KsqlPartitionLocation;
 import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.MaterializedWindowedTable;
 import io.confluent.ksql.execution.streams.materialization.WindowedRow;
 import io.confluent.ksql.execution.streams.materialization.ks.KsLocator;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializedQueryResult;
 import io.confluent.ksql.physical.common.QueryRow;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.KeyConstraint;
 import io.confluent.ksql.planner.plan.QueryFilterNode.WindowBounds;
+import io.confluent.ksql.util.IteratorUtil;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
@@ -133,13 +133,17 @@ public class KeyedWindowedTableLookupOperatorTest {
         materialization, logicalNode);
     when(materialization.windowed()).thenReturn(windowedTable);
     when(materialization.windowed().get(GKEY1, 1, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW1, WINDOWED_ROW2));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW1, WINDOWED_ROW2)));
     when(materialization.windowed().get(GKEY2, 2, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(Collections.emptyList());
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of()));
     when(materialization.windowed().get(GKEY3, 3, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW3));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW3)));
     when(materialization.windowed().get(GKEY4, 3, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW2, WINDOWED_ROW4));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW2, WINDOWED_ROW4)));
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);
     lookupOperator.open();
 
@@ -168,13 +172,16 @@ public class KeyedWindowedTableLookupOperatorTest {
     when(windowBounds1.getMergedEnd()).thenReturn(WINDOW_END_BOUNDS);
     when(materialization.windowed()).thenReturn(windowedTable);
     when(materialization.windowed().get(GKEY1, 1, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW1, WINDOWED_ROW2));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW1, WINDOWED_ROW2)));
     when(materialization.windowed().get(GKEY2, 1, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(Collections.emptyList());
+        .thenReturn(KsMaterializedQueryResult.rowIterator(IteratorUtil.of()));
     when(materialization.windowed().get(GKEY3, 3, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW3));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW3)));
     when(materialization.windowed().get(GKEY4, 3, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW2, WINDOWED_ROW4));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW2, WINDOWED_ROW4)));
     lookupOperator.setPartitionLocations(multipleKeysPartitionLocations);
     lookupOperator.open();
 
@@ -217,13 +224,15 @@ public class KeyedWindowedTableLookupOperatorTest {
     when(windowBounds4.getMergedEnd()).thenReturn(Range.all());
     when(materialization.windowed()).thenReturn(windowedTable);
     when(materialization.windowed().get(GKEY1, 1, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW1, WINDOWED_ROW2));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW1, WINDOWED_ROW2)));
     when(materialization.windowed().get(GKEY2, 2, Range.all(), WINDOW_END_BOUNDS))
-        .thenReturn(Collections.emptyList());
+        .thenReturn(KsMaterializedQueryResult.rowIterator(IteratorUtil.of()));
     when(materialization.windowed().get(GKEY3, 3, WINDOW_START_BOUNDS, Range.all()))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW3));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(IteratorUtil.of(WINDOWED_ROW3)));
     when(materialization.windowed().get(GKEY4, 3, Range.all(), Range.all()))
-        .thenReturn(ImmutableList.of(WINDOWED_ROW2, WINDOWED_ROW4));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW2, WINDOWED_ROW4)));
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);
     lookupOperator.open();
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/TableScanOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/TableScanOperatorTest.java
@@ -13,9 +13,9 @@ import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.MaterializedTable;
 import io.confluent.ksql.execution.streams.materialization.Row;
 import io.confluent.ksql.execution.streams.materialization.ks.KsLocator;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializedQueryResult;
 import io.confluent.ksql.physical.common.QueryRow;
 import io.confluent.ksql.planner.plan.DataSourceNode;
-import io.confluent.ksql.planner.plan.KeyConstraint.ConstraintOperator;
 import io.confluent.ksql.util.IteratorUtil;
 import java.util.ArrayList;
 import java.util.List;
@@ -85,9 +85,12 @@ public class TableScanOperatorTest {
         = new TableScanOperator(materialization, logicalNode, shouldCancelOperations);
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
 
-    when(nonWindowedTable.get(1)).thenReturn(IteratorUtil.of(ROW1_1, ROW1_2));
-    when(nonWindowedTable.get(2)).thenReturn(IteratorUtil.of());
-    when(nonWindowedTable.get(3)).thenReturn(IteratorUtil.of(ROW3_1, ROW3_2));
+    when(nonWindowedTable.get(1)).thenReturn(KsMaterializedQueryResult.rowIterator(
+        IteratorUtil.of(ROW1_1, ROW1_2)));
+    when(nonWindowedTable.get(2)).thenReturn(KsMaterializedQueryResult.rowIterator(
+        IteratorUtil.of()));
+    when(nonWindowedTable.get(3)).thenReturn(KsMaterializedQueryResult.rowIterator(
+        IteratorUtil.of(ROW3_1, ROW3_2)));
 
 
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);
@@ -119,7 +122,8 @@ public class TableScanOperatorTest {
         = new TableScanOperator(materialization, logicalNode, shouldCancelOperations);
     when(materialization.nonWindowed()).thenReturn(nonWindowedTable);
 
-    when(nonWindowedTable.get(1)).thenReturn(IteratorUtil.of(ROW1_1, ROW1_2));
+    when(nonWindowedTable.get(1)).thenReturn(KsMaterializedQueryResult.rowIterator(
+        IteratorUtil.of(ROW1_1, ROW1_2)));
 
 
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/WindowedTableScanOperatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/pull/operators/WindowedTableScanOperatorTest.java
@@ -14,6 +14,7 @@ import io.confluent.ksql.execution.streams.materialization.Materialization;
 import io.confluent.ksql.execution.streams.materialization.MaterializedWindowedTable;
 import io.confluent.ksql.execution.streams.materialization.WindowedRow;
 import io.confluent.ksql.execution.streams.materialization.ks.KsLocator;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializedQueryResult;
 import io.confluent.ksql.physical.common.QueryRow;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.util.IteratorUtil;
@@ -86,11 +87,13 @@ public class WindowedTableScanOperatorTest {
         new WindowedTableScanOperator(materialization, logicalNode, shouldCancelOperations);
     when(materialization.windowed()).thenReturn(windowedTable);
     when(windowedTable.get(1, Range.all(), Range.all()))
-        .thenReturn(IteratorUtil.of(WINDOWED_ROW1, WINDOWED_ROW2));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW1,WINDOWED_ROW2)));
     when(windowedTable.get(2, Range.all(), Range.all()))
-        .thenReturn(IteratorUtil.of());
+        .thenReturn(KsMaterializedQueryResult.rowIterator(IteratorUtil.of()));
     when(windowedTable.get(3, Range.all(), Range.all()))
-        .thenReturn(IteratorUtil.of(WINDOWED_ROW3, WINDOWED_ROW2, WINDOWED_ROW4));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW3, WINDOWED_ROW2, WINDOWED_ROW4)));
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);
     lookupOperator.open();
 
@@ -121,7 +124,8 @@ public class WindowedTableScanOperatorTest {
         new WindowedTableScanOperator(materialization, logicalNode, shouldCancelOperations);
     when(materialization.windowed()).thenReturn(windowedTable);
     when(windowedTable.get(1, Range.all(), Range.all()))
-        .thenReturn(IteratorUtil.of(WINDOWED_ROW1, WINDOWED_ROW2));
+        .thenReturn(KsMaterializedQueryResult.rowIterator(
+            IteratorUtil.of(WINDOWED_ROW1, WINDOWED_ROW2)));
     lookupOperator.setPartitionLocations(singleKeyPartitionLocations);
     lookupOperator.open();
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterialization.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterialization.java
@@ -142,9 +142,7 @@ class KsqlMaterialization implements Materialization {
         return table.get(key, partition);
       }
 
-      final Iterator<Row> result = table.get(key, partition)
-          .getRowIterator()
-          .get();
+      final Iterator<Row> result = table.get(key, partition).getRowIterator();
 
       return KsMaterializedQueryResult.rowIterator(
           Streams.stream(result)
@@ -161,9 +159,7 @@ class KsqlMaterialization implements Materialization {
         return table.get(partition);
       }
 
-      final Iterator<Row> result = table.get(partition)
-          .getRowIterator()
-          .get();
+      final Iterator<Row> result = table.get(partition).getRowIterator();
 
       return KsMaterializedQueryResult.rowIterator(
           Streams.stream(result)
@@ -175,15 +171,13 @@ class KsqlMaterialization implements Materialization {
     }
 
     @Override
-    public KsMaterializedQueryResult<Row> get(final int partition, final GenericKey from,
-    final GenericKey to) {
+    public KsMaterializedQueryResult<Row> get(
+        final int partition, final GenericKey from, final GenericKey to) {
       if (transforms.isEmpty()) {
         return table.get(partition, from, to);
       }
 
-      final Iterator<Row> result = table.get(partition, from, to)
-          .getRowIterator()
-          .get();
+      final Iterator<Row> result = table.get(partition, from, to).getRowIterator();
 
       return KsMaterializedQueryResult.rowIterator(
           Streams.stream(result)
@@ -215,8 +209,7 @@ class KsqlMaterialization implements Materialization {
       }
 
       final Iterator<WindowedRow> iterator = table.get(key, partition, windowStart, windowEnd)
-          .getRowIterator()
-          .get();
+          .getRowIterator();
 
       final Builder<WindowedRow> builder = ImmutableList.builder();
 
@@ -239,8 +232,7 @@ class KsqlMaterialization implements Materialization {
       }
 
       final Iterator<WindowedRow> result = table.get(partition, windowStartBounds, windowEndBounds)
-          .getRowIterator()
-          .get();
+          .getRowIterator();
 
       return KsMaterializedQueryResult.rowIterator(
           Streams.stream(result)
@@ -254,32 +246,32 @@ class KsqlMaterialization implements Materialization {
     }
   }
 
-    /*
-     Today, we are unconditionally adding the extra fields to windowed rows.
-     We should decide if we need these additional fields for the
-     Windowed Rows case and remove them if possible.
-     */
-    public static GenericRow getIntermediateRow(final TableRow row) {
-      final GenericKey key = row.key();
-      final GenericRow value = row.value();
+  /*
+   Today, we are unconditionally adding the extra fields to windowed rows.
+   We should decide if we need these additional fields for the
+   Windowed Rows case and remove them if possible.
+   */
+  public static GenericRow getIntermediateRow(final TableRow row) {
+    final GenericKey key = row.key();
+    final GenericRow value = row.value();
 
-      final List<?> keyFields = key.values();
+    final List<?> keyFields = key.values();
 
-      value.ensureAdditionalCapacity(
-          1 // ROWTIME
-              + keyFields.size() //all the keys
-              + row.window().map(w -> 2).orElse(0) //windows
-      );
+    value.ensureAdditionalCapacity(
+        1 // ROWTIME
+            + keyFields.size() //all the keys
+            + row.window().map(w -> 2).orElse(0) //windows
+    );
 
-      value.append(row.rowTime());
-      value.appendAll(keyFields);
+    value.append(row.rowTime());
+    value.appendAll(keyFields);
 
-      row.window().ifPresent(window -> {
-        value.append(window.start().toEpochMilli());
-        value.append(window.end().toEpochMilli());
-      });
+    row.window().ifPresent(window -> {
+      value.append(window.start().toEpochMilli());
+      value.append(window.end().toEpochMilli());
+    });
 
-      return value;
-    }
+    return value;
+  }
 }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/MaterializedTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/MaterializedTable.java
@@ -16,8 +16,7 @@
 package io.confluent.ksql.execution.streams.materialization;
 
 import io.confluent.ksql.GenericKey;
-import java.util.Iterator;
-import java.util.Optional;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializedQueryResult;
 
 /**
  * Materialization of a table with a non-windowed key
@@ -31,7 +30,7 @@ public interface MaterializedTable {
    * @param partition partition to limit the get to
    * @return the value, if one is exists.
    */
-  Optional<Row> get(GenericKey key, int partition);
+  KsMaterializedQueryResult<Row> get(GenericKey key, int partition);
 
   /**
    * Scan the table for rows
@@ -39,7 +38,7 @@ public interface MaterializedTable {
    * @param partition partition to limit the get to
    * @return the rows.
    */
-  Iterator<Row> get(int partition);
+  KsMaterializedQueryResult<Row> get(int partition);
 
   /**
    * RangeScan the table for rows
@@ -49,5 +48,5 @@ public interface MaterializedTable {
    * @param to last key in range
    * @return the rows.
    */
-  Iterator<Row> get(int partition, GenericKey from, GenericKey to);
+  KsMaterializedQueryResult<Row> get(int partition, GenericKey from, GenericKey to);
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/MaterializedWindowedTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/MaterializedWindowedTable.java
@@ -17,9 +17,8 @@ package io.confluent.ksql.execution.streams.materialization;
 
 import com.google.common.collect.Range;
 import io.confluent.ksql.GenericKey;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializedQueryResult;
 import java.time.Instant;
-import java.util.Iterator;
-import java.util.List;
 
 /**
  * Materialization of a table with a windowed key
@@ -36,8 +35,8 @@ public interface MaterializedWindowedTable {
    * @param windowEnd the bounds on the window's end time.
    * @return the rows for the key that exist within the range.
    */
-  List<WindowedRow> get(GenericKey key, int partition, Range<Instant> windowStart,
-      Range<Instant> windowEnd);
+  KsMaterializedQueryResult<WindowedRow> get(GenericKey key, int partition, Range<Instant> windowStart,
+                                Range<Instant> windowEnd);
 
   /**
    * Get the values in table where the window start time is within the
@@ -48,5 +47,5 @@ public interface MaterializedWindowedTable {
    * @param windowEnd the bounds on the window's end time.
    * @return the rows for the key that exist within the range.
    */
-  Iterator<WindowedRow> get(int partition, Range<Instant> windowStart, Range<Instant> windowEnd);
+  KsMaterializedQueryResult<WindowedRow> get(int partition, Range<Instant> windowStart, Range<Instant> windowEnd);
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/MaterializedWindowedTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/MaterializedWindowedTable.java
@@ -35,8 +35,8 @@ public interface MaterializedWindowedTable {
    * @param windowEnd the bounds on the window's end time.
    * @return the rows for the key that exist within the range.
    */
-  KsMaterializedQueryResult<WindowedRow> get(GenericKey key, int partition, Range<Instant> windowStart,
-                                Range<Instant> windowEnd);
+  KsMaterializedQueryResult<WindowedRow> get(
+      GenericKey key, int partition, Range<Instant> windowStart, Range<Instant> windowEnd);
 
   /**
    * Get the values in table where the window start time is within the
@@ -47,5 +47,6 @@ public interface MaterializedWindowedTable {
    * @param windowEnd the bounds on the window's end time.
    * @return the rows for the key that exist within the range.
    */
-  KsMaterializedQueryResult<WindowedRow> get(int partition, Range<Instant> windowStart, Range<Instant> windowEnd);
+  KsMaterializedQueryResult<WindowedRow> get(
+      int partition, Range<Instant> windowStart, Range<Instant> windowEnd);
 }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedQueryResult.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedQueryResult.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams.materialization.ks;
+
+import io.confluent.ksql.execution.streams.materialization.TableRow;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.kafka.streams.query.Position;
+
+public class KsMaterializedQueryResult<T extends TableRow> {
+
+  final Optional<Iterator<T>> rowIterator;
+//  final Optional<Iterator<WindowedRow>> windowedRowIterator;
+  final Optional<Position> position;
+
+  public static <T extends TableRow> KsMaterializedQueryResult<T> rowIterator(
+      final Iterator<T> iterator) {
+    return new KsMaterializedQueryResult<>(Optional.of(iterator), Optional.empty());
+  }
+
+  public static <T extends TableRow> KsMaterializedQueryResult<T> rowIteratorWithPosition(
+      final Iterator<T> iterator, final Position position) {
+    return new KsMaterializedQueryResult<>(Optional.of(iterator), Optional.of(position));
+  }
+
+//  public static KsMaterializedQueryResult windowedRowIterator(
+//      final Iterator<WindowedRow> iterator) {
+//    return new KsMaterializedQueryResult(Optional.empty(), Optional.empty(), Optional.empty(),
+//                                         Optional.of(iterator), Optional.empty());
+//  }
+//
+//  public static KsMaterializedQueryResult windowedRowIteratorWithPosition(
+//      final Iterator<WindowedRow> iterator, final Position position) {
+//    return new KsMaterializedQueryResult(Optional.empty(),  Optional.empty(), Optional.empty(),
+//                                         Optional.of(iterator), Optional.of(position));
+//  }
+
+  private KsMaterializedQueryResult(final Optional<Iterator<T>> rowIterator,
+                                    final Optional<Position> position) {
+    this.rowIterator = Objects.requireNonNull(rowIterator, "rowIterator");
+    this.position = Objects.requireNonNull(position, "position");
+  }
+
+  public Optional<Iterator<T>> getRowIterator() {
+    return rowIterator;
+  }
+
+//  public Optional<Iterator<WindowedRow>> getWindowedRowIterator() {
+//    return windowedRowIterator;
+//  }
+
+  public Optional<Position> getPosition() {
+    return position;
+  }
+}

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedQueryResult.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedQueryResult.java
@@ -24,7 +24,6 @@ import org.apache.kafka.streams.query.Position;
 public class KsMaterializedQueryResult<T extends TableRow> {
 
   final Optional<Iterator<T>> rowIterator;
-//  final Optional<Iterator<WindowedRow>> windowedRowIterator;
   final Optional<Position> position;
 
   public static <T extends TableRow> KsMaterializedQueryResult<T> rowIterator(
@@ -37,18 +36,6 @@ public class KsMaterializedQueryResult<T extends TableRow> {
     return new KsMaterializedQueryResult<>(Optional.of(iterator), Optional.of(position));
   }
 
-//  public static KsMaterializedQueryResult windowedRowIterator(
-//      final Iterator<WindowedRow> iterator) {
-//    return new KsMaterializedQueryResult(Optional.empty(), Optional.empty(), Optional.empty(),
-//                                         Optional.of(iterator), Optional.empty());
-//  }
-//
-//  public static KsMaterializedQueryResult windowedRowIteratorWithPosition(
-//      final Iterator<WindowedRow> iterator, final Position position) {
-//    return new KsMaterializedQueryResult(Optional.empty(),  Optional.empty(), Optional.empty(),
-//                                         Optional.of(iterator), Optional.of(position));
-//  }
-
   private KsMaterializedQueryResult(final Optional<Iterator<T>> rowIterator,
                                     final Optional<Position> position) {
     this.rowIterator = Objects.requireNonNull(rowIterator, "rowIterator");
@@ -58,10 +45,6 @@ public class KsMaterializedQueryResult<T extends TableRow> {
   public Optional<Iterator<T>> getRowIterator() {
     return rowIterator;
   }
-
-//  public Optional<Iterator<WindowedRow>> getWindowedRowIterator() {
-//    return windowedRowIterator;
-//  }
 
   public Optional<Position> getPosition() {
     return position;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedQueryResult.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedQueryResult.java
@@ -21,28 +21,28 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.streams.query.Position;
 
-public class KsMaterializedQueryResult<T extends TableRow> {
+public final class KsMaterializedQueryResult<T extends TableRow> {
 
-  final Optional<Iterator<T>> rowIterator;
+  final Iterator<T> rowIterator;
   final Optional<Position> position;
 
   public static <T extends TableRow> KsMaterializedQueryResult<T> rowIterator(
       final Iterator<T> iterator) {
-    return new KsMaterializedQueryResult<>(Optional.of(iterator), Optional.empty());
+    return new KsMaterializedQueryResult<>(iterator, Optional.empty());
   }
 
   public static <T extends TableRow> KsMaterializedQueryResult<T> rowIteratorWithPosition(
       final Iterator<T> iterator, final Position position) {
-    return new KsMaterializedQueryResult<>(Optional.of(iterator), Optional.of(position));
+    return new KsMaterializedQueryResult<>(iterator, Optional.of(position));
   }
 
-  private KsMaterializedQueryResult(final Optional<Iterator<T>> rowIterator,
+  private KsMaterializedQueryResult(final Iterator<T> rowIterator,
                                     final Optional<Position> position) {
     this.rowIterator = Objects.requireNonNull(rowIterator, "rowIterator");
     this.position = Objects.requireNonNull(position, "position");
   }
 
-  public Optional<Iterator<T>> getRowIterator() {
+  public Iterator<T> getRowIterator() {
     return rowIterator;
   }
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedQueryResult.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedQueryResult.java
@@ -15,12 +15,14 @@
 
 package io.confluent.ksql.execution.streams.materialization.ks;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.streams.materialization.TableRow;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.streams.query.Position;
 
+@SuppressFBWarnings(value = "EI_EXPOSE_REP")
 public final class KsMaterializedQueryResult<T extends TableRow> {
 
   final Iterator<T> rowIterator;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTable.java
@@ -26,7 +26,6 @@ import io.confluent.ksql.execution.streams.materialization.WindowedRow;
 import io.confluent.ksql.execution.streams.materialization.ks.SessionStoreCacheBypass.SessionStoreCacheBypassFetcher;
 import io.confluent.ksql.execution.streams.materialization.ks.SessionStoreCacheBypass.SessionStoreCacheBypassFetcherRange;
 import java.time.Instant;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.streams.KeyValue;
@@ -55,7 +54,7 @@ class KsMaterializedSessionTable implements MaterializedWindowedTable {
   }
 
   @Override
-  public List<WindowedRow> get(
+  public KsMaterializedQueryResult<WindowedRow> get(
       final GenericKey key,
       final int partition,
       final Range<Instant> windowStart,
@@ -65,14 +64,15 @@ class KsMaterializedSessionTable implements MaterializedWindowedTable {
       final ReadOnlySessionStore<GenericKey, GenericRow> store = stateStore
           .store(QueryableStoreTypes.sessionStore(), partition);
 
-      return findSession(store, key, windowStart, windowEnd);
+      return KsMaterializedQueryResult.rowIterator(
+          findSession(store, key, windowStart, windowEnd).iterator());
     } catch (final Exception e) {
       throw new MaterializationException("Failed to get value from materialized table", e);
     }
   }
 
   @Override
-  public Iterator<WindowedRow> get(final int partition, final Range<Instant> windowStartBounds,
+  public KsMaterializedQueryResult<WindowedRow> get(final int partition, final Range<Instant> windowStartBounds,
       final Range<Instant> windowEndBounds) {
     throw new MaterializationException("Table scan unsupported on session tables");
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTable.java
@@ -72,7 +72,9 @@ class KsMaterializedSessionTable implements MaterializedWindowedTable {
   }
 
   @Override
-  public KsMaterializedQueryResult<WindowedRow> get(final int partition, final Range<Instant> windowStartBounds,
+  public KsMaterializedQueryResult<WindowedRow> get(
+      final int partition,
+      final Range<Instant> windowStartBounds,
       final Range<Instant> windowEndBounds) {
     throw new MaterializationException("Table scan unsupported on session tables");
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableIQv2.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableIQv2.java
@@ -107,7 +107,9 @@ class KsMaterializedSessionTableIQv2 implements MaterializedWindowedTable {
   }
 
   @Override
-  public KsMaterializedQueryResult<WindowedRow> get(final int partition, final Range<Instant> windowStartBounds,
+  public KsMaterializedQueryResult<WindowedRow> get(
+      final int partition,
+      final Range<Instant> windowStartBounds,
       final Range<Instant> windowEndBounds) {
     throw new MaterializationException("Table scan unsupported on session tables");
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTable.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTable.java
@@ -81,7 +81,8 @@ class KsMaterializedTable implements MaterializedTable {
   }
 
   @Override
-  public KsMaterializedQueryResult<Row> get(final int partition, final GenericKey from, final GenericKey to) {
+  public KsMaterializedQueryResult<Row> get(
+      final int partition, final GenericKey from, final GenericKey to) {
     try {
       final ReadOnlyKeyValueStore<GenericKey, ValueAndTimestamp<GenericRow>> store = stateStore
           .store(QueryableStoreTypes.timestampedKeyValueStore(), partition);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableIQv2.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableIQv2.java
@@ -119,8 +119,8 @@ class KsMaterializedTableIQv2 implements MaterializedTable {
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   @Override
-  public KsMaterializedQueryResult<Row> get(final int partition, final GenericKey from,
-  final GenericKey to) {
+  public KsMaterializedQueryResult<Row> get(
+      final int partition, final GenericKey from, final GenericKey to) {
     // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     try {
       final RangeQuery<GenericKey, ValueAndTimestamp<GenericRow>> query;

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableIQv2.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableIQv2.java
@@ -176,7 +176,7 @@ class KsMaterializedWindowTableIQv2 implements MaterializedWindowedTable {
                     next.value.timestamp()
                 );
 
-                return row;})
+                return row; })
               .filter(Objects::nonNull)
               .iterator(),
           result.getPosition()

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
@@ -271,7 +271,7 @@ public class KsqlMaterializationTest {
     when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    table.get(aKey, partition).getRowIterator().get().next();
+    table.get(aKey, partition).getRowIterator().next();
 
     // Then:
     verify(filter).apply(aKey, aValue, new PullProcessingContext(aRowtime));
@@ -285,7 +285,7 @@ public class KsqlMaterializationTest {
     when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    table.get(aKey, partition, windowStartBounds, windowEndBounds).getRowIterator().get().next();
+    table.get(aKey, partition, windowStartBounds, windowEndBounds).getRowIterator().next();
 
     // Then:
     verify(filter).apply(
@@ -307,8 +307,7 @@ public class KsqlMaterializationTest {
     final KsMaterializedQueryResult<Row> result = table.get(aKey, partition);
 
     // Then:
-    assertThat(result.getRowIterator(), not(Optional.empty()));
-    assertThat(result.getRowIterator().get().hasNext(), is(false));
+    assertThat(result.getRowIterator().hasNext(), is(false));
   }
 
   @Test
@@ -324,8 +323,7 @@ public class KsqlMaterializationTest {
         table.get(aKey, partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result.getRowIterator(), not(Optional.empty()));
-    assertThat(result.getRowIterator().get().hasNext(), is(false));
+    assertThat(result.getRowIterator().hasNext(), is(false));
   }
 
   @Test
@@ -339,8 +337,7 @@ public class KsqlMaterializationTest {
     final KsMaterializedQueryResult<Row> result = table.get(aKey, partition);
 
     // Then:
-    assertThat(result.getRowIterator(), not(Optional.empty()));
-    assertThat(result.getRowIterator().get().hasNext(), is(false));
+    assertThat(result.getRowIterator().hasNext(), is(false));
   }
 
   @Test
@@ -355,8 +352,7 @@ public class KsqlMaterializationTest {
         table.get(aKey, partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result.getRowIterator(), not(Optional.empty()));
-    assertThat(result.getRowIterator().get().hasNext(), is(false));
+    assertThat(result.getRowIterator().hasNext(), is(false));
   }
 
   @Test
@@ -370,8 +366,7 @@ public class KsqlMaterializationTest {
     final KsMaterializedQueryResult<Row> result = table.get(partition);
 
     // Then:
-    assertThat(result.getRowIterator(), not(Optional.empty()));
-    assertThat(result.getRowIterator().get().hasNext(), is(false));
+    assertThat(result.getRowIterator().hasNext(), is(false));
   }
 
   @Test
@@ -386,8 +381,8 @@ public class KsqlMaterializationTest {
         table.get(partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result.getRowIterator(), not(Optional.empty()));
-    assertThat(result.getRowIterator().get().hasNext(), is(false));
+    
+    assertThat(result.getRowIterator().hasNext(), is(false));
   }
 
   @Test
@@ -398,7 +393,7 @@ public class KsqlMaterializationTest {
     when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    table.get(aKey, partition).getRowIterator().get().next();
+    table.get(aKey, partition).getRowIterator().next();
 
     // Then:
     final InOrder inOrder = inOrder(project, filter);
@@ -430,7 +425,7 @@ public class KsqlMaterializationTest {
     when(filter.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    table.get(aKey, partition).getRowIterator().get().next();
+    table.get(aKey, partition).getRowIterator().next();
 
     // Then:
     verify(project).apply(aKey, transformed, new PullProcessingContext(aRowtime));
@@ -464,8 +459,8 @@ public class KsqlMaterializationTest {
     // When:
     final KsMaterializedQueryResult<Row> result =
         table.get(partition);
-    result.getRowIterator().get().next();
-    result.getRowIterator().get().next();
+    result.getRowIterator().next();
+    result.getRowIterator().next();
 
     // Then:
     verify(project).apply(aKey, transformed, new PullProcessingContext(aRowtime));
@@ -482,8 +477,8 @@ public class KsqlMaterializationTest {
     // When:
     final KsMaterializedQueryResult<WindowedRow> result =
         table.get(partition, windowStartBounds, windowEndBounds);
-    result.getRowIterator().get().next();
-    result.getRowIterator().get().next();
+    result.getRowIterator().next();
+    result.getRowIterator().next();
 
     // Then:
     verify(project).apply(
@@ -511,8 +506,8 @@ public class KsqlMaterializationTest {
 
     // Then:
     assertThat(result.getRowIterator(), is(not(Optional.empty())));
-    assertThat(result.getRowIterator().get().hasNext(), is(true));
-    final Row row = result.getRowIterator().get().next();
+    assertThat(result.getRowIterator().hasNext(), is(true));
+    final Row row = result.getRowIterator().next();
     assertThat(row.key(), is(aKey));
     assertThat(row.window(), is(Optional.empty()));
     assertThat(row.value(), is(transformed));
@@ -531,8 +526,8 @@ public class KsqlMaterializationTest {
 
     // Then:
     assertThat(result.getRowIterator(), is(not(Optional.empty())));
-    assertThat(result.getRowIterator().get().hasNext(), is(true));
-    final WindowedRow row = result.getRowIterator().get().next();
+    assertThat(result.getRowIterator().hasNext(), is(true));
+    final WindowedRow row = result.getRowIterator().next();
     assertThat(row.key(), is(aKey));
     assertThat(row.window(), is(Optional.of(aWindow)));
     assertThat(row.value(), is(transformed));
@@ -569,9 +564,8 @@ public class KsqlMaterializationTest {
         table.get(aKey, partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result.getRowIterator(), not(Optional.empty()));
-    assertThat(result.getRowIterator().get().hasNext(), is(true));
-    final List<WindowedRow> resultList = Lists.newArrayList(result.getRowIterator().get());
+    assertThat(result.getRowIterator().hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(result.getRowIterator());
     assertThat(resultList, hasSize(rows.size()));
     assertThat(resultList.get(0).windowedKey().window(), is(window1));
     assertThat(resultList.get(1).windowedKey().window(), is(window2));

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationTest.java
@@ -15,10 +15,22 @@
 
 package io.confluent.ksql.execution.streams.materialization;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Range;
-import com.google.common.collect.Streams;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
 import io.confluent.ksql.GenericKey;
@@ -27,36 +39,24 @@ import io.confluent.ksql.Window;
 import io.confluent.ksql.execution.streams.materialization.KsqlMaterialization.KsqlMaterializedTable;
 import io.confluent.ksql.execution.streams.materialization.KsqlMaterialization.KsqlMaterializedWindowedTable;
 import io.confluent.ksql.execution.streams.materialization.KsqlMaterialization.Transform;
+import io.confluent.ksql.execution.streams.materialization.ks.KsMaterializedQueryResult;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.time.Instant;
-import java.util.Iterator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import org.apache.commons.compress.utils.Lists;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.sameInstance;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -79,6 +79,8 @@ public class KsqlMaterializationTest {
   private WindowedRow windowedRow;
   private WindowedRow windowedRow2;
 
+  private static final Instant LOWER_INSTANT = Instant.ofEpochMilli(System.currentTimeMillis());
+  private static final Instant UPPER_INSTANT = LOWER_INSTANT.plusSeconds(10);
 
   @Mock
   private Materialization inner;
@@ -120,7 +122,7 @@ public class KsqlMaterializationTest {
     aValue = GenericRow.genericRow("a", "b");
     aValue2 = GenericRow.genericRow("a2", "b2");
     transformed = GenericRow.genericRow("x", "y");
-    aWindow = Window.of(Instant.now(), Instant.now().plusMillis(10));
+    aWindow = Window.of(LOWER_INSTANT, UPPER_INSTANT);
     streamWindow = new TimeWindow(
             aWindow.start().toEpochMilli(),
             aWindow.end().toEpochMilli()
@@ -163,11 +165,14 @@ public class KsqlMaterializationTest {
     when(inner.nonWindowed()).thenReturn(innerNonWindowed);
     when(inner.windowed()).thenReturn(innerWindowed);
 
-    when(innerNonWindowed.get(any(), anyInt())).thenReturn(Optional.of(row));
-    when(innerNonWindowed.get(anyInt())).thenReturn(Iterators.forArray(row, row2));
-    when(innerWindowed.get(any(), anyInt(), any(), any())).thenReturn(ImmutableList.of(windowedRow));
-    when(innerWindowed.get(anyInt(), any(), any()))
-        .thenReturn(ImmutableList.of(windowedRow, windowedRow2).iterator());
+    when(innerNonWindowed.get(any(), anyInt())).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Iterators.forArray(row)));
+    when(innerNonWindowed.get(anyInt())).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Iterators.forArray(row, row2)));
+    when(innerWindowed.get(any(), anyInt(), any(), any())).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Iterators.forArray(windowedRow)));
+    when(innerWindowed.get(anyInt(), any(), any())).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Iterators.forArray(windowedRow, windowedRow2)));
   }
 
   @SuppressWarnings("UnstableApiUsage")
@@ -235,7 +240,7 @@ public class KsqlMaterializationTest {
     // Given:
     final MaterializedTable table = materialization.nonWindowed();
     givenNoopFilter();
-    when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
+//    when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
     table.get(aKey, partition);
@@ -265,9 +270,8 @@ public class KsqlMaterializationTest {
     givenNoopFilter();
     when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
-
     // When:
-    table.get(aKey, partition);
+    table.get(aKey, partition).getRowIterator().get().next();
 
     // Then:
     verify(filter).apply(aKey, aValue, new PullProcessingContext(aRowtime));
@@ -281,7 +285,7 @@ public class KsqlMaterializationTest {
     when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    table.get(aKey, partition, windowStartBounds, windowEndBounds);
+    table.get(aKey, partition, windowStartBounds, windowEndBounds).getRowIterator().get().next();
 
     // Then:
     verify(filter).apply(
@@ -295,28 +299,33 @@ public class KsqlMaterializationTest {
   public void shouldReturnEmptyIfInnerNonWindowedReturnsEmpty() {
     // Given:
     final MaterializedTable table = materialization.nonWindowed();
-    when(innerNonWindowed.get(any(), anyInt())).thenReturn(Optional.empty());
+    when(innerNonWindowed.get(any(), anyInt())).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Collections.emptyIterator()));
     givenNoopTransforms();
 
     // When:
-    final Optional<?> result = table.get(aKey, partition);
+    final KsMaterializedQueryResult<Row> result = table.get(aKey, partition);
 
     // Then:
-    assertThat(result, is(Optional.empty()));
+    assertThat(result.getRowIterator(), not(Optional.empty()));
+    assertThat(result.getRowIterator().get().hasNext(), is(false));
   }
 
   @Test
   public void shouldReturnEmptyIfInnerWindowedReturnsEmpty() {
     // Given:
     final MaterializedWindowedTable table = materialization.windowed();
-    when(innerWindowed.get(any(), anyInt(), any(), any())).thenReturn(ImmutableList.of());
+    when(innerWindowed.get(any(), anyInt(), any(), any())).thenReturn(
+        KsMaterializedQueryResult.rowIterator(Collections.emptyIterator()));
     givenNoopTransforms();
 
     // When:
-    final List<?> result = table.get(aKey, partition, windowStartBounds, windowEndBounds);
+    final KsMaterializedQueryResult<WindowedRow> result =
+        table.get(aKey, partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(result.getRowIterator(), not(Optional.empty()));
+    assertThat(result.getRowIterator().get().hasNext(), is(false));
   }
 
   @Test
@@ -327,10 +336,11 @@ public class KsqlMaterializationTest {
     when(filter.apply(any(), any(), any())).thenReturn(Optional.empty());
 
     // When:
-    final Optional<?> result = table.get(aKey, partition);
+    final KsMaterializedQueryResult<Row> result = table.get(aKey, partition);
 
     // Then:
-    assertThat(result, is(Optional.empty()));
+    assertThat(result.getRowIterator(), not(Optional.empty()));
+    assertThat(result.getRowIterator().get().hasNext(), is(false));
   }
 
   @Test
@@ -341,10 +351,12 @@ public class KsqlMaterializationTest {
     when(filter.apply(any(), any(), any())).thenReturn(Optional.empty());
 
     // When:
-    final List<?> result = table.get(aKey, partition, windowStartBounds, windowEndBounds);
+    final KsMaterializedQueryResult<WindowedRow> result =
+        table.get(aKey, partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(result.getRowIterator(), not(Optional.empty()));
+    assertThat(result.getRowIterator().get().hasNext(), is(false));
   }
 
   @Test
@@ -355,10 +367,11 @@ public class KsqlMaterializationTest {
     when(filter.apply(any(), any(), any())).thenReturn(Optional.empty());
 
     // When:
-    final Iterator<?> result = table.get(partition);
+    final KsMaterializedQueryResult<Row> result = table.get(partition);
 
     // Then:
-    assertThat(result.hasNext(), is(false));
+    assertThat(result.getRowIterator(), not(Optional.empty()));
+    assertThat(result.getRowIterator().get().hasNext(), is(false));
   }
 
   @Test
@@ -369,10 +382,12 @@ public class KsqlMaterializationTest {
     when(filter.apply(any(), any(), any())).thenReturn(Optional.empty());
 
     // When:
-    final Iterator<?> result = table.get(partition, windowStartBounds, windowEndBounds);
+    final KsMaterializedQueryResult<WindowedRow> result =
+        table.get(partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result.hasNext(), is(false));
+    assertThat(result.getRowIterator(), not(Optional.empty()));
+    assertThat(result.getRowIterator().get().hasNext(), is(false));
   }
 
   @Test
@@ -383,7 +398,7 @@ public class KsqlMaterializationTest {
     when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    table.get(aKey, partition);
+    table.get(aKey, partition).getRowIterator().get().next();
 
     // Then:
     final InOrder inOrder = inOrder(project, filter);
@@ -415,7 +430,7 @@ public class KsqlMaterializationTest {
     when(filter.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    table.get(aKey, partition);
+    table.get(aKey, partition).getRowIterator().get().next();
 
     // Then:
     verify(project).apply(aKey, transformed, new PullProcessingContext(aRowtime));
@@ -447,8 +462,10 @@ public class KsqlMaterializationTest {
     when(filter.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    Streams.stream(table.get(partition)).collect(Collectors.toList());
-
+    final KsMaterializedQueryResult<Row> result =
+        table.get(partition);
+    result.getRowIterator().get().next();
+    result.getRowIterator().get().next();
 
     // Then:
     verify(project).apply(aKey, transformed, new PullProcessingContext(aRowtime));
@@ -463,8 +480,10 @@ public class KsqlMaterializationTest {
     when(filter.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    Streams.stream(table.get(partition, windowStartBounds, windowEndBounds))
-        .collect(Collectors.toList());
+    final KsMaterializedQueryResult<WindowedRow> result =
+        table.get(partition, windowStartBounds, windowEndBounds);
+    result.getRowIterator().get().next();
+    result.getRowIterator().get().next();
 
     // Then:
     verify(project).apply(
@@ -488,13 +507,15 @@ public class KsqlMaterializationTest {
     when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    final Optional<Row> result = table.get(aKey, partition);
+    final KsMaterializedQueryResult<Row> result = table.get(aKey, partition);
 
     // Then:
-    assertThat(result, is(not(Optional.empty())));
-    assertThat(result.get().key(), is(aKey));
-    assertThat(result.get().window(), is(Optional.empty()));
-    assertThat(result.get().value(), is(transformed));
+    assertThat(result.getRowIterator(), is(not(Optional.empty())));
+    assertThat(result.getRowIterator().get().hasNext(), is(true));
+    final Row row = result.getRowIterator().get().next();
+    assertThat(row.key(), is(aKey));
+    assertThat(row.window(), is(Optional.empty()));
+    assertThat(row.value(), is(transformed));
   }
 
   @Test
@@ -505,14 +526,16 @@ public class KsqlMaterializationTest {
     when(project.apply(any(), any(), any())).thenReturn(Optional.of(transformed));
 
     // When:
-    final List<WindowedRow> result = table.get(aKey, partition, windowStartBounds,
-            windowEndBounds);
+    final KsMaterializedQueryResult<WindowedRow> result =
+        table.get(aKey, partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result, hasSize(1));
-    assertThat(result.get(0).key(), is(aKey));
-    assertThat(result.get(0).window(), is(Optional.of(aWindow)));
-    assertThat(result.get(0).value(), is(transformed));
+    assertThat(result.getRowIterator(), is(not(Optional.empty())));
+    assertThat(result.getRowIterator().get().hasNext(), is(true));
+    final WindowedRow row = result.getRowIterator().get().next();
+    assertThat(row.key(), is(aKey));
+    assertThat(row.window(), is(Optional.of(aWindow)));
+    assertThat(row.value(), is(transformed));
   }
 
   @Test
@@ -538,17 +561,21 @@ public class KsqlMaterializationTest {
         WindowedRow.of(schema, new Windowed<>(aKey, window3), aValue, aRowtime)
     );
 
-    when(innerWindowed.get(any(), anyInt(), any(), any())).thenReturn(rows);
+    when(innerWindowed.get(any(), anyInt(), any(), any())).thenReturn(
+        KsMaterializedQueryResult.rowIterator(rows.iterator()));
 
     // When:
-    final List<WindowedRow> result = table.get(aKey, partition, windowStartBounds,
-            windowEndBounds);
+    final KsMaterializedQueryResult<WindowedRow> result =
+        table.get(aKey, partition, windowStartBounds, windowEndBounds);
 
     // Then:
-    assertThat(result, hasSize(rows.size()));
-    assertThat(result.get(0).windowedKey().window(), is(window1));
-    assertThat(result.get(1).windowedKey().window(), is(window2));
-    assertThat(result.get(2).windowedKey().window(), is(window3));
+    assertThat(result.getRowIterator(), not(Optional.empty()));
+    assertThat(result.getRowIterator().get().hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(result.getRowIterator().get());
+    assertThat(resultList, hasSize(rows.size()));
+    assertThat(resultList.get(0).windowedKey().window(), is(window1));
+    assertThat(resultList.get(1).windowedKey().window(), is(window2));
+    assertThat(resultList.get(2).windowedKey().window(), is(window3));
   }
 
   @Test

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableIQv2Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableIQv2Test.java
@@ -18,10 +18,10 @@ package io.confluent.ksql.execution.streams.materialization.ks;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -40,7 +40,10 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
+import org.apache.commons.compress.utils.Lists;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -166,15 +169,20 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(LOWER_INSTANT, wend);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, startBounds, Range.all());
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    assertThat(result, contains(WindowedRow.of(
-      SCHEMA,
-      sessionKey(LOWER_INSTANT, wend),
-      A_VALUE,
-      wend.toEpochMilli()
-    )));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(
+        WindowedRow.of(
+            SCHEMA,
+            sessionKey(LOWER_INSTANT, wend),
+            A_VALUE,
+            wend.toEpochMilli()
+        )
+    ));
   }
 
   @Test
@@ -189,10 +197,12 @@ public class KsMaterializedSessionTableIQv2Test {
   @Test
   public void shouldReturnEmptyIfKeyNotPresent() {
     // When:
-    final List<?> result = table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -201,10 +211,12 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(LOWER_INSTANT.minusMillis(1), LOWER_INSTANT.minusMillis(1));
 
     // When:
-    final List<?> result = table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -213,10 +225,12 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(UPPER_INSTANT.plusMillis(1), UPPER_INSTANT.plusMillis(1));
 
     // When:
-    final List<?> result = table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -230,10 +244,12 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(LOWER_INSTANT, LOWER_INSTANT.plusMillis(1));
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, startBounds, Range.all());
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -248,15 +264,20 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(UPPER_INSTANT, wend);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, startBounds, Range.all());
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    assertThat(result, contains(WindowedRow.of(
-      SCHEMA,
-      sessionKey(UPPER_INSTANT, wend),
-      A_VALUE,
-      wend.toEpochMilli()
-    )));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(
+        WindowedRow.of(
+            SCHEMA,
+            sessionKey(UPPER_INSTANT, wend),
+            A_VALUE,
+            wend.toEpochMilli()
+        )
+    ));
   }
 
   @Test
@@ -270,10 +291,12 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(UPPER_INSTANT, UPPER_INSTANT.plusMillis(1));
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, startBounds, Range.all());
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -283,15 +306,20 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(LOWER_INSTANT.plusMillis(1), wend);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, Range.all());
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, Range.all()).rowIterator;
 
     // Then:
-    assertThat(result, contains(WindowedRow.of(
-      SCHEMA,
-      sessionKey(LOWER_INSTANT.plusMillis(1), wend),
-      A_VALUE,
-      wend.toEpochMilli()
-    )));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(
+        WindowedRow.of(
+            SCHEMA,
+            sessionKey(LOWER_INSTANT.plusMillis(1), wend),
+            A_VALUE,
+            wend.toEpochMilli()
+        )
+    ));
   }
 
   @Test
@@ -306,15 +334,20 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(wstart, LOWER_INSTANT);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, Range.all(), endBounds);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, Range.all(), endBounds).rowIterator;
 
     // Then:
-    assertThat(result, contains(WindowedRow.of(
-      SCHEMA,
-      sessionKey(wstart, LOWER_INSTANT),
-      A_VALUE,
-      LOWER_INSTANT.toEpochMilli()
-    )));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(
+        WindowedRow.of(
+            SCHEMA,
+            sessionKey(wstart, LOWER_INSTANT),
+            A_VALUE,
+            LOWER_INSTANT.toEpochMilli()
+        )
+    ));
   }
 
   @Test
@@ -328,10 +361,12 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(LOWER_INSTANT.minusMillis(1), LOWER_INSTANT);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, Range.all(), endBounds);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, Range.all(), endBounds).rowIterator;
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -346,15 +381,20 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(wstart, UPPER_INSTANT);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, Range.all(), endBounds);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, Range.all(), endBounds).rowIterator;
 
     // Then:
-    assertThat(result, contains(WindowedRow.of(
-      SCHEMA,
-      sessionKey(wstart, UPPER_INSTANT),
-      A_VALUE,
-      UPPER_INSTANT.toEpochMilli()
-    )));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(
+        WindowedRow.of(
+            SCHEMA,
+            sessionKey(wstart, UPPER_INSTANT),
+            A_VALUE,
+            UPPER_INSTANT.toEpochMilli()
+        )
+    ));
   }
 
   @Test
@@ -368,10 +408,12 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(UPPER_INSTANT.minusMillis(1), UPPER_INSTANT);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, Range.all(), endBounds);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, Range.all(), endBounds).rowIterator;
 
     // Then:
-    assertThat(result, is(empty()));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -382,15 +424,20 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(wstart, wend);
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, Range.all(), WINDOW_END_BOUNDS);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, Range.all(), WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(result, contains(WindowedRow.of(
-      SCHEMA,
-      sessionKey(wstart, wend),
-      A_VALUE,
-      wend.toEpochMilli()
-    )));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(
+        WindowedRow.of(
+            SCHEMA,
+            sessionKey(wstart, wend),
+            A_VALUE,
+            wend.toEpochMilli()
+        )
+    ));
   }
 
   @Test
@@ -404,11 +451,14 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(UPPER_INSTANT.plusMillis(1), UPPER_INSTANT.plusSeconds(1));
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS,
-      WINDOW_END_BOUNDS);
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(result, contains(
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    assertThat(resultList, contains(
       WindowedRow.of(
         SCHEMA,
         sessionKey(LOWER_INSTANT, wend0),
@@ -431,10 +481,14 @@ public class KsMaterializedSessionTableIQv2Test {
     givenSingleSession(Instant.now().minusSeconds(1000), Instant.now().plusSeconds(1000));
 
     // When:
-    final List<WindowedRow> result = table.get(A_KEY, PARTITION, Range.all(), Range.all());
+    final Optional<Iterator<WindowedRow>> rowIterator =
+        table.get(A_KEY, PARTITION, Range.all(), Range.all()).rowIterator;
 
     // Then:
-    assertThat(result, hasSize(2));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    assertThat(resultList, hasSize(2));
   }
 
   private void givenSingleSession(

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableIQv2Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableIQv2Test.java
@@ -139,8 +139,7 @@ public class KsMaterializedSessionTableIQv2Test {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString(
-        "Boom"));
+    assertThat(e.getMessage(), containsString("Boom"));
     assertThat(e, (instanceOf(MaterializationTimeOutException.class)));
   }
 
@@ -158,8 +157,7 @@ public class KsMaterializedSessionTableIQv2Test {
     );
 
     // Then:
-    assertThat(e.getMessage(), containsString(
-      "Boom"));
+    assertThat(e.getMessage(), containsString("Boom"));
     assertThat(e, (instanceOf(MaterializationException.class)));
   }
 
@@ -223,7 +221,6 @@ public class KsMaterializedSessionTableIQv2Test {
         table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    
     assertThat(rowIterator.hasNext(), is(false));
   }
 
@@ -237,7 +234,6 @@ public class KsMaterializedSessionTableIQv2Test {
         table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    
     assertThat(rowIterator.hasNext(), is(false));
   }
 
@@ -256,7 +252,6 @@ public class KsMaterializedSessionTableIQv2Test {
         table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    
     assertThat(rowIterator.hasNext(), is(false));
   }
 
@@ -305,7 +300,6 @@ public class KsMaterializedSessionTableIQv2Test {
         table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    
     assertThat(rowIterator.hasNext(), is(false));
   }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -45,7 +44,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import org.apache.commons.compress.utils.Lists;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -188,12 +186,11 @@ public class KsMaterializedSessionTableTest {
   @Test
   public void shouldReturnEmptyIfKeyNotPresent() {
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -202,12 +199,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(LOWER_INSTANT.minusMillis(1), LOWER_INSTANT.minusMillis(1));
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -216,12 +212,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(UPPER_INSTANT.plusMillis(1), UPPER_INSTANT.plusMillis(1));
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -236,13 +231,12 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(LOWER_INSTANT, wend);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(), is(
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(), is(
         WindowedRow.of(
             SCHEMA,
             sessionKey(LOWER_INSTANT, wend),
@@ -263,12 +257,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(LOWER_INSTANT, LOWER_INSTANT.plusMillis(1));
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -283,11 +276,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(UPPER_INSTANT, wend);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator.get().next(), is(
+    assertThat(rowIterator.next(), is(
         WindowedRow.of(
             SCHEMA,
             sessionKey(UPPER_INSTANT, wend),
@@ -308,12 +301,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(UPPER_INSTANT, UPPER_INSTANT.plusMillis(1));
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, startBounds, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -323,11 +315,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(LOWER_INSTANT.plusMillis(1), wend);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator.get().next(), is(
+    assertThat(rowIterator.next(), is(
         WindowedRow.of(
             SCHEMA,
             sessionKey(LOWER_INSTANT.plusMillis(1), wend),
@@ -349,11 +341,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(wstart, LOWER_INSTANT);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), endBounds).rowIterator;
 
     // Then:
-    assertThat(rowIterator.get().next(), is(
+    assertThat(rowIterator.next(), is(
         WindowedRow.of(
             SCHEMA,
             sessionKey(wstart, LOWER_INSTANT),
@@ -374,12 +366,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(LOWER_INSTANT.minusMillis(1), LOWER_INSTANT);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), endBounds).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -394,11 +385,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(wstart, UPPER_INSTANT);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), endBounds).rowIterator;
 
     // Then:
-    assertThat(rowIterator.get().next(), is(
+    assertThat(rowIterator.next(), is(
         WindowedRow.of(
             SCHEMA,
             sessionKey(wstart, UPPER_INSTANT),
@@ -419,12 +410,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(UPPER_INSTANT.minusMillis(1), UPPER_INSTANT);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), endBounds).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -435,11 +425,11 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(wstart, wend);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(rowIterator.get().next(), is(
+    assertThat(rowIterator.next(), is(
         WindowedRow.of(
             SCHEMA,
             sessionKey(wstart, wend),
@@ -460,13 +450,12 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(UPPER_INSTANT.plusMillis(1), UPPER_INSTANT.plusSeconds(1));
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    assertThat(rowIterator.hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator);
     assertThat(resultList, contains(
         WindowedRow.of(
             SCHEMA,
@@ -490,13 +479,12 @@ public class KsMaterializedSessionTableTest {
     givenSingleSession(Instant.now().minusSeconds(1000), Instant.now().plusSeconds(1000));
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    assertThat(rowIterator.hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator);
     assertThat(resultList, hasSize(2));
   }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedSessionTableTest.java
@@ -69,7 +69,7 @@ public class KsMaterializedSessionTableTest {
   private static final GenericRow A_VALUE = GenericRow.genericRow("c0l");
   private static final int PARTITION = 0;
 
-  private static final Instant LOWER_INSTANT = Instant.now();
+  private static final Instant LOWER_INSTANT = Instant.ofEpochMilli(System.currentTimeMillis());
   private static final Instant UPPER_INSTANT = LOWER_INSTANT.plusSeconds(10);
 
   private static final Range<Instant> WINDOW_START_BOUNDS = Range.closed(

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableIQv2Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableIQv2Test.java
@@ -48,6 +48,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.KeyQuery;
+import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.RangeQuery;
 import org.apache.kafka.streams.query.StateQueryRequest;
@@ -74,7 +75,6 @@ public class KsMaterializedTableIQv2Test {
   private static final GenericKey A_KEY = GenericKey.genericKey("x");
   private static final GenericKey A_KEY2 = GenericKey.genericKey("y");
   private static final int PARTITION = 0;
-
   private static final GenericRow ROW1 = GenericRow.genericRow("col0");
   private static final GenericRow ROW2 = GenericRow.genericRow("col1");
   private static final long TIME1 = 1;
@@ -88,6 +88,8 @@ public class KsMaterializedTableIQv2Test {
   private static final KeyValue<GenericKey, ValueAndTimestamp<GenericRow>> KEY_VALUE2
       = KeyValue.pair(A_KEY2, VALUE_AND_TIMESTAMP2);
   private static final String STATE_STORE_NAME = "store";
+  private static final String TOPIC = "topic";
+  private static final long OFFSET = 100L;
 
   @Mock
   private KafkaStreams kafkaStreams;
@@ -289,10 +291,10 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getRowResult(null));
 
     // When:
-    final Optional<?> result = table.get(A_KEY, PARTITION).rowIterator;
+    final Iterator<Row> result = table.get(A_KEY, PARTITION).rowIterator;
 
     // Then:
-    assertThat(result, is(Optional.of(Collections.emptyIterator())));
+    assertThat(result, is(Collections.emptyIterator()));
   }
 
   @Test
@@ -301,11 +303,10 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getEmptyIteratorResult());
 
     // When:
-    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION, A_KEY, null).rowIterator;
+    final Iterator<Row> rowIterator = table.get(PARTITION, A_KEY, null).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
 
@@ -317,12 +318,11 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getRowResult(ROW1));
 
     // When:
-    final Optional<Iterator<Row>> rowIterator = table.get(A_KEY, PARTITION).rowIterator;
+    final Iterator<Row> rowIterator = table.get(A_KEY, PARTITION).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, value, rowTime)));
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY, value, rowTime)));
   }
 
   @Test
@@ -331,14 +331,16 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getIteratorResult());
 
     // When:
-    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION).rowIterator;
+    final KsMaterializedQueryResult<Row> result = table.get(PARTITION);
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    Iterator<Row> rowIterator = result.getRowIterator();
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.hasNext(), is(false));
+    assertThat(result.getPosition(), not(Optional.empty()));
+    assertThat(result.getPosition().get(), is(getTestPosition()));
   }
 
   @Test
@@ -347,15 +349,18 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getIteratorResult());
 
     // When:
-    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION, A_KEY, null).rowIterator;
+    final KsMaterializedQueryResult<Row> result = table.get(PARTITION, A_KEY, null);
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    Iterator<Row> rowIterator = result.getRowIterator();
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.hasNext(), is(false));
+    assertThat(result.getPosition(), not(Optional.empty()));
+    assertThat(result.getPosition().get(), is(getTestPosition()));
   }
+
 
   @Test
   public void shouldReturnValuesUpperBound() {
@@ -363,14 +368,16 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getIteratorResult());
 
     // When:
-    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION, null, A_KEY2).getRowIterator();
+    final KsMaterializedQueryResult<Row> result = table.get(PARTITION, null, A_KEY2);
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    Iterator<Row> rowIterator = result.getRowIterator();
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.hasNext(), is(false));
+    assertThat(result.getPosition(), not(Optional.empty()));
+    assertThat(result.getPosition().get(), is(getTestPosition()));
   }
 
   @Test
@@ -379,14 +386,16 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getIteratorResult());
 
     // When:
-    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION, A_KEY, A_KEY2).rowIterator;
+    final KsMaterializedQueryResult<Row> result = table.get(PARTITION, A_KEY, A_KEY2);
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    Iterator<Row> rowIterator = result.getRowIterator();
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.hasNext(), is(false));
+    assertThat(result.getPosition(), not(Optional.empty()));
+    assertThat(result.getPosition().get(), is(getTestPosition()));
   }
 
 
@@ -398,7 +407,7 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(result);
 
     // When:
-    Streams.stream((table.get(PARTITION).getRowIterator().get()))
+    Streams.stream((table.get(PARTITION).getRowIterator()))
         .collect(Collectors.toList());
 
     // Then:
@@ -417,7 +426,7 @@ public class KsMaterializedTableIQv2Test {
         .thenReturn(KEY_VALUE2);
 
     // When:
-    Streams.stream(table.get(PARTITION, A_KEY, A_KEY2).rowIterator.get())
+    Streams.stream(table.get(PARTITION, A_KEY, A_KEY2).rowIterator)
         .collect(Collectors.toList());
 
     // Then:
@@ -426,7 +435,11 @@ public class KsMaterializedTableIQv2Test {
 
   private static StateQueryResult getRowResult(final GenericRow row) {
     final StateQueryResult result = new StateQueryResult<>();
-    result.addResult(PARTITION, QueryResult.forResult(ValueAndTimestamp.make(row, -1)));
+    final QueryResult queryResult = QueryResult.forResult(ValueAndTimestamp.make(row, -1));
+    final Position position = Position.emptyPosition();
+    position.withComponent(TOPIC, PARTITION, OFFSET);
+    queryResult.setPosition(position);
+    result.addResult(PARTITION, queryResult);
     return result;
   }
 
@@ -445,7 +458,11 @@ public class KsMaterializedTableIQv2Test {
     map.put(A_KEY, VALUE_AND_TIMESTAMP1);
     map.put(A_KEY2, VALUE_AND_TIMESTAMP2);
     final KeyValueIterator iterator = new TestKeyValueIterator(keySet, map);
-    result.addResult(PARTITION, QueryResult.forResult(iterator));
+    final QueryResult queryResult = QueryResult.forResult(iterator);
+    final Position position = Position.emptyPosition();
+    position.withComponent(TOPIC, PARTITION, OFFSET);
+    queryResult.setPosition(position);
+    result.addResult(PARTITION, queryResult);
     return result;
   }
 
@@ -456,6 +473,12 @@ public class KsMaterializedTableIQv2Test {
     final KeyValueIterator iterator = new TestKeyValueIterator(keySet, map);
     result.addResult(PARTITION, QueryResult.forResult(iterator));
     return result;
+  }
+
+  private static Position getTestPosition() {
+    final Position position = Position.emptyPosition();
+    position.withComponent(TOPIC, PARTITION, OFFSET);
+    return position;
   }
 
   private static class TestKeyValueIterator implements

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableIQv2Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableIQv2Test.java
@@ -19,6 +19,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -35,6 +36,7 @@ import io.confluent.ksql.execution.streams.materialization.Row;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -287,10 +289,10 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getRowResult(null));
 
     // When:
-    final Optional<?> result = table.get(A_KEY, PARTITION);
+    final Optional<?> result = table.get(A_KEY, PARTITION).rowIterator;
 
     // Then:
-    assertThat(result, is(Optional.empty()));
+    assertThat(result, is(Optional.of(Collections.emptyIterator())));
   }
 
   @Test
@@ -299,10 +301,11 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getEmptyIteratorResult());
 
     // When:
-    final Iterator<Row> rows = table.get(PARTITION, A_KEY, null);
+    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION, A_KEY, null).rowIterator;
 
     // Then:
-    assertThat(rows.hasNext(), is(false));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
 
@@ -314,10 +317,12 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getRowResult(ROW1));
 
     // When:
-    final Optional<Row> result = table.get(A_KEY, PARTITION);
+    final Optional<Iterator<Row>> rowIterator = table.get(A_KEY, PARTITION).rowIterator;
 
     // Then:
-    assertThat(result, is(Optional.of(Row.of(SCHEMA, A_KEY, value, rowTime))));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, value, rowTime)));
   }
 
   @Test
@@ -326,12 +331,14 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getIteratorResult());
 
     // When:
-    Iterator<Row> rows = table.get(PARTITION);
+    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION).rowIterator;
 
     // Then:
-    assertThat(rows.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rows.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rows.hasNext(), is(false));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -340,12 +347,14 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getIteratorResult());
 
     // When:
-    Iterator<Row> rows = table.get(PARTITION, A_KEY, null);
+    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION, A_KEY, null).rowIterator;
 
     // Then:
-    assertThat(rows.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rows.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rows.hasNext(), is(false));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -354,12 +363,14 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getIteratorResult());
 
     // When:
-    Iterator<Row> rows = table.get(PARTITION, null, A_KEY2);
+    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION, null, A_KEY2).getRowIterator();
 
     // Then:
-    assertThat(rows.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rows.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rows.hasNext(), is(false));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
   @Test
@@ -368,12 +379,14 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(getIteratorResult());
 
     // When:
-    Iterator<Row> rows = table.get(PARTITION, A_KEY, A_KEY2);
+    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION, A_KEY, A_KEY2).rowIterator;
 
     // Then:
-    assertThat(rows.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rows.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rows.hasNext(), is(false));
+    assertThat(rowIterator, not(Optional.empty()));
+    assertThat(rowIterator.get().hasNext(), is(true));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.get().hasNext(), is(false));
   }
 
 
@@ -385,7 +398,7 @@ public class KsMaterializedTableIQv2Test {
     when(kafkaStreams.query(any())).thenReturn(result);
 
     // When:
-    Streams.stream(table.get(PARTITION))
+    Streams.stream((table.get(PARTITION).getRowIterator().get()))
         .collect(Collectors.toList());
 
     // Then:
@@ -404,7 +417,7 @@ public class KsMaterializedTableIQv2Test {
         .thenReturn(KEY_VALUE2);
 
     // When:
-    Streams.stream(table.get(PARTITION, A_KEY, A_KEY2))
+    Streams.stream(table.get(PARTITION, A_KEY, A_KEY2).rowIterator.get())
         .collect(Collectors.toList());
 
     // Then:

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedTableTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -39,7 +38,6 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -175,10 +173,10 @@ public class KsMaterializedTableTest {
   @Test
   public void shouldReturnEmptyIfKeyNotPresent() {
     // When:
-    final Optional<?> result = table.get(A_KEY, PARTITION).rowIterator;
+    final Iterator<Row> result = table.get(A_KEY, PARTITION).rowIterator;
 
     // Then:
-    assertThat(result, is(Optional.of(Collections.emptyIterator())));
+    assertThat(result, is(Collections.emptyIterator()));
   }
 
   @Test
@@ -189,12 +187,11 @@ public class KsMaterializedTableTest {
     when(tableStore.get(any())).thenReturn(ValueAndTimestamp.make(value, rowTime));
 
     // When:
-    final Optional<Iterator<Row>> rowIterator = table.get(A_KEY, PARTITION).rowIterator;
+    final Iterator<Row> rowIterator = table.get(A_KEY, PARTITION).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, value, rowTime)));
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY, value, rowTime)));
   }
 
   @Test
@@ -207,14 +204,13 @@ public class KsMaterializedTableTest {
         .thenReturn(KEY_VALUE2);
 
     // When:
-    final Optional<Iterator<Row>> rowIterator = table.get(PARTITION).rowIterator;
+    final Iterator<Row> rowIterator = table.get(PARTITION).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
-    assertThat(rowIterator.get().next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY, ROW1, TIME1)));
+    assertThat(rowIterator.next(), is(Row.of(SCHEMA, A_KEY2, ROW2, TIME2)));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -227,7 +223,7 @@ public class KsMaterializedTableTest {
         .thenReturn(KEY_VALUE2);
 
     // When:
-    Streams.stream(table.get(PARTITION).rowIterator.get())
+    Streams.stream(table.get(PARTITION).rowIterator)
         .collect(Collectors.toList());
 
     // Then:

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -46,7 +45,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import org.apache.commons.compress.utils.Lists;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -414,7 +412,7 @@ public class KsMaterializedWindowTableTest {
   @Test
   public void shouldCloseIterator_fetchAll() {
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
@@ -424,12 +422,11 @@ public class KsMaterializedWindowTableTest {
   @Test
   public void shouldReturnEmptyIfKeyNotPresent() {
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -453,13 +450,12 @@ public class KsMaterializedWindowTableTest {
     when(cacheBypassFetcher.fetch(eq(tableStore), any(), any(), any())).thenReturn(fetchIterator);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, start, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    assertThat(rowIterator.hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator);
     assertThat(resultList, contains(
         WindowedRow.of(
             SCHEMA,
@@ -498,26 +494,26 @@ public class KsMaterializedWindowTableTest {
 
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(PARTITION, start, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(),
+    
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(),
         is (WindowedRow.of(
             SCHEMA,
             windowedKey(start.lowerEndpoint()),
             VALUE_1.value(),
             VALUE_1.timestamp())));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(),
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(),
         is(WindowedRow.of(
             SCHEMA,
             windowedKey(A_KEY2, start.upperEndpoint()),
             VALUE_2.value(),
             VALUE_2.timestamp())));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -546,13 +542,13 @@ public class KsMaterializedWindowTableTest {
     when(cacheBypassFetcher.fetch(eq(tableStore), any(), any(), any())).thenReturn(fetchIterator);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), end).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    
+    assertThat(rowIterator.hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator);
     assertThat(resultList, contains(
         WindowedRow.of(
             SCHEMA,
@@ -596,27 +592,27 @@ public class KsMaterializedWindowTableTest {
 
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(PARTITION, Range.all(), end).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(),
+    
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(),
         is (WindowedRow.of(
             SCHEMA,
             windowedKey(startEqiv.lowerEndpoint()),
             VALUE_1.value(),
             VALUE_1.timestamp())));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(),
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(),
         is(WindowedRow.of(
             SCHEMA,
             windowedKey(A_KEY2, startEqiv.upperEndpoint()),
             VALUE_2.value(),
             VALUE_2.timestamp())));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -642,13 +638,13 @@ public class KsMaterializedWindowTableTest {
     when(cacheBypassFetcher.fetch(eq(tableStore), any(), any(), any())).thenReturn(fetchIterator);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, start, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    
+    assertThat(rowIterator.hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator);
     assertThat(resultList, contains(
         WindowedRow.of(
             SCHEMA,
@@ -684,19 +680,19 @@ public class KsMaterializedWindowTableTest {
 
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(PARTITION, start, Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(),
+    
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(),
         is (WindowedRow.of(
             SCHEMA,
             windowedKey(A_KEY2, start.lowerEndpoint().plusMillis(1)),
             VALUE_2.value(),
             VALUE_2.timestamp())));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -728,13 +724,13 @@ public class KsMaterializedWindowTableTest {
     when(cacheBypassFetcher.fetch(eq(tableStore), any(), any(), any())).thenReturn(fetchIterator);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), end).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    
+    assertThat(rowIterator.hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator);
     assertThat(resultList, contains(
         WindowedRow.of(
             SCHEMA,
@@ -775,19 +771,19 @@ public class KsMaterializedWindowTableTest {
 
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(PARTITION, Range.all(), end).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    assertThat(rowIterator.get().next(),
+    
+    assertThat(rowIterator.hasNext(), is(true));
+    assertThat(rowIterator.next(),
         is (WindowedRow.of(
             SCHEMA,
             windowedKey(A_KEY2, startEquiv.lowerEndpoint().plusMillis(1)),
             VALUE_2.value(),
             VALUE_2.timestamp())));
-    assertThat(rowIterator.get().hasNext(), is(false));
+    assertThat(rowIterator.hasNext(), is(false));
   }
 
   @Test
@@ -810,13 +806,13 @@ public class KsMaterializedWindowTableTest {
     when(cacheBypassFetcher.fetch(eq(tableStore), any(), any(), any())).thenReturn(fetchIterator);
 
     // When:
-    final Optional<Iterator<WindowedRow>> rowIterator =
+    final Iterator<WindowedRow> rowIterator =
         table.get(A_KEY, PARTITION, Range.all(), Range.all()).rowIterator;
 
     // Then:
-    assertThat(rowIterator, not(Optional.empty()));
-    assertThat(rowIterator.get().hasNext(), is(true));
-    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator.get());
+    
+    assertThat(rowIterator.hasNext(), is(true));
+    final List<WindowedRow> resultList = Lists.newArrayList(rowIterator);
     assertThat(resultList, contains(
         WindowedRow.of(
             SCHEMA,

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Range;
+import com.google.common.collect.Streams;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.testing.NullPointerTester.Visibility;
 import io.confluent.ksql.GenericKey;
@@ -45,6 +46,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.compress.utils.Lists;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -77,7 +79,7 @@ public class KsMaterializedWindowTableTest {
   private static final GenericKey A_KEY2 = GenericKey.genericKey(1);
   private static final GenericKey A_KEY3 = GenericKey.genericKey(1);
 
-  protected static final Instant NOW = Instant.now();
+  protected static final Instant NOW = Instant.ofEpochMilli(System.currentTimeMillis());
 
   private static final Range<Instant> WINDOW_START_BOUNDS = Range.closed(
       NOW,
@@ -412,8 +414,8 @@ public class KsMaterializedWindowTableTest {
   @Test
   public void shouldCloseIterator_fetchAll() {
     // When:
-    final Iterator<WindowedRow> rowIterator =
-        table.get(PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).rowIterator;
+    Streams.stream((table.get(PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS).getRowIterator()))
+        .collect(Collectors.toList());
 
     // Then:
     verify(keyValueIterator).close();


### PR DESCRIPTION
### Description 
Created a new return type `KsMaterializedQueryResult` for `table.get` methods that query the streams store to return, besides the KeyValue, also the position used for consistency. Previously, the methods returned a single object, a list, an iterator but all were converted to iterators. So I changed the return type to always be an iterator. 

Note, this is only an API change. The actual using of the position will be done in a separate PR

### Testing done 
Updated all unit tests for IQv1 and IQv2

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

