### PR TITLE
fix: Fixes an NPE which was causing terminate to fail

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/QueryStateMetricsReportingListener.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/QueryStateMetricsReportingListener.java
@@ -86,10 +86,8 @@ public class QueryStateMetricsReportingListener implements QueryEventListener {
 
   @Override
   public void onDeregister(final QueryMetadata query) {
-    perQuery.computeIfPresent(query.getQueryId(), (queryId, perQueryListener) -> {
-      perQueryListener.onDeregister();
-      return null;
-    });
+    perQuery.get(query.getQueryId()).onDeregister();
+    perQuery.remove(query.getQueryId());
   }
 
   private static final String NO_ERROR = "NO_ERROR";

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/QueryStateMetricsReportingListener.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/QueryStateMetricsReportingListener.java
@@ -86,8 +86,10 @@ public class QueryStateMetricsReportingListener implements QueryEventListener {
 
   @Override
   public void onDeregister(final QueryMetadata query) {
-    perQuery.get(query.getQueryId()).onDeregister();
-    perQuery.remove(query.getQueryId());
+    perQuery.computeIfPresent(query.getQueryId(), (queryId, perQueryListener) -> {
+      perQueryListener.onDeregister();
+      return null;
+    });
   }
 
   private static final String NO_ERROR = "NO_ERROR";

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/TerminateTransientQueryFunctionalTest.java
@@ -164,7 +164,6 @@ public class TerminateTransientQueryFunctionalTest {
 
   public boolean checkForTransientQuery (){
     List<RunningQuery> queries = showQueries();
-    System.out.println("Got queries size: " + queries.size() + " value: " + queries);
     return queries.stream()
         .anyMatch(q -> q.getId().toString().contains("transient"));
   }


### PR DESCRIPTION
### Description 
In tests, at times, a double call was being made to `QueryStateMetricsReportingListener.onDeregister` which would cause an NPE the second time.  This was causing terminations to fail, such as in `TerminateTransientQueryFunctionalTest`.

The two calls were caused by first the termination, which calls `TransientQueryMetadata.close` and issues a complete event to be send to the client, causing it to close the connection and end the request, which in turn caused a `TransientQueryMetadata.close` to be called again.  If each was done just right, the `onDeregister` call would complete in one case and then the second would fail.  Other times, they would each run, finding the query, and not get an NPE.

This should ensure that whether the query ends entirely by the client or as a result of a termination, the logic of `TransientQueryMetadata.close` is called just once.

### Testing done 
Ran `TerminateTransientQueryFunctionalTest` many times to verify fix.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

