### PR TITLE
feat: Add is_json_string UDF

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -734,6 +734,29 @@ multiple elements, like those containing wildcards, aren't supported.
 
     `CREATE STREAM LOGS (LOG STRUCT<CLOUD STRING, APP STRING, INSTANCE INT>, ...) WITH (VALUE_FORMAT='JSON', ...)`
 
+### `IS_JSON_STRING`
+
+Since: 0.25.0
+
+```sql
+is_json_string(json_string) -> Boolean
+```
+
+Given a string, returns `true` if it can be parsed as a valid JSON value, `false` otherwise.
+
+Examples:
+
+```sql
+is_json_string("[1, 2, 3]") => true
+is_json_string("{}") => true
+is_json_string("1") => true
+is_json_string("\"abc\"") => true
+is_json_string("null") => true
+is_json_string("") => false
+is_json_string("abc") => false
+is_json_string(NULL) => false
+```
+
 ### `INITCAP`
 
 Since: 0.6.0

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/IsJsonString.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/IsJsonString.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.json;
+
+import io.confluent.ksql.function.FunctionCategory;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+    name = "IS_JSON_STRING",
+    category = FunctionCategory.JSON,
+    description = "Given a string, returns true if it can be parsed as a valid JSON value, false"
+        + " otherwise.",
+    author = KsqlConstants.CONFLUENT_AUTHOR)
+public class IsJsonString {
+
+  @Udf
+  public boolean check(@UdfParameter(description = "The input JSON string") final String input) {
+    if (input == null) {
+      return false;
+    }
+
+    try {
+      return !UdfJsonMapper.parseJson(input).isMissingNode();
+    } catch (KsqlFunctionException e) {
+      return false;
+    }
+  }
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonArrayContains.java
@@ -53,7 +53,7 @@ public class JsonArrayContains {
   private static final JsonFactory PARSER_FACTORY = new JsonFactoryBuilder()
       .disable(CANONICALIZE_FIELD_NAMES)
       .build()
-      .setCodec(UdfJsonMapper.INSTANCE.get());
+      .setCodec(UdfJsonMapper.INSTANCE);
 
   private static final EnumMap<JsonToken, Predicate<Object>> TOKEN_COMPAT;
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractString.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractString.java
@@ -16,16 +16,13 @@
 package io.confluent.ksql.function.udf.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.FunctionCategory;
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.json.JsonPathTokenizer;
-import java.io.IOException;
 import java.util.List;
 
 @UdfDescription(
@@ -34,8 +31,6 @@ import java.util.List;
     description = "Given a STRING that contains JSON data, extract the value at the specified "
         + " JSONPath or NULL if the specified path does not exist.")
 public class JsonExtractString {
-
-  private static final ObjectReader OBJECT_READER = UdfJsonMapper.INSTANCE.get().reader();
 
   private String latestPath = null;
   private List<String> latestTokens = null;
@@ -56,7 +51,7 @@ public class JsonExtractString {
       latestPath = path;
     }
 
-    JsonNode currentNode = parseJsonDoc(input);
+    JsonNode currentNode = UdfJsonMapper.parseJson(input);
     for (final String token : latestTokens) {
       if (currentNode instanceof ArrayNode) {
         try {
@@ -78,14 +73,6 @@ public class JsonExtractString {
       return currentNode.asText();
     } else {
       return currentNode.toString();
-    }
-  }
-
-  private static JsonNode parseJsonDoc(final String jsonString) {
-    try {
-      return OBJECT_READER.readTree(jsonString);
-    } catch (final IOException e) {
-      throw new KsqlFunctionException("Invalid JSON format:" + jsonString, e);
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/UdfJsonMapper.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/UdfJsonMapper.java
@@ -15,26 +15,57 @@
 
 package io.confluent.ksql.function.udf.json;
 
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.confluent.ksql.function.KsqlFunctionException;
 
 /**
  * Shared Object mapper used by JSON processing UDFs
  */
-public enum UdfJsonMapper {
+final class UdfJsonMapper {
 
-  INSTANCE;
+  private UdfJsonMapper() {}
 
-  private final ObjectMapper mapper = new ObjectMapper()
-      .disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
-      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-      .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
-      .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
-      .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+  /**
+   * It is thread-safe to share an instance of the configured ObjectMapper
+   * (see https://fasterxml.github.io/jackson-databind/javadoc/2.12/com/fasterxml/jackson/databind/ObjectReader.html for more details).
+   * The object is configured as part of static initialization, so it is published safely
+   * as well.
+   */
+  public static final ObjectMapper INSTANCE;
+  /**
+   * Akin to the {@link UdfJsonMapper#INSTANCE}, the reader is fully thread-safe, so there is
+   * no need to construct more than one instance. See https://fasterxml.github.io/jackson-databind/javadoc/2.12/com/fasterxml/jackson/databind/ObjectReader.html
+   * for more details.
+   */
+  private static final ObjectReader OBJECT_READER;
 
-  public ObjectMapper get() {
-    return mapper.copy();
+  static {
+    INSTANCE = new ObjectMapper()
+        .disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+        .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN)
+        .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+    OBJECT_READER = INSTANCE.reader();
+  }
+
+  /**
+   * Parses string into a {@link JsonNode}; throws {@link KsqlFunctionException} on invalid JSON.
+   *
+   * @param jsonString the string to parse
+   * @return a JSON node
+   */
+  public static JsonNode parseJson(final String jsonString) {
+    try {
+      return OBJECT_READER.readTree(jsonString);
+    } catch (final JacksonException e) {
+      throw new KsqlFunctionException("Invalid JSON format:" + jsonString, e);
+    }
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/IsJsonStringTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/IsJsonStringTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.json;
+
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class IsJsonStringTest {
+  private IsJsonString udf;
+
+  @Before
+  public void setUp() {
+    udf = new IsJsonString();
+  }
+
+  @Test
+  public void shouldInterpretNumber() {
+    assertTrue(udf.check("1"));
+  }
+
+  @Test
+  public void shouldInterpretString() {
+    assertTrue(udf.check("\"abc\""));
+  }
+
+  @Test
+  public void shouldInterpretNullString() {
+    assertTrue(udf.check("null"));
+  }
+
+  @Test
+  public void shouldInterpretArray() {
+    assertTrue(udf.check("[1, 2, 3]"));
+  }
+
+  @Test
+  public void shouldInterpretObject() {
+    assertTrue(udf.check("{\"1\": 2}"));
+  }
+
+  @Test
+  public void shouldNotInterpretUnquotedString() {
+    assertFalse(udf.check("abc"));
+  }
+
+  @Test
+  public void shouldNotInterpretEmptyString() {
+    assertFalse(udf.check(""));
+  }
+
+  @Test
+  public void shouldNotInterpretNull() {
+    assertFalse(udf.check(null));
+  }
+
+  @Test
+  public void shouldNotInterpretStringWithSyntaxErrors() {
+    assertFalse(udf.check("{1:2]"));
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/is_json_string_-_filter_rows_that_contain_valid_JSON/7.2.0_1642756156693/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/is_json_string_-_filter_rows_that_contain_valid_JSON/7.2.0_1642756156693/plan.json
@@ -1,0 +1,189 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (K STRING KEY, MAYBEJSON STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`K` STRING KEY, `MAYBEJSON` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  TEST.K K,\n  TEST.MAYBEJSON JSON\nFROM TEST TEST\nWHERE IS_JSON_STRING(TEST.MAYBEJSON)\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K` STRING KEY, `JSON` STRING",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamFilterV1",
+            "properties" : {
+              "queryContext" : "WhereFilter"
+            },
+            "source" : {
+              "@type" : "streamSourceV1",
+              "properties" : {
+                "queryContext" : "KsqlTopic/Source"
+              },
+              "topicName" : "test_topic",
+              "formats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA"
+                },
+                "valueFormat" : {
+                  "format" : "JSON"
+                }
+              },
+              "sourceSchema" : "`K` STRING KEY, `MAYBEJSON` STRING",
+              "pseudoColumnVersion" : 1
+            },
+            "filterExpression" : "IS_JSON_STRING(MAYBEJSON)"
+          },
+          "keyColumnNames" : [ "K" ],
+          "selectExpressions" : [ "MAYBEJSON AS JSON" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "metric.reporters" : "",
+    "ksql.transient.prefix" : "transient_",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.shared.runtimes.count" : "8",
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.query.pull.consistency.token.enabled" : "false",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.suppress.enabled" : "false",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.connect.error.handler" : null,
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/is_json_string_-_filter_rows_that_contain_valid_JSON/7.2.0_1642756156693/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/is_json_string_-_filter_rows_that_contain_valid_JSON/7.2.0_1642756156693/spec.json
@@ -1,0 +1,149 @@
+{
+  "version" : "7.2.0",
+  "timestamp" : 1642756156693,
+  "path" : "query-validation-tests/is_json_string.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K` STRING KEY, `MAYBEJSON` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K` STRING KEY, `JSON` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "filter rows that contain valid JSON",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "maybeJSON" : "1"
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "maybeJSON" : "abc"
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "maybeJSON" : "[1, 2, 3]"
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "maybeJSON" : "\"abc\""
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "maybeJSON" : "",
+        "timestamp" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : "1",
+      "value" : {
+        "maybeJSON" : null,
+        "timestamp" : 0
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "JSON" : "1"
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "JSON" : "[1, 2, 3]"
+      },
+      "timestamp" : 0
+    }, {
+      "topic" : "OUTPUT",
+      "key" : "1",
+      "value" : {
+        "JSON" : "\"abc\""
+      },
+      "timestamp" : 0
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM test (K STRING KEY, maybeJSON STRING) WITH (kafka_topic='test_topic', VALUE_FORMAT='JSON');", "CREATE STREAM OUTPUT AS SELECT K, maybeJSON as JSON FROM test WHERE IS_JSON_STRING(maybeJSON);" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `JSON` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`K` STRING KEY, `MAYBEJSON` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/is_json_string_-_filter_rows_that_contain_valid_JSON/7.2.0_1642756156693/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/is_json_string_-_filter_rows_that_contain_valid_JSON/7.2.0_1642756156693/topology
@@ -1,0 +1,16 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> WhereFilter
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: WhereFilter (stores: [])
+      --> Project
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000004
+      <-- WhereFilter
+    Sink: KSTREAM-SINK-0000000004 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/is_json_string.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/is_json_string.json
@@ -1,0 +1,27 @@
+{
+  "comments": [
+    "Tests covering the use of the IS_JSON_STRING function."
+  ],
+  "tests": [
+    {
+      "name": "filter rows that contain valid JSON",
+      "statements": [
+        "CREATE STREAM test (K STRING KEY, maybeJSON STRING) WITH (kafka_topic='test_topic', VALUE_FORMAT='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT K, maybeJSON as JSON FROM test WHERE IS_JSON_STRING(maybeJSON);"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "1", "value": {"maybeJSON": "1"}, "timestamp": 0},
+        {"topic": "test_topic", "key": "1", "value": {"maybeJSON": "abc"}, "timestamp": 0},
+        {"topic": "test_topic", "key": "1", "value": {"maybeJSON": "[1, 2, 3]"}, "timestamp": 0},
+        {"topic": "test_topic", "key": "1", "value": {"maybeJSON": "\"abc\""}, "timestamp": 0},
+        {"topic": "test_topic", "key": "1", "value": {"maybeJSON": "", "timestamp": 0}},
+        {"topic": "test_topic", "key": "1", "value": {"maybeJSON": null, "timestamp": 0}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"JSON":"1"}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": "1", "value": {"JSON":"[1, 2, 3]"}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": "1", "value": {"JSON":"\"abc\""}, "timestamp": 0}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 

This PR introduces a new UDF - `is_json_string` that returns `true` if the argument string can be parsed as a valid JSON value, `false` otherwise. See the corresponding section in [KIP-59](https://github.com/confluentinc/ksql/blob/4cd79269dcb217e5b43aa47ee420a85b720f72fb/design-proposals/klip-59-json-functions.md#is_json_string) for more details.

### Testing done 

Added unit and functional tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

