### PR TITLE
feat: uses internal topics prefix for shared runtimes

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -568,9 +568,9 @@ final class QueryBuilder {
 
     if (config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
       newStreamsProperties.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
-          ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX +
-              config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG) +
-              "query");
+          ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
+              + config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
+              + "query");
     }
 
     // Passing shared state into managed components

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -66,6 +66,7 @@ import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.PushQueryMetadata.ResultType;
 import io.confluent.ksql.util.QueryApplicationId;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.util.SandboxedBinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.SandboxedSharedKafkaStreamsRuntimeImpl;
 import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
@@ -564,6 +565,12 @@ final class QueryBuilder {
         StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG,
         StorageUtilizationMetricsReporter.class.getName()
     );
+
+    if (config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+      newStreamsProperties.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
+          ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX +
+              config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    }
 
     // Passing shared state into managed components
     newStreamsProperties.put(KsqlConfig.KSQL_INTERNAL_METRIC_COLLECTORS_CONFIG, metricCollectors);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -569,7 +569,8 @@ final class QueryBuilder {
     if (config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
       newStreamsProperties.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
           ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX +
-              config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+              config.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG) +
+              "query");
     }
 
     // Passing shared state into managed components

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -22,6 +22,7 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
@@ -240,6 +241,13 @@ public class EndToEndIntegrationTest {
 
     final List<Object> columns = waitForFirstRow(queryMetadata);
 
+    if (sharedRuntimes) {
+      assertThat(TEST_HARNESS.getKafkaCluster().getTopics(),
+          hasItem("_confluent-ksql-default_-CSAS_CART_EVENT_PRODUCT_1-Join-repartition"));
+    } else {
+      assertThat(TEST_HARNESS.getKafkaCluster().getTopics(),
+          hasItem("_confluent-ksql-default_query_CSAS_CART_EVENT_PRODUCT_1-Join-repartition"));
+    }
     assertThat(CONSUMED_COUNT.get(), greaterThan(0));
     assertThat(PRODUCED_COUNT.get(), greaterThan(0));
     assertThat(columns.get(0).toString(), startsWith("USER_"));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -243,7 +243,7 @@ public class EndToEndIntegrationTest {
 
     if (sharedRuntimes) {
       assertThat(TEST_HARNESS.getKafkaCluster().getTopics(),
-          hasItem("_confluent-ksql-default_-CSAS_CART_EVENT_PRODUCT_1-Join-repartition"));
+          hasItem("_confluent-ksql-default_query-CSAS_CART_EVENT_PRODUCT_1-Join-repartition"));
     } else {
       assertThat(TEST_HARNESS.getKafkaCluster().getTopics(),
           hasItem("_confluent-ksql-default_query_CSAS_CART_EVENT_PRODUCT_1-Join-repartition"));


### PR DESCRIPTION
Without shared runtimes: `_confluent-ksql-default_query_CSAS_CART_EVENT_PRODUCT_1-Join-repartition`
shared runtimes without change: `_confluent-ksql-default_query_-1-CSAS_CART_EVENT_PRODUCT_1-Join-repartition`
shared runtimes with change: `_confluent-ksql-default_query-CSAS_CART_EVENT_PRODUCT_1-Join-repartition`

Will remove the runtime Id from internal topics so that we will be able to use topic in a different application with later work

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

