### PR TITLE
fix: Gives a query completed message for stream pull queries

### DIFF
--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-streams.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-streams.json
@@ -12,7 +12,8 @@
       "responses": [
         {"admin": {"@type": "currentStatus"}},
         {"query": [
-          {"header":{"schema":"`MYKEY` INTEGER, `MYVALUE` INTEGER"}}
+          {"header":{"schema":"`MYKEY` INTEGER, `MYVALUE` INTEGER"}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },
@@ -87,7 +88,8 @@
           {"row":{"columns":[10, 1]}},
           {"row":{"columns":[11, 2]}},
           {"row":{"columns":[12, 3]}},
-          {"row":{"columns":[13, 4]}}
+          {"row":{"columns":[13, 4]}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },
@@ -113,7 +115,8 @@
           {"row":{"columns":[10, 1]}},
           {"row":{"columns":[11, 2]}},
           {"row":{"columns":[12, 3]}},
-          {"row":{"columns":[13, 4]}}
+          {"row":{"columns":[13, 4]}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },
@@ -139,7 +142,8 @@
           {"row":{"columns":[10]}},
           {"row":{"columns":[11]}},
           {"row":{"columns":[12]}},
-          {"row":{"columns":[13]}}
+          {"row":{"columns":[13]}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },
@@ -165,7 +169,8 @@
           {"row":{"columns":[1]}},
           {"row":{"columns":[2]}},
           {"row":{"columns":[3]}},
-          {"row":{"columns":[4]}}
+          {"row":{"columns":[4]}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },
@@ -191,7 +196,8 @@
           {"row":{"columns":[10, 2]}},
           {"row":{"columns":[11, 4]}},
           {"row":{"columns":[12, 6]}},
-          {"row":{"columns":[13, 8]}}
+          {"row":{"columns":[13, 8]}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },
@@ -215,7 +221,8 @@
         {"query": [
           {"header":{"schema":"`MYKEY` INTEGER, `MYVALUE` INTEGER"}},
           {"row":{"columns":[11, 2]}},
-          {"row":{"columns":[12, 3]}}
+          {"row":{"columns":[12, 3]}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-headers.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-headers.json
@@ -45,7 +45,8 @@
         {"query": [
           {"header":{"schema":"`MYKEY` INTEGER, `MYVALUE` INTEGER, `MYHEADERS` ARRAY<STRUCT<`KEY` STRING, `VALUE` BYTES>>"}},
           {"row":{"columns":[10, 1, []]}},
-          {"row":{"columns":[11, 2, [{"KEY": "abc", "VALUE": "IQ=="}]]}}
+          {"row":{"columns":[11, 2, [{"KEY": "abc", "VALUE": "IQ=="}]]}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-limit-clause.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-with-limit-clause.json
@@ -72,7 +72,8 @@
           {"row":{"columns":["right",37.3952,-123.0813]}},
           {"row":{"columns":["think",37.3944,-123.0813]}},
           {"row":{"columns":["three",37.4049,-123.0822]}},
-          {"row":{"columns":["years",37.7857,-123.4011]}}
+          {"row":{"columns":["years",37.7857,-123.4011]}},
+          {"finalMessage":"Query Completed"}
         ]}
       ]
     },

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java
@@ -167,7 +167,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
   ) {
 
     final QueryResponseMetadata metadata;
-    final Optional<String> completionMessage = Optional.empty();
+    Optional<String> completionMessage = Optional.empty();
     Optional<String> limitMessage = Optional.of("Limit Reached");
 
     if (queryPublisher.isPullQuery()) {
@@ -211,6 +211,7 @@ public class QueryStreamHandler implements Handler<RoutingContext> {
           queryPublisher.getColumnNames(),
           queryPublisher.getColumnTypes(),
           preparePushProjectionSchema(queryPublisher.geLogicalSchema()));
+      completionMessage = Optional.of("Query Completed");
 
       // When response is complete, publisher should be closed and query unregistered
       routingContext.response().endHandler(v -> {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -125,6 +125,8 @@ class QueryStreamWriter implements StreamingOutput {
 
       if (limitReached) {
         objectMapper.writeValue(out, StreamedRow.finalMessage("Limit Reached"));
+      } else if (complete) {
+        objectMapper.writeValue(out, StreamedRow.finalMessage("Query Completed"));
       }
 
       out.write("]\n".getBytes(StandardCharsets.UTF_8));

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriterTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.util.KeyValue;
 import io.confluent.ksql.util.KeyValueMetadata;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
@@ -67,7 +68,7 @@ public class JsonStreamedRowResponseWriterTest {
   public void setUp() {
     when(response.write((Buffer) any())).thenAnswer(a -> {
       final Buffer buffer = a.getArgument(0);
-      stringBuilder.append(new String(buffer.getBytes()));
+      stringBuilder.append(new String(buffer.getBytes(), StandardCharsets.UTF_8));
       return response;
     });
     when(response.write((String) any())).thenAnswer(a -> {

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.rest.entity.QueryResponseMetadata;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KeyValue;
+import io.confluent.ksql.util.KeyValueMetadata;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerResponse;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JsonStreamedRowResponseWriterTest {
+
+  private static final String QUERY_ID = "queryId";
+  private static final List<String> COL_NAMES = ImmutableList.of(
+      "A", "B", "C"
+  );
+  private static final List<String> COL_TYPES = ImmutableList.of(
+      "INTEGER", "DOUBLE", "ARRAY"
+  );
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .keyColumn(ColumnName.of("A"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("B"), SqlTypes.DOUBLE)
+      .valueColumn(ColumnName.of("C"), SqlTypes.array(SqlTypes.STRING))
+      .build();
+
+  @Mock
+  private HttpServerResponse response;
+  @Mock
+  private QueryPublisher publisher;
+
+  private JsonStreamedRowResponseWriter writer;
+  private StringBuilder stringBuilder = new StringBuilder();
+
+  @Before
+  public void setUp() {
+    when(response.write((Buffer) any())).thenAnswer(a -> {
+      final Buffer buffer = a.getArgument(0);
+      stringBuilder.append(new String(buffer.getBytes()));
+      return response;
+    });
+    when(response.write((String) any())).thenAnswer(a -> {
+      final String str = a.getArgument(0);
+      stringBuilder.append(str);
+      return response;
+    });
+
+    writer = new JsonStreamedRowResponseWriter(response, publisher, Optional.empty(),
+        Optional.empty());
+  }
+
+  private void setupWithMessages(String completionMessage, String limitMessage) {
+    writer = new JsonStreamedRowResponseWriter(response, publisher, Optional.of(completionMessage),
+        Optional.of(limitMessage));
+  }
+
+  @Test
+  public void shouldSucceedWithNoEndMessages() {
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+    writer.writeCompletionMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString(),
+        is("[{\"header\":{\"queryId\":\"queryId\"," 
+            + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
+            + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}}]"));
+  }
+
+  @Test
+  public void shouldSucceedWithCompletionMessage() {
+    // Given:
+    setupWithMessages("complete!", "limit hit!");
+
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+    writer.writeCompletionMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString(),
+        is("[{\"header\":{\"queryId\":\"queryId\","
+            + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
+            + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}},\n"
+            + "{\"finalMessage\":\"complete!\"}]"));
+  }
+
+  @Test
+  public void shouldSucceedWithLimitMessage() {
+    // Given:
+    setupWithMessages("complete!", "limit hit!");
+
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+    writer.writeLimitMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString(),
+        is("[{\"header\":{\"queryId\":\"queryId\","
+            + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
+            + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}},\n"
+            + "{\"finalMessage\":\"limit hit!\"}]"));
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.api.spi.Endpoints;
+import io.confluent.ksql.api.spi.QueryPublisher;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.QueryStreamArgs;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KeyValueMetadata;
+import io.confluent.ksql.util.PushQueryMetadata;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.ext.web.RoutingContext;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.reactivestreams.Subscriber;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueryStreamHandlerTest {
+
+  private static final String QUERY_ID = "queryId";
+  private static final List<String> COL_NAMES = ImmutableList.of(
+      "A", "B", "C"
+  );
+  private static final List<String> COL_TYPES = ImmutableList.of(
+      "INTEGER", "DOUBLE", "ARRAY"
+  );
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .keyColumn(ColumnName.of("A"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("B"), SqlTypes.DOUBLE)
+      .valueColumn(ColumnName.of("C"), SqlTypes.array(SqlTypes.STRING))
+      .build();
+
+  @Mock
+  private Endpoints endpoints;
+  @Mock
+  private ConnectionQueryManager connectionQueryManager;
+  @Mock
+  private Context context;
+  @Mock
+  private Server server;
+  @Mock
+  private HttpServerRequest request;
+  @Mock
+  private HttpServerResponse response;
+  @Mock
+  private RoutingContext routingContext;
+  @Mock
+  private QueryPublisher queryPublisher;
+  @Mock
+  private PushQueryHolder pushQueryHolder;
+  @Captor
+  private ArgumentCaptor<Handler<Void>> endHandler;
+  @Captor
+  private ArgumentCaptor<Subscriber<KeyValueMetadata<List<?>, GenericRow>>> subscriber;
+
+  private QueryStreamHandler handler;
+
+
+  @Before
+  public void setUp() {
+    when(routingContext.request()).thenReturn(request);
+    when(routingContext.response()).thenReturn(response);
+    when(request.version()).thenReturn(HttpVersion.HTTP_2);
+    CompletableFuture<QueryPublisher> future = new CompletableFuture<>();
+    future.complete(queryPublisher);
+    when(endpoints.createQueryPublisher(any(), any(), any(), any(), any(), any(), any(), any(),
+        any())).thenReturn(future);
+    when(response.endHandler(endHandler.capture())).thenReturn(response);
+    when(queryPublisher.queryId()).thenReturn(new QueryId(QUERY_ID));
+    when(queryPublisher.getColumnNames()).thenReturn(COL_NAMES);
+    when(queryPublisher.getColumnTypes()).thenReturn(COL_TYPES);
+    when(queryPublisher.geLogicalSchema()).thenReturn(SCHEMA);
+    when(queryPublisher.isPullQuery()).thenReturn(true);
+    doNothing().when(queryPublisher).subscribe(subscriber.capture());
+    handler = new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false);
+  }
+
+  private void givenRequest(final QueryStreamArgs req) {
+    when(routingContext.getBody()).thenReturn(ServerUtils.serializeObject(req));
+  }
+
+  @Test
+  public void shouldSucceed_pullQuery() {
+    // Given:
+    final QueryStreamArgs req = new QueryStreamArgs("select * from foo;",
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    givenRequest(req);
+
+    // When:
+    handler.handle(routingContext);
+    endHandler.getValue().handle(null);
+
+    // Then:
+    assertThat(subscriber.getValue(), notNullValue());
+    verify(queryPublisher).close();
+  }
+
+  @Test
+  public void shouldSucceed_pushQuery() {
+    // Given:
+    when(queryPublisher.isPullQuery()).thenReturn(false);
+    final QueryStreamArgs req = new QueryStreamArgs("select * from foo emit changes;",
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    givenRequest(req);
+    when(connectionQueryManager.createApiQuery(any(), any())).thenReturn(pushQueryHolder);
+
+    // When:
+    handler.handle(routingContext);
+    endHandler.getValue().handle(null);
+
+    // Then:
+    assertThat(subscriber.getValue(), notNullValue());
+    verify(pushQueryHolder).close();
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.util.KeyValueMetadata;
 import io.confluent.ksql.util.PushQueryMetadata;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
@@ -98,6 +99,7 @@ public class QueryStreamHandlerTest {
     when(routingContext.request()).thenReturn(request);
     when(routingContext.response()).thenReturn(response);
     when(request.version()).thenReturn(HttpVersion.HTTP_2);
+    when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
     CompletableFuture<QueryPublisher> future = new CompletableFuture<>();
     future.complete(queryPublisher);
     when(endpoints.createQueryPublisher(any(), any(), any(), any(), any(), any(), any(), any(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/QueryStreamHandlerTest.java
@@ -39,6 +39,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Collections;
 import java.util.List;
@@ -86,6 +87,8 @@ public class QueryStreamHandlerTest {
   private QueryPublisher queryPublisher;
   @Mock
   private PushQueryHolder pushQueryHolder;
+  @Mock
+  private SocketAddress requestAddress;
   @Captor
   private ArgumentCaptor<Handler<Void>> endHandler;
   @Captor
@@ -100,6 +103,7 @@ public class QueryStreamHandlerTest {
     when(routingContext.response()).thenReturn(response);
     when(request.version()).thenReturn(HttpVersion.HTTP_2);
     when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    when(request.remoteAddress()).thenReturn(SocketAddress.inetSocketAddress(9000, "remote"));
     CompletableFuture<QueryPublisher> future = new CompletableFuture<>();
     future.complete(queryPublisher);
     when(endpoints.createQueryPublisher(any(), any(), any(), any(), any(), any(), any(), any(),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryLimitHARoutingTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryLimitHARoutingTest.java
@@ -79,6 +79,7 @@ public class PullQueryLimitHARoutingTest {
     private static final int TOTAL_RECORDS = USER_PROVIDER.getNumRecords();
     private static final int HEADER = 1;
     private static final int LIMIT_REACHED_MESSAGE = 1;
+    private static final int COMPLETE_MESSAGE = 1;
     private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
     private static final TemporaryFolder TMP = KsqlTestFolder.temporaryFolder();
     private static final int BASE_TIME = 1_000_000;
@@ -314,7 +315,7 @@ public class PullQueryLimitHARoutingTest {
                 sqlStreamPull, null, USER_CREDS);
 
         //check that we got back all the rows
-        assertThat(rows_0, hasSize(HEADER + TOTAL_RECORDS));
+        assertThat(rows_0, hasSize(HEADER + TOTAL_RECORDS + COMPLETE_MESSAGE));
 
         //issue pull query on stream with limit
         final List<StreamedRow> rows_1 = makePullQueryRequest(TEST_APP_0.getApp(),
@@ -343,7 +344,7 @@ public class PullQueryLimitHARoutingTest {
                 sqlStreamPull, null, USER_CREDS);
 
         // check that we get all rows back
-        assertThat(rows_2, hasSize(HEADER + TOTAL_RECORDS));
+        assertThat(rows_2, hasSize(HEADER + TOTAL_RECORDS + COMPLETE_MESSAGE));
         assertThat(rows_0, is(matchersRowsAnyOrder(rows_2)));
 
         // issue pull query with limit after partitioning an app

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -544,7 +544,7 @@ public class RestApiTest {
                 + "{\"row\":{\"columns\":[\"USER_0\",\"PAGE_5\",5]}},\n"
                 + "{\"row\":{\"columns\":[\"USER_2\",\"PAGE_5\",6]}},\n"
                 + "{\"row\":{\"columns\":[\"USER_3\",\"PAGE_5\",7]}},\n"
-                + "]"
+                + "{\"finalMessage\":\"Query Completed\"}]"
     )
     );
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -179,7 +179,7 @@ public class QueryStreamWriterTest {
         "{\"row\":{\"columns\":[\"Row1\"]}},",
         "{\"row\":{\"columns\":[\"Row2\"]}},",
         "{\"row\":{\"columns\":[\"Row3\"]}},",
-        "]"
+        "{\"finalMessage\":\"Query Completed\"}]"
     )));
   }
 


### PR DESCRIPTION
### Description 

fixes #8554 

Stream pull queries current produce invalid json #8554.  

This fix produces a final message for stream pull queries saying "Query Completed".  Normal pull queries keep a row buffered to avoid this bug so that they know if there is another row that follows, allowing them to output a comma or not.  While I could have ported stream pull queries over to the logic of normal pull queries, this would have been a much larger change since stream pull queries resemble push queries much more than pull. Also, a final message is just part of the API, so should be handled regardless of the nature of push, pull, etc.

### Testing done 
Tested examples given in the issue and ran existing tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

