### PR TITLE
feat: allow custom connect auth header configuration

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/connect/ConnectRequestHeadersExtension.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/connect/ConnectRequestHeadersExtension.java
@@ -15,8 +15,10 @@
 
 package io.confluent.ksql.connect;
 
-import io.confluent.ksql.security.KsqlPrincipal;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 /**
@@ -26,15 +28,43 @@ import java.util.Optional;
 public interface ConnectRequestHeadersExtension {
 
   /**
+   * Returns whether to use the custom auth header returned from
+   * {@link ConnectRequestHeadersExtension#getAuthHeader(List)} instead of
+   * ksqlDB's default auth header for ksqlDB connector requests. This auth header
+   * configured by this extension takes precedence over any other custom auth
+   * configurations for ksqlDB connector requests, including basic auth configured in
+   * ksqlDB server properties.
+   *
+   * @return whether to use the custom auth header returned from
+   *         {@link ConnectRequestHeadersExtension#getAuthHeader(List)} instead of
+   *         ksqlDB's default auth header for ksqlDB connector requests
+   */
+  default boolean shouldUseCustomAuthHeader() {
+    return true;
+  }
+
+  /**
+   * Specifies the custom auth header value to be sent with connector requests made
+   * by ksqlDB. If empty, no auth header will be sent. This replaces the default
+   * auth header sent by ksqlDB with connector requests by default. Only applicable if
+   * {@link ConnectRequestHeadersExtension#shouldUseCustomAuthHeader()} is {@code true}.
+   *
+   * @param incomingHeaders request headers from the incoming ksql request that
+   *                        triggered this outgoing connector request from ksqlDB
+   * @return custom auth header value to be sent with connector requests made by ksqlDB
+   */
+  Optional<String> getAuthHeader(List<Entry<String, String>> incomingHeaders);
+
+  /**
    * Creates custom headers to be included with all connector requests made by ksqlDB.
    * Note that this is in addition to any headers already sent by ksqlDB by default,
-   * such as those required for authenticating with Connect.
+   * such as those required for authenticating with Connect. The custom headers are added
+   * to the request in addition to, and after, ksqlDB's default headers.
    *
-   * @param userPrincipal principal associated with the user who submitted the connector
-   *                      request to ksqlDB, if present (i.e., if user authentication
-   *                      is enabled)
    * @return additional headers to be included with connector requests made by ksqlDB
    */
-  Map<String, String> getHeaders(Optional<KsqlPrincipal> userPrincipal);
+  default Map<String, String> getHeaders() {
+    return Collections.emptyMap();
+  }
 
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/connect/ConnectRequestHeadersExtension.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/connect/ConnectRequestHeadersExtension.java
@@ -30,10 +30,17 @@ public interface ConnectRequestHeadersExtension {
   /**
    * Returns whether to use the custom auth header returned from
    * {@link ConnectRequestHeadersExtension#getAuthHeader(List)} instead of
-   * ksqlDB's default auth header for ksqlDB connector requests. This auth header
-   * configured by this extension takes precedence over any other custom auth
-   * configurations for ksqlDB connector requests, including basic auth configured in
-   * ksqlDB server properties.
+   * ksqlDB's default auth header for ksqlDB connector requests.
+   *
+   * <p>If {@code true}, then the auth header configured by this extension
+   * takes precedence over any other custom auth configurations for ksqlDB
+   * connector requests, including basic auth configured in ksqlDB server
+   * properties.
+   *
+   * <p>Set this to {@code false} in order to use this
+   * {@code ConnectRequestHeadersExtension} for additional custom headers
+   * (via {@link ConnectRequestHeadersExtension#getHeaders()}) only, without
+   * impacting ksqlDB's default behavior for the auth header.
    *
    * @return whether to use the custom auth header returned from
    *         {@link ConnectRequestHeadersExtension#getAuthHeader(List)} instead of

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ConnectClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ConnectClientFactory.java
@@ -15,12 +15,16 @@
 
 package io.confluent.ksql.services;
 
-import io.confluent.ksql.security.KsqlPrincipal;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 public interface ConnectClientFactory {
 
-  ConnectClient get(Optional<String> authHeader, Optional<KsqlPrincipal> userPrincipal);
+  ConnectClient get(
+      Optional<String> authHeader,
+      List<Entry<String, String>> incomingRequestHeaders
+  );
 
   default void close() {}
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -40,7 +40,9 @@ public final class ServiceContextFactory {
         new KsqlSchemaRegistryClientFactory(
             ksqlConfig,
             Collections.emptyMap())::get,
-        () -> new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty(), Optional.empty()),
+        () -> new DefaultConnectClientFactory(ksqlConfig).get(
+            Optional.empty(),
+            Collections.emptyList()),
         ksqlClientSupplier
     );
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
@@ -61,7 +61,7 @@ public final class KsqlContextTestUtil {
         adminClient,
         kafkaTopicClient,
         () -> schemaRegistryClient,
-        new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty(), Optional.empty())
+        new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty(), Collections.emptyList())
     );
 
     final String metricsPrefix = "instance-" + COUNTER.getAndIncrement() + "-";

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -114,7 +114,7 @@ public final class TestServiceContext {
         adminClient,
         new KafkaTopicClientImpl(() -> adminClient),
         srClientFactory,
-        new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty(), Optional.empty()),
+        new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty(), Collections.emptyList()),
         new KafkaConsumerGroupClientImpl(() -> adminClient)
     );
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/ApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/ApiSecurityContext.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.api.auth;
 
 import io.confluent.ksql.security.KsqlPrincipal;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 public interface ApiSecurityContext {
@@ -23,4 +25,6 @@ public interface ApiSecurityContext {
   Optional<KsqlPrincipal> getPrincipal();
 
   Optional<String> getAuthToken();
+
+  List<Entry<String, String>> getRequestHeaders();
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.auth;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.security.KsqlPrincipal;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
@@ -63,6 +64,6 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
 
   @Override
   public List<Entry<String, String>> getRequestHeaders() {
-    return requestHeaders;
+    return ImmutableList.copyOf(requestHeaders);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
@@ -18,12 +18,15 @@ package io.confluent.ksql.api.auth;
 import io.confluent.ksql.security.KsqlPrincipal;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 public final class DefaultApiSecurityContext implements ApiSecurityContext {
 
   private final Optional<KsqlPrincipal> principal;
   private final Optional<String> authToken;
+  private final List<Entry<String, String>> requestHeaders;
 
   public static DefaultApiSecurityContext create(final RoutingContext routingContext) {
     final User user = routingContext.user();
@@ -32,13 +35,20 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
     }
     final ApiUser apiUser = (ApiUser) user;
     final String authToken = routingContext.request().getHeader("Authorization");
-    return new DefaultApiSecurityContext(apiUser != null ? apiUser.getPrincipal() : null,
-        authToken);
+    final List<Entry<String, String>> requestHeaders = routingContext.request().headers().entries();
+    return new DefaultApiSecurityContext(
+        apiUser != null ? apiUser.getPrincipal() : null,
+        authToken,
+        requestHeaders);
   }
 
-  private DefaultApiSecurityContext(final KsqlPrincipal principal, final String authToken) {
+  private DefaultApiSecurityContext(
+      final KsqlPrincipal principal,
+      final String authToken,
+      final List<Entry<String, String>> requestHeaders) {
     this.principal = Optional.ofNullable(principal);
     this.authToken = Optional.ofNullable(authToken);
+    this.requestHeaders = requestHeaders;
   }
 
   @Override
@@ -51,4 +61,8 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
     return authToken;
   }
 
+  @Override
+  public List<Entry<String, String>> getRequestHeaders() {
+    return requestHeaders;
+  }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProvider.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProvider.java
@@ -26,6 +26,8 @@ import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.ConnectClientFactory;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -62,6 +64,7 @@ public class DefaultKsqlSecurityContextProvider implements KsqlSecurityContextPr
 
     final Optional<KsqlPrincipal> principal = apiSecurityContext.getPrincipal();
     final Optional<String> authHeader = apiSecurityContext.getAuthToken();
+    final List<Entry<String, String>> requestHeaders = apiSecurityContext.getRequestHeaders();
 
     // A user context is not necessary if a user context provider is not present or the user
     // principal is missing. If a failed authentication attempt results in a missing principle,
@@ -77,8 +80,13 @@ public class DefaultKsqlSecurityContextProvider implements KsqlSecurityContextPr
     if (!requiresUserContext) {
       return new KsqlSecurityContext(
           principal,
-          defaultServiceContextFactory.create(ksqlConfig, authHeader, schemaRegistryClientFactory,
-              connectClientFactory, sharedClient, principal)
+          defaultServiceContextFactory.create(
+              ksqlConfig,
+              authHeader,
+              schemaRegistryClientFactory,
+              connectClientFactory,
+              sharedClient,
+              requestHeaders)
       );
     }
 
@@ -92,7 +100,7 @@ public class DefaultKsqlSecurityContextProvider implements KsqlSecurityContextPr
                 provider.getSchemaRegistryClientFactory(principal.get()),
                 connectClientFactory,
                 sharedClient,
-                principal)))
+                requestHeaders)))
         .get();
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -641,7 +641,8 @@ public final class KsqlRestApplication implements Executable {
 
     final ServiceContext tempServiceContext = new LazyServiceContext(() ->
         RestServiceContextFactory.create(ksqlConfig, Optional.empty(),
-            schemaRegistryClientFactory, connectClientFactory, sharedClient, Optional.empty()));
+            schemaRegistryClientFactory, connectClientFactory, sharedClient,
+            Collections.emptyList()));
     final String kafkaClusterId = KafkaClusterUtil.getKafkaClusterId(tempServiceContext);
     final String ksqlServerId = ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     updatedRestProps.putAll(
@@ -655,7 +656,7 @@ public final class KsqlRestApplication implements Executable {
             schemaRegistryClientFactory,
             connectClientFactory,
             sharedClient,
-            Optional.empty()));
+            Collections.emptyList()));
 
     return buildApplication(
         "",

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -17,11 +17,12 @@ package io.confluent.ksql.rest.server.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.rest.client.KsqlClient;
-import io.confluent.ksql.security.KsqlPrincipal;
 import io.confluent.ksql.services.ConnectClientFactory;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -40,7 +41,7 @@ public final class RestServiceContextFactory {
         Supplier<SchemaRegistryClient> srClientFactory,
         ConnectClientFactory connectClientFactory,
         KsqlClient sharedClient,
-        Optional<KsqlPrincipal> userPrincipal
+        List<Entry<String, String>> requestHeaders
     );
   }
 
@@ -53,7 +54,7 @@ public final class RestServiceContextFactory {
         Supplier<SchemaRegistryClient> srClientFactory,
         ConnectClientFactory connectClientFactory,
         KsqlClient sharedClient,
-        Optional<KsqlPrincipal> userPrincipal
+        List<Entry<String, String>> requestHeaders
     );
   }
 
@@ -63,7 +64,7 @@ public final class RestServiceContextFactory {
       final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
       final ConnectClientFactory connectClientFactory,
       final KsqlClient sharedClient,
-      final Optional<KsqlPrincipal> userPrincipal
+      final List<Entry<String, String>> requestHeaders
   ) {
     return create(
         ksqlConfig,
@@ -72,7 +73,7 @@ public final class RestServiceContextFactory {
         schemaRegistryClientFactory,
         connectClientFactory,
         sharedClient,
-        userPrincipal
+        requestHeaders
     );
   }
 
@@ -83,13 +84,13 @@ public final class RestServiceContextFactory {
       final Supplier<SchemaRegistryClient> srClientFactory,
       final ConnectClientFactory connectClientFactory,
       final KsqlClient sharedClient,
-      final Optional<KsqlPrincipal> userPrincipal
+      final List<Entry<String, String>> requestHeaders
   ) {
     return ServiceContextFactory.create(
         ksqlConfig,
         kafkaClientSupplier,
         srClientFactory,
-        () -> connectClientFactory.get(authHeader, userPrincipal),
+        () -> connectClientFactory.get(authHeader, requestHeaders),
         () -> new DefaultKsqlClient(authHeader, sharedClient)
     );
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProviderTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProviderTest.java
@@ -33,6 +33,8 @@ import io.confluent.ksql.security.KsqlUserContextProvider;
 import io.confluent.ksql.services.ConnectClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,6 +67,8 @@ public class DefaultKsqlSecurityContextProviderTest {
   @Mock
   private KsqlPrincipal user1;
   @Mock
+  private List<Entry<String, String>> incomingRequestHeaders;
+  @Mock
   private ApiSecurityContext apiSecurityContext;
 
   private DefaultKsqlSecurityContextProvider ksqlSecurityContextProvider;
@@ -83,6 +87,7 @@ public class DefaultKsqlSecurityContextProviderTest {
 
     when(apiSecurityContext.getPrincipal()).thenReturn(Optional.of(user1));
     when(apiSecurityContext.getAuthToken()).thenReturn(Optional.empty());
+    when(apiSecurityContext.getRequestHeaders()).thenReturn(incomingRequestHeaders);
 
     when(defaultServiceContextFactory.create(any(), any(), any(), any(), any(), any()))
         .thenReturn(defaultServiceContext);
@@ -163,7 +168,7 @@ public class DefaultKsqlSecurityContextProviderTest {
   }
 
   @Test
-  public void shouldPassUserPrincipalToDefaultFactory() {
+  public void shouldPassRequestHeadersToDefaultFactory() {
     // Given:
     when(securityExtension.getUserContextProvider()).thenReturn(Optional.empty());
 
@@ -171,11 +176,11 @@ public class DefaultKsqlSecurityContextProviderTest {
     ksqlSecurityContextProvider.provide(apiSecurityContext);
 
     // Then:
-    verify(defaultServiceContextFactory).create(any(), any(), any(), any(), any(), eq(Optional.of(user1)));
+    verify(defaultServiceContextFactory).create(any(), any(), any(), any(), any(), eq(incomingRequestHeaders));
   }
 
   @Test
-  public void shouldPassUserPrincipalToUserFactory() {
+  public void shouldPassRequestHeadersToUserFactory() {
     // Given:
     when(securityExtension.getUserContextProvider()).thenReturn(Optional.of(userContextProvider));
 
@@ -184,6 +189,6 @@ public class DefaultKsqlSecurityContextProviderTest {
 
     // Then:
     verify(userServiceContextFactory)
-        .create(any(), any(), any(), any(), any(), any(), eq(Optional.of(user1)));
+        .create(any(), any(), any(), any(), any(), any(), eq(incomingRequestHeaders));
   }
 }


### PR DESCRIPTION
### Description 

This PR builds on the custom connect headers extension introduced in https://github.com/confluentinc/ksql/pull/8357. Three changes in this PR:
* The auth header used by ksqlDB for connector requests is now configurable as well. 
* The principal associated with the incoming ksql request is no longer piped through to the extension, as the interface for custom headers no longer accepts the KsqlPrincipal as a parameter. (We thought we had a use case for this but turns out we don't, so I've cleaned up the code.)
* Incoming request headers are now piped through to the extension instead, as the custom auth header might be interested in these.

### Testing done 

Unit tests + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

