### PR TITLE
fix: clean up custom prefixed internal topics

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/QueryApplicationId.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/QueryApplicationId.java
@@ -69,7 +69,7 @@ public final class QueryApplicationId {
   public static String buildPrefix(
       final String serviceId,
       final String queryPrefix
-   ) {
+  ) {
     return ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
         + serviceId
         + queryPrefix;

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/QueryApplicationId.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/QueryApplicationId.java
@@ -30,7 +30,7 @@ public final class QueryApplicationId {
       final boolean persistent,
       final int sharedRuntimeIndex
   ) {
-    final String queryAppId = buildPrefix(config, persistent) + sharedRuntimeIndex;
+    final String queryAppId = buildInternalTopicPrefix(config, persistent) + sharedRuntimeIndex;
     if (persistent) {
       return queryAppId;
     } else {
@@ -43,7 +43,7 @@ public final class QueryApplicationId {
       final boolean persistent,
       final QueryId queryId
   ) {
-    final String queryAppId = buildPrefix(config, persistent) + queryId;
+    final String queryAppId = buildInternalTopicPrefix(config, persistent) + queryId;
     if (persistent) {
       return queryAppId;
     } else {
@@ -51,7 +51,7 @@ public final class QueryApplicationId {
     }
   }
 
-  public static String buildPrefix(
+  public static String buildInternalTopicPrefix(
       final KsqlConfig config,
       final boolean persistent
   ) {
@@ -63,10 +63,10 @@ public final class QueryApplicationId {
 
     final String queryPrefix = config.getString(configName);
 
-    return buildPrefix(serviceId, queryPrefix);
+    return buildInternalTopicPrefix(serviceId, queryPrefix);
   }
 
-  public static String buildPrefix(
+  public static String buildInternalTopicPrefix(
       final String serviceId,
       final String queryPrefix
   ) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/QueryApplicationId.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/QueryApplicationId.java
@@ -30,7 +30,7 @@ public final class QueryApplicationId {
       final boolean persistent,
       final int sharedRuntimeIndex
   ) {
-    final String queryAppId = buildPrefix(config, persistent) + "-" + sharedRuntimeIndex;
+    final String queryAppId = buildPrefix(config, persistent) + sharedRuntimeIndex;
     if (persistent) {
       return queryAppId;
     } else {
@@ -51,7 +51,7 @@ public final class QueryApplicationId {
     }
   }
 
-  private static String buildPrefix(
+  public static String buildPrefix(
       final KsqlConfig config,
       final boolean persistent
   ) {
@@ -63,6 +63,13 @@ public final class QueryApplicationId {
 
     final String queryPrefix = config.getString(configName);
 
+    return buildPrefix(serviceId, queryPrefix);
+  }
+
+  public static String buildPrefix(
+      final String serviceId,
+      final String queryPrefix
+   ) {
     return ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
         + serviceId
         + queryPrefix;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -650,7 +650,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
                           .defaultValues()
                           .get(StreamsConfig.STATE_DIR_CONFIG))
                     .toString(),
-                ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
+                ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+                ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG)));
       } else {
         log.info("Skipping cleanup for query {} since it was never started", applicationId);
       }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -649,8 +649,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
                         StreamsConfig.configDef()
                           .defaultValues()
                           .get(StreamsConfig.STATE_DIR_CONFIG))
-                    .toString()
-            ));
+                    .toString(),
+                ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)));
       } else {
         log.info("Skipping cleanup for query {} since it was never started", applicationId);
       }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/OrphanedTransientQueryCleaner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/OrphanedTransientQueryCleaner.java
@@ -79,8 +79,8 @@ public class OrphanedTransientQueryCleaner {
                       StreamsConfig.STATE_DIR_CONFIG,
                       StreamsConfig.configDef().defaultValues().get(StreamsConfig.STATE_DIR_CONFIG))
                   .toString(),
-              ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
-          ));
+              ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+              ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG)));
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/OrphanedTransientQueryCleaner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/OrphanedTransientQueryCleaner.java
@@ -78,7 +78,8 @@ public class OrphanedTransientQueryCleaner {
                   .getOrDefault(
                       StreamsConfig.STATE_DIR_CONFIG,
                       StreamsConfig.configDef().defaultValues().get(StreamsConfig.STATE_DIR_CONFIG))
-                  .toString()
+                  .toString(),
+              ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
           ));
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
@@ -108,7 +108,7 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
       this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
       this.appId = Objects.requireNonNull(appId, "appId");
       this.topologyName = Objects.requireNonNull(topologyName, "topologyName");
-      queryTopicPrefix = topologyName.map(s -> appId + "-" + s).orElse(appId);
+      queryTopicPrefix = topologyName.map(s -> getQueryTopicPrefix() + "-" + s).orElse(appId);
       //generate the prefix depending on if using named topologies
       this.isTransient = isTransient;
       pathName = topologyName
@@ -117,6 +117,11 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
       if (isTransient && topologyName.isPresent()) {
         throw new IllegalArgumentException("Transient Queries can not have named topologies");
       }
+    }
+
+    private String getQueryTopicPrefix() {
+      return appId.split("query")[0]
+          + "query"; //we need to chop off the runtime ID form the appID
     }
 
     public String getAppId() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
@@ -108,7 +108,7 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
       this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
       this.appId = Objects.requireNonNull(appId, "appId");
       this.topologyName = Objects.requireNonNull(topologyName, "topologyName");
-      queryTopicPrefix = topologyName.map(s -> getQueryTopicPrefix() + "-" + s).orElse(appId);
+      queryTopicPrefix = getQueryTopicPrefix();
       //generate the prefix depending on if using named topologies
       this.isTransient = isTransient;
       pathName = topologyName
@@ -120,8 +120,10 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
     }
 
     private String getQueryTopicPrefix() {
-      return appId.split("query")[0]
-          + "query"; //we need to chop off the runtime ID form the appID
+      return topologyName.map(s -> appId.split("query")[0]
+          + "query-"
+          + s).orElse(appId);
+      //we need to chop off the runtime ID form the appID
     }
 
     public String getAppId() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/QueryCleanupService.java
@@ -106,12 +106,13 @@ public class QueryCleanupService extends AbstractExecutionThreadService {
         final Optional<String> topologyName,
         final boolean isTransient,
         final String stateDir,
-        final String serviceId) {
+        final String serviceId,
+        final String persistentQueryPrefix) {
       this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
       this.appId = Objects.requireNonNull(appId, "appId");
       this.topologyName = Objects.requireNonNull(topologyName, "topologyName");
       queryTopicPrefix = topologyName
-          .map(s-> QueryApplicationId.buildPrefix(serviceId, KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_DEFAULT) + s)
+          .map(s-> QueryApplicationId.buildPrefix(serviceId, persistentQueryPrefix) + s)
           .orElse(appId);
       //generate the prefix depending on if using named topologies
       this.isTransient = isTransient;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
@@ -28,7 +28,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 
 /**
  * This locator contacts all hosts since there currently isn't a mechanism to find which hosts own

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -315,12 +315,12 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   }
 
   @Override
-  public void deleteInternalTopics(final String applicationId) {
+  public void deleteInternalTopics(final String internalTopicPrefix) {
     try {
       final Set<String> topicNames = listTopicNames();
       final List<String> internalTopics = Lists.newArrayList();
       for (final String topicName : topicNames) {
-        if (isInternalTopic(topicName, applicationId)) {
+        if (isInternalTopic(topicName, internalTopicPrefix)) {
           internalTopics.add(topicName);
         }
       }
@@ -330,7 +330,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       }
     } catch (final Exception e) {
       LOG.error("Exception while trying to clean up internal topics for application id: {}.",
-          applicationId, e
+          internalTopicPrefix, e
       );
     }
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -84,6 +84,7 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.ReservedInternalTopics;
 import io.confluent.ksql.util.SandboxedBinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.SandboxedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.SandboxedTransientQueryMetadata;
@@ -139,6 +140,10 @@ public class KsqlEngineTest {
   @Before
   public void setUp() {
     sharedRuntimeEnabled.put(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true);
+    sharedRuntimeEnabled.put(StreamsConfig.InternalConfig.TOPIC_PREFIX_ALTERNATIVE,
+        ReservedInternalTopics.KSQL_INTERNAL_TOPIC_PREFIX
+            + "default_"
+            + "query");
     sharedRuntimeDisabled.put(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, false);
     ksqlConfig = KsqlConfigTestUtil.create("what-eva", sharedRuntimeEnabled);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -2354,7 +2354,7 @@ public class KsqlEngineTest {
     } else {
       nameTopology = Optional.empty();
     }
-    ksqlEngine.getCleanupService().addCleanupTask(new QueryCleanupTask(serviceContext, "", nameTopology, false, "", KsqlConfig.KSQL_SERVICE_ID_DEFAULT) {
+    ksqlEngine.getCleanupService().addCleanupTask(new QueryCleanupTask(serviceContext, "", nameTopology, false, "", KsqlConfig.KSQL_SERVICE_ID_DEFAULT, KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_DEFAULT) {
       @Override
       public void run() {
         // do nothing

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -468,7 +468,8 @@ public final class KsqlRestApplication implements Executable {
           StreamsConfig.STATE_DIR_CONFIG,
           StreamsConfig.configDef().defaultValues().get(StreamsConfig.STATE_DIR_CONFIG))
         .toString(),
-        serviceContext)
+        serviceContext,
+        configWithApplicationServer)
     );
 
     commandRunner.start();

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -423,7 +423,7 @@ public class KsqlRestoreCommandTopic {
       final StreamsConfig streamsConfig = new StreamsConfig(streamsProperties);
       final String topicPrefix = sharedRuntimeQuery
           ? streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)
-          : QueryApplicationId.buildPrefix(ksqlConfig, sharedRuntimeQuery) + queryId;
+          : QueryApplicationId.buildInternalTopicPrefix(ksqlConfig, sharedRuntimeQuery) + queryId;
 
       try {
         final Admin admin = new DefaultKafkaClientSupplier()

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
@@ -394,16 +395,25 @@ public class KsqlRestoreCommandTopic {
     boolean queryIdFound = false;
     final Map<String, Object> streamsProperties =
         new HashMap<>(ksqlConfig.getKsqlStreamConfigProps());
+    boolean sharedRuntimeQuery = false;
+    String queryId = "";
     final JSONObject jsonObject = new JSONObject(new String(command, StandardCharsets.UTF_8));
     if (hasKey(jsonObject, "plan")) {
       final JSONObject plan = jsonObject.getJSONObject("plan");
       if (hasKey(plan, "queryPlan")) {
         final JSONObject queryPlan = plan.getJSONObject("queryPlan");
-        final String queryId = queryPlan.getString("queryId");
-        streamsProperties.put(
-            StreamsConfig.APPLICATION_ID_CONFIG,
-            QueryApplicationId.build(ksqlConfig, true, new QueryId(queryId)));
-
+        queryId = queryPlan.getString("queryId");
+        if (hasKey(queryPlan, "runtimeId")
+            && ((Optional<String>) queryPlan.get("runtimeId")).isPresent()) {
+          streamsProperties.put(
+              StreamsConfig.APPLICATION_ID_CONFIG,
+              ((Optional<String>) queryPlan.get("runtimeId")).get());
+          sharedRuntimeQuery = true;
+        } else {
+          streamsProperties.put(
+              StreamsConfig.APPLICATION_ID_CONFIG,
+              QueryApplicationId.build(ksqlConfig, true, new QueryId(queryId)));
+        }
         queryIdFound = true;
       }
     }
@@ -411,13 +421,16 @@ public class KsqlRestoreCommandTopic {
     // the command contains a query, clean up it's internal state store and also the internal topics
     if (queryIdFound) {
       final StreamsConfig streamsConfig = new StreamsConfig(streamsProperties);
-      final String applicationId =
-          streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+      String topicPrefix = streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG);;
+      if (sharedRuntimeQuery) {
+        topicPrefix = getQueryTopicPrefix(topicPrefix, queryId);
+      }
+
       try {
         final Admin admin = new DefaultKafkaClientSupplier()
             .getAdmin(ksqlConfig.getKsqlAdminClientConfigProps());
         final KafkaTopicClient topicClient = new KafkaTopicClientImpl(() -> admin);
-        topicClient.deleteInternalTopics(applicationId);
+        topicClient.deleteInternalTopics(topicPrefix);
 
         new StateDirectory(
             streamsConfig,
@@ -427,11 +440,18 @@ public class KsqlRestoreCommandTopic {
         System.out.println(
             String.format(
                 "Cleaned up internal state store and internal topics for query %s",
-                applicationId));
+                topicPrefix));
       } catch (final Exception e) {
-        System.out.println(String.format("Failed to clean up query %s ", applicationId));
+        System.out.println(String.format("Failed to clean up query %s ", topicPrefix));
       }
     }
+  }
+
+  private static String getQueryTopicPrefix(final String runtimeId, final String queryId) {
+    return runtimeId.split("query")[0]
+        + "query-"
+        + queryId;
+    //we need to chop off the runtime ID form the appID
   }
 
   private static boolean hasKey(final JSONObject jsonObject, final String key) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -421,10 +421,9 @@ public class KsqlRestoreCommandTopic {
     // the command contains a query, clean up it's internal state store and also the internal topics
     if (queryIdFound) {
       final StreamsConfig streamsConfig = new StreamsConfig(streamsProperties);
-      String topicPrefix = streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG);;
-      if (sharedRuntimeQuery) {
-        topicPrefix = getQueryTopicPrefix(topicPrefix, queryId);
-      }
+      final String topicPrefix = sharedRuntimeQuery
+          ? streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG)
+          : QueryApplicationId.buildPrefix(ksqlConfig, sharedRuntimeQuery) + queryId;
 
       try {
         final Admin admin = new DefaultKafkaClientSupplier()
@@ -445,13 +444,6 @@ public class KsqlRestoreCommandTopic {
         System.out.println(String.format("Failed to clean up query %s ", topicPrefix));
       }
     }
-  }
-
-  private static String getQueryTopicPrefix(final String runtimeId, final String queryId) {
-    return runtimeId.split("query")[0]
-        + "query-"
-        + queryId;
-    //we need to chop off the runtime ID form the appID
   }
 
   private static boolean hasKey(final JSONObject jsonObject, final String key) {

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
@@ -19,6 +19,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.engine.QueryCleanupService;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.io.File;
 import java.util.Arrays;
@@ -36,9 +37,11 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
   private final String stateDir;
   private final ServiceContext serviceContext;
   private final QueryCleanupService queryCleanupService;
+  private final KsqlConfig ksqlConfig;
 
-  public PersistentQueryCleanupImpl(final String stateDir, final ServiceContext serviceContext) {
+  public PersistentQueryCleanupImpl(final String stateDir, final ServiceContext serviceContext, final KsqlConfig ksqlConfig) {
     this.stateDir = stateDir;
+    this.ksqlConfig = ksqlConfig;
     this.serviceContext = serviceContext;
     queryCleanupService = new QueryCleanupService();
     queryCleanupService.startAsync();
@@ -82,13 +85,9 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
                 : Optional.empty(),
             false,
             stateDir,
-            getServiceId(storeName.split("/")[0])
-          )));
+            ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+            ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG))));
     }
-  }
-
-  private String getServiceId(final String appId) {
-    return appId.split("query_")[0].split("-")[2];
   }
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP")

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
@@ -75,14 +75,20 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
       allStateStores.removeAll(stateStoreNames);
       allStateStores.forEach((storeName) -> queryCleanupService.addCleanupTask(
           new QueryCleanupService.QueryCleanupTask(
-          serviceContext,
-          storeName.split("/")[0],
-           1 <  storeName.split("__").length
-               ? Optional.of(storeName.split("__")[1])
-               : Optional.empty(),
-          false,
-          stateDir)));
+            serviceContext,
+            storeName.split("/")[0],
+            1 <  storeName.split("__").length
+                ? Optional.of(storeName.split("__")[1])
+                : Optional.empty(),
+            false,
+            stateDir,
+            getServiceId(storeName.split("/")[0])
+          )));
     }
+  }
+
+  private String getServiceId(final String appId) {
+    return appId.split("query_")[0].split("-")[2];
   }
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP")

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
@@ -39,7 +39,10 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
   private final QueryCleanupService queryCleanupService;
   private final KsqlConfig ksqlConfig;
 
-  public PersistentQueryCleanupImpl(final String stateDir, final ServiceContext serviceContext, final KsqlConfig ksqlConfig) {
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP")
+  public PersistentQueryCleanupImpl(final String stateDir,
+                                    final ServiceContext serviceContext,
+                                    final KsqlConfig ksqlConfig) {
     this.stateDir = stateDir;
     this.ksqlConfig = ksqlConfig;
     this.serviceContext = serviceContext;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -272,7 +272,8 @@ public class RecoveryTest {
             StreamsConfig.STATE_DIR_CONFIG,
             StreamsConfig.configDef().defaultValues().get(StreamsConfig.STATE_DIR_CONFIG))
           .toString(),
-        serviceContext)
+        serviceContext,
+        ksqlConfig)
       );
     }
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImplTest.java
@@ -114,7 +114,7 @@ public class PersistentQueryCleanupImplTest {
   private void awaitCleanupComplete() {
     // add a task to the end of the queue to make sure that
     // we've finished processing everything up until this point
-    cleanup.getQueryCleanupService().addCleanupTask(new QueryCleanupService.QueryCleanupTask(context, "", Optional.empty(), false, "", KsqlConfig.KSQL_SERVICE_ID_DEFAULT) {
+    cleanup.getQueryCleanupService().addCleanupTask(new QueryCleanupService.QueryCleanupTask(context, "", Optional.empty(), false, "", KsqlConfig.KSQL_SERVICE_ID_DEFAULT, "") {
       @Override
       public void run() {
         // do nothing

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImplTest.java
@@ -47,6 +47,8 @@ public class PersistentQueryCleanupImplTest {
   PersistentQueryCleanupImpl cleanup;
 
   @Mock
+  KsqlConfig ksqlConfig;
+  @Mock
   ServiceContext context;
   @Mock
   PersistentQueryMetadata runningQuery;
@@ -62,7 +64,7 @@ public class PersistentQueryCleanupImplTest {
       }
     }
 
-    cleanup = new PersistentQueryCleanupImpl("/tmp/cat/", context);
+    cleanup = new PersistentQueryCleanupImpl("/tmp/cat/", context, ksqlConfig);
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImplTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.engine.QueryCleanupService;
 import io.confluent.ksql.logging.query.TestAppender;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -113,7 +114,7 @@ public class PersistentQueryCleanupImplTest {
   private void awaitCleanupComplete() {
     // add a task to the end of the queue to make sure that
     // we've finished processing everything up until this point
-    cleanup.getQueryCleanupService().addCleanupTask(new QueryCleanupService.QueryCleanupTask(context, "", Optional.empty(),false, "") {
+    cleanup.getQueryCleanupService().addCleanupTask(new QueryCleanupService.QueryCleanupTask(context, "", Optional.empty(), false, "", KsqlConfig.KSQL_SERVICE_ID_DEFAULT) {
       @Override
       public void run() {
         // do nothing


### PR DESCRIPTION
https://github.com/confluentinc/ksql/pull/8607 made it so the app id was not always the prefix for internal topics now we clean up based on that not the app id 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

