### PR TITLE
chore: add custom metrics tags to the total bytes sum metric for the server

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.metrics.TopicSensors.SensorMetric;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,9 +68,9 @@ public class ConsumerCollector implements MetricCollector, ConsumerInterceptor<O
       id = (String) map.get(ConsumerConfig.CLIENT_ID_CONFIG);
     }
 
-    final KsqlConfig config = new KsqlConfig(map);
-    final Map<String, String> metricsTags =
-        config.getStringAsMap(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS);
+    final Map<String, String> metricsTags = KsqlConfig.parseStringAsMap(
+        KsqlConfig.KSQL_CUSTOM_METRICS_TAGS,
+        (String) map.get(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS));
 
     final MetricCollectors collectors = (MetricCollectors) Objects.requireNonNull(
         map.get(KsqlConfig.KSQL_INTERNAL_METRIC_COLLECTORS_CONFIG));

--- a/ksqldb-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -68,9 +68,9 @@ public class ConsumerCollector implements MetricCollector, ConsumerInterceptor<O
       id = (String) map.get(ConsumerConfig.CLIENT_ID_CONFIG);
     }
 
-    final Map<String, String> metricsTags = KsqlConfig.parseStringAsMap(
-        KsqlConfig.KSQL_CUSTOM_METRICS_TAGS,
-        (String) map.get(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS));
+    final KsqlConfig config = new KsqlConfig(map);
+    final Map<String, String> metricsTags =
+        config.getStringAsMap(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS);
 
     final MetricCollectors collectors = (MetricCollectors) Objects.requireNonNull(
         map.get(KsqlConfig.KSQL_INTERNAL_METRIC_COLLECTORS_CONFIG));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -576,6 +576,11 @@ final class QueryBuilder {
     // Passing shared state into managed components
     newStreamsProperties.put(KsqlConfig.KSQL_INTERNAL_METRIC_COLLECTORS_CONFIG, metricCollectors);
     newStreamsProperties.put(
+        KsqlConfig.KSQL_CUSTOM_METRICS_TAGS,
+        config.getString(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS)
+    );
+
+    newStreamsProperties.put(
         KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG,
         metricCollectors.getMetrics()
     );

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -226,6 +226,7 @@ public class QueryBuilderTest {
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
     when(processingLoggerFactory.getLogger(any())).thenReturn(processingLogger);
     when(ksqlConfig.getKsqlStreamConfigProps(anyString())).thenReturn(Collections.emptyMap());
+    when(ksqlConfig.getString(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS)).thenReturn("");
     when(ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG))
         .thenReturn(PERSISTENT_PREFIX);
     when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn(SERVICE_ID);
@@ -691,6 +692,25 @@ public class QueryBuilderTest {
     assertThat(
         streamsProps.get(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER),
         is(logger));
+  }
+
+  @Test
+  public void shouldConfigureCustomMetricsTags() {
+    // Given:
+    when(ksqlConfig.getString(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS)).thenReturn("custom-tag:custom-tag-value");
+
+    // When:
+    buildPersistentQuery(
+        SOURCES,
+        KsqlConstants.PersistentQueryType.CREATE_AS,
+        QUERY_ID
+    ).initialize();
+
+    // Then:
+    final Map<String, Object> streamsProps = capturedStreamsProperties();
+    assertThat(
+        streamsProps.get(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS),
+        is("custom-tag:custom-tag-value"));
   }
 
   public static class DummyConsumerInterceptor implements ConsumerInterceptor {


### PR DESCRIPTION
### Description 
We want to also include custom metrics tags in the total bytes consumed metric in the ConsumerCollector class. We do this by adding the value from the KsqlConfig into the streams properties map in QueryBuilder

### Testing done 
Unit tests

Added `ksql.metrics.tags.custom=test-tag:1337` to the server properties
Started up server
Opened jconsole
Looked at the bean name: `io.confluent.ksql.metrics:type=consumer-metrics,test-tag:1337`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

