### PR TITLE
fix: remove usages of internal Streams API/variable that was removed upstream

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
@@ -62,7 +62,6 @@ public class AllHostsLocator implements PushLocator {
         .map(QueryMetadata::getAllMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
-        .filter(streamsMetadata -> !(streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)))
         .map(StreamsMetadata::hostInfo)
         .map(hi -> new Node(isLocalhost(hi), buildLocation(hi)))
         .distinct()

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocatorTest.java
@@ -9,6 +9,7 @@ import io.confluent.ksql.physical.scalablepush.locator.PushLocator.KsqlNode;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -17,8 +18,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static org.apache.kafka.streams.state.internals.StreamsMetadataImpl.NOT_AVAILABLE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AllHostsLocatorTest {
@@ -44,7 +43,7 @@ public class AllHostsLocatorTest {
     when(metadata1.getAllMetadata())
         .thenReturn(ImmutableList.of(streamsMetadata1, streamsMetadata2));
     when(metadata2.getAllMetadata())
-        .thenReturn(ImmutableList.of(streamsMetadata3, NOT_AVAILABLE));
+        .thenReturn(Collections.emptyList());
     when(streamsMetadata1.hostInfo())
         .thenReturn(new HostInfo("abc", 101), new HostInfo("localhost", 8088));
     when(streamsMetadata2.hostInfo()).thenReturn(new HostInfo("localhost", 8088));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 
 /**
  * Endpoint that reports the view of the cluster that this server has.
@@ -103,8 +102,7 @@ public class ClusterStatusResource {
     final Map<String, ActiveStandbyEntity> perQueryMap = new HashMap<>();
     for (PersistentQueryMetadata persistentQueryMetadata: engine.getPersistentQueries()) {
       for (StreamsMetadata streamsMetadata: persistentQueryMetadata.getAllMetadata()) {
-        if (streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)
-            || !streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
+        if (streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
           continue;
         }
         final QueryIdAndStreamsMetadata queryIdAndStreamsMetadata = new QueryIdAndStreamsMetadata(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 
 public final class DiscoverRemoteHostsUtil {
 
@@ -43,7 +42,6 @@ public final class DiscoverRemoteHostsUtil {
         .map(QueryMetadata::getAllMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
-        .filter(streamsMetadata -> !(streamsMetadata.equals(StreamsMetadataImpl.NOT_AVAILABLE)))
         .map(StreamsMetadata::hostInfo)
         .filter(hostInfo -> !(hostInfo.host().equals(localHost.host())
             && hostInfo.port() == (localHost.port())))


### PR DESCRIPTION
Apparently we used the StreamsMetadataImpl.NOT_AVAILABLE variable throughout the ksql repo, but we very much should not have been since this is actually not in the public API of Streams. The risk of using internal APIs is that they have no public contract or compatability guarantees of any kind, and can for example be removed at any time without deprecation/warning.

Unfortunately this is exactly what just happened to `StreamsMetadataImpl.NOT_AVAILABLE`, but at least we can easily address this since it was pretty much just a convenience to begin with used for comparisons, and we no longer return any metadata for unavailable clients rather than build up this metadata and then just filter it out on the user side (ie ksql)