### PR TITLE
fix: don't throw on drop

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -97,7 +97,8 @@ public class RuntimeAssignor {
   public void rebuildAssignment(final Collection<PersistentQueryMetadata> queries) {
     for (PersistentQueryMetadata queryMetadata: queries) {
       if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
-        runtimesToSources.get(queryMetadata.getQueryApplicationId()).addAll(queryMetadata.getSourceNames());
+        runtimesToSources.get(queryMetadata.getQueryApplicationId())
+            .addAll(queryMetadata.getSourceNames());
         idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());
       }
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -97,8 +97,7 @@ public class RuntimeAssignor {
   public void rebuildAssignment(final Collection<PersistentQueryMetadata> queries) {
     for (PersistentQueryMetadata queryMetadata: queries) {
       if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
-        runtimesToSources.put(queryMetadata.getQueryApplicationId(),
-            new HashSet<>(queryMetadata.getSourceNames()));
+        runtimesToSources.get(queryMetadata.getQueryApplicationId()).addAll(queryMetadata.getSourceNames());
         idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());
       }
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -98,7 +98,7 @@ public class RuntimeAssignor {
     for (PersistentQueryMetadata queryMetadata: queries) {
       if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
         runtimesToSources.put(queryMetadata.getQueryApplicationId(),
-            queryMetadata.getSourceNames());
+            new HashSet<>(queryMetadata.getSourceNames()));
         idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());
       }
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
@@ -1,5 +1,6 @@
 package io.confluent.ksql.engine;
 
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
@@ -44,12 +45,14 @@ public class RuntimeAssignorTest {
     );
     when(queryMetadata.getQueryApplicationId()).thenReturn(firstRuntime);
     when(queryMetadata.getQueryId()).thenReturn(query1);
-    when(queryMetadata.getSourceNames()).thenReturn(new HashSet<>(sources1));
+    when(queryMetadata.getSourceNames()).thenReturn(ImmutableSet.copyOf(new HashSet<>(sources1)));
   }
 
   @Test
   public void shouldCreateSandboxAndDroppingAQueryWillNotChangeReal() {
     final RuntimeAssignor sandbox = runtimeAssignor.createSandbox();
+    sandbox.rebuildAssignment(Collections.singleton(queryMetadata));
+
     sandbox.dropQuery(queryMetadata);
     assertThat("Was changed by sandbox.", runtimeAssignor.getIdToRuntime().containsKey(query1));
     assertThat("The query was not removed.", !sandbox.getIdToRuntime().containsKey(query1));


### PR DESCRIPTION
Don't hit an immutability issue. the query returns its list of sources in an immutable set so we need to add them all to the existing set instead of replace them


ksql> drop stream filtered_users;

 Message                                                      
--------------------------------------------------------------
 Source `FILTERED_USERS` (topic: FILTERED_USERS) was dropped. 
--------------------------------------------------------------


instead of


ksql> drop table users_agg_2;

 Message                              
--------------------------------------
 Source `USERS_AGG_2` does not exist. 
--------------------------------------

### Testing done 
added coverage in unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

