### PR TITLE
fix: keep shared runtime dirs even if no query has state

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
@@ -87,17 +87,18 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
       allStateStores.removeAll(stateStoreNames);
       allStateStores.forEach((storeName) -> queryCleanupService.addCleanupTask(
           new QueryCleanupService.QueryCleanupTask(
-              serviceContext,
-              storeName.split("/")[0],
-              1 <  storeName.split("__").length
-                  ? Optional.of(storeName.split("__")[1])
-                  : Optional.empty(),
-              false,
-              stateDir,
-              ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
-              ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG))));
+            serviceContext,
+            storeName.split("/")[0],
+            1 <  storeName.split("__").length
+                ? Optional.of(storeName.split("__")[1])
+                : Optional.empty(),
+            false,
+            stateDir,
+            ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+            ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG))));
     }
   }
+
   @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public QueryCleanupService getQueryCleanupService() {
     return queryCleanupService;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
@@ -60,7 +60,10 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
               final List<String> doNotDelete = new ArrayList<>(
                   Collections.singletonList(s.getQueryApplicationId()));
               if (s instanceof BinPackedPersistentQueryMetadataImpl) {
-                doNotDelete.add(s.getQueryApplicationId() + "/__" + s.getQueryId().toString() + "__");
+                doNotDelete.add(s.getQueryApplicationId()
+                    + "/__"
+                    + s.getQueryId().toString()
+                    + "__");
               }
               return doNotDelete.stream();
             })

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImpl.java
@@ -22,7 +22,9 @@ import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -53,14 +55,16 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
   public void cleanupLeakedQueries(final List<PersistentQueryMetadata> persistentQueries) {
     final Set<String> stateStoreNames =
         persistentQueries
-        .stream()
-        .map(s -> {
-          if (s instanceof BinPackedPersistentQueryMetadataImpl) {
-            return s.getQueryApplicationId() + "/__" + s.getQueryId().toString() + "__";
-          }
-          return s.getQueryApplicationId();
-        })
-        .collect(Collectors.toSet());
+            .stream()
+            .flatMap(s -> {
+              final List<String> doNotDelete = new ArrayList<>(
+                  Collections.singletonList(s.getQueryApplicationId()));
+              if (s instanceof BinPackedPersistentQueryMetadataImpl) {
+                doNotDelete.add(s.getQueryApplicationId() + "/__" + s.getQueryId().toString() + "__");
+              }
+              return doNotDelete.stream();
+            })
+            .collect(Collectors.toSet());
 
     final String[] stateDirFileNames = new File(stateDir).list();
     if (stateDirFileNames == null) {
@@ -72,7 +76,9 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
             if (null == fileNames) {
               return Stream.of(f);
             } else if (Arrays.stream(fileNames).anyMatch(t -> t.matches("__*__"))) {
-              return Arrays.stream(fileNames).filter(t -> t.matches("__*__"));
+              return Arrays.stream(fileNames)
+                  .filter(t -> t.matches("__*__"))
+                  .map(s -> f + "/" + s);
             } else {
               return Stream.of(f);
             }
@@ -81,18 +87,17 @@ public class PersistentQueryCleanupImpl implements PersistentQueryCleanup {
       allStateStores.removeAll(stateStoreNames);
       allStateStores.forEach((storeName) -> queryCleanupService.addCleanupTask(
           new QueryCleanupService.QueryCleanupTask(
-            serviceContext,
-            storeName.split("/")[0],
-            1 <  storeName.split("__").length
-                ? Optional.of(storeName.split("__")[1])
-                : Optional.empty(),
-            false,
-            stateDir,
-            ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
-            ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG))));
+              serviceContext,
+              storeName.split("/")[0],
+              1 <  storeName.split("__").length
+                  ? Optional.of(storeName.split("__")[1])
+                  : Optional.empty(),
+              false,
+              stateDir,
+              ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+              ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG))));
     }
   }
-
   @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public QueryCleanupService getQueryCleanupService() {
     return queryCleanupService;


### PR DESCRIPTION
we were looking at all dir for queries and removing all the ones that were being actively used. but for named topologies if there was no state then we would not see that runtime as being used and we would delete it out from under streams. Streams would get confused and when you then tried to drop the query for real everything would hang

### Testing done 
Manual testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

