### PR TITLE
fix: error message for named topologies is different

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -88,6 +88,9 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     QueryError.Type errorType = QueryError.Type.UNKNOWN;
     try {
       errorType = errorClassifier.classify(e);
+      if (e.getCause() != null && errorType == QueryError.Type.UNKNOWN) {
+        errorType = errorClassifier.classify(e.getCause());
+      }
     } catch (final Exception classificationException) {
       log.error("Error classifying unhandled exception", classificationException);
     } finally {


### PR DESCRIPTION
error message for named topologies is different and is wrapped in the streams exception now

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

