### PR TITLE
feat: remove old runtimes

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -471,6 +471,10 @@ public class QueryRegistryImpl implements QueryRegistry {
       final QueryId queryId = persistentQuery.getQueryId();
       persistentQueries.remove(queryId);
 
+      final Set<SharedKafkaStreamsRuntime> toClose = streams.stream().filter(s -> s.getCollocatedQueries().isEmpty()).collect(Collectors.toSet());
+      streams.removeAll(toClose);
+      toClose.forEach(SharedKafkaStreamsRuntime::close);
+
       switch (persistentQuery.getPersistentQueryType()) {
         case CREATE_SOURCE:
           createAsQueries.remove(Iterables.getOnlyElement(persistentQuery.getSourceNames()));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -471,7 +471,10 @@ public class QueryRegistryImpl implements QueryRegistry {
       final QueryId queryId = persistentQuery.getQueryId();
       persistentQueries.remove(queryId);
 
-      final Set<SharedKafkaStreamsRuntime> toClose = streams.stream().filter(s -> s.getCollocatedQueries().isEmpty()).collect(Collectors.toSet());
+      final Set<SharedKafkaStreamsRuntime> toClose = streams
+          .stream()
+          .filter(s -> s.getCollocatedQueries().isEmpty())
+          .collect(Collectors.toSet());
       streams.removeAll(toClose);
       toClose.forEach(SharedKafkaStreamsRuntime::close);
 


### PR DESCRIPTION
### Description 
When shared runtimes are needed they are added but currently they are not removed after all the queries have stopped processing. When runtimes no longer have queries running in them we should close them

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

