### PR TITLE
fix: use topology-specific IQ APIs

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocator.java
@@ -58,7 +58,7 @@ public class AllHostsLocator implements PushLocator {
     }
 
     return currentQueries.stream()
-        .map(QueryMetadata::getAllMetadata)
+        .map(QueryMetadata::getAllStreamsHostMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
         .map(StreamsMetadata::hostInfo)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -140,7 +140,6 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.scalablePushRegistry = requireNonNull(scalablePushRegistry, "scalablePushRegistry");
   }
 
-
   // for creating sandbox instances
   protected BinPackedPersistentQueryMetadataImpl(
           final BinPackedPersistentQueryMetadataImpl original,
@@ -309,7 +308,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public Collection<StreamsMetadata> getAllMetadata() {
     try {
-      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.allMetadata());
+      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.streamsMetadataForQuery(queryId));
     } catch (IllegalStateException e) {
       LOG.error(e.getMessage());
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -251,7 +251,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public Set<StreamsTaskMetadata> getTaskMetadata() {
-    return sharedKafkaStreamsRuntime.getTaskMetadata();
+    return sharedKafkaStreamsRuntime.getAllTaskMetadataForQuery(queryId);
   }
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "overriddenProperties is immutable")
@@ -302,13 +302,13 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLags() {
-    return sharedKafkaStreamsRuntime.allLocalStorePartitionLags(queryId);
+    return sharedKafkaStreamsRuntime.getAllLocalStorePartitionLagsForQuery(queryId);
   }
 
   @Override
-  public Collection<StreamsMetadata> getAllMetadata() {
+  public Collection<StreamsMetadata> getAllStreamsHostMetadata() {
     try {
-      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.streamsMetadataForQuery(queryId));
+      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.getAllStreamsClientsMetadataForQuery(queryId));
     } catch (IllegalStateException e) {
       LOG.error(e.getMessage());
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -308,7 +308,8 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public Collection<StreamsMetadata> getAllStreamsHostMetadata() {
     try {
-      return ImmutableList.copyOf(sharedKafkaStreamsRuntime.getAllStreamsClientsMetadataForQuery(queryId));
+      return ImmutableList.copyOf(
+          sharedKafkaStreamsRuntime.getAllStreamsClientsMetadataForQuery(queryId));
     } catch (IllegalStateException e) {
       LOG.error(e.getMessage());
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -51,7 +51,7 @@ public interface QueryMetadata {
 
   Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLags();
 
-  Collection<StreamsMetadata> getAllMetadata();
+  Collection<StreamsMetadata> getAllStreamsHostMetadata();
 
   Map<String, Object> getStreamsProperties();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -259,7 +259,7 @@ public class QueryMetadataImpl implements QueryMetadata {
     }
   }
 
-  public Collection<StreamsMetadata> getAllMetadata() {
+  public Collection<StreamsMetadata> getAllStreamsHostMetadata() {
     try {
       return ImmutableList.copyOf(kafkaStreams.metadataForAllStreamsClients());
     } catch (IllegalStateException e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -83,8 +83,8 @@ public abstract class SharedKafkaStreamsRuntime {
     return kafkaStreams.state();
   }
 
-  public Collection<StreamsMetadata> allMetadata() {
-    return kafkaStreams.metadataForAllStreamsClients();
+  public Collection<StreamsMetadata> streamsMetadataForQuery(final QueryId queryId) {
+    return kafkaStreams.streamsMetadataForTopology(queryId.toString());
   }
 
   public Set<StreamsTaskMetadata> getTaskMetadata() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -34,8 +34,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
-import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +96,8 @@ public abstract class SharedKafkaStreamsRuntime {
         .collect(Collectors.toSet());
   }
 
-  public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLagsForQuery(final QueryId queryId) {
+  public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLagsForQuery(
+      final QueryId queryId) {
     try {
       return kafkaStreams.allLocalStorePartitionLagsForTopology(queryId.toString());
     } catch (IllegalStateException | StreamsException e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -34,6 +34,8 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,9 +90,10 @@ public abstract class SharedKafkaStreamsRuntime {
   }
 
   public Set<StreamsTaskMetadata> getAllTaskMetadataForQuery(final QueryId queryId) {
-    return kafkaStreams.metadataForLocalThreads(queryId.toString())
+    return kafkaStreams.metadataForLocalThreads()
         .stream()
         .flatMap(t -> t.activeTasks().stream())
+        .filter(m -> queryId.toString().equals(m.taskId().topologyName()))
         .map(StreamsTaskMetadata::fromStreamsTaskMetadata)
         .collect(Collectors.toSet());
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -83,19 +83,19 @@ public abstract class SharedKafkaStreamsRuntime {
     return kafkaStreams.state();
   }
 
-  public Collection<StreamsMetadata> streamsMetadataForQuery(final QueryId queryId) {
-    return kafkaStreams.streamsMetadataForTopology(queryId.toString());
+  public Collection<StreamsMetadata> getAllStreamsClientsMetadataForQuery(final QueryId queryId) {
+    return kafkaStreams.allStreamsClientsMetadataForTopology(queryId.toString());
   }
 
-  public Set<StreamsTaskMetadata> getTaskMetadata() {
-    return kafkaStreams.metadataForLocalThreads()
+  public Set<StreamsTaskMetadata> getAllTaskMetadataForQuery(final QueryId queryId) {
+    return kafkaStreams.metadataForLocalThreads(queryId.toString())
         .stream()
         .flatMap(t -> t.activeTasks().stream())
         .map(StreamsTaskMetadata::fromStreamsTaskMetadata)
         .collect(Collectors.toSet());
   }
 
-  public Map<String, Map<Integer, LagInfo>> allLocalStorePartitionLags(final QueryId queryId) {
+  public Map<String, Map<Integer, LagInfo>> getAllLocalStorePartitionLagsForQuery(final QueryId queryId) {
     try {
       return kafkaStreams.allLocalStorePartitionLagsForTopology(queryId.toString());
     } catch (IllegalStateException | StreamsException e) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -65,7 +65,9 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
       final QueryId queryId
   ) {
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
-    log.info("mapping {}", collocatedQueries);
+    log.info("Registered query in shared runtime: {}\n"
+                 + "Runtime {} is executing these queries: {}",
+             queryId, getApplicationId(), collocatedQueries.keySet());
   }
 
   private void setupAndStartKafkaStreams(final KafkaStreams kafkaStreams) {
@@ -167,7 +169,8 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void stop(final QueryId queryId, final boolean resetOffsets) {
-    log.info("Attempting to stop Query: " + queryId.toString());
+    log.info("Attempting to stop query: {} in runtime {} with resetOffsets={}",
+             queryId, getApplicationId(), resetOffsets);
     if (collocatedQueries.containsKey(queryId)) {
       if (kafkaStreams.state().isRunningOrRebalancing()) {
         try {
@@ -178,15 +181,14 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
             kafkaStreams.cleanUpNamedTopology(queryId.toString());
           }
         } catch (final TimeoutException | ExecutionException | InterruptedException e) {
-          log.error("Failed to close query {} within the allotted timeout {} due to",
-              queryId,
-              shutdownTimeout,
-              e);
+          log.error(String.format(
+              "Failed to close query %s within the allotted timeout %s due to",
+              queryId, shutdownTimeout), e);
           if (e instanceof TimeoutException) {
             log.warn(
-                "query has not terminated even after trying to remove the topology. "
-                    + "This may happen when streams threads are hung. State: "
-                    + kafkaStreams.state());
+                "Query {} has not terminated even after trying to remove the topology. "
+                    + "This may happen when streams threads are hung. State is {}",
+                queryId, kafkaStreams.state());
           }
         }
       } else {
@@ -204,6 +206,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void start(final QueryId queryId) {
+    log.info("Attempting to start query {} in runtime {}", queryId, getApplicationId());
     if (collocatedQueries.containsKey(queryId) && !collocatedQueries.get(queryId).everStarted) {
       if (!kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
         try {
@@ -220,10 +223,12 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
               e);
         }
       } else {
-        throw new IllegalArgumentException("not done removing query: " + queryId);
+        throw new IllegalArgumentException("Cannot start because Streams is not done terminating"
+                                               + " an older version of query : " + queryId);
       }
     } else {
-      throw new IllegalArgumentException("query: " + queryId + " not added to runtime");
+      throw new IllegalArgumentException("Cannot start because query " + queryId + " was not"
+                                             + "registered to runtime " + getApplicationId());
     }
   }
 
@@ -234,6 +239,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void restartStreamsRuntime() {
+    log.info("Restarting runtime {}", getApplicationId();
     final KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper = kafkaStreamsBuilder
         .buildNamedTopologyWrapper(streamsProperties);
     kafkaStreams.close();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/physical/scalablepush/locator/AllHostsLocatorTest.java
@@ -38,9 +38,9 @@ public class AllHostsLocatorTest {
         () -> ImmutableList.of(metadata1, metadata2),
         new URL("http://localhost:8088")
     );
-    when(metadata1.getAllMetadata())
+    when(metadata1.getAllStreamsHostMetadata())
         .thenReturn(ImmutableList.of(streamsMetadata1, streamsMetadata2));
-    when(metadata2.getAllMetadata())
+    when(metadata2.getAllStreamsHostMetadata())
         .thenReturn(ImmutableList.of(streamsMetadata3));
     when(streamsMetadata1.hostInfo())
         .thenReturn(new HostInfo("abc", 101), new HostInfo("localhost", 8088));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.util;
 
-import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryError.Type;
 import io.confluent.ksql.query.QueryErrorClassifier;
@@ -34,11 +32,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -213,7 +209,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
     
     @Test
     public void allLocalStorePartitionLagsCallsTopologyMethod() {
-        sharedKafkaStreamsRuntimeImpl.allLocalStorePartitionLags(queryId);
+        sharedKafkaStreamsRuntimeImpl.getAllLocalStorePartitionLagsForQuery(queryId);
         verify(kafkaStreamsNamedTopologyWrapper)
             .allLocalStorePartitionLagsForTopology("query-1");
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
 import java.util.HashMap;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.namedtopology.AddNamedTopologyResult;
@@ -49,8 +50,6 @@ public class SharedKafkaStreamsRuntimeImplTest {
     @Mock
     private KafkaStreamsBuilder kafkaStreamsBuilder;
     @Mock
-    private Map<String, Object> streamProps;
-    @Mock
     private KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper;
     @Mock
     private KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper2;
@@ -69,6 +68,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
 
     private final QueryId queryId = new QueryId("query-1");
     private final QueryId queryId2= new QueryId("query-2");
+    private Map<String, Object> streamProps = new HashMap();
 
     private final StreamsException query1Exception =
         new StreamsException("query down!", new TaskId(0, 0, queryId.toString()));
@@ -84,6 +84,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
     @Before
     public void setUp() throws Exception {
         when(kafkaStreamsBuilder.buildNamedTopologyWrapper(any())).thenReturn(kafkaStreamsNamedTopologyWrapper).thenReturn(kafkaStreamsNamedTopologyWrapper2);
+        streamProps.put(StreamsConfig.APPLICATION_ID_CONFIG, "runtime");
         sharedKafkaStreamsRuntimeImpl = new SharedKafkaStreamsRuntimeImpl(
             kafkaStreamsBuilder,
             queryErrorClassifier,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
@@ -101,7 +101,7 @@ public class ClusterStatusResource {
   ) {
     final Map<String, ActiveStandbyEntity> perQueryMap = new HashMap<>();
     for (PersistentQueryMetadata persistentQueryMetadata: engine.getPersistentQueries()) {
-      for (StreamsMetadata streamsMetadata: persistentQueryMetadata.getAllMetadata()) {
+      for (StreamsMetadata streamsMetadata: persistentQueryMetadata.getAllStreamsHostMetadata()) {
         if (!streamsMetadata.hostInfo().equals(asHostInfo(ksqlHostInfo))) {
           continue;
         }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtil.java
@@ -39,7 +39,7 @@ public final class DiscoverRemoteHostsUtil {
     return currentQueries.stream()
         // required filter else QueryMetadata.getAllMetadata() throws
         .filter(q -> q.getState().isRunningOrRebalancing())
-        .map(QueryMetadata::getAllMetadata)
+        .map(QueryMetadata::getAllStreamsHostMetadata)
         .filter(Objects::nonNull)
         .flatMap(Collection::stream)
         .map(StreamsMetadata::hostInfo)

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/HeartbeatAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/HeartbeatAgentTest.java
@@ -98,10 +98,10 @@ public class HeartbeatAgentTest {
     heartbeatAgent.setHostsStatus(hostsStatus);
     when(ksqlEngine.getPersistentQueries()).thenReturn(ImmutableList.of(query0, query1));
 
-    when(query0.getAllMetadata()).thenReturn(allMetadata0);
+    when(query0.getAllStreamsHostMetadata()).thenReturn(allMetadata0);
     when(streamsMetadata0.hostInfo()).thenReturn(localHostInfo);
 
-    when(query1.getAllMetadata()).thenReturn(allMetadata1);
+    when(query1.getAllStreamsHostMetadata()).thenReturn(allMetadata1);
     when(streamsMetadata1.hostInfo()).thenReturn(remoteHostInfo);
 
     DiscoverClusterService discoverService = heartbeatAgent.new DiscoverClusterService();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -522,7 +522,7 @@ public class ListQueriesExecutorTest {
     final List<StreamsMetadata> streamsData = new ArrayList<>();
     streamsData.add(localStreamsMetadata);
     streamsData.add(remoteStreamsMetadata);
-    when(metadata.getAllMetadata()).thenReturn(streamsData);
+    when(metadata.getAllStreamsHostMetadata()).thenReturn(streamsData);
   }
 
   public static RunningQuery persistentQueryMetadataToRunningQuery(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtilTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/DiscoverRemoteHostsUtilTest.java
@@ -52,7 +52,7 @@ public class DiscoverRemoteHostsUtilTest {
   @Before
   public void setUp() {
     when(runningQuery.getState()).thenReturn(State.RUNNING);
-    when(runningQuery.getAllMetadata()).thenReturn(Collections.singleton(streamsMetadata));
+    when(runningQuery.getAllStreamsHostMetadata()).thenReturn(Collections.singleton(streamsMetadata));
     when(notRunningQuery.getState()).thenReturn(State.CREATED);
     when(streamsMetadata.hostInfo()).thenReturn(OTHER_HOST_INFO);
   }
@@ -68,7 +68,7 @@ public class DiscoverRemoteHostsUtilTest {
     // Then:
     assertThat(info, contains(OTHER_HOST_INFO));
 
-    verify(notRunningQuery, never()).getAllMetadata();
+    verify(notRunningQuery, never()).getAllStreamsHostMetadata();
   }
 
 }


### PR DESCRIPTION
a rebase of https://github.com/confluentinc/ksql/pull/8579

