### PR TITLE
feat: limit set to query level configs with shared runtimes enabled

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -558,7 +558,7 @@ public class KsqlConfig extends AbstractConfig {
           + "CREATE SOURCE [TABLE|STREAM] statements will continue being read-only.";
 
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
-  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
+  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = true;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
       "Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -152,6 +152,9 @@ final class EngineExecutor {
     this.config = Objects.requireNonNull(config, "config");
 
     KsqlEngineProps.throwOnImmutableOverride(config.getOverrides());
+    if (config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+      KsqlEngineProps.throwOnNonQueryLevelConfigs(config.getOverrides());
+    }
   }
 
   static EngineExecutor create(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngineProps.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngineProps.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.engine;
 
 import io.confluent.ksql.config.ImmutableProperties;
+import io.confluent.ksql.rest.entity.PropertiesList;
+
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -32,6 +34,17 @@ final class KsqlEngineProps {
 
     if (!immutableProps.isEmpty()) {
       throw new IllegalArgumentException("Cannot override properties: " + immutableProps);
+    }
+  }
+
+  static void throwOnNonQueryLevelConfigs(final Map<String, Object> overriddenProperties) {
+    final String nonQueryLevelConfigs = overriddenProperties.keySet().stream()
+        .filter(s -> !PropertiesList.QueryLevelPropertyList.contains(s))
+        .distinct()
+        .collect(Collectors.joining(","));
+
+    if (!nonQueryLevelConfigs.isEmpty()) {
+      throw new IllegalArgumentException("Cannot override properties: " + nonQueryLevelConfigs);
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -76,18 +75,18 @@ public final class PropertyOverrider {
               setProperty.getPropertyName(),
               setProperty.getPropertyValue()
           ));
-    if (statement
+      if (statement
           .getSessionConfig()
           .getConfig(true)
           .getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
-        && !QUERY_LEVEL_CONFIGS.contains(setProperty.getPropertyName())) {
-            throw new KsqlException(String.format("%s is not a settable property at the query"
-                    + " level with %s on. Please use ALTER SYSTEM to set %s for the cluster.",
-                setProperty.getPropertyName(),
-                KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED,
-                setProperty.getPropertyName())
+          && !QUERY_LEVEL_CONFIGS.contains(setProperty.getPropertyName())) {
+        throw new KsqlException(String.format("%s is not a settable property at the query"
+                + " level with %s on. Please use ALTER SYSTEM to set %s for the cluster.",
+            setProperty.getPropertyName(),
+            KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED,
+            setProperty.getPropertyName())
         );
-    }
+      }
     } catch (final Exception e) {
       throw new KsqlStatementException(
           e.getMessage(), statement.getStatementText(), e.getCause());

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/properties/PropertyOverriderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/properties/PropertyOverriderTest.java
@@ -1,0 +1,64 @@
+package io.confluent.ksql.properties;
+
+import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.SetProperty;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlStatementException;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PropertyOverriderTest {
+
+  public KsqlConfig ksqlConfig;
+  public ConfiguredStatement<SetProperty> configuredStatement;
+
+  @Mock
+  public SetProperty setProperty;
+  @Mock
+  public KsqlParser.PreparedStatement<SetProperty> preparedStatement;
+
+  @Before
+  public void setUp() {
+    ksqlConfig = new KsqlConfig(mkMap(mkEntry(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)));
+    configuredStatement = ConfiguredStatement.of(preparedStatement, SessionConfig.of(ksqlConfig, new HashMap<>()));
+    when(preparedStatement.getStatement()).thenReturn(setProperty);
+    when(setProperty.getPropertyName()).thenReturn("");
+    when((setProperty.getPropertyValue())).thenReturn("");
+  }
+
+  @Test
+  public void shouldNotSetNonQueryLevelParams()  {
+    when(setProperty.getPropertyName()).thenReturn(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
+    when((setProperty.getPropertyValue())).thenReturn("100");
+    Exception e = assertThrows(KsqlStatementException.class,
+        () -> PropertyOverrider.set(configuredStatement, new HashMap<>()));
+    assertThat(e.getMessage(), containsString("commit.interval.ms is not a settable property at the query"
+        + " level with ksql.runtime.feature.shared.enabled on."
+        + " Please use ALTER SYSTEM to set commit.interval.ms for the cluster.\n"
+    ));
+  }
+
+  @Test
+  public void shouldSetQueryLevelParams()  {
+    when(setProperty.getPropertyName()).thenReturn(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
+    when((setProperty.getPropertyValue())).thenReturn("100");
+    PropertyOverrider.set(configuredStatement, new HashMap<>());
+  }
+
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -107,7 +107,7 @@ import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertiesList extends KsqlEntity {
-  private static final List<String> QueryLevelPropertyList = ImmutableList.of(
+  public static final List<String> QueryLevelPropertyList = ImmutableList.of(
       KSQL_STRING_CASE_CONFIG_TOGGLE,
       KSQL_NESTED_ERROR_HANDLING_CONFIG,
       KSQL_QUERY_ERROR_MAX_QUEUE_SIZE,


### PR DESCRIPTION
### Description 
Limits the set cmd to only be able to set query level config when the shared runtimes are enabled. It directs all other config set attempts to use `ALTER SYSTEM` instead.

### Testing done 
unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

