### PR TITLE
chore: pipe user IP via KsqlPrincipal to connect headers extension

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/connect/ConnectRequestHeadersExtension.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/connect/ConnectRequestHeadersExtension.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.connect;
 
+import io.confluent.ksql.security.KsqlPrincipal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,7 @@ public interface ConnectRequestHeadersExtension {
    *
    * <p>Set this to {@code false} in order to use this
    * {@code ConnectRequestHeadersExtension} for additional custom headers
-   * (via {@link ConnectRequestHeadersExtension#getHeaders()}) only, without
+   * (via {@link ConnectRequestHeadersExtension#getHeaders(Optional)}) only, without
    * impacting ksqlDB's default behavior for the auth header.
    *
    * @return whether to use the custom auth header returned from
@@ -68,9 +69,12 @@ public interface ConnectRequestHeadersExtension {
    * such as those required for authenticating with Connect. The custom headers are added
    * to the request in addition to, and after, ksqlDB's default headers.
    *
+   * @param userPrincipal principal associated with the user who submitted the connector
+   *                      request to ksqlDB, if present (i.e., if user authentication
+   *                      is enabled)
    * @return additional headers to be included with connector requests made by ksqlDB
    */
-  default Map<String, String> getHeaders() {
+  default Map<String, String> getHeaders(Optional<KsqlPrincipal> userPrincipal) {
     return Collections.emptyMap();
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
@@ -28,9 +28,15 @@ import java.util.Objects;
 public class DefaultKsqlPrincipal implements KsqlPrincipal {
 
   private final Principal principal;
+  private String ipAddress;
 
   public DefaultKsqlPrincipal(final Principal principal) {
+    this(principal, "");
+  }
+
+  protected DefaultKsqlPrincipal(final Principal principal, final String ipAddress) {
     this.principal = Objects.requireNonNull(principal, "principal");
+    this.ipAddress = Objects.requireNonNull(ipAddress, "ipAddress");
   }
 
   @Override
@@ -53,5 +59,17 @@ public class DefaultKsqlPrincipal implements KsqlPrincipal {
    */
   public Principal getOriginalPrincipal() {
     return principal;
+  }
+
+  public String getIpAddress() {
+    return ipAddress;
+  }
+
+  /**
+   * IP address is populated from the request context, and subsequently passed
+   * throughout the engine.
+   */
+  public DefaultKsqlPrincipal withIpAddress(final String ipAddress) {
+    return new DefaultKsqlPrincipal(principal, ipAddress);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/DefaultKsqlPrincipal.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 public class DefaultKsqlPrincipal implements KsqlPrincipal {
 
   private final Principal principal;
-  private String ipAddress;
+  private final String ipAddress;
 
   public DefaultKsqlPrincipal(final Principal principal) {
     this(principal, "");
@@ -61,6 +61,7 @@ public class DefaultKsqlPrincipal implements KsqlPrincipal {
     return principal;
   }
 
+  @Override
   public String getIpAddress() {
     return ipAddress;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlPrincipal.java
@@ -34,6 +34,10 @@ public interface KsqlPrincipal extends Principal {
   /**
    * Returns the user's IP address, as set by the ksqlDB server's request context.
    *
+   * <p>This method never returns {@code null}. An empty string may be returned in
+   * certain situations (those where an IP address is not available, e.g., domain
+   * socket requests).
+   *
    * <p>Overriding the implementation of this method from custom {@code KsqlPrincipal}
    * implementations has no effect on the return value of this method, when called from
    * custom extensions, because incoming {@code KsqlPrincipal} instances are wrapped

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlPrincipal.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/KsqlPrincipal.java
@@ -31,4 +31,17 @@ public interface KsqlPrincipal extends Principal {
     return Collections.emptyMap();
   }
 
+  /**
+   * Returns the user's IP address, as set by the ksqlDB server's request context.
+   *
+   * <p>Overriding the implementation of this method from custom {@code KsqlPrincipal}
+   * implementations has no effect on the return value of this method, when called from
+   * custom extensions, because incoming {@code KsqlPrincipal} instances are wrapped
+   * inside ksqlDB's own {@link DefaultKsqlPrincipal} before being passed throughout
+   * the ksqlDB engine, and {@code DefaultKsqlPrincipal} has its own implementation
+   * for tracking and returning the IP address from this method.
+   */
+  default String getIpAddress() {
+    return "";
+  }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ConnectClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ConnectClientFactory.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.services;
 
+import io.confluent.ksql.security.KsqlPrincipal;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -23,7 +24,8 @@ public interface ConnectClientFactory {
 
   ConnectClient get(
       Optional<String> authHeader,
-      List<Entry<String, String>> incomingRequestHeaders
+      List<Entry<String, String>> incomingRequestHeaders,
+      Optional<KsqlPrincipal> userPrincipal
   );
 
   default void close() {}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClientFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClientFactory.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.services;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.connect.ConnectRequestHeadersExtension;
+import io.confluent.ksql.security.KsqlPrincipal;
 import io.confluent.ksql.util.FileWatcher;
 import io.confluent.ksql.util.KsqlConfig;
 import java.io.FileInputStream;
@@ -78,7 +79,8 @@ public class DefaultConnectClientFactory implements ConnectClientFactory {
   @Override
   public synchronized DefaultConnectClient get(
       final Optional<String> ksqlAuthHeader,
-      final List<Entry<String, String>> incomingRequestHeaders
+      final List<Entry<String, String>> incomingRequestHeaders,
+      final Optional<KsqlPrincipal> userPrincipal
   ) {
     if (defaultConnectAuthHeader == null) {
       defaultConnectAuthHeader = buildDefaultAuthHeader();
@@ -91,7 +93,7 @@ public class DefaultConnectClientFactory implements ConnectClientFactory {
         ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
         buildAuthHeader(ksqlAuthHeader, incomingRequestHeaders),
         requestHeadersExtension
-            .map(ConnectRequestHeadersExtension::getHeaders)
+            .map(extension -> extension.getHeaders(userPrincipal))
             .orElse(Collections.emptyMap()),
         Optional.ofNullable(newSslContext(configWithPrefixOverrides)),
         shouldVerifySslHostname(configWithPrefixOverrides)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -42,7 +42,8 @@ public final class ServiceContextFactory {
             Collections.emptyMap())::get,
         () -> new DefaultConnectClientFactory(ksqlConfig).get(
             Optional.empty(),
-            Collections.emptyList()),
+            Collections.emptyList(),
+            Optional.empty()),
         ksqlClientSupplier
     );
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
@@ -61,7 +61,8 @@ public final class KsqlContextTestUtil {
         adminClient,
         kafkaTopicClient,
         () -> schemaRegistryClient,
-        new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty(), Collections.emptyList())
+        new DefaultConnectClientFactory(ksqlConfig)
+            .get(Optional.empty(), Collections.emptyList(), Optional.empty())
     );
 
     final String metricsPrefix = "instance-" + COUNTER.getAndIncrement() + "-";

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -114,7 +114,8 @@ public final class TestServiceContext {
         adminClient,
         new KafkaTopicClientImpl(() -> adminClient),
         srClientFactory,
-        new DefaultConnectClientFactory(ksqlConfig).get(Optional.empty(), Collections.emptyList()),
+        new DefaultConnectClientFactory(ksqlConfig)
+            .get(Optional.empty(), Collections.emptyList(), Optional.empty()),
         new KafkaConsumerGroupClientImpl(() -> adminClient)
     );
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/ApiUser.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/ApiUser.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.api.auth;
 
-import io.confluent.ksql.security.KsqlPrincipal;
+import io.confluent.ksql.security.DefaultKsqlPrincipal;
 import io.vertx.ext.auth.User;
 
 public interface ApiUser extends User {
 
-  KsqlPrincipal getPrincipal();
+  DefaultKsqlPrincipal getPrincipal();
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/AuthenticationPluginHandler.java
@@ -26,7 +26,6 @@ import io.confluent.ksql.api.server.KsqlApiException;
 import io.confluent.ksql.api.server.Server;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.security.DefaultKsqlPrincipal;
-import io.confluent.ksql.security.KsqlPrincipal;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
@@ -101,7 +100,7 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
 
   private static class AuthPluginUser implements ApiUser {
 
-    private final KsqlPrincipal principal;
+    private final DefaultKsqlPrincipal principal;
 
     AuthPluginUser(final Principal principal) {
       Objects.requireNonNull(principal);
@@ -132,7 +131,7 @@ public class AuthenticationPluginHandler implements Handler<RoutingContext> {
     }
 
     @Override
-    public KsqlPrincipal getPrincipal() {
+    public DefaultKsqlPrincipal getPrincipal() {
       return principal;
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
@@ -37,7 +37,7 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
     final ApiUser apiUser = (ApiUser) user;
     final String authToken = routingContext.request().getHeader("Authorization");
     final List<Entry<String, String>> requestHeaders = routingContext.request().headers().entries();
-    final String ipAddress = routingContext.request().remoteAddress().host(); // TODO: do we also want port and/or path?
+    final String ipAddress = routingContext.request().remoteAddress().host();
     return new DefaultApiSecurityContext(
         apiUser != null ? apiUser.getPrincipal().withIpAddress(ipAddress) : null,
         authToken,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
@@ -37,8 +37,9 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
     final ApiUser apiUser = (ApiUser) user;
     final String authToken = routingContext.request().getHeader("Authorization");
     final List<Entry<String, String>> requestHeaders = routingContext.request().headers().entries();
+    final String ipAddress = routingContext.request().remoteAddress().host(); // TODO: do we also want port and/or path?
     return new DefaultApiSecurityContext(
-        apiUser != null ? apiUser.getPrincipal() : null,
+        apiUser != null ? apiUser.getPrincipal().withIpAddress(ipAddress) : null,
         authToken,
         requestHeaders);
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/DefaultApiSecurityContext.java
@@ -39,7 +39,9 @@ public final class DefaultApiSecurityContext implements ApiSecurityContext {
     final List<Entry<String, String>> requestHeaders = routingContext.request().headers().entries();
     final String ipAddress = routingContext.request().remoteAddress().host();
     return new DefaultApiSecurityContext(
-        apiUser != null ? apiUser.getPrincipal().withIpAddress(ipAddress) : null,
+        apiUser != null
+            ? apiUser.getPrincipal().withIpAddress(ipAddress == null ? "" : ipAddress)
+            : null,
         authToken,
         requestHeaders);
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasAuthProvider.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasAuthProvider.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.api.auth;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.api.server.Server;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.security.DefaultKsqlPrincipal;
 import io.confluent.ksql.security.KsqlPrincipal;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -131,7 +132,7 @@ public class JaasAuthProvider implements AuthProvider {
     final boolean authorized = validateRoles(lc, allowedRoles);
 
     // if the subject from the login context is already a KsqlPrincipal, use the subject
-    // directly rather than creating a new one
+    // (wrapped inside another DefaultKsqlPrincipal) rather than creating a new one
     final Optional<KsqlPrincipal> ksqlPrincipal = lc.getSubject().getPrincipals().stream()
         .filter(p -> p instanceof KsqlPrincipal)
         .map(p -> (KsqlPrincipal)p)
@@ -157,7 +158,7 @@ public class JaasAuthProvider implements AuthProvider {
   @SuppressWarnings("deprecation")
   static class JaasUser extends io.vertx.ext.auth.AbstractUser implements ApiUser {
 
-    private final KsqlPrincipal principal;
+    private final DefaultKsqlPrincipal principal;
     private final boolean authorized;
 
     JaasUser(
@@ -165,18 +166,21 @@ public class JaasAuthProvider implements AuthProvider {
         final String password,
         final boolean authorized
     ) {
-      this(
-          new JaasPrincipal(
-              Objects.requireNonNull(username, "username"),
-              Objects.requireNonNull(password, "password")),
-          authorized);
+      this.principal = new JaasPrincipal(
+          Objects.requireNonNull(username, "username"),
+          Objects.requireNonNull(password, "password")
+      );
+      this.authorized = authorized;
     }
 
     JaasUser(
         final KsqlPrincipal principal,
         final boolean authorized
     ) {
-      this.principal = Objects.requireNonNull(principal, "principal");
+      Objects.requireNonNull(principal, "principal");
+      this.principal = principal instanceof DefaultKsqlPrincipal
+          ? (DefaultKsqlPrincipal) principal
+          : new DefaultKsqlPrincipal(principal);
       this.authorized = authorized;
     }
 
@@ -198,7 +202,7 @@ public class JaasAuthProvider implements AuthProvider {
     }
 
     @Override
-    public KsqlPrincipal getPrincipal() {
+    public DefaultKsqlPrincipal getPrincipal() {
       return principal;
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/JaasPrincipal.java
@@ -15,8 +15,9 @@
 
 package io.confluent.ksql.api.auth;
 
-import io.confluent.ksql.security.KsqlPrincipal;
+import io.confluent.ksql.security.DefaultKsqlPrincipal;
 import java.nio.charset.StandardCharsets;
+import java.security.Principal;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
@@ -29,12 +30,14 @@ import java.util.Objects;
  *  extensions.
  * </p>
  */
-public class JaasPrincipal implements KsqlPrincipal {
+public class JaasPrincipal extends DefaultKsqlPrincipal {
 
   private final String name;
   private final String token;
 
   public JaasPrincipal(final String name, final String password) {
+    super(new BasicJaasPrincipal(name));
+
     this.name = Objects.requireNonNull(name, "name");
     this.token = createToken(name, Objects.requireNonNull(password));
   }
@@ -56,6 +59,20 @@ public class JaasPrincipal implements KsqlPrincipal {
 
   public String getToken() {
     return token;
+  }
+
+  static class BasicJaasPrincipal implements Principal {
+
+    private final String name;
+
+    BasicJaasPrincipal(final String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
   }
 }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/SystemAuthenticationHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/auth/SystemAuthenticationHandler.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.api.auth;
 
 import io.confluent.ksql.security.DefaultKsqlPrincipal;
-import io.confluent.ksql.security.KsqlPrincipal;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpConnection;
@@ -61,7 +60,7 @@ public class SystemAuthenticationHandler implements Handler<RoutingContext> {
 
   private static class SystemUser implements ApiUser {
 
-    private final KsqlPrincipal principal;
+    private final DefaultKsqlPrincipal principal;
 
     SystemUser(final Principal principal) {
       Objects.requireNonNull(principal);
@@ -94,7 +93,7 @@ public class SystemAuthenticationHandler implements Handler<RoutingContext> {
     }
 
     @Override
-    public KsqlPrincipal getPrincipal() {
+    public DefaultKsqlPrincipal getPrincipal() {
       return principal;
     }
   }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProvider.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/impl/DefaultKsqlSecurityContextProvider.java
@@ -86,7 +86,8 @@ public class DefaultKsqlSecurityContextProvider implements KsqlSecurityContextPr
               schemaRegistryClientFactory,
               connectClientFactory,
               sharedClient,
-              requestHeaders)
+              requestHeaders,
+              principal)
       );
     }
 
@@ -100,7 +101,8 @@ public class DefaultKsqlSecurityContextProvider implements KsqlSecurityContextPr
                 provider.getSchemaRegistryClientFactory(principal.get()),
                 connectClientFactory,
                 sharedClient,
-                requestHeaders)))
+                requestHeaders,
+                principal)))
         .get();
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -642,7 +642,7 @@ public final class KsqlRestApplication implements Executable {
     final ServiceContext tempServiceContext = new LazyServiceContext(() ->
         RestServiceContextFactory.create(ksqlConfig, Optional.empty(),
             schemaRegistryClientFactory, connectClientFactory, sharedClient,
-            Collections.emptyList()));
+            Collections.emptyList(), Optional.empty()));
     final String kafkaClusterId = KafkaClusterUtil.getKafkaClusterId(tempServiceContext);
     final String ksqlServerId = ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     updatedRestProps.putAll(
@@ -656,7 +656,8 @@ public final class KsqlRestApplication implements Executable {
             schemaRegistryClientFactory,
             connectClientFactory,
             sharedClient,
-            Collections.emptyList()));
+            Collections.emptyList(),
+            Optional.empty()));
 
     return buildApplication(
         "",

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.rest.client.KsqlClient;
+import io.confluent.ksql.security.KsqlPrincipal;
 import io.confluent.ksql.services.ConnectClientFactory;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
@@ -41,7 +42,8 @@ public final class RestServiceContextFactory {
         Supplier<SchemaRegistryClient> srClientFactory,
         ConnectClientFactory connectClientFactory,
         KsqlClient sharedClient,
-        List<Entry<String, String>> requestHeaders
+        List<Entry<String, String>> requestHeaders,
+        Optional<KsqlPrincipal> userPrincipal
     );
   }
 
@@ -54,7 +56,8 @@ public final class RestServiceContextFactory {
         Supplier<SchemaRegistryClient> srClientFactory,
         ConnectClientFactory connectClientFactory,
         KsqlClient sharedClient,
-        List<Entry<String, String>> requestHeaders
+        List<Entry<String, String>> requestHeaders,
+        Optional<KsqlPrincipal> userPrincipal
     );
   }
 
@@ -64,7 +67,8 @@ public final class RestServiceContextFactory {
       final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
       final ConnectClientFactory connectClientFactory,
       final KsqlClient sharedClient,
-      final List<Entry<String, String>> requestHeaders
+      final List<Entry<String, String>> requestHeaders,
+      final Optional<KsqlPrincipal> userPrincipal
   ) {
     return create(
         ksqlConfig,
@@ -73,7 +77,8 @@ public final class RestServiceContextFactory {
         schemaRegistryClientFactory,
         connectClientFactory,
         sharedClient,
-        requestHeaders
+        requestHeaders,
+        userPrincipal
     );
   }
 
@@ -84,13 +89,14 @@ public final class RestServiceContextFactory {
       final Supplier<SchemaRegistryClient> srClientFactory,
       final ConnectClientFactory connectClientFactory,
       final KsqlClient sharedClient,
-      final List<Entry<String, String>> requestHeaders
+      final List<Entry<String, String>> requestHeaders,
+      final Optional<KsqlPrincipal> userPrincipal
   ) {
     return ServiceContextFactory.create(
         ksqlConfig,
         kafkaClientSupplier,
         srClientFactory,
-        () -> connectClientFactory.get(authHeader, requestHeaders),
+        () -> connectClientFactory.get(authHeader, requestHeaders, userPrincipal),
         () -> new DefaultKsqlClient(authHeader, sharedClient)
     );
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -337,7 +337,7 @@ public class TestKsqlRestApp extends ExternalResource {
           3,
           serviceContext.get(),
           () -> serviceContext.get().getSchemaRegistryClient(),
-          (authHeader, userPrincipal) -> serviceContext.get().getConnectClient(),
+          (authHeader, requestHeaders, userPrincipal) -> serviceContext.get().getConnectClient(),
           vertx,
           InternalKsqlClientFactory.createInternalClient(
               PropertiesUtil.toMapStrings(ksqlRestConfig.originals()),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestRestServiceContextFactory.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/services/TestRestServiceContextFactory.java
@@ -22,8 +22,8 @@ public class TestRestServiceContextFactory {
   public static DefaultServiceContextFactory createDefault(
       final InternalSimpleKsqlClientFactory ksqlClientFactory
   ) {
-    return (ksqlConfig, authHeader, srClientFactory,
-            connectClientFactory, sharedClient, userPrincipal) -> {
+    return (ksqlConfig, authHeader, srClientFactory, connectClientFactory,
+            sharedClient, requestHeaders, userPrincipal) -> {
       return createUser(ksqlClientFactory).create(
           ksqlConfig,
           authHeader,
@@ -31,6 +31,7 @@ public class TestRestServiceContextFactory {
           srClientFactory,
           connectClientFactory,
           sharedClient,
+          requestHeaders,
           userPrincipal
       );
     };
@@ -39,8 +40,8 @@ public class TestRestServiceContextFactory {
   public static UserServiceContextFactory createUser(
     final InternalSimpleKsqlClientFactory ksqlClientFactory
   ) {
-    return (ksqlConfig, authHeader, kafkaClientSupplier,
-            srClientFactory, connectClientFactory, sharedClient, userPrincipal) -> {
+    return (ksqlConfig, authHeader, kafkaClientSupplier, srClientFactory,
+            connectClientFactory, sharedClient, requestHeaders, userPrincipal) -> {
       return ServiceContextFactory.create(
           ksqlConfig,
           kafkaClientSupplier,


### PR DESCRIPTION
### Description 

One main change in this PR:
* KsqlPrincipal now carries the incoming request IP address (as obtained from the routing context). This IP address is set before the KsqlPrincipal is piped throughout the ksqlDB engine. As part of doing this, the ApiUser interface was updated to return a DefaultKsqlPrincipal, rather than a KsqlPrincipal.

And two minor ones:
* KsqlPrincipal is made available to the ConnectRequestHeadersExtension interface, which requires piping the principal throughout various parts of the request flow.
* the subject obtained from the HTTP basic auth handler (JaasAuthProvider) is always wrapped inside a DefaultKsqlPrincipal, regardless of whether the incoming subject already implements KsqlPrincipal or not, in order to be consistent with the AuthenticationPluginHandler.

### Testing done 

Unit + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

