### PR TITLE
fix: remove references to deprecated config in QTT tests

### DIFF
--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -568,7 +568,7 @@ SET 'cache.max.bytes.buffering'='20000000';
 For more information, see the
 [Streams parameter reference](https://docs.confluent.io/platform/current/streams/developer-guide/config-streams.html#optional-configuration-parameters)
 and
-[CACHE_MAX_BYTES_BUFFERING_CONFIG](https://docs.confluent.io/{{ site.ksqldbversion }}/streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#CACHE_MAX_BYTES_BUFFERING_CONFIG).
+[STATESTORE_CACHE_MAX_BYTES_CONFIG](https://docs.confluent.io/{{ site.ksqldbversion }}/streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#STATESTORE_CACHE_MAX_BYTES_CONFIG).
 
 ## `ksql.streams.num.standby.replicas`
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1484,7 +1484,7 @@ public class KsqlConfig extends AbstractConfig {
     streamsConfigDefaults.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, KsqlConstants
         .defaultCommitIntervalMsConfig);
     streamsConfigDefaults.put(
-        StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, KsqlConstants
+        StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, KsqlConstants
             .defaultCacheMaxBytesBufferingConfig);
     streamsConfigDefaults.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, KsqlConstants
         .defaultNumberOfStreamsThreads);

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -239,22 +239,22 @@ public class KsqlConfigTest {
   @Test
   public void shouldSetStreamsConfigProperties() {
     final KsqlConfig ksqlConfig = new KsqlConfig(
-        Collections.singletonMap(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, "128"));
+        Collections.singletonMap(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, "128"));
     final Object result = ksqlConfig.getKsqlStreamConfigProps().get(
-        StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG);
+        StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG);
     assertThat(result, equalTo(128L));
   }
 
   @Test
   public void shouldSetPrefixedStreamsConfigProperties() {
     final KsqlConfig ksqlConfig = new KsqlConfig(Collections.singletonMap(
-        KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, "128"));
+        KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, "128"));
 
     assertThat(ksqlConfig.getKsqlStreamConfigProps().
-        get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG), equalTo(128L));
+        get(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG), equalTo(128L));
 
     assertThat(ksqlConfig.getKsqlStreamConfigProps().
-            get(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG),
+            get(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG),
         is(nullValue()));
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -71,7 +71,7 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
     final long configured = getCacheMaxBytesBuffering(config);
     final long usedByRunning = running.stream()
         .mapToLong(r -> new StreamsConfig(r.getStreamsProperties())
-                .getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG))
+                .getLong(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG))
         .sum();
     if (configured + usedByRunning > limit) {
       throw new KsqlException(String.format(
@@ -83,7 +83,7 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
   }
 
   private long getCacheMaxBytesBuffering(final SessionConfig config) {
-    return getDummyStreamsConfig(config).getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG);
+    return getDummyStreamsConfig(config).getLong(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG);
   }
 
   private StreamsConfig getDummyStreamsConfig(final SessionConfig config) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
@@ -126,7 +126,7 @@ public class KafkaStreamsQueryValidatorTest {
     final SessionConfig config = SessionConfig.of(
         new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 30)),
         ImmutableMap.of(
-            StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 50,
+            StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 50,
             KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 500
         )
     );
@@ -165,14 +165,14 @@ public class KafkaStreamsQueryValidatorTest {
         : BASE_STREAMS_PROPERTIES;
     return SessionConfig.of(
         new KsqlConfig(ksqlProperties),
-        ImmutableMap.of(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, queryLimit)
+        ImmutableMap.of(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, queryLimit)
     );
   }
 
   private ImmutableMap<String, Object> streamPropsWithCacheLimit(long limit) {
     return ImmutableMap.<String, Object>builder()
         .putAll(BASE_STREAMS_PROPERTIES)
-        .put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, limit)
+        .put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, limit)
         .build();
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -100,7 +100,7 @@ public class TestExecutor implements Closeable {
       .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:0")
       .put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 0)
       .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-      .put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0)
+      .put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0)
       .put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "some.ksql.service.id")
       .put(KsqlConfig.KSQL_HEADERS_COLUMNS_ENABLED, true)
       .put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "schema_registry.url:0")

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/driver/KsqlTesterTest.java
@@ -108,7 +108,7 @@ public class KsqlTesterTest {
       .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:0")
       .put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, 0)
       .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-      .put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0)
+      .put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0)
       .put(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG, 0L)
       .put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "some.ksql.service.id")
       .put(KsqlConfig.KSQL_HEADERS_COLUMNS_ENABLED, true)

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -88,6 +88,7 @@ import static org.apache.kafka.streams.StreamsConfig.PROCESSING_GUARANTEE_CONFIG
 import static org.apache.kafka.streams.StreamsConfig.REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.SECURITY_PROTOCOL_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.STATE_CLEANUP_DELAY_MS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.TASK_TIMEOUT_MS_CONFIG;
@@ -168,7 +169,7 @@ public class PropertiesList extends KsqlEntity {
       ACCEPTABLE_RECOVERY_LAG_CONFIG,
       APPLICATION_SERVER_CONFIG,
       BUILT_IN_METRICS_VERSION_CONFIG,
-      CACHE_MAX_BYTES_BUFFERING_CONFIG,
+      STATESTORE_CACHE_MAX_BYTES_CONFIG,
       COMMIT_INTERVAL_MS_CONFIG,
       DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
       DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG,
@@ -179,6 +180,7 @@ public class PropertiesList extends KsqlEntity {
       MAX_WARMUP_REPLICAS_CONFIG,
       NUM_STANDBY_REPLICAS_CONFIG,
       POLL_MS_CONFIG,
+      CACHE_MAX_BYTES_BUFFERING_CONFIG,
       PROBING_REBALANCE_INTERVAL_MS_CONFIG,
       PROCESSING_GUARANTEE_CONFIG,
       REPLICATION_FACTOR_CONFIG,
@@ -186,6 +188,7 @@ public class PropertiesList extends KsqlEntity {
       SECURITY_PROTOCOL_CONFIG,
       STATE_CLEANUP_DELAY_MS_CONFIG,
       STATE_DIR_CONFIG,
+      STATESTORE_CACHE_MAX_BYTES_CONFIG,
       TASK_TIMEOUT_MS_CONFIG,
       WINDOW_SIZE_MS_CONFIG,
       UPGRADE_FROM_CONFIG


### PR DESCRIPTION
### Description 
https://github.com/apache/kafka/commit/14c6030c6ad70997863070f5b93c817ea8829425
has deprecated "buffered.records.per.partition" config
in favour of "input.buffer.max.bytes". Our fk-join QTT test
was failing when the suite was configured with the old
config key, so I've find+replaced the old config key and
used the new one throughout

### Testing done 
Ran the failing QTT fk-join.json locally

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

