### PR TITLE
docs: restore BYTES and ARRAY_CONCAT content (DOCS-11937)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/type-coercion.md
+++ b/docs/developer-guide/ksqldb-reference/type-coercion.md
@@ -70,6 +70,7 @@ behavior depends on the type of the first non-null element.
    type is a numeric type that's wide enough to hold all numbers found in the
    list.
  * `BOOLEAN`: all other expressions must be coercible to `BOOLEAN`.
+ * `BYTES`: all other expressions must be coercible to `BYTES`.
  * `TIMESTAMP`: all other expressions must be coercible to `TIMESTAMP`.
  * `TIME`: all other expressions must be coercible to `TIME`.
  * `DATE`: all other expressions must be coercible to `DATE`.

--- a/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
@@ -123,7 +123,7 @@ Response JSON Object:
 - **sourceDescription.fields[i].schema** (object): A schema object that describes
   the schema of the field.
 - **sourceDescription.fields[i].schema.type** (string): The type the schema
-  represents. One of INTEGER, BIGINT, BOOLEAN, DOUBLE, STRING, TIMESTAMP, TIME, DATE, MAP, ARRAY, or
+  represents. One of INTEGER, BIGINT, BOOLEAN, BYTES, DOUBLE, STRING, TIMESTAMP, TIME, DATE, MAP, ARRAY, or
   STRUCT.
 - **sourceDescription.fields[i].schema.memberSchema** (object): A schema object.
   For MAP and ARRAY types, contains the schema of the map values and array
@@ -157,7 +157,7 @@ Response JSON Object:
 - **queryDescription.fields** (array): A list of field objects that describes each field in the query output.
 - **queryDescription.fields[i].name** (string): The name of the field.
 - **queryDescription.fields[i].schema** (object): A schema object that describes the schema of the field.
-- **queryDescription.fields[i].schema.type** (string): The type the schema represents. One of INTEGER, BIGINT, BOOLEAN, DOUBLE, STRING, TIMESTAMP, TIME, DATE, MAP, ARRAY, or STRUCT.
+- **queryDescription.fields[i].schema.type** (string): The type the schema represents. One of INTEGER, BIGINT, BOOLEAN, BYTES, DOUBLE, STRING, TIMESTAMP, TIME, DATE, MAP, ARRAY, or STRUCT.
 - **queryDescription.fields[i].schema.memberSchema** (object): A schema object. For MAP and ARRAY types, contains the schema of the map values and array elements, respectively. For other types this field is not used and its value is undefined.
 - **queryDescription.fields[i].schema.fields** (array): For STRUCT types, contains a list of field objects that descrbies each field within the struct. For other types this field is not used and its value is undefined.
 - **queryDescription.sources** (array): The streams and tables being read by the query.

--- a/docs/how-to-guides/update-a-running-persistent-query.md
+++ b/docs/how-to-guides/update-a-running-persistent-query.md
@@ -46,7 +46,7 @@ ksqlDB provides two mechanisms to change a query that is already running:
 
 Obviously, it would be preferable to always perform an in-place upgrade
 when you change a query. But because of how streaming programs are constructed,
-this isn't not always possible to do that.
+it's not always possible to do this.
 
 To better understand the different types of upgrades that are allowed on persistent
 queries, here's a taxonomy using the combination of three

--- a/docs/reference/serialization.md
+++ b/docs/reference/serialization.md
@@ -146,9 +146,10 @@ This data format supports all SQL
 [data types](/reference/sql/data-types) except `ARRAY`, `MAP` and
 `STRUCT`. 
 
-`TIMESTAMP` typed data is serialized as a `long` value indicating the Unix epoch time in milliseconds.
-`TIME` typed data is serialized as an `int` value indicating the number of milliseconds since the beginning of the day.
-`DATA` typed data is serialized as an `int` value indicating the number of days since the Unix epoch.
+- `TIMESTAMP` typed data is serialized as a `long` value indicating the Unix epoch time in milliseconds.
+- `TIME` typed data is serialized as an `int` value indicating the number of milliseconds since the beginning of the day.
+- `DATE` typed data is serialized as an `int` value indicating the number of days since the Unix epoch.
+- `BYTES` typed data is serialized as a Base64-encoded string value.
 
 ### JSON
 
@@ -296,6 +297,19 @@ a timestamp at `1970-01-03` is serialized as
 ```
 
 ksqlDb deserializes a number as a `DATE` if it corresponds to a `DATE` typed field in
+the stream.
+
+#### Bytes Serialization
+Bytes are serialized as a Base64-encoded string value. For example, the byte
+array `[61, 62, 63]` is serialized as:
+
+```json
+{
+  "value": "YWJj"
+}
+```
+
+ksqlDb deserializes a string as `BYTES` if it corresponds to a `BYTES` typed field in
 the stream.
 
 #### Field Name Case Sensitivity

--- a/docs/reference/sql/appendix.md
+++ b/docs/reference/sql/appendix.md
@@ -23,6 +23,7 @@ The following table shows all keywords in the language.
 | `BEGINNING`    | print from start of topic               | `PRINT <topic-name> FROM BEGINNING;`                                 |
 | `BETWEEN`      | constrain a value to a range            | `SELECT event FROM events WHERE event_id BETWEEN 10 AND 20 …`        |
 | `BY`           | specify expression                      | `GROUP BY regionid`, `ADVANCE BY 10 SECONDS`, `PARTITION BY userid`  |
+| `BYTES`        | bytes data type                         |                                                                      |
 | `CASE`         | select a condition from expressions     | `SELECT CASE WHEN condition THEN result [ WHEN … THEN … ] … END`     |
 | `CAST`         | change expression type                  | `SELECT id, CONCAT(CAST(COUNT(*) AS VARCHAR), '_HELLO') FROM views …`|
 | `CHANGES`      | specify incremental refinement type     | `SELECT * FROM users EMIT CHANGES;`                                  |

--- a/docs/reference/sql/data-types.md
+++ b/docs/reference/sql/data-types.md
@@ -17,10 +17,13 @@ keywords: ksqldb, sql, syntax, data type
 | name                | description            | backing Java type
 |---------------------|------------------------|------------------
 | `varchar`, `string` | variable-length string | [`java.lang.String`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html)
+| `bytes`             | variable-length byte array | [byte []](https://docs.oracle.com/javase/8/docs/api/java/lang/Byte.html)
 
 The `varchar` type represents a string in UTF-16 format.
 
 Comparisons between `varchar` instances don't account for locale.
+
+The `bytes` type represents an array of raw bytes.
 
 ## Numeric types
 

--- a/docs/reference/user-defined-functions.md
+++ b/docs/reference/user-defined-functions.md
@@ -34,6 +34,7 @@ values.
 | `ARRAY`   | `java.util.List`                      |
 | `MAP`     | `java.util.Map`                       |
 | `STRUCT`  | `org.apache.kafka.connect.data.Struct`|
+| `BYTES`   | `java.nio.ByteBuffer`                 |
 
 !!! note
     Using `Struct` or `BigDecimal` in your functions requires specifying the


### PR DESCRIPTION
### Description 
Restore BYTES and ARRAY_CONCAT content that was reverted in https://github.com/confluentinc/ksql/pull/8016 for v0.20.0.