### PR TITLE
fix: give common-docker a version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.2.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
+        <io.confluent.common-docker.version>${confluent.version.range}</io.confluent.common-docker.version>
         <mockito.version>3.8.0</mockito.version>
         <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against 4.1.49.Final -->


### PR DESCRIPTION
This might be the last bit required to
"make release stabilisation depend on common-docker"
As I understand it, this means it will inherit whatever
the current nanoversion range is resolved to and then
proceed to pick the latest nanoversion in the "current"
version run

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

