### PR TITLE
fix: recreating old queries in the old runtime will still use the old runtimes

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -292,7 +292,7 @@ public class QueryRegistryImpl implements QueryRegistry {
       );
     } else {
       query = queryBuilder.buildPersistentQueryInDedicatedRuntime(
-          oldQuery != null
+          oldQuery != null && sharedRuntimeId.isPresent()
               ? ksqlConfig.cloneWithPropertyOverwrite(oldQuery.getOverriddenProperties())
               : ksqlConfig,
           persistentQueryType,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -268,7 +268,9 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     final PersistentQueryMetadata query;
 
-    if (sharedRuntimeId.isPresent()) {
+    final PersistentQueryMetadata oldQuery = persistentQueries.get(queryId);
+
+    if (sharedRuntimeId.isPresent() && (oldQuery == null || oldQuery instanceof BinPackedPersistentQueryMetadataImpl)) {
       if (sandbox) {
         streams.addAll(sourceStreams.stream()
             .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -270,7 +270,8 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     final PersistentQueryMetadata oldQuery = persistentQueries.get(queryId);
 
-    if (sharedRuntimeId.isPresent() && (oldQuery == null || oldQuery instanceof BinPackedPersistentQueryMetadataImpl)) {
+    if (sharedRuntimeId.isPresent() && (oldQuery == null
+        || oldQuery instanceof BinPackedPersistentQueryMetadataImpl)) {
       if (sandbox) {
         streams.addAll(sourceStreams.stream()
             .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)
@@ -292,9 +293,7 @@ public class QueryRegistryImpl implements QueryRegistry {
       );
     } else {
       query = queryBuilder.buildPersistentQueryInDedicatedRuntime(
-          oldQuery != null && sharedRuntimeId.isPresent()
-              ? ksqlConfig.cloneWithPropertyOverwrite(oldQuery.getOverriddenProperties())
-              : ksqlConfig,
+          ksqlConfig,
           persistentQueryType,
           statementText,
           queryId,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -292,7 +292,9 @@ public class QueryRegistryImpl implements QueryRegistry {
       );
     } else {
       query = queryBuilder.buildPersistentQueryInDedicatedRuntime(
-          ksqlConfig,
+          oldQuery != null
+              ? ksqlConfig.cloneWithPropertyOverwrite(oldQuery.getOverriddenProperties())
+              : ksqlConfig,
           persistentQueryType,
           statementText,
           queryId,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -141,24 +141,24 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   }
 
   // for creating sandbox instances
-  protected BinPackedPersistentQueryMetadataImpl(
+  public BinPackedPersistentQueryMetadataImpl(
           final BinPackedPersistentQueryMetadataImpl original,
           final QueryMetadata.Listener listener
   ) {
-    this.persistentQueryType = original.persistentQueryType;
+    this.persistentQueryType = original.getPersistentQueryType();
     this.statementString = original.statementString;
     this.executionPlan = original.executionPlan;
     this.applicationId = original.applicationId;
     this.topology = original.topology;
     this.sharedKafkaStreamsRuntime = original.sharedKafkaStreamsRuntime;
-    this.sinkDataSource = original.sinkDataSource;
+    this.sinkDataSource = original.getSink();
     this.schemas = original.schemas;
     this.overriddenProperties =
-            ImmutableMap.copyOf(original.overriddenProperties);
-    this.sourceNames = original.sourceNames;
-    this.queryId = original.queryId;
+            ImmutableMap.copyOf(original.getOverriddenProperties());
+    this.sourceNames = original.getSourceNames();
+    this.queryId = original.getQueryId();
     this.processingLogger = original.processingLogger;
-    this.physicalPlan = original.physicalPlan;
+    this.physicalPlan = original.getPhysicalPlan();
     this.resultSchema = original.resultSchema;
     this.materializationProviderBuilder = original.materializationProviderBuilder;
     this.listener = requireNonNull(listener, "listener");
@@ -227,7 +227,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   }
 
   public void stop(final boolean resetOffsets) {
-    sharedKafkaStreamsRuntime.stop(queryId, false);
+    sharedKafkaStreamsRuntime.stop(queryId, resetOffsets);
     scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -133,7 +133,7 @@ public class PersistentQueryMetadataImpl
     this.schemas = original.schemas;
     this.resultSchema = original.resultSchema;
     this.materializationProvider = original.materializationProvider;
-    this.physicalPlan = original.physicalPlan;
+    this.physicalPlan = original.getPhysicalPlan();
     this.materializationProviderBuilder = original.materializationProviderBuilder;
     this.processingLogger = original.processingLogger;
     this.scalablePushRegistry = original.scalablePushRegistry;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -373,7 +373,7 @@ public class QueryMetadataImpl implements QueryMetadata {
     private final Duration duration;
     private final Queue<QueryError> queue;
 
-    public TimeBoundedQueue(final Duration duration, final int capacity) {
+    TimeBoundedQueue(final Duration duration, final int capacity) {
       queue = EvictingQueue.create(capacity);
       this.duration = duration;
     }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/QueryMetadataImpl.java
@@ -373,7 +373,7 @@ public class QueryMetadataImpl implements QueryMetadata {
     private final Duration duration;
     private final Queue<QueryError> queue;
 
-    TimeBoundedQueue(final Duration duration, final int capacity) {
+    public TimeBoundedQueue(final Duration duration, final int capacity) {
       queue = EvictingQueue.create(capacity);
       this.duration = duration;
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -10,14 +10,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.RETURNS_SMART_NULLS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -30,7 +26,6 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.physical.PhysicalPlan;
 import io.confluent.ksql.query.QueryError.Type;
 import io.confluent.ksql.query.QueryRegistryImpl.QueryBuilderFactory;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -42,13 +37,10 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.QueryMetadataImpl;
-import io.confluent.ksql.util.SandboxedBinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.SharedKafkaStreamsRuntime;
 import io.confluent.ksql.util.SharedKafkaStreamsRuntimeImpl;
 import io.confluent.ksql.util.TransientQueryMetadata;
-
 import java.lang.reflect.Field;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -67,12 +59,10 @@ import org.junit.runners.Parameterized;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
-import scala.collection.immutable.IntMap;
 
 @RunWith(Parameterized.class)
 public class QueryRegistryImplTest {
@@ -575,7 +565,8 @@ public class QueryRegistryImplTest {
       e.printStackTrace();
     }
 
-    when(runtime.getNewQueryErrorQueue()).thenReturn(new QueryMetadataImpl.TimeBoundedQueue(Duration.ZERO,1));
+
+    when(runtime.getNewQueryErrorQueue()).thenReturn(mock(QueryMetadataImpl.TimeBoundedQueue.class));
 
     when(query.getQueryId()).thenReturn(queryId);
     when(query.getSink()).thenReturn(Optional.of(sinkSource));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -501,14 +501,21 @@ public class QueryRegistryImplTest {
 
   @Test
   public void shouldReplaceQueryfromOldRuntimeUsingOldRuntime() {
+    //Given:
     sharedRuntimes = false;
     QueryMetadata query = givenCreate(registry, "q1", "source",
         Optional.of("sink1"), CREATE_AS);
     assertThat("does not use old runtime", query instanceof PersistentQueryMetadataImpl);
+    //When:
     sharedRuntimes = true;
     query = givenCreate(registry, "q1", "source",
         Optional.of("sink1"), CREATE_AS);
+    //Expect:
     assertThat("does not use old runtime", query instanceof PersistentQueryMetadataImpl);
+    query = givenCreate(registry, "q2", "source",
+        Optional.of("sink1"), CREATE_AS);
+    assertThat("does not use old runtime", query instanceof BinPackedPersistentQueryMetadataImpl);
+
   }
 
   private QueryMetadata.Listener givenCreateGetListener(


### PR DESCRIPTION
When a query using the old runtimes is recreated with the shared runtimes flag on then it should still use the shared runtimes.  This PR makes it so that the query will stay in the appropriate runtime


### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

