### PR TITLE
chore: Port over buffering for pull queries to /query-stream

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriter.java
@@ -80,8 +80,8 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
     this.clock = clock;
     this.bufferOutput = bufferOutput;
     this.context = context;
-    Preconditions.checkState(bufferOutput || limitMessage.isPresent() ||
-            completionMessage.isPresent(),
+    Preconditions.checkState(bufferOutput || limitMessage.isPresent()
+            || completionMessage.isPresent(),
         "If buffering isn't used, a limit/completion message must be set");
   }
 
@@ -238,8 +238,8 @@ public class JsonStreamedRowResponseWriter implements QueryStreamResponseWriter 
     if (timerId >= 0) {
       return;
     }
-    long sinceLastFlushMs = clock.millis() - writerState.getLastFlushMs();
-    long waitTimeMs = Math.min(Math.max(0, MAX_FLUSH_MS - sinceLastFlushMs), MAX_FLUSH_MS);
+    final long sinceLastFlushMs = clock.millis() - writerState.getLastFlushMs();
+    final long waitTimeMs = Math.min(Math.max(0, MAX_FLUSH_MS - sinceLastFlushMs), MAX_FLUSH_MS);
     this.timerId = context.owner().setTimer(waitTimeMs, timerId -> {
       this.timerId = -1;
       maybeFlushBuffer();

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/JsonStreamedRowResponseWriterTest.java
@@ -15,9 +15,14 @@
 
 package io.confluent.ksql.api.server;
 
+import static io.confluent.ksql.api.server.JsonStreamedRowResponseWriter.MAX_FLUSH_MS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -29,11 +34,16 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KeyValue;
 import io.confluent.ksql.util.KeyValueMetadata;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,13 +66,27 @@ public class JsonStreamedRowResponseWriterTest {
       .valueColumn(ColumnName.of("C"), SqlTypes.array(SqlTypes.STRING))
       .build();
 
+  private static final long TIME_NOW_MS = 1000;
+
   @Mock
   private HttpServerResponse response;
   @Mock
   private QueryPublisher publisher;
+  @Mock
+  private Clock clock;
+  @Mock
+  private Context context;
+  @Mock
+  private Vertx vertx;
+
+  private AtomicLong timeMs = new AtomicLong(TIME_NOW_MS);
+  private Runnable simulatedVertxTimerCallback;
 
   private JsonStreamedRowResponseWriter writer;
   private StringBuilder stringBuilder = new StringBuilder();
+
+  public JsonStreamedRowResponseWriterTest() {
+  }
 
   @Before
   public void setUp() {
@@ -76,18 +100,51 @@ public class JsonStreamedRowResponseWriterTest {
       stringBuilder.append(str);
       return response;
     });
+    when(context.owner()).thenReturn(vertx);
+    when(clock.millis()).thenAnswer(a -> timeMs.get());
+
 
     writer = new JsonStreamedRowResponseWriter(response, publisher, Optional.empty(),
-        Optional.empty());
+        Optional.empty(), clock, true, context);
   }
 
-  private void setupWithMessages(String completionMessage, String limitMessage) {
+  private void setupWithMessages(String completionMessage, String limitMessage, boolean buffering) {
+    // No buffering for these responses
     writer = new JsonStreamedRowResponseWriter(response, publisher, Optional.of(completionMessage),
-        Optional.of(limitMessage));
+        Optional.of(limitMessage), clock, buffering, context);
+  }
+
+  private void expectTimer() {
+    AtomicLong delay = new AtomicLong(TIME_NOW_MS);
+    when(vertx.setTimer(anyLong(), any())).thenAnswer(a -> {
+      Handler<Long> handler = a.getArgument(1);
+      simulatedVertxTimerCallback = () -> {
+        delay.addAndGet(MAX_FLUSH_MS);
+        timeMs.set(delay.get());
+        handler.handle(1L);
+        simulatedVertxTimerCallback = null;
+      };
+      return 1L;
+    });
   }
 
   @Test
-  public void shouldSucceedWithNoEndMessages() {
+  public void shouldSucceedWithBuffering_noRows() {
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+    writer.writeCompletionMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString(),
+        is("[{\"header\":{\"queryId\":\"queryId\","
+            + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}}]"));
+    verify(response, times(1)).write((String) any());
+    verify(response, never()).write((Buffer) any());
+    verify(vertx,  never()).setTimer(anyLong(), any());
+  }
+
+  @Test
+  public void shouldSucceedWithBuffering_oneRow() {
     // When:
     writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
     writer.writeRow(new KeyValueMetadata<>(
@@ -99,17 +156,25 @@ public class JsonStreamedRowResponseWriterTest {
         is("[{\"header\":{\"queryId\":\"queryId\"," 
             + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
             + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}}]"));
+    verify(response, times(1)).write((String) any());
+    verify(response, never()).write((Buffer) any());
+    verify(vertx, times(1)).setTimer(anyLong(), any());
+    verify(vertx, times(1)).cancelTimer(anyLong());
   }
 
   @Test
-  public void shouldSucceedWithCompletionMessage() {
+  public void shouldSucceedWithBuffering_twoRows_timeout() {
     // Given:
-    setupWithMessages("complete!", "limit hit!");
+    expectTimer();
 
     // When:
     writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
     writer.writeRow(new KeyValueMetadata<>(
         KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+    simulatedVertxTimerCallback.run();
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(456, 789.0d, ImmutableList.of("bye")))));
+    simulatedVertxTimerCallback.run();
     writer.writeCompletionMessage().end();
 
     // Then:
@@ -117,18 +182,126 @@ public class JsonStreamedRowResponseWriterTest {
         is("[{\"header\":{\"queryId\":\"queryId\","
             + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
             + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}},\n"
-            + "{\"finalMessage\":\"complete!\"}]"));
+            + "{\"row\":{\"columns\":[456,789.0,[\"bye\"]]}}]"));
+    verify(response, times(3)).write((String) any());
+    verify(response, never()).write((Buffer) any());
+    verify(vertx, times(2)).setTimer(anyLong(), any());
+    verify(vertx, never()).cancelTimer(anyLong());
   }
 
   @Test
-  public void shouldSucceedWithLimitMessage() {
+  public void shouldSucceedWithBuffering_twoRows_noTimeout() {
     // Given:
-    setupWithMessages("complete!", "limit hit!");
+    expectTimer();
 
     // When:
     writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
     writer.writeRow(new KeyValueMetadata<>(
         KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(456, 789.0d, ImmutableList.of("bye")))));
+    writer.writeCompletionMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString(),
+        is("[{\"header\":{\"queryId\":\"queryId\","
+            + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
+            + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}},\n"
+            + "{\"row\":{\"columns\":[456,789.0,[\"bye\"]]}}]"));
+    verify(response, times(1)).write((String) any());
+    verify(response, never()).write((Buffer) any());
+    verify(vertx, times(1)).setTimer(anyLong(), any());
+    verify(vertx).cancelTimer(anyLong());
+  }
+
+  @Test
+  public void shouldSucceedWithBuffering_largeBuffer() {
+    // Given:
+    expectTimer();
+
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+
+    for (int i = 0; i < 4000; i++) {
+      writer.writeRow(new KeyValueMetadata<>(
+          KeyValue.keyValue(null, GenericRow.genericRow(i, 100.0d + i,
+              ImmutableList.of("hello" + i)))));
+    }
+    writer.writeCompletionMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString().split("\n").length, is(4001));
+    verify(response, times(4)).write((String) any());
+    verify(response, never()).write((Buffer) any());
+    verify(vertx, times(4)).setTimer(anyLong(), any());
+    verify(vertx, times(4)).cancelTimer(anyLong());
+  }
+
+  @Test
+  public void shouldSucceedWithCompletionMessage_noBuffering() {
+    // Given:
+    setupWithMessages("complete!", "limit hit!", false);
+
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(456, 789.0d, ImmutableList.of("bye")))));
+    writer.writeCompletionMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString(),
+        is("[{\"header\":{\"queryId\":\"queryId\","
+            + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
+            + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}},\n"
+            + "{\"row\":{\"columns\":[456,789.0,[\"bye\"]]}},\n"
+            + "{\"finalMessage\":\"complete!\"}]"));
+    verify(response, times(5)).write((Buffer) any());
+    verify(response, never()).write((String) any());
+    verify(vertx, never()).setTimer(anyLong(), any());
+    verify(vertx, never()).cancelTimer(anyLong());
+  }
+
+  @Test
+  public void shouldSucceedWithCompletionMessage_buffering() {
+    // Given:
+    setupWithMessages("complete!", "limit hit!", true);
+    expectTimer();
+
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(456, 789.0d, ImmutableList.of("bye")))));
+    writer.writeCompletionMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString(),
+        is("[{\"header\":{\"queryId\":\"queryId\","
+            + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
+            + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}},\n"
+            + "{\"row\":{\"columns\":[456,789.0,[\"bye\"]]}},\n"
+            + "{\"finalMessage\":\"complete!\"}]"));
+    verify(response, times(1)).write((String) any());
+    verify(response, never()).write((Buffer) any());
+    verify(vertx, times(1)).setTimer(anyLong(), any());
+    verify(vertx).cancelTimer(anyLong());
+  }
+
+  @Test
+  public void shouldSucceedWithLimitMessage_noBuffering() {
+    // Given:
+    setupWithMessages("complete!", "limit hit!", false);
+
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(456, 789.0d, ImmutableList.of("bye")))));
     writer.writeLimitMessage().end();
 
     // Then:
@@ -136,6 +309,38 @@ public class JsonStreamedRowResponseWriterTest {
         is("[{\"header\":{\"queryId\":\"queryId\","
             + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
             + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}},\n"
+            + "{\"row\":{\"columns\":[456,789.0,[\"bye\"]]}},\n"
             + "{\"finalMessage\":\"limit hit!\"}]"));
+    verify(response, times(5)).write((Buffer) any());
+    verify(response, never()).write((String) any());
+    verify(vertx, never()).setTimer(anyLong(), any());
+    verify(vertx, never()).cancelTimer(anyLong());
+  }
+
+  @Test
+  public void shouldSucceedWithLimitMessage_buffering() {
+    // Given:
+    setupWithMessages("complete!", "limit hit!", true);
+    expectTimer();
+
+    // When:
+    writer.writeMetadata(new QueryResponseMetadata(QUERY_ID, COL_NAMES, COL_TYPES, SCHEMA));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(123, 234.0d, ImmutableList.of("hello")))));
+    writer.writeRow(new KeyValueMetadata<>(
+        KeyValue.keyValue(null, GenericRow.genericRow(456, 789.0d, ImmutableList.of("bye")))));
+    writer.writeLimitMessage().end();
+
+    // Then:
+    assertThat(stringBuilder.toString(),
+        is("[{\"header\":{\"queryId\":\"queryId\","
+            + "\"schema\":\"`A` INTEGER KEY, `B` DOUBLE, `C` ARRAY<STRING>\"}},\n"
+            + "{\"row\":{\"columns\":[123,234.0,[\"hello\"]]}},\n"
+            + "{\"row\":{\"columns\":[456,789.0,[\"bye\"]]}},\n"
+            + "{\"finalMessage\":\"limit hit!\"}]"));
+    verify(response, times(1)).write((String) any());
+    verify(response, never()).write((Buffer) any());
+    verify(vertx, times(1)).setTimer(anyLong(), any());
+    verify(vertx).cancelTimer(anyLong());
   }
 }


### PR DESCRIPTION
### Description 
Ports over the buffering behavior to `/query-stream` for pull queries that exists in `PullQueryStreamWriter`.  This ensures that each chunk is a good size rather than outputting one row per chunk.

### Testing done 
Unit and existing integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

