### PR TITLE
build: add docker plugin for release stabilization

### DIFF
--- a/ksqldb-docker/pom.xml
+++ b/ksqldb-docker/pom.xml
@@ -122,6 +122,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>dockerfile-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>package</id>
+            <goals>
+              <goal>build</goal>
+              <goal>push</goal>
+            </goals>
+            <configuration>
+              <repository>${docker.registry}confluentinc/${project.artifactId}</repository>
+              <tag>${docker.tag}</tag>
+              <buildArgs>
+                <DOCKER_UPSTREAM_REGISTRY>${docker.upstream-registry}</DOCKER_UPSTREAM_REGISTRY>
+                <DOCKER_UPSTREAM_TAG>${docker.upstream-tag}</DOCKER_UPSTREAM_TAG>
+              </buildArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Adds the docker plugin to pom.xml as described in https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2535687371/Support+for+repo-specific+callbacks+during+release+build#Example-pom.xml-modifications

in order to build the on prem docker images for ksqldb

