### PR TITLE
feat: allow for only Gen 1 create or replace queries with server level configs via rest api, bars all gen 2 queries

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.services.ServiceContext;
@@ -277,6 +278,7 @@ public class QueryRegistryImpl implements QueryRegistry {
             .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)
             .collect(Collectors.toList()));
       }
+      throwOnNonQueryLevelConfigs(config.getOverrides());
       query = queryBuilder.buildPersistentQueryInSharedRuntime(
           ksqlConfig,
           persistentQueryType,
@@ -309,6 +311,21 @@ public class QueryRegistryImpl implements QueryRegistry {
     }
     registerPersistentQuery(serviceContext, metaStore, query);
     return query;
+  }
+
+  private static void throwOnNonQueryLevelConfigs(final Map<String, Object> overriddenProperties) {
+    final String nonQueryLevelConfigs = overriddenProperties.keySet().stream()
+        .filter(s -> !PropertiesList.QueryLevelPropertyList.contains(s))
+        .distinct()
+        .collect(Collectors.joining(","));
+
+    if (!nonQueryLevelConfigs.isEmpty()) {
+      throw new IllegalArgumentException(String.format("When shared runtimes are enabled, the"
+              + " configs %s can only be set for the entire cluster and all queries currently"
+              + " running in it, and not configurable for individual queries."
+              + " Please use ALTER SYSTEM to change these config for all queries.",
+          nonQueryLevelConfigs));
+    }
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -273,12 +273,12 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     if (sharedRuntimeId.isPresent() && (oldQuery == null
         || oldQuery instanceof BinPackedPersistentQueryMetadataImpl)) {
+      throwOnNonQueryLevelConfigs(config.getOverrides());
       if (sandbox) {
         streams.addAll(sourceStreams.stream()
             .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)
             .collect(Collectors.toList()));
       }
-      throwOnNonQueryLevelConfigs(config.getOverrides());
       query = queryBuilder.buildPersistentQueryInSharedRuntime(
           ksqlConfig,
           persistentQueryType,

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -107,7 +107,7 @@ import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertiesList extends KsqlEntity {
-  private static final List<String> QueryLevelPropertyList = ImmutableList.of(
+  public static final List<String> QueryLevelPropertyList = ImmutableList.of(
       KSQL_STRING_CASE_CONFIG_TOGGLE,
       KSQL_NESTED_ERROR_HANDLING_CONFIG,
       KSQL_QUERY_ERROR_MAX_QUEUE_SIZE,


### PR DESCRIPTION
This forces any queries coming into the shared runtimes to not have overridden the server level props. If the query will not be going into the new shared runtimes (i.e. is a `create or replace` of an old query) it will not be held to those standards.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

