### PR TITLE
fix: when a isolated query is restarted then it should stay isolated

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -272,7 +272,7 @@ public class QueryRegistryImpl implements QueryRegistry {
     final PersistentQueryMetadata oldQuery = persistentQueries.get(queryId);
 
     if (sharedRuntimeId.isPresent()
-        && config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
+        && ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
         && (oldQuery == null
         || oldQuery instanceof BinPackedPersistentQueryMetadataImpl)) {
       throwOnNonQueryLevelConfigs(config.getOverrides());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -271,7 +271,9 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     final PersistentQueryMetadata oldQuery = persistentQueries.get(queryId);
 
-    if (sharedRuntimeId.isPresent() && (oldQuery == null
+    if (sharedRuntimeId.isPresent()
+        && config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
+        && (oldQuery == null
         || oldQuery instanceof BinPackedPersistentQueryMetadataImpl)) {
       throwOnNonQueryLevelConfigs(config.getOverrides());
       if (sandbox) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -117,6 +117,7 @@ public class QueryRegistryImplTest {
     when(listener1.createSandbox()).thenReturn(Optional.of(sandboxListener));
     when(listener2.createSandbox()).thenReturn(Optional.empty());
     registry = new QueryRegistryImpl(ImmutableList.of(listener1, listener2), executorFactory, new MetricCollectors());
+    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(sharedRuntimes);
   }
 
   @Test
@@ -519,6 +520,7 @@ public class QueryRegistryImplTest {
         Optional.of("sink1"), CREATE_AS);
     //Expect:
     assertThat("does not use old runtime", query instanceof PersistentQueryMetadataImpl);
+    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)).thenReturn(sharedRuntimes);
     query = givenCreate(registry, "q2", "source",
         Optional.of("sink1"), CREATE_AS);
     assertThat("does not use old runtime", query instanceof BinPackedPersistentQueryMetadataImpl);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.computation;
 import static org.apache.kafka.streams.StreamsConfig.PROCESSING_GUARANTEE_CONFIG;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.config.ConfigItem;
 import io.confluent.ksql.config.KsqlConfigResolver;
@@ -37,6 +38,7 @@ import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlServerException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collection;
 import java.util.Objects;
@@ -212,11 +214,20 @@ public final class ValidatedCommandFactory {
   ) {
     final KsqlPlan plan = context.plan(serviceContext, statement);
 
-    final ConfiguredKsqlPlan configuredPlan = ConfiguredKsqlPlan
+    ConfiguredKsqlPlan configuredPlan = ConfiguredKsqlPlan
         .of(plan, statement.getSessionConfig());
 
-    context.execute(serviceContext, configuredPlan);
-
+    final KsqlExecutionContext.ExecuteResult result = context.execute(serviceContext, configuredPlan);
+    if (result.getQuery().isPresent()
+        && result.getQuery().get() instanceof PersistentQueryMetadataImpl
+        && configuredPlan.getConfig()
+          .getConfig(false)
+          .getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+      configuredPlan = ConfiguredKsqlPlan.of(
+          plan,
+          statement.getSessionConfig().copyWith(ImmutableMap.of(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, false))
+      );
+    }
     return Command.of(configuredPlan);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ValidatedCommandFactory.java
@@ -217,7 +217,8 @@ public final class ValidatedCommandFactory {
     ConfiguredKsqlPlan configuredPlan = ConfiguredKsqlPlan
         .of(plan, statement.getSessionConfig());
 
-    final KsqlExecutionContext.ExecuteResult result = context.execute(serviceContext, configuredPlan);
+    final KsqlExecutionContext.ExecuteResult result = context
+        .execute(serviceContext, configuredPlan);
     if (result.getQuery().isPresent()
         && result.getQuery().get() instanceof PersistentQueryMetadataImpl
         && configuredPlan.getConfig()
@@ -225,7 +226,8 @@ public final class ValidatedCommandFactory {
           .getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
       configuredPlan = ConfiguredKsqlPlan.of(
           plan,
-          statement.getSessionConfig().copyWith(ImmutableMap.of(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, false))
+          statement.getSessionConfig()
+              .copyWith(ImmutableMap.of(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, false))
       );
     }
     return Command.of(configuredPlan);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -102,6 +102,7 @@ import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.properties.DenyListPropertyValidator;
 import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
 import io.confluent.ksql.rest.DefaultErrorMessages;
@@ -349,6 +350,9 @@ public class KsqlResourceTest {
     registerValueSchema(schemaRegistryClient);
     ksqlRestConfig = new KsqlRestConfig(getDefaultKsqlConfig());
     ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlConfigProperties());
+    final KsqlExecutionContext.ExecuteResult result = mock(KsqlExecutionContext.ExecuteResult.class);
+    when(sandbox.execute(any(), any(ConfiguredKsqlPlan.class))).thenReturn(result);
+    when(result.getQuery()).thenReturn(Optional.empty());
 
     MutableFunctionRegistry fnRegistry = new InternalFunctionRegistry();
     final Metrics metrics = new Metrics();


### PR DESCRIPTION
When we restart a query with `create or replace` stmt we would like to use the previous runtime that query was executed on. Today if we `create or replace` an existing query that's running on the old, non-shared runtime, it will still come up in a non shared runtime. However it's plan written to the cmd topic will indicate that it should use the new shared runtime.

To fix this, when executing the `create or replace` stmt we would only create the new query in the new runtime only if 1) a shared runtime id is assigned, 2) The queries config has the shared runtimes FF enabled and 3) the old query either does not exist or it has already been running on the shared runtime.

### Testing done 
Test to make sure the cmd gen'd is for a gen 1 query in the case it is being replaced. And that is doesn't happen to a gen 2 query.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

