### PR TITLE
fix: skip docker build for packaging

### DIFF
--- a/ksqldb-docker/pom.xml
+++ b/ksqldb-docker/pom.xml
@@ -139,6 +139,7 @@
                 <DOCKER_UPSTREAM_REGISTRY>${docker.upstream-registry}</DOCKER_UPSTREAM_REGISTRY>
                 <DOCKER_UPSTREAM_TAG>${docker.upstream-tag}</DOCKER_UPSTREAM_TAG>
               </buildArgs>
+              <skip>${docker.skip-build}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Fix packaging/master by only building the docker image when the docker profile is activated on Jenkins, for more context see https://confluent.slack.com/archives/C8486MR1C/p1643918373509689

Summary of thread is that there is no docker build support out in packaging builder VMs, so we skip building docker globally,  and only build it when we activate the docker profile.

