### PR TITLE
chore: check SNI value matches HOST header

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -322,7 +322,10 @@ public class Server {
       final String keyStoreAlias,
       final ClientAuth clientAuth
   ) {
-    options.setUseAlpn(true).setSsl(true).setSni(true);
+    options.setUseAlpn(true).setSsl(true);
+    if (ksqlRestConfig.getBoolean(KsqlRestConfig.KSQL_SERVER_SNI_CHECK_ENABLE)) {
+      options.setSni(true);
+    }
 
     configureTlsKeyStore(ksqlRestConfig, options, keyStoreAlias);
     configureTlsTrustStore(ksqlRestConfig, options);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/Server.java
@@ -322,7 +322,7 @@ public class Server {
       final String keyStoreAlias,
       final ClientAuth clientAuth
   ) {
-    options.setUseAlpn(true).setSsl(true);
+    options.setUseAlpn(true).setSsl(true).setSni(true);
 
     configureTlsKeyStore(ksqlRestConfig, options, keyStoreAlias);
     configureTlsTrustStore(ksqlRestConfig, options);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.rest.entity.HeartbeatMessage;
 import io.confluent.ksql.rest.entity.KsqlMediaType;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpHeaders;
@@ -114,7 +115,9 @@ public class ServerVerticle extends AbstractVerticle {
     final Router router = Router.router(vertx);
 
     router.route().handler(new LoggingHandler(server, loggingRateLimiter));
-    router.route().handler(new SniHandler());
+    if (server.getConfig().getBoolean(KsqlRestConfig.KSQL_SERVER_SNI_CHECK_ENABLE)) {
+      router.route().handler(new SniHandler());
+    }
 
     KsqlCorsHandler.setupCorsHandler(server, router);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -114,6 +114,7 @@ public class ServerVerticle extends AbstractVerticle {
     final Router router = Router.router(vertx);
 
     router.route().handler(new LoggingHandler(server, loggingRateLimiter));
+    router.route().handler(new SniHandler());
 
     KsqlCorsHandler.setupCorsHandler(server, router);
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SniHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SniHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SniHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SniHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.server;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.MISDIRECTED_REQUEST;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import io.confluent.ksql.rest.Errors;
+
+public class SniHandler implements Handler<RoutingContext> {
+
+  public SniHandler() {
+  }
+
+  @Override
+  public void handle(final RoutingContext routingContext) {
+    if (routingContext.request().isSSL()) {
+      final String indicatedServerName = routingContext.request().connection()
+          .indicatedServerName();
+      if (!indicatedServerName.equals("")) {
+        if (!routingContext.request().getHeader(HttpHeaders.HOST).equals(indicatedServerName)) {
+          routingContext.fail(MISDIRECTED_REQUEST.code(),
+              new KsqlApiException("This request was incorrectly sent to this ksqlDB server",
+                 Errors.ERROR_CODE_MISDIRECTED_REQUEST));
+          return;
+        }
+      }
+    }
+    routingContext.next();
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SniHandler.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/SniHandler.java
@@ -20,8 +20,11 @@ import static io.netty.handler.codec.http.HttpResponseStatus.MISDIRECTED_REQUEST
 import io.confluent.ksql.rest.Errors;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SniHandler implements Handler<RoutingContext> {
+  private static final Logger log = LoggerFactory.getLogger(SniHandler.class);
 
   public SniHandler() {
   }
@@ -36,6 +39,11 @@ public class SniHandler implements Handler<RoutingContext> {
         // sometimes the port is present in the host header, remove it
         final String requestHostNoPort = requestHost.replaceFirst(":\\d+", "");
         if (!requestHostNoPort.equals(indicatedServerName)) {
+          log.error(String.format(
+              "Sni check failed, host header: %s, sni value %s",
+              requestHostNoPort,
+              indicatedServerName)
+          );
           routingContext.fail(MISDIRECTED_REQUEST.code(),
               new KsqlApiException("This request was incorrectly sent to this ksqlDB server",
                   Errors.ERROR_CODE_MISDIRECTED_REQUEST));

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -387,6 +387,14 @@ public class KsqlRestConfig extends AbstractConfig {
   public static final String KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DOC =
       "The maximum connection pool size used by Vertx for http2 internal connections";
 
+  public static final String KSQL_SERVER_SNI_CHECK_ENABLE =
+      KSQL_CONFIG_PREFIX + "server.sni.check.enable";
+  public static final boolean KSQL_SERVER_SNI_CHECK_ENABLE_DEFAULT = false;
+
+  private static final String KSQL_SERVER_SNI_CHECK_ENABLE_DOC =
+      "Whether or not to check the SNI against the Host header. If the values don't match, "
+          + "returns a 421 mis-directed response";
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -734,6 +742,12 @@ public class KsqlRestConfig extends AbstractConfig {
             KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DEFAULT,
             Importance.LOW,
             KSQL_INTERNAL_HTTP2_MAX_POOL_SIZE_DOC
+        ).define(
+            KSQL_SERVER_SNI_CHECK_ENABLE,
+            Type.BOOLEAN,
+            KSQL_SERVER_SNI_CHECK_ENABLE_DEFAULT,
+            Importance.LOW,
+            KSQL_SERVER_SNI_CHECK_ENABLE_DOC
         );
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -393,7 +393,8 @@ public class KsqlRestConfig extends AbstractConfig {
 
   private static final String KSQL_SERVER_SNI_CHECK_ENABLE_DOC =
       "Whether or not to check the SNI against the Host header. If the values don't match, "
-          + "returns a 421 mis-directed response";
+          + "returns a 421 mis-directed response. (NOTE: this check should not be enabled if "
+          + "ksqlDB servers have mutual TLS enabled)";
 
   private static final ConfigDef CONFIG_DEF;
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/SniHandlerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/server/SniHandlerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.confluent.ksql.api.server;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SniHandlerTest {
+
+  @Mock
+  private HttpConnection httpConnection;
+  @Mock
+  private HttpServerRequest serverRequest;
+  @Mock
+  private RoutingContext routingContext;
+
+  private SniHandler sniHandler;
+
+  @Before
+  public void setUp() {
+    when(routingContext.request()).thenReturn(serverRequest);
+    when(serverRequest.connection()).thenReturn(httpConnection);
+    when(serverRequest.isSSL()).thenReturn(true);
+    when(serverRequest.host()).thenReturn("");
+    when(httpConnection.indicatedServerName()).thenReturn("");
+    sniHandler = new SniHandler();
+  }
+
+  @Test
+  public void shouldCheckOnlyIfTls() {
+    // Given:
+    when(routingContext.request()).thenReturn(serverRequest);
+    when(serverRequest.isSSL()).thenReturn(false);
+
+    // When:
+    new SniHandler().handle(routingContext);
+
+    // Then:
+    verify(routingContext, never()).fail(anyInt(), any());
+    verify(routingContext).next();
+  }
+
+  @Test
+  public void shouldNotCheckIfSniNull() {
+    // Given:
+    when(httpConnection.indicatedServerName()).thenReturn(null);
+
+    // When:
+    sniHandler.handle(routingContext);
+
+    // Then:
+    verify(routingContext, never()).fail(anyInt(), any());
+    verify(routingContext, times(1)).next();
+  }
+
+  @Test
+  public void shouldNotCheckIfHostNull() {
+    // Given:
+    when(serverRequest.host()).thenReturn(null);
+
+    // When:
+    sniHandler.handle(routingContext);
+
+    // Then:
+    verify(routingContext, never()).fail(anyInt(), any());
+    verify(routingContext, times(1)).next();
+  }
+
+  @Test
+  public void shouldReturnMisdirectedResponse() {
+    // Given:
+    when(serverRequest.host()).thenReturn("localhost");
+    when(httpConnection.indicatedServerName()).thenReturn("anotherhost");
+
+    // When:
+    sniHandler.handle(routingContext);
+
+    // Then:
+    verify(routingContext, never()).next();
+    verify(routingContext).fail(anyInt(), any());
+  }
+
+  @Test
+  public void shouldReturnMisdirectedResponseEvenIfPortInHost() {
+    // Given:
+    when(serverRequest.host()).thenReturn("localhost:80");
+    when(httpConnection.indicatedServerName()).thenReturn("anotherhost");
+
+    // When:
+    sniHandler.handle(routingContext);
+
+    // Then:
+    verify(routingContext).fail(anyInt(), any());
+    verify(routingContext, never()).next();
+  }
+
+  @Test
+  public void shouldNotReturnMisdirectedResponseIfMatch() {
+    // Given:
+    when(serverRequest.host()).thenReturn("localhost");
+    when(httpConnection.indicatedServerName()).thenReturn("localhost");
+
+    // When:
+    sniHandler.handle(routingContext);
+
+    // Then:
+    verify(routingContext, never()).fail(anyInt(), any());
+    verify(routingContext, times(1)).next();
+  }
+
+  @Test
+  public void shouldNotReturnMisdirectedResponseIfMatchHostPort() {
+    // Given:
+    when(serverRequest.host()).thenReturn("localhost:80");
+    when(httpConnection.indicatedServerName()).thenReturn("localhost");
+
+    // When:
+    sniHandler.handle(routingContext);
+
+    // Then:
+    verify(routingContext, never()).fail(anyInt(), any());
+    verify(routingContext, times(1)).next();
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/SystemAuthenticationFunctionalTest.java
@@ -262,6 +262,7 @@ public class SystemAuthenticationFunctionalTest {
         .withProperty(KsqlRestConfig.KSQL_INTERNAL_SSL_CLIENT_AUTHENTICATION_CONFIG,
             KsqlRestConfig.SSL_CLIENT_AUTHENTICATION_NONE)
         .withProperty(KsqlRestConfig.KSQL_SSL_KEYSTORE_ALIAS_INTERNAL_CONFIG, "node-1.example.com")
+        .withProperty(KsqlRestConfig.KSQL_SERVER_SNI_CHECK_ENABLE, true)
         .withProperties(COMMON_CONFIG)
         .withProperties(internalKeyStoreProps(true))
         .build();
@@ -276,6 +277,7 @@ public class SystemAuthenticationFunctionalTest {
         .withProperty(KsqlRestConfig.KSQL_INTERNAL_SSL_CLIENT_AUTHENTICATION_CONFIG,
             KsqlRestConfig.SSL_CLIENT_AUTHENTICATION_NONE)
         .withProperty(KsqlRestConfig.KSQL_SSL_KEYSTORE_ALIAS_INTERNAL_CONFIG, "node-2.example.com")
+        .withProperty(KsqlRestConfig.KSQL_SERVER_SNI_CHECK_ENABLE, true)
         .withProperties(COMMON_CONFIG)
         .withProperties(internalKeyStoreProps(false))
         .build();

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
@@ -19,6 +19,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.RETRY_AFTER;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.MISDIRECTED_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.PRECONDITION_REQUIRED;
 import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
@@ -35,6 +36,8 @@ import org.apache.kafka.common.errors.TopicAuthorizationException;
 public final class Errors {
 
   private static final int HTTP_TO_ERROR_CODE_MULTIPLIER = 100;
+
+  public static final int ERROR_CODE_MISDIRECTED_REQUEST = toErrorCode(MISDIRECTED_REQUEST.code());
 
   public static final int ERROR_CODE_BAD_REQUEST = toErrorCode(BAD_REQUEST.code());
   public static final int ERROR_CODE_BAD_STATEMENT = toErrorCode(BAD_REQUEST.code()) + 1;


### PR DESCRIPTION
### Description 
Add a new handler to each ServerVerticle (if KSQL rest config enables it) to check the SNI against the Host Header to make sure KSQL is the appropriate server to handle the request.

SNI in Vertx
https://vertx.io/docs/apidocs/io/vertx/core/http/HttpConnection.html#indicatedServerName--

Host Header in Vertx
https://vertx.io/docs/apidocs/io/vertx/core/http/HttpServerRequest.html#host--

### Testing done 
Test on a KSQL server with Confluent UI, saw Kafka requests sent to KSQL and the following logs show up on the KSQL server.
```
[ERROR] 2022-02-05 02:12:53,456 [vert.x-eventloop-thread-0] io.confluent.ksql.api.server.FailureHandler handle - Failed to handle request 421 /2.0/kafka/lkc-qk937/topics
io.confluent.ksql.api.server.KsqlApiException: This request was incorrectly sent to this ksqlDB server
	at io.confluent.ksql.api.server.SniHandler.handle(SniHandler.java:39)
	at io.confluent.ksql.api.server.SniHandler.handle(SniHandler.java:24)
	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1038)
	at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:137)
	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:132)
	at io.confluent.ksql.api.server.LoggingHandler.handle(LoggingHandler.java:135)
	at io.confluent.ksql.api.server.LoggingHandler.handle(LoggingHandler.java:35)
	at io.vertx.ext.web.impl.RouteState.handleContext(RouteState.java:1038)
	at io.vertx.ext.web.impl.RoutingContextImplBase.iterateNext(RoutingContextImplBase.java:137)
	at io.vertx.ext.web.impl.RoutingContextImpl.next(RoutingContextImpl.java:132)
	at io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:54)
	at io.vertx.ext.web.impl.RouterImpl.handle(RouterImpl.java:36)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:366)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:43)
	at io.vertx.core.impl.ContextImpl.executeFromIO(ContextImpl.java:229)
	at io.vertx.core.http.impl.Http2ServerConnection.onHeadersRead(Http2ServerConnection.java:140)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:48)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:409)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$1.processFragment(DefaultHttp2FrameReader.java:450)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:457)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:253)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:159)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:173)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:63)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:378)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:438)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:507)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:446)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.vertx.core.http.impl.VertxHttp2ConnectionHandler.channelRead(VertxHttp2ConnectionHandler.java:418)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1371)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1234)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1283)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:507)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:446)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:276)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

