### PR TITLE
chore: update netty to 4.1.72.Final to account for CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
-        <vertx.version>3.9.10</vertx.version>
+        <vertx.version>3.9.12</vertx.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <skip.docker.build>true</skip.docker.build>
         <skip.docker.test>true</skip.docker.test>
@@ -133,10 +133,10 @@
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
         <scala.version>2.13.2</scala.version>
 
-        <netty-tcnative-version>2.0.39.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
-        <netty.version>4.1.69.Final</netty.version>
-        <netty-codec-http2-version>4.1.69.Final</netty-codec-http2-version>
+        <netty.version>4.1.72.Final</netty.version>
+        <netty-codec-http2-version>4.1.72.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
     </properties>
 


### PR DESCRIPTION
Updating netty to 4.1.72 and also netty-tcnative-boringssl-static to 2.0.46