### PR TITLE
fix: only check configs on validation

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -273,8 +273,8 @@ public class QueryRegistryImpl implements QueryRegistry {
 
     if (sharedRuntimeId.isPresent() && (oldQuery == null
         || oldQuery instanceof BinPackedPersistentQueryMetadataImpl)) {
-      throwOnNonQueryLevelConfigs(config.getOverrides());
       if (sandbox) {
+        throwOnNonQueryLevelConfigs(config.getOverrides());
         streams.addAll(sourceStreams.stream()
             .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)
             .collect(Collectors.toList()));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -269,17 +269,17 @@ public class QueryRegistryImplTest {
   }
 
   @Test
-  public void shouldOnlyAllowServerLevelConfigsForDedicatedRuntimes() {
+  public void shouldOnlyAllowServerLevelConfigsForDedicatedRuntimesSandbox() {
     // Given:
     when(config.getOverrides()).thenReturn(ImmutableMap.of("commit.interval.ms", 9));
     if (sharedRuntimes) {
       final Exception e = assertThrows(IllegalArgumentException.class,
-          () -> givenCreate(registry, "q1", "source",
+          () -> givenCreate(registry.createSandbox(), "q1", "source",
           Optional.of("sink1"), CREATE_AS));
       assertThat(e.getMessage(), containsString("commit.interval.ms"));
-    } else {
-      givenCreate(registry, "q1", "source", Optional.of("sink1"), CREATE_AS);
     }
+    givenCreate(registry, "q1", "source", Optional.of("sink1"), CREATE_AS);
+
   }
 
   @Test


### PR DESCRIPTION
### Description 
To avoid having a broken query in the cmd topic we should only do the check for query level configs during validation

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

