### PR TITLE
docs: fix line continuation chars in curl examples

### DIFF
--- a/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/ksql-endpoint.md
@@ -192,7 +192,7 @@ The ``/ksql`` endpoint may return the following error codes in the ``error_code`
 ### Example curl command
 
 ```bash
-curl --http1.1
+curl --http1.1 \
      -X "POST" "http://<ksqldb-host-name>:8088/ksql" \
      -H "Accept: application/vnd.ksql.v1+json" \
      -H "Content-Type: application/json" \

--- a/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
+++ b/docs/developer-guide/ksqldb-rest-api/query-endpoint.md
@@ -59,7 +59,7 @@ Response JSON Object:
 ### Example curl command
 
 ```bash
-curl --http1.1
+curl --http1.1 \
      -X "POST" "http://<ksqldb-host-name>:8088/query" \
      -H "Accept: application/vnd.ksql.v1+json" \
      -d $'{


### PR DESCRIPTION
### Description 

Minor docs fix: these two curl examples are missing line continuation characters so they don't work when copy-pasted.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

