### PR TITLE
docs: remove beta packages url

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -70,21 +70,12 @@ Start by creating a `pom.xml` for your Java application:
             <name>ksqlDB</name>
             <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
         </repository>
-        <repository>
-            <id>confluent-packages</id>
-            <name>Confluent</name>
-            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/{{ site.kstreamsbetabuild }}/maven/</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>ksqlDB</id>
             <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>confluent-packages</id>
-            <url>https://jenkins-confluent-packages-beta-maven.s3.amazonaws.com/{{ site.kstreamsbetatag }}/{{ site.kstreamsbetabuild }}/maven/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
We no longer use beta packaging builds for our dependencies anymore, we now publish those dependency jars directly to  'https://ksqldb-maven.s3.amazonaws.com/maven/' , so we can just remove the beta packaging urls all together


