### PR TITLE
docs: remove beta tag tokens

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -260,8 +260,6 @@ extra:
         # Build-related string tokens
         kafkaversion: 3.1
         ksqldbversion: 0.24.0
-        kstreamsbetatag: 7.1.0-beta210918170926
-        kstreamsbetabuild: 1
         cprelease: 7.1.0
         releasepostbranch: 7.1.0-post
         scalaversion: 2.13


### PR DESCRIPTION
Similar reasoning to https://github.com/confluentinc/ksql/pull/8729, but essentially we no longer use beta tags for our dependency, so we don't need these tokens to try find the correct beta packaging url. Intsead we just use https://ksqldb-maven.s3.amazonaws.com/maven/ for everything


