### PR TITLE
WIP: fix: Apply the ExtensionSecurityManager to UDAFs

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.security.ExtensionSecurityManager;
 import io.confluent.ksql.util.KsqlException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -262,6 +263,7 @@ public final class FunctionLoaderUtils {
       final String functionName
   ) {
     try {
+      ExtensionSecurityManager.INSTANCE.pushInUdf();
       return (SqlType) m.invoke(instance, args);
     } catch (IllegalAccessException
         | InvocationTargetException e) {
@@ -269,6 +271,8 @@ public final class FunctionLoaderUtils {
               + "method %s for UDF %s. ",
           m.getName(), functionName
       ), e);
+    } finally {
+      ExtensionSecurityManager.INSTANCE.popOutUdf();
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import io.confluent.ksql.security.ExtensionSecurityManager;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.lang.reflect.Method;
@@ -186,8 +187,10 @@ public class UdfLoader {
       final Object actualUdf = FunctionLoaderUtils.instantiateFunctionInstance(
           method.getDeclaringClass(), udfDescriptionAnnotation.name());
       if (actualUdf instanceof Configurable) {
+        ExtensionSecurityManager.INSTANCE.pushInUdf();
         ((Configurable) actualUdf)
             .configure(ksqlConfig.getKsqlFunctionsConfigProps(functionName));
+        ExtensionSecurityManager.INSTANCE.popOutUdf();
       }
       final PluggableUdf theUdf = new PluggableUdf(invoker, actualUdf);
       return metrics.<Kudf>map(m -> new UdfMetricProducer(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -51,7 +51,6 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
 import io.confluent.ksql.metastore.TypeRegistry;
-import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
@@ -62,6 +61,7 @@ import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.security.ExtensionSecurityManager;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -138,6 +138,44 @@ public class UdfLoaderTest {
     assertThat(substring2.evaluate("foo", 2, 1), equalTo("o"));
   }
 
+  @Test
+  public void shouldLoadBadFunctionButNotLetItExit() {
+    final List<SqlArgument> argList =  Arrays.asList(SqlArgument.of(SqlTypes.STRING));
+    // We do need to set up the ExtensionSecurityManager for our test.
+    // This is controlled by a feature flag and in this test, we just directly enable it.
+    SecurityManager manager = System.getSecurityManager();
+    System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
+
+    final UdfFactory function = FUNC_REG.getUdfFactory(FunctionName.of("test_udf"));
+    assertThat(function, not(nullValue()));
+
+    KsqlScalarFunction ksqlScalarFunction = function.getFunction(argList);
+    final Kudf badFunction = ksqlScalarFunction.newInstance(ksqlConfig);
+
+    final Exception e0 = assertThrows(
+        java.lang.SecurityException.class,
+        () -> FUNC_REG.getUdfFactory(FunctionName.of("bad_test_udf"))
+            .getFunction(argList).newInstance(ksqlConfig)
+    );
+    assertThat(e0.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    final Exception e1 = assertThrows(
+        KsqlException.class,
+        () -> ksqlScalarFunction.getReturnType(argList)
+    );
+    assertThat(e1.getMessage(), containsString(
+        "Cannot invoke the schema provider method exit for UDF test_udf."));
+
+    final Exception e2 = assertThrows(
+        KsqlFunctionException.class,
+        () -> badFunction.evaluate("foo")
+    );
+    assertThat(e2.getMessage(), containsString(
+        "Failed to invoke function public org.apache.kafka.connect.data.Struct "
+            + "io.confluent.ksql.function.udf.TestUdf.returnList(java.lang.String)"));
+    System.setSecurityManager(manager);
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void shouldLoadUdafs() {
@@ -179,6 +217,100 @@ public class UdfLoaderTest {
         ),
         equalTo(new Struct(schema).put("A", 1).put("B", 2)));
   }
+
+  @Test
+  public void shouldNotLetBadUdafsExit() {
+    // We do need to set up the ExtensionSecurityManager for our test.
+    // This is controlled by a feature flag and in this test, we just directly enable it.
+    SecurityManager manager = System.getSecurityManager();
+    System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
+
+    // This will exit via create
+    final Exception e1 = assertThrows(
+        KsqlException.class,
+        () ->
+            ((KsqlAggregateFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.array(SqlTypes.INTEGER),
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).aggregate("foo", 2L)
+    );
+    assertThat(e1.getMessage(), containsString("Failed to invoke UDAF factory method"));
+
+    // This will exit via configure
+    final Exception e2 = assertThrows(
+        KsqlException.class,
+        () ->
+            ((Configurable)FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.INTEGER,
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).configure(Collections.EMPTY_MAP)
+    );
+    assertThat(e2.getMessage(), containsString("Failed to invoke UDAF factory method"));
+
+
+    // This will exit via initialize
+    final Exception e3 = assertThrows(
+        SecurityException.class,
+        () ->
+            FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.DOUBLE,
+                    AggregateFunctionInitArguments.EMPTY_ARGS).getInitialValueSupplier().get()
+    );
+    assertThat(e3.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    // This will exit via map
+    final Exception e4 = assertThrows(
+        SecurityException.class,
+        () ->
+            ((KsqlAggregateFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.BOOLEAN,
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).getResultMapper().apply(true)
+    );
+    assertThat(e4.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+
+    // This will exit via merge
+    final Schema schema = SchemaBuilder.struct()
+        .field("A", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("B", Schema.OPTIONAL_INT32_SCHEMA)
+        .optional()
+        .build();
+    final SqlStruct sqlSchema = SqlTypes.struct()
+        .field("A", SqlTypes.INTEGER)
+        .field("B", SqlTypes.INTEGER)
+        .build();
+    final Struct input = new Struct(schema).put("A", 0).put("B", 0);
+    final Exception e5 = assertThrows(
+        SecurityException.class,
+        () ->
+            ((KsqlAggregateFunction) FUNC_REG.getAggregateFunction(FunctionName.of("bad_test_udaf"),
+                sqlSchema,
+                AggregateFunctionInitArguments.EMPTY_ARGS)).getMerger().apply(null, input, input)
+    );
+    assertThat(e5.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+
+    // This will exit via aggregate
+    final Exception e6 = assertThrows(
+        SecurityException.class,
+        () ->
+            ((KsqlAggregateFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.STRING,
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).aggregate("foo", 2L)
+    );
+    assertThat(e6.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    // This will exit via undo.
+    final Exception e7 = assertThrows(
+        SecurityException.class,
+        () ->
+            ((TableAggregationFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.BIGINT,
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).undo(1L, 1L)
+    );
+    assertThat(e7.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    System.setSecurityManager(manager);
+  }
+
 
   @Test
   public void shouldLoadDecimalUdfs() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/BadTestUdaf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/BadTestUdaf.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.util.KsqlConstants;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+@UdafDescription(
+    name = "bad_test_udaf",
+    description = "bad_test_udaf",
+    author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public final class BadTestUdaf {
+
+  private BadTestUdaf() {
+  }
+
+  @SuppressFBWarnings("DM_EXIT")
+  private static void runBadCode() {
+    System.exit(-1);
+  }
+
+  @UdafFactory(description = "sums longs with bad 'undo' method")
+  public static TableUdaf<Long, Long, Long> createSumLong() {
+    return new TableUdaf<Long, Long, Long>() {
+      @Override
+      public Long undo(final Long valueToUndo, final Long aggregateValue) {
+        runBadCode();
+        return aggregateValue - valueToUndo;
+      }
+
+      @Override
+      public Long initialize() {
+        return 0L;
+      }
+
+      @Override
+      public Long aggregate(final Long value, final Long aggregate) {
+        return aggregate + value;
+      }
+
+      @Override
+      public Long merge(final Long aggOne, final Long aggTwo) {
+        return aggOne + aggTwo;
+      }
+
+      @Override
+      public Long map(final Long agg) {
+        return agg;
+      }
+    };
+  }
+
+  @UdafFactory(description = "sums int with a bad factory call")
+  public static TableUdaf<List<Integer>, Long, Long> createFactoryExiting() {
+    runBadCode();
+    return null;
+  }
+
+  @UdafFactory(description = "sums int")
+  public static TableUdaf<Integer, Long, Long> createSumInt() {
+    return new SumIntUdaf();
+  }
+
+  @UdafFactory(description = "sums double with a bad initialize")
+  public static Udaf<Double, Double, Double> createSumDouble() {
+    return new Udaf<Double, Double, Double>() {
+      @Override
+      public Double initialize() {
+        runBadCode();
+        return 0.0;
+      }
+
+      @Override
+      public Double aggregate(final Double val, final Double aggregate) {
+        return aggregate + val;
+      }
+
+      @Override
+      public Double merge(final Double aggOne, final Double aggTwo) {
+        return aggOne + aggTwo;
+      }
+
+      @Override
+      public Double map(final Double agg) {
+        return agg;
+      }
+    };
+  }
+
+  @UdafFactory(description = "sums the length of strings with a bad aggregate")
+  public static Udaf<String, Long, Long> createSumLengthString() {
+    return new Udaf<String, Long, Long>() {
+      @Override
+      public Long initialize() {
+        return (long) "initial".length();
+      }
+
+      @Override
+      public Long aggregate(final String s, final Long aggregate) {
+        runBadCode();
+        return aggregate + s.length();
+      }
+
+      @Override
+      public Long merge(final Long aggOne, final Long aggTwo) {
+        return aggOne + aggTwo;
+      }
+
+      @Override
+      public Long map(final Long agg) {
+        return agg;
+      }
+    };
+  }
+
+  @UdafFactory(
+      description = "returns a struct with {SUM(in->A), SUM(in->B)} with a bad merger",
+      paramSchema = "STRUCT<A INTEGER, B INTEGER>",
+      aggregateSchema = "STRUCT<A INTEGER, B INTEGER>",
+      returnSchema = "STRUCT<A INTEGER, B INTEGER>")
+  public static Udaf<Struct, Struct, Struct> createStructUdaf() {
+    return new Udaf<Struct, Struct, Struct>() {
+
+      @Override
+      public Struct initialize() {
+        return new Struct(SchemaBuilder.struct()
+            .field("A", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("B", Schema.OPTIONAL_INT32_SCHEMA)
+            .optional()
+            .build())
+            .put("A", 0)
+            .put("B", 0);
+      }
+
+      @Override
+      public Struct aggregate(final Struct current, final Struct aggregate) {
+        aggregate.put("A", current.getInt32("A") + aggregate.getInt32("A"));
+        aggregate.put("B", current.getInt32("B") + aggregate.getInt32("B"));
+        return aggregate;
+      }
+
+      @Override
+      public Struct merge(final Struct aggOne, final Struct aggTwo) {
+        runBadCode();
+        return aggregate(aggOne, aggTwo);
+      }
+
+      @Override
+      public Struct map(final Struct agg) {
+        return agg;
+      }
+    };
+  }
+
+  // With a bad map method
+  static class SumIntUdaf implements TableUdaf<Integer, Long, Long>, Configurable {
+
+    public static final String INIT_CONFIG = "ksql.functions.test_udaf.init";
+    private long init = 0L;
+
+    @Override
+    public Long undo(final Integer valueToUndo, final Long aggregateValue) {
+      return aggregateValue - valueToUndo;
+    }
+
+    @Override
+    public Long initialize() {
+      return init;
+    }
+
+    @Override
+    public Long aggregate(final Integer current, final Long aggregate) {
+      return current + aggregate;
+    }
+
+    @Override
+    public Long merge(final Long aggOne, final Long aggTwo) {
+      return aggOne + aggTwo;
+    }
+
+    @Override
+    public Long map(final Long agg) {
+      runBadCode();
+      return agg;
+    }
+
+    @Override
+    public void configure(final Map<String, ?> map) {
+      runBadCode();
+      final Object init = map.get(INIT_CONFIG);
+      this.init = (init == null) ? this.init : (long) init;
+    }
+  }
+
+  @UdafFactory(
+      description = "bad map",
+      paramSchema = "BOOLEAN",
+      aggregateSchema = "BOOLEAN",
+      returnSchema = "BOOLEAN")
+  public static Udaf<Boolean, Boolean, Boolean> createBadMapUdaf() {
+    return new Udaf<Boolean, Boolean, Boolean>() {
+
+      @Override
+      public Boolean initialize() {
+        return Boolean.FALSE;
+      }
+
+      @Override
+      public Boolean aggregate(Boolean current, Boolean aggregate) {
+        return Boolean.FALSE;
+      }
+
+      @Override
+      public Boolean merge(Boolean aggOne, Boolean aggTwo) {
+        return Boolean.FALSE;
+      }
+
+      @Override
+      public Boolean map(Boolean agg) {
+        runBadCode();
+        return Boolean.FALSE;
+      }
+    };
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdf.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.util.Map;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.connect.data.Struct;
+
+@UdfDescription(name="bad_test_udf", description = "test")
+@SuppressWarnings("unused")
+public class BadTestUdf implements Configurable {
+
+  @SuppressFBWarnings("DM_EXIT")
+  @Override
+  public void configure(Map<String, ?> map) {
+    System.exit(-5);
+  }
+
+  private static final SqlStruct RETURN =
+      SqlStruct.builder().field("A", SqlTypes.STRING).build();
+
+  @Udf(description = "Sample Bad")
+  public Struct returnList(final String string) {
+    return null;
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdtf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdtf.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf;
+
+import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.function.udtf.Udtf;
+import io.confluent.ksql.function.udtf.UdtfDescription;
+import io.confluent.ksql.schema.ksql.types.SqlDecimal;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.data.Struct;
+
+@UdtfDescription(name = "bad_test_udtf", description = "test")
+@SuppressWarnings("unused")
+public class BadTestUdtf {
+
+  @SuppressFBWarnings("DM_EXIT")
+  private static void runBadCode() {
+    System.exit(-1);
+  }
+
+  @Udtf
+  public List<String> standardParams(
+      final int i, final long l, final double d, final boolean b, final String s,
+      final BigDecimal bd, @UdfParameter(schema = "STRUCT<A VARCHAR>") final Struct struct
+  ) {
+    return ImmutableList.of(String.valueOf(i), String.valueOf(l), String.valueOf(d),
+        String.valueOf(b), s, bd.toString(), struct.toString()
+    );
+  }
+
+  @Udtf
+  public List<String> parameterizedListParams(
+      final List<Integer> i, final List<Long> l, final List<Double> d, final List<Boolean> b, final List<String> s,
+      final List<BigDecimal> bd, @UdfParameter(schema = "ARRAY<STRUCT<A VARCHAR>>") final List<Struct> struct
+  ) {
+    return ImmutableList
+        .of(String.valueOf(i.get(0)), String.valueOf(l.get(0)), String.valueOf(d.get(0)),
+            String.valueOf(b.get(0)), s.get(0), bd.get(0).toString(), struct.get(0).toString()
+        );
+  }
+
+  @Udtf
+  public List<String> parameterizedMapParams(
+      final Map<String, Integer> i,
+      final Map<String, Long> l,
+      final Map<String, Double> d,
+      final Map<String, Boolean> b,
+      final Map<String, String> s,
+      final Map<String, BigDecimal> bd,
+      @UdfParameter(schema = "MAP<STRING, STRUCT<A VARCHAR>>") final Map<String, Struct> struct
+  ) {
+    return ImmutableList
+        .of(
+            String.valueOf(i.values().iterator().next()),
+            String.valueOf(l.values().iterator().next()),
+            String.valueOf(d.values().iterator().next()),
+            String.valueOf(b.values().iterator().next()),
+            s.values().iterator().next(),
+            bd.values().iterator().next().toString(),
+            struct.values().iterator().next().toString()
+        );
+  }
+
+  @Udtf
+  public List<String> parameterizedMapParams2(
+      final Map<Long, Integer> i,
+      final Map<String, Long> l,
+      final Map<String, Double> d,
+      final Map<String, Boolean> b,
+      final Map<String, String> s,
+      final Map<String, BigDecimal> bd,
+      @UdfParameter(schema = "MAP<STRING, STRUCT<A VARCHAR>>") final Map<String, Struct> struct
+  ) {
+    return ImmutableList
+        .of(
+            String.valueOf(i.values().iterator().next()),
+            String.valueOf(l.values().iterator().next()),
+            String.valueOf(d.values().iterator().next()),
+            String.valueOf(b.values().iterator().next()),
+            s.values().iterator().next(),
+            bd.values().iterator().next().toString(),
+            struct.values().iterator().next().toString()
+        );
+  }
+
+  @Udtf
+  public List<Integer> listIntegerReturn(final int i) {
+    return ImmutableList.of(i);
+  }
+
+  @Udtf
+  public List<Long> listLongReturn(final long l) {
+    return ImmutableList.of(l);
+  }
+
+  @Udtf
+  public List<Double> listDoubleReturn(final double d) {
+    System.setSecurityManager(new SecurityManager());
+    runBadCode();
+    return ImmutableList.of(d);
+  }
+
+  @Udtf
+  public List<Boolean> listBooleanReturn(final boolean b)
+      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Class shutdown = Class.forName("java.lang.Shutdown");
+    Method method = shutdown.getDeclaredMethod("exit", int.class);
+    method.setAccessible(true);
+    method.invoke(shutdown, -10);
+    return ImmutableList.of(b);
+  }
+
+  @Udtf
+  public List<String> listStringReturn(final String s) {
+    runBadCode();
+    return ImmutableList.of(s);
+  }
+
+  @Udtf(schemaProvider = "provideSchema")
+  public List<BigDecimal> listBigDecimalReturnWithSchemaProvider(final BigDecimal bd) {
+    return ImmutableList.of(bd);
+  }
+
+  @Udtf(schema = "STRUCT<A VARCHAR>")
+  public List<Struct> listStructReturn(@UdfParameter(schema = "STRUCT<A VARCHAR>") final Struct struct) {
+    return ImmutableList.of(struct);
+  }
+
+  @UdfSchemaProvider
+  public SqlType provideSchema(final List<SqlType> params)  {
+    runBadCode();
+    return SqlDecimal.of(30, 10);
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/TestUdf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/TestUdf.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udf;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -67,4 +68,21 @@ public class TestUdf {
   public SqlType structProvider(final List<SqlType> params) {
     return RETURN;
   }
+
+  @SuppressFBWarnings("DM_EXIT")
+  @Udf(description = "Sample Bad", schemaProvider = "exit")
+  public Struct returnList(String string) {
+    System.out.println("In returnList");
+    System.exit(-1);
+    return null;
+  }
+
+  @SuppressFBWarnings("DM_EXIT")
+  @UdfSchemaProvider
+  public SqlType exit(final List<SqlType> params) {
+    System.out.println("In schemaProvider");
+    System.exit(-3);
+    return RETURN;
+  }
+
 }


### PR DESCRIPTION
This commit covers the case where UDFs have a "bad" schemaProvider.

### Description 
This PR will eventually address https://github.com/confluentinc/ksql/issues/8662.

### Testing done 
Adding/added unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

