### PR TITLE
John fix truncated spq

### DIFF
--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -41,6 +41,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericKey;
 import io.confluent.ksql.GenericRow;
@@ -107,12 +108,21 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.RecordsToDelete;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.connect.data.Struct;
@@ -172,6 +182,13 @@ public class ClientIntegrationTest {
   private static final String EMPTY_TEST_TOPIC = EMPTY_TEST_DATA_PROVIDER.topicName();
   private static final String EMPTY_TEST_STREAM = EMPTY_TEST_DATA_PROVIDER.sourceName();
 
+  private static final TestDataProvider TRUNCATED_TEST_DATA_PROVIDER = new StructuredTypesDataProvider(
+      "TRUNCATED_STRUCTURED_TYPES"
+  );
+  private static final String TRUNCATED_TEST_TOPIC = TRUNCATED_TEST_DATA_PROVIDER.topicName();
+  private static final String TRUNCATED_TEST_STREAM = TRUNCATED_TEST_DATA_PROVIDER.sourceName();
+
+
   private static final String PUSH_QUERY = "SELECT * FROM " + TEST_STREAM + " EMIT CHANGES;";
   private static final String PULL_QUERY_ON_STREAM = "SELECT * FROM " + TEST_STREAM + ";";
   private static final String PULL_QUERY_ON_TABLE =
@@ -225,9 +242,12 @@ public class ClientIntegrationTest {
 
   @BeforeClass
   public static void setUpClass() throws Exception {
-    TEST_HARNESS.ensureTopics(TEST_TOPIC, EMPTY_TEST_TOPIC);
+    TEST_HARNESS.ensureTopics(TEST_TOPIC, EMPTY_TEST_TOPIC, TRUNCATED_TEST_TOPIC);
     TEST_HARNESS.produceRows(TEST_TOPIC, TEST_DATA_PROVIDER, KEY_FORMAT, VALUE_FORMAT, TS_SUPPLIER, HEADERS_SUPPLIER);
     RestIntegrationTestUtil.createStream(REST_APP, TEST_DATA_PROVIDER);
+    TEST_HARNESS.produceRows(TRUNCATED_TEST_TOPIC, TRUNCATED_TEST_DATA_PROVIDER, KEY_FORMAT, VALUE_FORMAT, TS_SUPPLIER, HEADERS_SUPPLIER);
+    truncateTopic(TRUNCATED_TEST_TOPIC);
+    RestIntegrationTestUtil.createStream(REST_APP, TRUNCATED_TEST_DATA_PROVIDER);
     RestIntegrationTestUtil.createStream(REST_APP, EMPTY_TEST_DATA_PROVIDER);
 
     makeKsqlRequest("CREATE TABLE " + AGG_TABLE + " AS "
@@ -263,6 +283,54 @@ public class ClientIntegrationTest {
 
     CONNECT = ConnectExecutable.of(connectFilePath);
     CONNECT.startAsync();
+  }
+
+  private static void truncateTopic(final String truncatedTestTopic) throws InterruptedException, ExecutionException {
+    try (final Admin admin = Admin.create(TEST_HARNESS.getKafkaCluster().getClientProperties())) {
+      final TopicDescription describeTopicsResult =
+          admin
+              .describeTopics(Collections.singleton(truncatedTestTopic))
+              .allTopicNames()
+              .get()
+              .get(truncatedTestTopic);
+      final Map<TopicPartition, ListOffsetsResultInfo> latestOffsets =
+          admin.listOffsets(
+                  describeTopicsResult.partitions().stream()
+                      .map(tpi -> new TopicPartition(truncatedTestTopic, tpi.partition())).collect(
+                          Collectors.toMap(tp -> tp, tp -> OffsetSpec.latest())
+                      )
+              )
+              .all()
+              .get();
+      admin.deleteRecords(
+              latestOffsets
+                  .entrySet()
+                  .stream()
+                  .collect(
+                      Collectors.toMap(
+                          Entry::getKey,
+                          e -> RecordsToDelete.beforeOffset(e.getValue().offset())
+                      )
+                  )
+          )
+          .all()
+          .get();
+
+      final Map<TopicPartition, ListOffsetsResultInfo> earliestOffsets =
+          admin.listOffsets(
+                  describeTopicsResult.partitions().stream()
+                      .map(tpi -> new TopicPartition(truncatedTestTopic, tpi.partition())).collect(
+                          Collectors.toMap(tp -> tp, tp -> OffsetSpec.earliest())
+                      )
+              )
+              .all()
+              .get();
+      for (final TopicPartition topicPartition : Sets.union(earliestOffsets.keySet(), latestOffsets.keySet())) {
+        assertThat(latestOffsets.get(topicPartition), notNullValue());
+        assertThat(earliestOffsets.get(topicPartition), notNullValue());
+        assertThat(earliestOffsets.get(topicPartition).offset(), is(latestOffsets.get(topicPartition).offset()));
+      }
+    }
   }
 
   private static void writeConnectConfigs(final String path, final Map<String, String> configs) throws Exception {
@@ -420,6 +488,36 @@ public class ClientIntegrationTest {
     // When
     final StreamedQueryResult streamedQueryResult = client.streamQuery(
         "SELECT * FROM " + EMPTY_TEST_STREAM + ";").get();
+
+    // Then
+    assertThat(streamedQueryResult.columnNames(), is(TEST_COLUMN_NAMES));
+    assertThat(streamedQueryResult.columnTypes(), is(TEST_COLUMN_TYPES));
+    assertThat(streamedQueryResult.queryID(), is(notNullValue()));
+
+    final List<Row> results = new LinkedList<>();
+    Row row;
+    while (true) {
+      row = streamedQueryResult.poll();
+      if (row == null) {
+        break;
+      } else {
+        results.add(row);
+      }
+    }
+
+    verifyStreamRows(results, 0);
+
+    assertThatEventually(streamedQueryResult::isComplete, is(true));
+  }
+
+  @Test
+  public void shouldStreamPullQueryOnTruncatedStreamSync() throws Exception {
+    // double-check to make sure it's really truncated
+    truncateTopic(TRUNCATED_TEST_TOPIC);
+
+    // When
+    final StreamedQueryResult streamedQueryResult = client.streamQuery(
+        "SELECT * FROM " + TRUNCATED_TEST_STREAM + ";").get();
 
     // Then
     assertThat(streamedQueryResult.columnNames(), is(TEST_COLUMN_NAMES));
@@ -797,7 +895,8 @@ public class ClientIntegrationTest {
     // Then
     assertThat("" + streams, streams, containsInAnyOrder(
         streamForProvider(TEST_DATA_PROVIDER),
-        streamForProvider(EMPTY_TEST_DATA_PROVIDER)
+        streamForProvider(EMPTY_TEST_DATA_PROVIDER),
+        streamForProvider(TRUNCATED_TEST_DATA_PROVIDER)
     ));
   }
 
@@ -825,6 +924,7 @@ public class ClientIntegrationTest {
     }, containsInAnyOrder(
         topicInfo(TEST_TOPIC),
         topicInfo(EMPTY_TEST_TOPIC),
+        topicInfo(TRUNCATED_TEST_TOPIC),
         topicInfo(AGG_TABLE),
         topicInfo("connect-config")
     ));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -394,7 +394,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
         .executeStreamPullQuery(statement, excludeTombstones, endOffsets);
 
     QueryLogger.info(
-        "Streaming stream pull query results '{}'",
+        "Streaming stream pull query results '{}' from earliest to " + endOffsets,
         statement.getStatementText()
     );
 
@@ -454,6 +454,9 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
         new ListOffsetsOptions(IsolationLevel.READ_UNCOMMITTED)
     );
 
+    final ImmutableMap<TopicPartition, Long> startOffsetsForStreamPullQuery =
+        getStartOffsetsForStreamPullQuery(admin, topicDescription);
+
     try {
       final Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> partitionResultMap =
           listOffsetsResult.all().get(10, TimeUnit.SECONDS);
@@ -463,7 +466,44 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
           // special case where we expect no work at all on the partition, so we don't even
           // need to check the committed offset (if we did, we'd potentially wait forever,
           // since Streams won't commit anything for an empty topic).
-          .filter(e -> e.getValue().offset() > 0L)
+          .filter(e -> e.getValue().offset() > 0L && e.getValue().offset() > startOffsetsForStreamPullQuery.get(e.getKey()))
+          .collect(toMap(Entry::getKey, e -> e.getValue().offset()));
+      return ImmutableMap.copyOf(result);
+    } catch (final InterruptedException e) {
+      log.error("Admin#listOffsets(" + topicDescription.name() + ") interrupted", e);
+      throw new KsqlServerException("Interrupted");
+    } catch (final ExecutionException e) {
+      log.error("Error executing Admin#listOffsets(" + topicDescription.name() + ")", e);
+      throw new KsqlServerException("Internal Server Error");
+    } catch (final TimeoutException e) {
+      log.error("Admin#listOffsets(" + topicDescription.name() + ") timed out", e);
+      throw new KsqlServerException("Backend timed out");
+    }
+  }
+
+  private ImmutableMap<TopicPartition, Long> getStartOffsetsForStreamPullQuery(
+      final Admin admin,
+      final TopicDescription topicDescription) {
+    final Map<TopicPartition, OffsetSpec> topicPartitions =
+        topicDescription
+            .partitions()
+            .stream()
+            .map(td -> new TopicPartition(topicDescription.name(), td.partition()))
+            .collect(toMap(identity(), tp -> OffsetSpec.earliest()));
+
+    final ListOffsetsResult listOffsetsResult = admin.listOffsets(
+        topicPartitions,
+        // Since stream pull queries are always ALOS, it will read uncommitted,
+        // so we should do the same when checking end offsets.
+        new ListOffsetsOptions(IsolationLevel.READ_UNCOMMITTED)
+    );
+
+    try {
+      final Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> partitionResultMap =
+          listOffsetsResult.all().get(10, TimeUnit.SECONDS);
+      final Map<TopicPartition, Long> result = partitionResultMap
+          .entrySet()
+          .stream()
           .collect(toMap(Entry::getKey, e -> e.getValue().offset()));
       return ImmutableMap.copyOf(result);
     } catch (final InterruptedException e) {


### PR DESCRIPTION
Previously, stream pull queries would hang on topics that had
been truncated (by explicit truncation or by all the data falling
out of retention).

Now, the queries will return an empty result as expected.

### Testing done 
* Existing test suite
* Added integration test for truncated stream pull queries

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

