### PR TITLE
chore: add comment about netty/tcnative version dependeny

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
 
         <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
+        <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
+             we might need to bump `tcnative`, too.
+             Please check top level `pom.xml` at https://github.com/netty/netty
+             for the netty version we bump to (ie, corresponding git tag),
+             to find the correct `tcnative` version. -->
         <netty.version>4.1.72.Final</netty.version>
         <netty-codec-http2-version>4.1.72.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>


### PR DESCRIPTION
Still not sure if we could actually "unpin" the `tcnative` version and rely on transitive version resolution? But it should be a good intermediate step to just add a commend to avoid pulling in incompatible versions in the future.