### PR TITLE
fix: various fixes for tracking shared runtime queries in validation

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -565,7 +565,7 @@ public class KsqlConfig extends AbstractConfig {
           + "CREATE SOURCE [TABLE|STREAM] statements will continue being read-only.";
 
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
-  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
+  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = true;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
       "Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -565,7 +565,7 @@ public class KsqlConfig extends AbstractConfig {
           + "CREATE SOURCE [TABLE|STREAM] statements will continue being read-only.";
 
   public static final String KSQL_SHARED_RUNTIME_ENABLED = "ksql.runtime.feature.shared.enabled";
-  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = true;
+  public static final Boolean KSQL_SHARED_RUNTIME_ENABLED_DEFAULT = false;
   public static final String KSQL_SHARED_RUNTIME_ENABLED_DOC =
       "Feature flag for sharing streams runtimes. "
           + "Default is false. If false, persistent queries will use separate "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -100,6 +100,9 @@ public class RuntimeAssignor {
   public void rebuildAssignment(final Collection<PersistentQueryMetadata> queries) {
     for (PersistentQueryMetadata queryMetadata: queries) {
       if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
+        if (!runtimesToSources.containsKey(queryMetadata.getQueryApplicationId())) {
+          runtimesToSources.put(queryMetadata.getQueryApplicationId(), new HashSet<>());
+        }
         runtimesToSources.get(queryMetadata.getQueryApplicationId())
             .addAll(queryMetadata.getSourceNames());
         idToRuntime.put(queryMetadata.getQueryId(), queryMetadata.getQueryApplicationId());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -295,6 +295,7 @@ public class QueryRegistryImpl implements QueryRegistry {
           sharedRuntimeId.get(),
           metricCollectors
       );
+      query.register();
     } else {
       query = queryBuilder.buildPersistentQueryInDedicatedRuntime(
           ksqlConfig,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -443,7 +443,7 @@ public class QueryRegistryImpl implements QueryRegistry {
 
       // don't close the old query so that we don't delete the changelog
       // topics and the state store, instead use QueryMetadata#stop
-      oldQuery.stop(false);
+      oldQuery.stop(true);
       unregisterQuery(oldQuery);
     }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -222,12 +222,11 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public void stop() {
-    sharedKafkaStreamsRuntime.stop(queryId, true);
-    scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
+    stop(false);
   }
 
-  public void stop(final boolean resetOffsets) {
-    sharedKafkaStreamsRuntime.stop(queryId, resetOffsets);
+  public void stop(final boolean isCreateOrReplace) {
+    sharedKafkaStreamsRuntime.stop(queryId, isCreateOrReplace);
     scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
   }
 
@@ -391,7 +390,6 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public void start() {
     if (!everStarted) {
-
       sharedKafkaStreamsRuntime.start(queryId);
     }
     everStarted = true;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -391,13 +391,18 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public void start() {
     if (!everStarted) {
-      sharedKafkaStreamsRuntime.register(
-          this,
-          queryId
-      );
+
       sharedKafkaStreamsRuntime.start(queryId);
     }
     everStarted = true;
+  }
+
+  @Override
+  public void register() {
+    sharedKafkaStreamsRuntime.register(
+        this,
+        queryId
+    );
   }
 
   Listener getListener() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -58,7 +58,7 @@ public interface PersistentQueryMetadata extends QueryMetadata {
 
   void stop();
 
-  void stop(boolean resetOffsets);
+  void stop(boolean isCreateOrReplace);
 
   void register();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -60,6 +60,8 @@ public interface PersistentQueryMetadata extends QueryMetadata {
 
   void stop(boolean resetOffsets);
 
+  void register();
+
   StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse uncaughtHandler(
       Throwable error
   );

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadataImpl.java
@@ -226,6 +226,11 @@ public class PersistentQueryMetadataImpl
     stop();
   }
 
+  @Override
+  public void register() {
+
+  }
+
   public Optional<ScalablePushRegistry> getScalablePushRegistry() {
     return scalablePushRegistry;
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -79,7 +79,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
   }
 
   @Override
-  public void stop(final QueryId queryId, final boolean resetOffsets) {
+  public void stop(final QueryId queryId, final boolean isCreateOrReplace) {
   }
 
   public TimeBoundedQueue getNewQueryErrorQueue() {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -71,7 +71,8 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
       final QueryId queryId
   ) {
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
-    if (!kafkaStreams.getTopologyByName(binpackedPersistentQueryMetadata.getQueryId().toString()).isPresent()) {
+    if (!kafkaStreams.getTopologyByName(
+        binpackedPersistentQueryMetadata.getQueryId().toString()).isPresent()) {
       kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopologyCopy(this));
     }
     log.debug("mapping {}", collocatedQueries);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -71,7 +71,9 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
       final QueryId queryId
   ) {
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
-    kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopology());
+    if (!kafkaStreams.getTopologyByName(binpackedPersistentQueryMetadata.getQueryId().toString()).isPresent()) {
+      kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopology());
+    }
     log.debug("mapping {}", collocatedQueries);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -36,6 +36,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
         getSandboxStreamsProperties(sharedRuntime)
     );
 
+    collocatedQueries.putAll(sharedRuntime.collocatedQueries);
     for (BinPackedPersistentQueryMetadataImpl query : sharedRuntime.collocatedQueries.values()) {
       kafkaStreams.addNamedTopology(query.getTopologyCopy(this));
     }
@@ -70,6 +71,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
       final QueryId queryId
   ) {
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
+    kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopology());
     log.debug("mapping {}", collocatedQueries);
   }
 
@@ -83,7 +85,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
 
   @Override
   public synchronized void close() {
-    log.debug("Closing validation runtime {}", getApplicationId());
+    log.info("Closing validation runtime {}", getApplicationId());
     kafkaStreams.close();
     kafkaStreams.cleanUp();
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -71,7 +71,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
       final QueryId queryId
   ) {
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
-    if (! kafkaStreams.getTopologyByName(binpackedPersistentQueryMetadata.getQueryId().toString()).isPresent()) {
+    if (!kafkaStreams.getTopologyByName(binpackedPersistentQueryMetadata.getQueryId().toString()).isPresent()) {
       kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopologyCopy(this));
     }
     log.debug("mapping {}", collocatedQueries);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -71,8 +71,8 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
       final QueryId queryId
   ) {
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
-    if (!kafkaStreams.getTopologyByName(binpackedPersistentQueryMetadata.getQueryId().toString()).isPresent()) {
-      kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopology());
+    if (! kafkaStreams.getTopologyByName(binpackedPersistentQueryMetadata.getQueryId().toString()).isPresent()) {
+      kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopologyCopy(this));
     }
     log.debug("mapping {}", collocatedQueries);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -68,7 +68,7 @@ public abstract class SharedKafkaStreamsRuntime {
 
   public abstract void close();
 
-  public abstract void stop(QueryId queryId, boolean resetOffsets);
+  public abstract void stop(QueryId queryId, boolean isCreateOrReplace);
 
   public abstract void start(QueryId queryId);
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -176,7 +176,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
   public void stop(final QueryId queryId, final boolean resetOffsets) {
     log.info("Attempting to stop query: {} in runtime {} with resetOffsets={}",
              queryId, getApplicationId(), resetOffsets);
-    if (collocatedQueries.containsKey(queryId)) {
+    if (kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
       if (kafkaStreams.state().isRunningOrRebalancing()) {
         try {
           kafkaStreams.removeNamedTopology(queryId.toString(), resetOffsets)
@@ -185,7 +185,6 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
           if (resetOffsets) {
             kafkaStreams.cleanUpNamedTopology(queryId.toString());
           }
-          collocatedQueries.remove(queryId);
         } catch (ExecutionException | InterruptedException e) {
           log.error(String.format(
               "Failed to close query %s within the allotted timeout %s due to",
@@ -196,6 +195,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
             + kafkaStreams.state());
       }
     }
+    collocatedQueries.remove(queryId);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -173,16 +173,20 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
   }
 
   @Override
-  public void stop(final QueryId queryId, final boolean resetOffsets) {
-    log.info("Attempting to stop query: {} in runtime {} with resetOffsets={}",
-             queryId, getApplicationId(), resetOffsets);
+  public void stop(final QueryId queryId, final boolean isCreateOrReplace) {
+    log.info("Attempting to stop query: {} in runtime {} with isCreateOrReplace={}",
+             queryId, getApplicationId(), isCreateOrReplace);
+    if (kafkaStreams.getTopologyByName(queryId.toString()).isPresent()
+        != collocatedQueries.containsKey(queryId)) {
+      log.error("Non SandBoxed queries should not be registered and never started.");
+    }
     if (kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
       if (kafkaStreams.state().isRunningOrRebalancing()) {
         try {
-          kafkaStreams.removeNamedTopology(queryId.toString(), resetOffsets)
+          kafkaStreams.removeNamedTopology(queryId.toString(), !isCreateOrReplace)
               .all()
               .get();
-          if (resetOffsets) {
+          if (!isCreateOrReplace) {
             kafkaStreams.cleanUpNamedTopology(queryId.toString());
           }
         } catch (ExecutionException | InterruptedException e) {
@@ -195,9 +199,8 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
             + kafkaStreams.state());
       }
     }
-    if (resetOffsets) {
-      //If we are not resetting the offsets we are replacing the query
-      // we don't want to lose it form this runtime
+    if (!isCreateOrReplace) {
+      // we don't want to lose it from this runtime
       collocatedQueries.remove(queryId);
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -195,7 +195,10 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
             + kafkaStreams.state());
       }
     }
-    collocatedQueries.remove(queryId);
+    if (resetOffsets) {
+      //If we are not resetting the offsets we are replacing the query and we don't want to lose it form this runtime
+      collocatedQueries.remove(queryId);
+    }
   }
 
   @Override
@@ -227,7 +230,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
                                                + " an older version of query : " + queryId);
       }
     } else {
-      throw new IllegalArgumentException("Cannot start because query " + queryId + " was not"
+      throw new IllegalArgumentException("Cannot start because query " + queryId + " was not "
                                              + "registered to runtime " + getApplicationId());
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -196,7 +196,8 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
       }
     }
     if (resetOffsets) {
-      //If we are not resetting the offsets we are replacing the query and we don't want to lose it form this runtime
+      //If we are not resetting the offsets we are replacing the query
+      // we don't want to lose it form this runtime
       collocatedQueries.remove(queryId);
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -185,6 +185,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
           if (resetOffsets) {
             kafkaStreams.cleanUpNamedTopology(queryId.toString());
           }
+          collocatedQueries.remove(queryId);
         } catch (ExecutionException | InterruptedException e) {
           log.error(String.format(
               "Failed to close query %s within the allotted timeout %s due to",

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -390,6 +390,7 @@ public class QueryBuilderTest {
         Optional.empty()
     );
     queryMetadata.initialize();
+    queryMetadata.register();
     queryMetadata.start();
 
     // When:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -455,6 +456,19 @@ public class QueryRegistryImplTest {
     // Then:
     verify(listener1).onError(query, error);
     verify(listener2).onError(query, error);
+  }
+
+  @Test
+  public void shouldRegisterQuery() {
+    //When:
+    final PersistentQueryMetadata q = givenCreate(registry, "q1", "source",
+        Optional.of("sink1"), CREATE_AS);
+
+    //Then:
+    if (sharedRuntimes) {
+      verify(q).register();
+    }
+    verify(q, never()).start();
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
@@ -105,7 +105,7 @@ public class BinPackedPersistentQueryMetadataImplTest {
 
         // Then:
         final InOrder inOrder = inOrder(sharedKafkaStreamsRuntimeImpl);
-        inOrder.verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, true);
+        inOrder.verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, false);
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -124,6 +124,6 @@ public class BinPackedPersistentQueryMetadataImplTest {
         query.stop();
 
         // Then:
-        verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, true);
+        verify(sharedKafkaStreamsRuntimeImpl).stop(QUERY_ID, false);
     }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
@@ -49,6 +49,9 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
   private BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata;
 
   @Mock
+  private NamedTopology topology;
+
+  @Mock
   private QueryId queryId;
 
   @Mock
@@ -66,7 +69,9 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
         streamProps
     );
     when(queryId.toString()).thenReturn("query 1");
-    when(queryId2.toString()).thenReturn("query 2");
+
+    when(binPackedPersistentQueryMetadata.getTopologyCopy(any())).thenReturn(topology);
+    when(binPackedPersistentQueryMetadata.getQueryId()).thenReturn(queryId);
 
     validationSharedKafkaStreamsRuntime.register(
         binPackedPersistentQueryMetadata,
@@ -103,12 +108,11 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
     verify(kafkaStreamsNamedTopologyWrapper).close();
   }
 
-  @Test void shouldAddTopologyDuringRegister() {
-    //When:
-    final NamedTopology topology = mock(NamedTopology.class);
-    when(binPackedPersistentQueryMetadata.getTopology()).thenReturn(topology);
+  @Test
+  public void shouldAddTopologyDuringRegister() {
 
     //Then:
+    verify(kafkaStreamsNamedTopologyWrapper).getTopologyByName(queryId.toString());
     verify(kafkaStreamsNamedTopologyWrapper).addNamedTopology(topology);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
@@ -93,7 +93,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
     validationSharedKafkaStreamsRuntime.start(queryId);
 
     //When:
-    validationSharedKafkaStreamsRuntime.stop(queryId, true);
+    validationSharedKafkaStreamsRuntime.stop(queryId, false);
 
     //Then:
     assertThat("Query was stopped", validationSharedKafkaStreamsRuntime.getQueries().contains(queryId));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImplTest.java
@@ -14,24 +14,22 @@
  */
 package io.confluent.ksql.util;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryId;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -103,5 +101,14 @@ public class SandboxedSharedKafkaStreamsRuntimeImplTest {
 
     //Then:
     verify(kafkaStreamsNamedTopologyWrapper).close();
+  }
+
+  @Test void shouldAddTopologyDuringRegister() {
+    //When:
+    final NamedTopology topology = mock(NamedTopology.class);
+    when(binPackedPersistentQueryMetadata.getTopology()).thenReturn(topology);
+
+    //Then:
+    verify(kafkaStreamsNamedTopologyWrapper).addNamedTopology(topology);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -237,7 +237,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
     }
 
     @Test
-    public void shouldRemoveQueryIfRegisteredButNotStarted() {
+    public void shouldNotStartOrAddedToStreamsIfOnlyRegistered() {
         //Given:
         sharedKafkaStreamsRuntimeImpl.register(binPackedPersistentQueryMetadata2, queryId2);
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -235,4 +235,18 @@ public class SharedKafkaStreamsRuntimeImplTest {
         verify(kafkaStreamsNamedTopologyWrapper2).start();
         verify(kafkaStreamsNamedTopologyWrapper2).setUncaughtExceptionHandler((StreamsUncaughtExceptionHandler) any());
     }
+
+    @Test
+    public void shouldRemoveQueryIfRegisteredButNotStarted() {
+        //Given:
+        sharedKafkaStreamsRuntimeImpl.register(binPackedPersistentQueryMetadata2, queryId2);
+
+        //When:
+        sharedKafkaStreamsRuntimeImpl.stop(queryId2, false);
+
+        //Then:
+        verify(binPackedPersistentQueryMetadata, never()).start();
+        verify(kafkaStreamsNamedTopologyWrapper, never())
+            .addNamedTopology(binPackedPersistentQueryMetadata2.getTopologyCopy(sharedKafkaStreamsRuntimeImpl));
+    }
 }

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -108,6 +108,7 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertiesList extends KsqlEntity {
   public static final List<String> QueryLevelPropertyList = ImmutableList.of(
+      AUTO_OFFSET_RESET_CONFIG,
       KSQL_STRING_CASE_CONFIG_TOGGLE,
       KSQL_NESTED_ERROR_HANDLING_CONFIG,
       KSQL_QUERY_ERROR_MAX_QUEUE_SIZE,


### PR DESCRIPTION
### Description 
During a refactor we missed a couple of issue. 

1. removing queries for the map when stoping the queries.
2. adding the topology to the sandbox to properly validate
3. registering the query outside for validation runtimes.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

