### PR TITLE
fix: reinstate the old KsqlRestClient.create overload

### DIFF
--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -66,6 +66,33 @@ public final class KsqlRestClient implements Closeable {
   private List<URI> serverAddresses;
   private boolean isCCloudServer;
 
+
+
+  /**
+   * @param serverAddress the address of the KSQL server to connect to.
+   * @param localProps initial set of local properties.
+   * @param clientProps properties used to build the client.
+   * @param creds optional credentials
+   */
+  @Deprecated
+  public static KsqlRestClient create(
+      final String serverAddress,
+      final Map<String, ?> localProps,
+      final Map<String, String> clientProps,
+      final Optional<BasicCredentials> creds
+  ) {
+    return create(
+        serverAddress,
+        localProps,
+        clientProps,
+        creds,
+        Optional.empty(),
+        (cprops, credz, lprops) -> new KsqlClient(cprops, credz, lprops,
+            new HttpClientOptions(),
+            Optional.of(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2)))
+    );
+  }
+
   /**
    * @param serverAddress the address of the KSQL server to connect to.
    * @param localProps initial set of local properties.

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.rest.client.KsqlRestClient.CCLOUD_CONNECT_PASSWO
 import static io.confluent.ksql.rest.client.KsqlRestClient.CCLOUD_CONNECT_USERNAME_HEADER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -220,6 +221,18 @@ public class KsqlRestClientTest {
     // Then:
     verify(client).target(new URI(SOME_SERVER_ADDRESS), Collections.emptyMap());
     verify(target).postKsqlRequest("some ksql;", Collections.emptyMap(), Optional.of(0L));
+  }
+
+  @Test
+  public void shouldAllowCallingCreateWithoutNeedingACCloudApiKey() {
+    // This is a backwards compatibility check
+
+    final KsqlRestClient client = KsqlRestClient.create(SOME_SERVER_ADDRESS, LOCAL_PROPS, CLIENT_PROPS, Optional.empty());
+    assertThat(client, is(instanceOf(KsqlRestClient.class)));
+
+    // Also with new signature
+    final KsqlRestClient ccloudClient = KsqlRestClient.create(SOME_SERVER_ADDRESS, LOCAL_PROPS, CLIENT_PROPS, Optional.empty(), Optional.empty());
+    assertThat(ccloudClient, is(instanceOf(KsqlRestClient.class)));
   }
 
   private KsqlRestClient clientWithServerAddresses(final String serverAddresses) {


### PR DESCRIPTION
### Description 
Commit a33b1e68426ae61fb8bf45c267f198d3eb3d6ff3
has changed the `create` method signature without
deprecating the old one first, causing the drift benchmarks
to fail with:
```
java.lang.NoSuchMethodError: io.confluent.ksql.rest.client.KsqlRestClient.create(
	java/lang/String;
	java/util/Map;
	java/util/Map;
	java/util/Optional;
)
io/confluent/ksql/rest/client/KsqlRestClient;
```
We're just adding back the missing signagure


### Testing done 
No test changes, just added a basic sanity check that we don't remove the signature later down the line

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

