### PR TITLE
fix: disable max_task_storage_used_bytes metric

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -86,8 +86,6 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
         metricRegistry.metricName("node_storage_used_bytes", METRIC_GROUP, customTags);
     final MetricName nodePct =
         metricRegistry.metricName("storage_utilization", METRIC_GROUP, customTags);
-    final MetricName maxTaskPerNode = 
-        metricRegistry.metricName("max_task_storage_used_bytes", METRIC_GROUP, customTags);
     final MetricName numStatefulTasks =
         metricRegistry.metricName("num_stateful_tasks", METRIC_GROUP, customTags);
     metricRegistry.addMetric(
@@ -107,10 +105,6 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
         (Gauge<Double>) (config, now) -> 
         (((double) baseDir.getTotalSpace() - (double) baseDir.getFreeSpace()) 
             / (double) baseDir.getTotalSpace())
-    );
-    metricRegistry.addMetric(
-        maxTaskPerNode,
-        (Gauge<BigInteger>) (config, now) -> (getMaxTaskUsage(metricRegistry))
     );
     metricRegistry.addMetric(
         numStatefulTasks,
@@ -243,21 +237,6 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
       queryMetricSum = queryMetricSum.add(gauge.get());
     }
     return queryMetricSum;
-  }
-  
-  public static synchronized BigInteger getMaxTaskUsage(final Metrics metricRegistry) {
-    final Collection<KafkaMetric> taskMetrics = metricRegistry
-        .metrics()
-        .entrySet()
-        .stream()
-        .filter(e -> e.getKey().name().contains(TASK_STORAGE_USED_BYTES))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-        .values();
-    final Optional<BigInteger> maxOfTaskMetrics = taskMetrics
-        .stream()
-        .map(e -> (BigInteger) e.metricValue())
-        .reduce(BigInteger::max);
-    return maxOfTaskMetrics.orElse(BigInteger.ZERO);
   }
 
   private synchronized Collection<Supplier<BigInteger>> getGaugesForQuery(final String queryId) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -93,8 +93,6 @@ public class StorageUtilizationMetricsReporterTest {
     final Object storageUsedValue = storageUsedGauge.value(null, 0);
     final Gauge<?> pctUsedGauge = verifyAndGetRegisteredMetric("storage_utilization", BASE_TAGS);
     final Object pctUsedValue = pctUsedGauge.value(null, 0);
-    final Gauge<?> maxTaskUsageGauge = verifyAndGetRegisteredMetric("max_task_storage_used_bytes", BASE_TAGS);
-    final Object maxTaskUsageValue = maxTaskUsageGauge.value(null, 0);
     final Gauge<?> numStatefulTasksGauge = verifyAndGetRegisteredMetric("num_stateful_tasks", BASE_TAGS);
     final Object numStatefulTasksValue = numStatefulTasksGauge.value(null, 0);
     
@@ -103,7 +101,6 @@ public class StorageUtilizationMetricsReporterTest {
     assertThat((Long) storageTotalValue, greaterThan(0L));
     assertThat((Long) storageUsedValue, greaterThan(0L));
     assertThat((Double) pctUsedValue, greaterThan(0.0));
-    assertThat((BigInteger) maxTaskUsageValue, greaterThanOrEqualTo(BigInteger.ZERO));
     assertEquals(numStatefulTasksValue, 7);
   }
 
@@ -266,44 +263,6 @@ public class StorageUtilizationMetricsReporterTest {
 
     // Then:
     assertThrows(AssertionError.class, () -> verifyAndGetRegisteredMetric(TASK_STORAGE_METRIC, TASK_ONE_TAGS));
-  }
-  
-  @Test
-  public void shouldRecordMaxTaskUsage() {
-    // Given:
-    KafkaMetric m1 = mockMetric(
-      KSQL_METRIC_GROUP,
-      TASK_STORAGE_METRIC,
-      BigInteger.valueOf(2),
-      ImmutableMap.of("task-id", "t1"));
-    KafkaMetric m2 = mockMetric(
-      KSQL_METRIC_GROUP,
-      TASK_STORAGE_METRIC,
-      BigInteger.valueOf(5),
-      ImmutableMap.of("task-id", "t2"));
-    MetricName n1 = m1.metricName();
-    MetricName n2 = m2.metricName();
-    when(metrics.metrics()).thenReturn(ImmutableMap.of(n1, m1, n2, m2));
-    
-    // When:
-    listener.metricChange(m1);
-    listener.metricChange(m2);
-    
-    // Then:
-    BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage(metrics);
-    assertTrue(maxVal.equals(BigInteger.valueOf(5)));
-  }
-
-  @Test
-  public void shouldRecordMaxTaskUsageWithNoTasks() {
-    // Given:
-    when(metrics.metrics()).thenReturn(Collections.EMPTY_MAP);
-
-    // When:
-
-    // Then:
-    BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage(metrics);
-    assertTrue(maxVal.equals(BigInteger.valueOf(0)));
   }
   
   @Test


### PR DESCRIPTION
### Description 
We previously added the `max_task_storage_used_bytes` metric but right now we're seeing stack-overflow errors in the logs related to collecting this metric. We want to go ahead and disable this metric for the 0.24 release and will re-enabled it properly in the 0.25 release

### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

