### PR TITLE
fix: change conflicting metrics name that leads to infinite loop

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -87,7 +87,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     final MetricName nodePct =
         metricRegistry.metricName("storage_utilization", METRIC_GROUP, customTags);
     final MetricName maxTaskPerNode = 
-        metricRegistry.metricName("max_task_storage_used_bytes", METRIC_GROUP, customTags);
+        metricRegistry.metricName("max_used_task_storage_bytes", METRIC_GROUP, customTags);
     final MetricName numStatefulTasks =
         metricRegistry.metricName("num_stateful_tasks", METRIC_GROUP, customTags);
     metricRegistry.addMetric(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -93,7 +93,7 @@ public class StorageUtilizationMetricsReporterTest {
     final Object storageUsedValue = storageUsedGauge.value(null, 0);
     final Gauge<?> pctUsedGauge = verifyAndGetRegisteredMetric("storage_utilization", BASE_TAGS);
     final Object pctUsedValue = pctUsedGauge.value(null, 0);
-    final Gauge<?> maxTaskUsageGauge = verifyAndGetRegisteredMetric("max_task_storage_used_bytes", BASE_TAGS);
+    final Gauge<?> maxTaskUsageGauge = verifyAndGetRegisteredMetric("max_used_task_storage_bytes", BASE_TAGS);
     final Object maxTaskUsageValue = maxTaskUsageGauge.value(null, 0);
     final Gauge<?> numStatefulTasksGauge = verifyAndGetRegisteredMetric("num_stateful_tasks", BASE_TAGS);
     final Object numStatefulTasksValue = numStatefulTasksGauge.value(null, 0);


### PR DESCRIPTION
[KCI-1455](https://confluentinc.atlassian.net/browse/KCI-1455)

### Description 
The metric name `max_used_task_storage_bytes` was conflicting with the `TASK_STORAGE_USED_BYTES` in `getMaxTaskUsage(metricRegistry)` and was thus leading to an infinite loop. 

### Testing done 
unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

