### PR TITLE
fix: always close validation runtimes even on an exception

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -162,19 +162,23 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
       final ServiceContext serviceContext,
       final ConfiguredKsqlPlan ksqlPlan
   ) {
-    final ExecuteResult result = EngineExecutor.create(
-        engineContext,
-        serviceContext,
-        ksqlPlan.getConfig()
-    ).execute(ksqlPlan.getPlan());
+    try {
+      final ExecuteResult result = EngineExecutor.create(
+          engineContext,
+          serviceContext,
+          ksqlPlan.getConfig()
+      ).execute(ksqlPlan.getPlan());
 
-    // Having a streams running in a sandboxed environment is not necessary
-    if (!getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
-      result.getQuery().map(QueryMetadata::getKafkaStreams).ifPresent(streams -> streams.close());
-    } else {
-      engineContext.getQueryRegistry().closeRuntimes();
+      // Having a streams running in a sandboxed environment is not necessary
+      if (!getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+        result.getQuery().map(QueryMetadata::getKafkaStreams).ifPresent(streams -> streams.close());
+      }
+      return result;
+    } finally {
+      if (getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
+        engineContext.getQueryRegistry().closeRuntimes();
+      }
     }
-    return result;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -382,7 +382,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   @Override
   public void close() {
-    sharedKafkaStreamsRuntime.stop(queryId, true);
+    sharedKafkaStreamsRuntime.stop(queryId, false);
     scalablePushRegistry.ifPresent(ScalablePushRegistry::close);
     listener.onClose(this);
   }


### PR DESCRIPTION
### Description 
If the validation fails due to an exception it can leave the runtimes lying around and this can cause issues for future validations until the cleaner service can get to them. To prevent that we should just clean them up even if there is an exception. 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

