### PR TITLE
fix: pass DCN_NULLPOINTER_EXCEPTION spotbugs error

### DIFF
--- a/ksqldb-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksqldb-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
@@ -364,14 +363,20 @@ public final class DataGen {
           timestampColumnName = Optional.ofNullable(timestampColumnName).orElse(null);
         }
 
-        try {
-          Objects.requireNonNull(schemaFile, "Schema file not provided");
-          Objects.requireNonNull(keyFormat, "Message key format not provided");
-          Objects.requireNonNull(valueFormat, "Message value format not provided");
-          Objects.requireNonNull(topicName, "Kafka topic name not provided");
-          Objects.requireNonNull(keyName, "Name of key column not provided");
-        } catch (final NullPointerException exception) {
-          throw new ArgumentParseException(exception.getMessage());
+        if (schemaFile == null) {
+          throw new ArgumentParseException("Schema file not provided");
+        }
+        if (keyFormat == null) {
+          throw new ArgumentParseException("Message key format not provided");
+        }
+        if (valueFormat == null) {
+          throw new ArgumentParseException("Message value format not provided");
+        }
+        if (topicName == null) {
+          throw new ArgumentParseException("Kafka topic name not provided");
+        }
+        if (keyName == null) {
+          throw new ArgumentParseException("Name of key column not provided");
         }
         return new Arguments(
             help,


### PR DESCRIPTION
### Description 
We have changed our SpotBugs version to 4.5.3 which was causing:

```
[ERROR] Medium: Do not catch NullPointerException like in io.confluent.ksql.datagen.DataGen$Arguments$Builder.build() [io.confluent.ksql.datagen.DataGen$Arguments$Builder] At DataGen.java:[line 440] DCN_NULLPOINTER_EXCEPTION
[INFO]
```

This change is SpotBugs compliant way of doing the same thing
- explicit null checks, rather than delegating to a method
that checks for null and throws NPE

### Testing done 
Verified that spotbugs is happy with the new code

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

