### PR TITLE
fix: Apply the ExtensionSecurityManager to UDAFs

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
@@ -40,6 +40,7 @@ public abstract class BaseAggregateFunction<I, A, O> implements KsqlAggregateFun
   private final SqlType aggregateSchema;
   private final SqlType outputSchema;
   private final ImmutableList<ParameterInfo> params;
+  private final ImmutableList<ParamType> paramTypes;
 
   protected final String functionName;
   private final String description;
@@ -70,6 +71,9 @@ public abstract class BaseAggregateFunction<I, A, O> implements KsqlAggregateFun
     this.aggregateSchema = Objects.requireNonNull(aggregateType, "aggregateType");
     this.outputSchema = Objects.requireNonNull(outputType, "outputType");
     this.params = ImmutableList.copyOf(Objects.requireNonNull(parameters, "parameters"));
+    this.paramTypes = ImmutableList.copyOf(
+        parameters.stream().map(ParameterInfo::type).collect(Collectors.toList())
+    );
     this.functionName = Objects.requireNonNull(functionName, "functionName");
     this.description = Objects.requireNonNull(description, "description");
   }
@@ -102,8 +106,7 @@ public abstract class BaseAggregateFunction<I, A, O> implements KsqlAggregateFun
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "paramTypes is ImmutableList")
   public List<ParamType> parameters() {
-    return ImmutableList.copyOf(
-        params.stream().map(ParameterInfo::type).collect(Collectors.toList()));
+    return paramTypes;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.security.ExtensionSecurityManager;
 import io.confluent.ksql.util.KsqlException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -262,6 +263,7 @@ public final class FunctionLoaderUtils {
       final String functionName
   ) {
     try {
+      ExtensionSecurityManager.INSTANCE.pushInUdf();
       return (SqlType) m.invoke(instance, args);
     } catch (IllegalAccessException
         | InvocationTargetException e) {
@@ -269,6 +271,8 @@ public final class FunctionLoaderUtils {
               + "method %s for UDF %s. ",
           m.getName(), functionName
       ), e);
+    } finally {
+      ExtensionSecurityManager.INSTANCE.popOutUdf();
     }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTableAggregateFunction.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafTableAggregateFunction.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.execution.function.TableAggregationFunction;
 import io.confluent.ksql.function.udaf.TableUdaf;
 import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.security.ExtensionSecurityManager;
 import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.common.metrics.Metrics;
@@ -42,6 +43,11 @@ public class UdafTableAggregateFunction<I, A, O>
 
   @Override
   public A undo(final I valueToUndo, final A aggregateValue) {
-    return ((TableUdaf<I, A, O>)udaf).undo(valueToUndo, aggregateValue);
+    ExtensionSecurityManager.INSTANCE.pushInUdf();
+    try {
+      return ((TableUdaf<I, A, O>)udaf).undo(valueToUndo, aggregateValue);
+    } finally {
+      ExtensionSecurityManager.INSTANCE.popOutUdf();
+    }
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/security/ExtensionSecurityManager.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/security/ExtensionSecurityManager.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.function.BaseAggregateFunction;
 import io.confluent.ksql.function.FunctionLoaderUtils;
 import io.confluent.ksql.function.UdfLoader;
 import io.confluent.ksql.function.udf.PluggableUdf;
-import java.lang.reflect.ReflectPermission;
 import java.security.AllPermission;
 import java.security.CodeSource;
 import java.security.Permission;
@@ -95,22 +94,6 @@ public final class ExtensionSecurityManager extends SecurityManager {
       throw new SecurityException("A UDF attempted to execute the following cmd: " + cmd);
     }
     super.checkExec(cmd);
-  }
-
-  @Override
-  public void checkPermission(final Permission perm) {
-    if (inUdfExecution()) {
-      if (perm instanceof ReflectPermission) {
-        throw new SecurityException("A UDF attempted to use reflection.");
-      }
-      /* if (perm instanceof RuntimePermission) {
-        System.out.println("Stopping system call");
-        new Exception().printStackTrace(System.out);
-        System.out.println("Done dumping stack");
-        throw new SecurityException("A UDF attempted to make a system call.");
-      } */
-    }
-    super.checkPermission(perm);
   }
 
   private boolean inUdfExecution() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -153,13 +153,6 @@ public class UdfLoaderTest {
     KsqlScalarFunction ksqlScalarFunction = function.getFunction(argList);
     final Kudf badFunction = ksqlScalarFunction.newInstance(ksqlConfig);
 
-    final Exception e0 = assertThrows(
-        java.lang.SecurityException.class,
-        () -> FUNC_REG.getUdfFactory(FunctionName.of("bad_test_udf"))
-            .getFunction(argList).newInstance(ksqlConfig)
-    );
-    assertThat(e0.getMessage(), containsString("A UDF attempted to call System.exit"));
-
     final Exception e1 = assertThrows(
         KsqlException.class,
         () -> ksqlScalarFunction.getReturnType(argList)

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -329,11 +329,12 @@ public class UdfLoaderTest {
     // This will exit due to a bad getAggregateSqlType.
     final Exception e8 = assertThrows(
         KsqlException.class,
-        () ->
-            ((KsqlAggregateFunction) FUNC_REG
+        () -> {
+            KsqlAggregateFunction func = ((KsqlAggregateFunction) FUNC_REG
                 .getAggregateFunction(FunctionName.of("bad_test_udaf"),
                     SqlTypes.array(SqlTypes.BIGINT),
-                    AggregateFunctionInitArguments.EMPTY_ARGS)).getAggregateType()
+                    AggregateFunctionInitArguments.EMPTY_ARGS));
+        }
     );
     assertThat(e8.getCause().getMessage(), containsString("A UDF attempted to call System.exit"));
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -51,7 +51,6 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
 import io.confluent.ksql.metastore.TypeRegistry;
-import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
@@ -62,6 +61,7 @@ import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.security.ExtensionSecurityManager;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -90,6 +90,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -138,6 +139,45 @@ public class UdfLoaderTest {
     assertThat(substring2.evaluate("foo", 2, 1), equalTo("o"));
   }
 
+  @Test
+  public void shouldLoadBadFunctionButNotLetItExit() {
+    final List<SqlArgument> argList =  Arrays.asList(SqlArgument.of(SqlTypes.STRING));
+    // We do need to set up the ExtensionSecurityManager for our test.
+    // This is controlled by a feature flag and in this test, we just directly enable it.
+    SecurityManager manager = System.getSecurityManager();
+    System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
+
+    final UdfFactory function = FUNC_REG.getUdfFactory(FunctionName.of("bad_test_udf"));
+    assertThat(function, not(nullValue()));
+
+    KsqlScalarFunction ksqlScalarFunction = function.getFunction(argList);
+    final Kudf badFunction = ksqlScalarFunction.newInstance(ksqlConfig);
+
+    final Exception e0 = assertThrows(
+        java.lang.SecurityException.class,
+        () -> FUNC_REG.getUdfFactory(FunctionName.of("bad_test_udf"))
+            .getFunction(argList).newInstance(ksqlConfig)
+    );
+    assertThat(e0.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    final Exception e1 = assertThrows(
+        KsqlException.class,
+        () -> ksqlScalarFunction.getReturnType(argList)
+    );
+    assertThat(e1.getMessage(), containsString(
+        "Cannot invoke the schema provider method exit for UDF bad_test_udf."));
+
+    final Exception e2 = assertThrows(
+        KsqlFunctionException.class,
+        () -> badFunction.evaluate("foo")
+    );
+    assertThat(e2.getMessage(), containsString(
+        "Failed to invoke function public org.apache.kafka.connect.data.Struct "
+            + "io.confluent.ksql.function.udf.BadTestUdf.returnList(java.lang.String)"));
+    System.setSecurityManager(manager);
+    assertEquals(System.getSecurityManager(), manager);
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void shouldLoadUdafs() {
@@ -179,6 +219,139 @@ public class UdfLoaderTest {
         ),
         equalTo(new Struct(schema).put("A", 1).put("B", 2)));
   }
+
+  @Test
+  public void shouldNotLetBadUdafsExit() {
+    // We do need to set up the ExtensionSecurityManager for our test.
+    // This is controlled by a feature flag and in this test, we just directly enable it.
+    SecurityManager manager = System.getSecurityManager();
+    System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
+
+    System.out.println("Trying to exit 1");
+    // This will exit via create
+    final Exception e1 = assertThrows(
+        KsqlException.class,
+        () -> {
+
+            KsqlAggregateFunction function = ((KsqlAggregateFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.array(SqlTypes.INTEGER),
+                    AggregateFunctionInitArguments.EMPTY_ARGS));
+                function.aggregate("foo", 2L);
+        }
+    );
+    assertThat(e1.getMessage(), containsString("Failed to invoke UDAF factory method"));
+
+    System.out.println("Trying to exit 2");
+
+    // This will exit via configure
+    final Exception e2 = assertThrows(
+        KsqlException.class,
+        () ->
+            ((Configurable)FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.INTEGER,
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).configure(Collections.EMPTY_MAP)
+    );
+    assertThat(e2.getMessage(), containsString("Failed to invoke UDAF factory method"));
+
+    System.out.println("Trying to exit 3");
+
+    // This will exit via initialize
+    final Exception e3 = assertThrows(
+        SecurityException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() throws Throwable {
+            FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.DOUBLE,
+                    AggregateFunctionInitArguments.EMPTY_ARGS).getInitialValueSupplier().get();
+          }
+        }
+    );
+    assertThat(e3.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    System.out.println("Trying to exit 4");
+
+    // This will exit via map
+    final Exception e4 = assertThrows(
+        SecurityException.class,
+        () ->
+            ((KsqlAggregateFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.BOOLEAN,
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).getResultMapper().apply(true)
+    );
+    assertThat(e4.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    System.out.println("Trying to exit 5");
+
+    // This will exit via merge
+    final Schema schema = SchemaBuilder.struct()
+        .field("A", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("B", Schema.OPTIONAL_INT32_SCHEMA)
+        .optional()
+        .build();
+    final SqlStruct sqlSchema = SqlTypes.struct()
+        .field("A", SqlTypes.INTEGER)
+        .field("B", SqlTypes.INTEGER)
+        .build();
+    final Struct input = new Struct(schema).put("A", 0).put("B", 0);
+    final Exception e5 = assertThrows(
+        SecurityException.class,
+        () ->
+            ((KsqlAggregateFunction) FUNC_REG.getAggregateFunction(FunctionName.of("bad_test_udaf"),
+                sqlSchema,
+                AggregateFunctionInitArguments.EMPTY_ARGS)).getMerger().apply(null, input, input)
+    );
+    assertThat(e5.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    System.out.println("Trying to exit 6");
+
+    // This will exit via aggregate
+    final Exception e6 = assertThrows(
+        SecurityException.class,
+        () ->
+            ((KsqlAggregateFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.STRING,
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).aggregate("foo", 2L)
+    );
+    assertThat(e6.getMessage(), containsString("A UDF attempted to call System.exit"));
+    System.out.println("Trying to exit 7");
+
+    // This will exit via undo.
+    final Exception e7 = assertThrows(
+        SecurityException.class,
+        () ->
+            ((TableAggregationFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.BIGINT,
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).undo(1L, 1L)
+    );
+    assertThat(e7.getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    // This will exit due to a bad getAggregateSqlType.
+    final Exception e8 = assertThrows(
+        KsqlException.class,
+        () ->
+            ((KsqlAggregateFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"),
+                    SqlTypes.array(SqlTypes.BIGINT),
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).getAggregateType()
+    );
+    assertThat(e8.getCause().getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    // This will exit due to a bad getReturnSqlType.
+    final Exception e9 = assertThrows(
+        KsqlException.class,
+        () -> {
+            KsqlAggregateFunction func = ((KsqlAggregateFunction) FUNC_REG
+                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.array(SqlTypes.BOOLEAN),
+                    AggregateFunctionInitArguments.EMPTY_ARGS));
+        }
+    );
+    assertThat(e9.getCause().getMessage(), containsString("A UDF attempted to call System.exit"));
+
+    System.setSecurityManager(manager);
+    assertEquals(System.getSecurityManager(), manager);
+  }
+
 
   @Test
   public void shouldLoadDecimalUdfs() {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
@@ -231,13 +231,15 @@ public class UdtfLoaderTest {
   }
 
   @Test
-  public void shouldNotLetBadUdtfsExit() {
+  public void shouldNotLetBadUdtfsExitViaBadSchemaProvider() {
+    // Given:
     // We do need to set up the ExtensionSecurityManager for our test.
     // This is controlled by a feature flag and in this test, we just directly enable it.
     SecurityManager manager = System.getSecurityManager();
     System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
 
-    final Exception e1 = assertThrows(
+    // When:
+    final Exception error = assertThrows(
         KsqlException.class,
         () ->
             FUNC_REG.getTableFunction(
@@ -245,45 +247,35 @@ public class UdtfLoaderTest {
                     Collections.singletonList(SqlArgument.of(SqlTypes.decimal(2,0))))
                 .getReturnType(ImmutableList.of(SqlArgument.of(SqlTypes.DOUBLE)))
     );
-    assertThat(e1.getMessage(), containsString(
-        "Cannot invoke the schema provider method provideSchema for UDF bad_test_udtf."));
 
-    final Exception e2 = assertThrows(
+    // Then:
+    assertThat(error.getMessage(), containsString(
+        "Cannot invoke the schema provider method provideSchema for UDF bad_test_udtf."));
+    System.setSecurityManager(manager);
+    assertEquals(System.getSecurityManager(), manager);
+  }
+
+  @Test
+  public void shouldNotLetBadUdtfsExit() {
+    // Given:
+    // We do need to set up the ExtensionSecurityManager for our test.
+    // This is controlled by a feature flag and in this test, we just directly enable it.
+    SecurityManager manager = System.getSecurityManager();
+    System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
+
+    // When:
+    final Exception error = assertThrows(
         KsqlFunctionException.class,
         () ->
             FUNC_REG.getTableFunction(
                 FunctionName.of("bad_test_udtf"),
                 Collections.singletonList(SqlArgument.of(SqlTypes.STRING))).apply("foo")
     );
-    assertThat(e2.getMessage(), containsString(
+
+    // Then:
+    assertThat(error.getMessage(), containsString(
         "Failed to invoke function public java.util.List "
             + "io.confluent.ksql.function.udf.BadTestUdtf.listStringReturn(java.lang.String)"));
-
-    // Stop reflection
-    /*
-    final Exception e3 = assertThrows(
-        KsqlFunctionException.class,
-        () ->
-            FUNC_REG.getTableFunction(
-                FunctionName.of("bad_test_udtf"),
-                Collections.singletonList(SqlArgument.of(SqlTypes.BOOLEAN))).apply(true)
-    );
-    assertThat(e3.getMessage(), containsString(
-        "Failed to invoke function public java.util.List "
-            + "io.confluent.ksql.function.udf.BadTestUdtf.listBooleanReturn(boolean)"));
-    */
-
-    final Exception e4 = assertThrows(
-        KsqlFunctionException.class,
-        () ->
-            FUNC_REG.getTableFunction(
-                FunctionName.of("bad_test_udtf"),
-                Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE))).apply(1.234)
-    );
-    assertThat(e4.getMessage(), containsString(
-        "Failed to invoke function public java.util.List "
-            + "io.confluent.ksql.function.udf.BadTestUdtf.listDoubleReturn(double)"));
-
     System.setSecurityManager(manager);
     assertEquals(System.getSecurityManager(), manager);
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
@@ -22,6 +22,7 @@ import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -32,10 +33,12 @@ import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.security.ExtensionSecurityManager;
 import io.confluent.ksql.util.KsqlException;
 import java.io.File;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -225,6 +228,62 @@ public class UdtfLoaderTest {
 
     // Then:
     assertThat(function.getReturnType(args), equalTo(STRUCT_SCHEMA));
+  }
+
+  @Test
+  public void shouldNotBadUdtfsExit() {
+    // We do need to set up the ExtensionSecurityManager for our test.
+    // This is controlled by a feature flag and in this test, we just directly enable it.
+    SecurityManager manager = System.getSecurityManager();
+    System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
+
+    final Exception e1 = assertThrows(
+        KsqlException.class,
+        () ->
+            FUNC_REG.getTableFunction(
+                    FunctionName.of("bad_test_udtf"),
+                    Collections.singletonList(SqlArgument.of(SqlTypes.decimal(2,0))))
+                .getReturnType(ImmutableList.of(SqlArgument.of(SqlTypes.DOUBLE)))
+    );
+    assertThat(e1.getMessage(), containsString(
+        "Cannot invoke the schema provider method provideSchema for UDF bad_test_udtf."));
+
+    final Exception e2 = assertThrows(
+        KsqlFunctionException.class,
+        () ->
+            FUNC_REG.getTableFunction(
+                FunctionName.of("bad_test_udtf"),
+                Collections.singletonList(SqlArgument.of(SqlTypes.STRING))).apply("foo")
+    );
+    assertThat(e2.getMessage(), containsString(
+        "Failed to invoke function public java.util.List "
+            + "io.confluent.ksql.function.udf.BadTestUdtf.listStringReturn(java.lang.String)"));
+
+    // Stop reflection
+    final Exception e3 = assertThrows(
+        KsqlFunctionException.class,
+        () ->
+            FUNC_REG.getTableFunction(
+                FunctionName.of("bad_test_udtf"),
+                Collections.singletonList(SqlArgument.of(SqlTypes.BOOLEAN))).apply(true)
+    );
+    assertThat(e3.getMessage(), containsString(
+        "Failed to invoke function public java.util.List "
+            + "io.confluent.ksql.function.udf.BadTestUdtf.listBooleanReturn(boolean)"));
+
+    final Exception e4 = assertThrows(
+        KsqlFunctionException.class,
+        () ->
+            FUNC_REG.getTableFunction(
+                FunctionName.of("bad_test_udtf"),
+                Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE))).apply(1.234)
+    );
+    assertThat(e4.getMessage(), containsString(
+        "Failed to invoke function public java.util.List "
+            + "io.confluent.ksql.function.udf.BadTestUdtf.listDoubleReturn(double)"));
+
+    System.setSecurityManager(manager);
+    assertEquals(System.getSecurityManager(), manager);
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
@@ -60,10 +60,10 @@ public class UdtfLoaderTest {
         SqlArgument.of(SqlTypes.INTEGER),
         SqlArgument.of(SqlTypes.BIGINT),
         SqlArgument.of(SqlTypes.DOUBLE),
-        SqlArgument.of( SqlTypes.BOOLEAN),
+        SqlArgument.of(SqlTypes.BOOLEAN),
         SqlArgument.of(SqlTypes.STRING),
-        SqlArgument.of( DECIMAL_SCHEMA),
-        SqlArgument.of( STRUCT_SCHEMA)
+        SqlArgument.of(DECIMAL_SCHEMA),
+        SqlArgument.of(STRUCT_SCHEMA)
     );
 
     // When:
@@ -231,7 +231,7 @@ public class UdtfLoaderTest {
   }
 
   @Test
-  public void shouldNotBadUdtfsExit() {
+  public void shouldNotLetBadUdtfsExit() {
     // We do need to set up the ExtensionSecurityManager for our test.
     // This is controlled by a feature flag and in this test, we just directly enable it.
     SecurityManager manager = System.getSecurityManager();
@@ -260,6 +260,7 @@ public class UdtfLoaderTest {
             + "io.confluent.ksql.function.udf.BadTestUdtf.listStringReturn(java.lang.String)"));
 
     // Stop reflection
+    /*
     final Exception e3 = assertThrows(
         KsqlFunctionException.class,
         () ->
@@ -270,6 +271,7 @@ public class UdtfLoaderTest {
     assertThat(e3.getMessage(), containsString(
         "Failed to invoke function public java.util.List "
             + "io.confluent.ksql.function.udf.BadTestUdtf.listBooleanReturn(boolean)"));
+    */
 
     final Exception e4 = assertThrows(
         KsqlFunctionException.class,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/BadTestUdaf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/BadTestUdaf.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.KsqlConstants;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+@UdafDescription(
+    name = "bad_test_udaf",
+    description = "bad_test_udaf",
+    author = KsqlConstants.CONFLUENT_AUTHOR
+)
+public final class BadTestUdaf {
+
+  private BadTestUdaf() {
+  }
+
+  @SuppressFBWarnings("DM_EXIT")
+  private static void runBadCode() {
+    System.exit(-1);
+  }
+
+  @UdafFactory(description = "sums longs with bad 'undo' method")
+  public static TableUdaf<Long, Long, Long> createSumLong() {
+    return new TableUdaf<Long, Long, Long>() {
+      @Override
+      public Long undo(final Long valueToUndo, final Long aggregateValue) {
+        runBadCode();
+        return aggregateValue - valueToUndo;
+      }
+
+      @Override
+      public Long initialize() {
+        return 0L;
+      }
+
+      @Override
+      public Long aggregate(final Long value, final Long aggregate) {
+        return aggregate + value;
+      }
+
+      @Override
+      public Long merge(final Long aggOne, final Long aggTwo) {
+        return aggOne + aggTwo;
+      }
+
+      @Override
+      public Long map(final Long agg) {
+        return agg;
+      }
+    };
+  }
+
+  @UdafFactory(description = "sums int with a bad factory call")
+  public static TableUdaf<List<Integer>, Long, Long> createFactoryExiting() {
+    runBadCode();
+    return null;
+  }
+
+  @UdafFactory(description = "sums int")
+  public static TableUdaf<Integer, Long, Long> createSumInt() {
+    return new SumIntUdaf();
+  }
+
+  @UdafFactory(description = "sums double with a bad initialize")
+  public static Udaf<Double, Double, Double> createSumDouble() {
+    return new Udaf<Double, Double, Double>() {
+      @Override
+      public Double initialize() {
+        runBadCode();
+        return 0.0;
+      }
+
+      @Override
+      public Double aggregate(final Double val, final Double aggregate) {
+        return aggregate + val;
+      }
+
+      @Override
+      public Double merge(final Double aggOne, final Double aggTwo) {
+        return aggOne + aggTwo;
+      }
+
+      @Override
+      public Double map(final Double agg) {
+        return agg;
+      }
+    };
+  }
+
+  @UdafFactory(description = "sums the length of strings with a bad aggregate")
+  public static Udaf<String, Long, Long> createSumLengthString() {
+    return new Udaf<String, Long, Long>() {
+      @Override
+      public Long initialize() {
+        return (long) "initial".length();
+      }
+
+      @Override
+      public Long aggregate(final String s, final Long aggregate) {
+        runBadCode();
+        return aggregate + s.length();
+      }
+
+      @Override
+      public Long merge(final Long aggOne, final Long aggTwo) {
+        return aggOne + aggTwo;
+      }
+
+      @Override
+      public Long map(final Long agg) {
+        return agg;
+      }
+    };
+  }
+
+  @UdafFactory(
+      description = "returns a struct with {SUM(in->A), SUM(in->B)} with a bad merger",
+      paramSchema = "STRUCT<A INTEGER, B INTEGER>",
+      aggregateSchema = "STRUCT<A INTEGER, B INTEGER>",
+      returnSchema = "STRUCT<A INTEGER, B INTEGER>")
+  public static Udaf<Struct, Struct, Struct> createStructUdaf() {
+    return new Udaf<Struct, Struct, Struct>() {
+
+      @Override
+      public Struct initialize() {
+        return new Struct(SchemaBuilder.struct()
+            .field("A", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("B", Schema.OPTIONAL_INT32_SCHEMA)
+            .optional()
+            .build())
+            .put("A", 0)
+            .put("B", 0);
+      }
+
+      @Override
+      public Struct aggregate(final Struct current, final Struct aggregate) {
+        aggregate.put("A", current.getInt32("A") + aggregate.getInt32("A"));
+        aggregate.put("B", current.getInt32("B") + aggregate.getInt32("B"));
+        return aggregate;
+      }
+
+      @Override
+      public Struct merge(final Struct aggOne, final Struct aggTwo) {
+        runBadCode();
+        return aggregate(aggOne, aggTwo);
+      }
+
+      @Override
+      public Struct map(final Struct agg) {
+        return agg;
+      }
+    };
+  }
+
+  // With a bad map method
+  static class SumIntUdaf implements TableUdaf<Integer, Long, Long>, Configurable {
+
+    public static final String INIT_CONFIG = "ksql.functions.test_udaf.init";
+    private long init = 0L;
+
+    @Override
+    public Long undo(final Integer valueToUndo, final Long aggregateValue) {
+      return aggregateValue - valueToUndo;
+    }
+
+    @Override
+    public Long initialize() {
+      return init;
+    }
+
+    @Override
+    public Long aggregate(final Integer current, final Long aggregate) {
+      return current + aggregate;
+    }
+
+    @Override
+    public Long merge(final Long aggOne, final Long aggTwo) {
+      return aggOne + aggTwo;
+    }
+
+    @Override
+    public Long map(final Long agg) {
+      runBadCode();
+      return agg;
+    }
+
+    @Override
+    public void configure(final Map<String, ?> map) {
+      runBadCode();
+      final Object init = map.get(INIT_CONFIG);
+      this.init = (init == null) ? this.init : (long) init;
+    }
+  }
+
+  @UdafFactory(
+      description = "bad map",
+      paramSchema = "BOOLEAN",
+      aggregateSchema = "BOOLEAN",
+      returnSchema = "BOOLEAN")
+  public static Udaf<Boolean, Boolean, Boolean> createBadMapUdaf() {
+    return new Udaf<Boolean, Boolean, Boolean>() {
+
+      @Override
+      public Boolean initialize() {
+        return Boolean.FALSE;
+      }
+
+      @Override
+      public Boolean aggregate(Boolean current, Boolean aggregate) {
+        return Boolean.FALSE;
+      }
+
+      @Override
+      public Boolean merge(Boolean aggOne, Boolean aggTwo) {
+        return Boolean.FALSE;
+      }
+
+      @Override
+      public Boolean map(Boolean agg) {
+        runBadCode();
+        return Boolean.FALSE;
+      }
+    };
+  }
+
+  @UdafFactory(description = "sums the length of strings with a bad aggregate")
+  public static Udaf<List<Long>, Long, Long> createBadAggregateTypeUdaf() {
+    return new Udaf<List<Long>, Long, Long>() {
+      @Override
+      public Long initialize() {
+        return null;
+      }
+
+      @Override
+      public Long aggregate(List<Long> current, Long aggregate) {
+        return null;
+      }
+
+      @Override
+      public Long merge(Long aggOne, Long aggTwo) {
+        return null;
+      }
+
+      @Override
+      public Long map(Long agg) {
+        return null;
+      }
+
+      @Override
+      public Optional<SqlType> getAggregateSqlType() {
+        runBadCode();
+        return null;
+      }
+    };
+  }
+
+  @UdafFactory(description = "sums the length of strings with a bad aggregate")
+  public static Udaf<List<Boolean>, Long, Long> createBadReturnTypeUdaf() {
+    return new Udaf<List<Boolean>, Long, Long>() {
+      @Override
+      public Long initialize() {
+        return null;
+      }
+
+      @Override
+      public Long aggregate(List<Boolean> current, Long aggregate) {
+        return null;
+      }
+
+      @Override
+      public Long merge(Long aggOne, Long aggTwo) {
+        return null;
+      }
+
+      @Override
+      public Long map(Long agg) {
+        return null;
+      }
+
+      @Override
+      public Optional<SqlType> getReturnSqlType() {
+        runBadCode();
+        return null;
+      }
+    };
+  }
+
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/BadTestUdaf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/BadTestUdaf.java
@@ -271,7 +271,7 @@ public final class BadTestUdaf {
       @Override
       public Optional<SqlType> getAggregateSqlType() {
         runBadCode();
-        return null;
+        return Optional.empty();
       }
     };
   }
@@ -302,7 +302,7 @@ public final class BadTestUdaf {
       @Override
       public Optional<SqlType> getReturnSqlType() {
         runBadCode();
-        return null;
+        return Optional.empty();
       }
     };
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdf.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.data.Struct;
+
+@UdfDescription(name="bad_test_udf", description = "test")
+@SuppressWarnings("unused")
+public class BadTestUdf { //implements Configurable {
+
+  @SuppressFBWarnings("DM_EXIT")
+  //@Override
+  public void configure(Map<String, ?> map) {
+    System.exit(-5);
+  }
+
+  private static final SqlStruct RETURN =
+      SqlStruct.builder().field("A", SqlTypes.STRING).build();
+
+  @SuppressFBWarnings("DM_EXIT")
+  @Udf(description = "Sample Bad", schemaProvider = "exit")
+  public Struct returnList(String string) {
+    System.out.println("In returnList");
+    System.exit(-1);
+    return null;
+  }
+
+  @SuppressFBWarnings("DM_EXIT")
+  @UdfSchemaProvider
+  public SqlType exit(final List<SqlType> params) {
+    System.out.println("In schemaProvider");
+    System.exit(-3);
+    return RETURN;
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdf.java
@@ -20,26 +20,17 @@ import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.List;
-import java.util.Map;
 import org.apache.kafka.connect.data.Struct;
 
 @UdfDescription(name="bad_test_udf", description = "test")
 @SuppressWarnings("unused")
-public class BadTestUdf { //implements Configurable {
-
-  @SuppressFBWarnings("DM_EXIT")
-  //@Override
-  public void configure(Map<String, ?> map) {
-    System.exit(-5);
-  }
-
+public class BadTestUdf {
   private static final SqlStruct RETURN =
       SqlStruct.builder().field("A", SqlTypes.STRING).build();
 
   @SuppressFBWarnings("DM_EXIT")
   @Udf(description = "Sample Bad", schemaProvider = "exit")
   public Struct returnList(String string) {
-    System.out.println("In returnList");
     System.exit(-1);
     return null;
   }
@@ -47,7 +38,6 @@ public class BadTestUdf { //implements Configurable {
   @SuppressFBWarnings("DM_EXIT")
   @UdfSchemaProvider
   public SqlType exit(final List<SqlType> params) {
-    System.out.println("In schemaProvider");
     System.exit(-3);
     return RETURN;
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdtf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdtf.java
@@ -113,12 +113,6 @@ public class BadTestUdtf {
   }
 
   @Udtf
-  public List<Double> listDoubleReturn(final double d) {
-    runBadCode();
-    return ImmutableList.of(d);
-  }
-
-  @Udtf
   public List<Boolean> listBooleanReturn(final boolean b)
       throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     Class shutdown = Class.forName("java.lang.Shutdown");

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdtf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdtf.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf;
+
+import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.function.udtf.Udtf;
+import io.confluent.ksql.function.udtf.UdtfDescription;
+import io.confluent.ksql.schema.ksql.types.SqlDecimal;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.data.Struct;
+
+@UdtfDescription(name = "bad_test_udtf", description = "test")
+@SuppressWarnings("unused")
+public class BadTestUdtf {
+
+  @SuppressFBWarnings("DM_EXIT")
+  private static void runBadCode() {
+    System.exit(-1);
+  }
+
+  @Udtf
+  public List<String> standardParams(
+      final int i, final long l, final double d, final boolean b, final String s,
+      final BigDecimal bd, @UdfParameter(schema = "STRUCT<A VARCHAR>") final Struct struct
+  ) {
+    return ImmutableList.of(String.valueOf(i), String.valueOf(l), String.valueOf(d),
+        String.valueOf(b), s, bd.toString(), struct.toString()
+    );
+  }
+
+  @Udtf
+  public List<String> parameterizedListParams(
+      final List<Integer> i, final List<Long> l, final List<Double> d, final List<Boolean> b, final List<String> s,
+      final List<BigDecimal> bd, @UdfParameter(schema = "ARRAY<STRUCT<A VARCHAR>>") final List<Struct> struct
+  ) {
+    return ImmutableList
+        .of(String.valueOf(i.get(0)), String.valueOf(l.get(0)), String.valueOf(d.get(0)),
+            String.valueOf(b.get(0)), s.get(0), bd.get(0).toString(), struct.get(0).toString()
+        );
+  }
+
+  @Udtf
+  public List<String> parameterizedMapParams(
+      final Map<String, Integer> i,
+      final Map<String, Long> l,
+      final Map<String, Double> d,
+      final Map<String, Boolean> b,
+      final Map<String, String> s,
+      final Map<String, BigDecimal> bd,
+      @UdfParameter(schema = "MAP<STRING, STRUCT<A VARCHAR>>") final Map<String, Struct> struct
+  ) {
+    return ImmutableList
+        .of(
+            String.valueOf(i.values().iterator().next()),
+            String.valueOf(l.values().iterator().next()),
+            String.valueOf(d.values().iterator().next()),
+            String.valueOf(b.values().iterator().next()),
+            s.values().iterator().next(),
+            bd.values().iterator().next().toString(),
+            struct.values().iterator().next().toString()
+        );
+  }
+
+  @Udtf
+  public List<String> parameterizedMapParams2(
+      final Map<Long, Integer> i,
+      final Map<String, Long> l,
+      final Map<String, Double> d,
+      final Map<String, Boolean> b,
+      final Map<String, String> s,
+      final Map<String, BigDecimal> bd,
+      @UdfParameter(schema = "MAP<STRING, STRUCT<A VARCHAR>>") final Map<String, Struct> struct
+  ) {
+    return ImmutableList
+        .of(
+            String.valueOf(i.values().iterator().next()),
+            String.valueOf(l.values().iterator().next()),
+            String.valueOf(d.values().iterator().next()),
+            String.valueOf(b.values().iterator().next()),
+            s.values().iterator().next(),
+            bd.values().iterator().next().toString(),
+            struct.values().iterator().next().toString()
+        );
+  }
+
+  @Udtf
+  public List<Integer> listIntegerReturn(final int i) {
+    return ImmutableList.of(i);
+  }
+
+  @Udtf
+  public List<Long> listLongReturn(final long l) {
+    return ImmutableList.of(l);
+  }
+
+  @Udtf
+  public List<Double> listDoubleReturn(final double d) {
+    runBadCode();
+    return ImmutableList.of(d);
+  }
+
+  @Udtf
+  public List<Boolean> listBooleanReturn(final boolean b)
+      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Class shutdown = Class.forName("java.lang.Shutdown");
+    Method method = shutdown.getDeclaredMethod("exit", int.class);
+    method.setAccessible(true);
+    method.invoke(shutdown, -10);
+    return ImmutableList.of(b);
+  }
+
+  @Udtf
+  public List<String> listStringReturn(final String s) {
+    runBadCode();
+    return ImmutableList.of(s);
+  }
+
+  @Udtf(schemaProvider = "provideSchema")
+  public List<BigDecimal> listBigDecimalReturnWithSchemaProvider(final BigDecimal bd) {
+    return ImmutableList.of(bd);
+  }
+
+  @Udtf(schema = "STRUCT<A VARCHAR>")
+  public List<Struct> listStructReturn(@UdfParameter(schema = "STRUCT<A VARCHAR>") final Struct struct) {
+    return ImmutableList.of(struct);
+  }
+
+  @UdfSchemaProvider
+  public SqlType provideSchema(final List<SqlType> params)  {
+    runBadCode();
+    return SqlDecimal.of(30, 10);
+  }
+
+}


### PR DESCRIPTION
### Description 
This PR adds calls to the `ExtensionSecurityManager` around all the calls that UDFs, UDAFs, and UDTFs can make.

Addresses https://github.com/confluentinc/ksql/issues/8662

### Testing done 
Unit tests have been added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

