### PR TITLE
fix: spotbugs warnings with Java 11

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.model.WindowType;
@@ -76,6 +77,7 @@ public class AnalysisTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldGetNoneWindowedSourceSchemasPreAggregate() {
     // Given:
     analysis.addDataSource(ALIAS, dataSource);
@@ -96,6 +98,7 @@ public class AnalysisTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldGetWindowedSourceSchemasPreAggregate() {
     // Given:
     analysis.addDataSource(ALIAS, dataSource);
@@ -116,6 +119,7 @@ public class AnalysisTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldGetWindowedGroupBySourceSchemasPreAggregate() {
     // Given:
     analysis.addDataSource(ALIAS, dataSource);
@@ -137,6 +141,7 @@ public class AnalysisTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldGetNonWindowedSourceSchemasPostAggregate() {
     // Given:
     analysis.addDataSource(ALIAS, dataSource);
@@ -157,6 +162,7 @@ public class AnalysisTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldGetWindowedSourceSchemasPostAggregate() {
     // Given:
     analysis.addDataSource(ALIAS, dataSource);
@@ -177,6 +183,7 @@ public class AnalysisTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldGetWindowedGroupBySourceSchemasPostAggregate() {
     // Given:
     analysis.addDataSource(ALIAS, dataSource);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/rewrite/StatementRewriterTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.engine.rewrite.StatementRewriter.Context;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
@@ -878,6 +879,7 @@ public class StatementRewriterTest {
     shouldUsePluginToRewrite(explain, pluginResult);
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   private void shouldUsePluginToRewrite(final AstNode original, final AstNode pluginResult) {
     // Given:
     when(mockPlugin.apply(any(), any())).thenReturn(Optional.of(pluginResult));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/lambda/ReduceTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/lambda/ReduceTest.java
@@ -33,6 +33,8 @@ import java.util.function.BiFunction;
 import org.junit.Before;
 import org.junit.Test;
 
+// Suppress at class level due to https://github.com/spotbugs/spotbugs/issues/724
+@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
 public class ReduceTest {
 
   private Reduce udf;
@@ -91,7 +93,6 @@ public class ReduceTest {
   }
 
   @Test
-  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldNotSkipNullValuesWhenReducing() {
     assertThrows(
         NullPointerException.class,

--- a/pom.xml
+++ b/pom.xml
@@ -461,12 +461,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-compress</artifactId>
-                <version>${commons.compress.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.codehaus.janino</groupId>
                 <artifactId>janino</artifactId>
                 <version>${janino.version}</version>


### PR DESCRIPTION
* ignore all spotbugs warnings in tests that only occur with Java 11
* remove duplicate commons-compress dependency declaration causing maven build warnings