### PR TITLE
chore: inherit mockito version from common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,6 @@
         <apache.io.version>2.7</apache.io.version>
         <io.confluent.ksql.version>7.2.0-0</io.confluent.ksql.version>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
-        <mockito.version>3.8.0</mockito.version>
         <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`


### PR DESCRIPTION
* common is on a newer version of mockito already
* overriding the version also prevents using the mockito-bom in
  https://github.com/confluentinc/common/pull/433 since 3.x doesn't
  publish a bom

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

