### PR TITLE
build: add staging s3 url for dependency jars

### DIFF
--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -16,17 +16,15 @@
           <name>Confluent</name>
           <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
         </repository>
-
         <!-- needed for HTML API doc generation post-release only -->
         <repository>
           <id>ksqldb-staging</id>
           <name>ksqlDB staging</name>
-          <url>https://ksqldb-maven.s3.amazonaws.com/maven/</url>
+          <url>https://staging-ksqldb-maven.s3.amazonaws.com/maven/</url>
         </repository>
       </repositories>
 
       <pluginRepositories>
-
         <pluginRepository>
           <id>confluent-other</id>
           <name>Confluent Plugin Repository</name>
@@ -39,7 +37,19 @@
             <enabled>true</enabled>
           </releases>
         </pluginRepository>
-
+        <!-- needed for running benchmarks on unreleased artifacts -->
+        <pluginRepository>
+          <id>confluent-staging</id>
+          <name>Confluent Staging Plugin Repository</name>
+          <url>https://staging-ksqldb-maven.s3.amazonaws.com/maven/</url>
+          <layout>default</layout>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </pluginRepository>
       </pluginRepositories>
     </profile>
   </profiles>


### PR DESCRIPTION
### Description 
As part of the internal release stabilization process, we produce non-public artifacts, and this change allows us to access them by using the staging repo.

