### PR TITLE
build: Use common Java build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,12 +2,9 @@
 
 def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksql-alerts' : '#ksqldb-warn'
 
-dockerfile {
+common {
     slackChannel = channel
     upstreamProjects = 'confluentinc/schema-registry'
-    dockerRepos = ['confluentinc/ksql-cli']
-    extraBuildArgs = '-Ddocker.skip=false'
-    extraDeployArgs = '-Ddocker.skip=true'
     disableConcurrentBuilds = true
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-def channel = "${env.BRANCH_NAME}".contains('master') ? '#ksql-alerts' : '#ksqldb-warn'
+def channel = env.BRANCH_NAME.equals('master') ? '#ksql-alerts' : '#ksqldb-warn'
 
 common {
     slackChannel = channel


### PR DESCRIPTION
- dockerfile{} uses a specific subset of workers meant for building
  docker images. There are a limited ammount of these workers. And there
  are a lot of ksql PRs & builds. This creates a lot of contention for
  docker-building infrastructure.
- So use the common{} java to build projects.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

