### PR TITLE
feat: support custom request headers from java client and migrations tool

### DIFF
--- a/docs/operate-and-deploy/migrations-tool.md
+++ b/docs/operate-and-deploy/migrations-tool.md
@@ -310,7 +310,7 @@ some of the statements will have been run on the ksqlDB server while later state
 have not.
 
 You can optionally pass custom request headers to be sent with all ksqlDB requests 
-made as part of the `apply` command. In order to do so, pass the location of a
+made as part of the `apply` command by passing the location of a
 file containing the custom request headers with the `--headers` flag:
 
 ```

--- a/docs/operate-and-deploy/migrations-tool.md
+++ b/docs/operate-and-deploy/migrations-tool.md
@@ -226,6 +226,7 @@ ksql-migrations {-c | --config-file} <config-file> apply
                 [ {-u | --until} <untilVersion> ] 
                 [ {-v | --version} <version> ]
                 [ {-d | --define} <variableName>=<variableValue> ]
+                [ --headers <headersFile> ]
                 [ --dry-run ] 
 ```
 
@@ -241,7 +242,8 @@ to apply:
 In addition to selecting a mode for `ksql-migrations apply`, you must also provide
 the path to the config file of your migrations project as part of the command.
 
-If both your ksqlDB server and migration tool are version 0.18 and newer, you can define variables by passing the `--define` flag followed by a string of the form
+If both your ksqlDB server and migration tool are version 0.18 and newer, you can 
+define variables by passing the `--define` flag followed by a string of the form
 `name=value` any number of times. For example, the following command
 
 ```bash
@@ -306,6 +308,26 @@ The `apply` command does not apply migration files atomically. If a migration fi
 containing multiple ksqlDB statements fails during the migration, it's possible that 
 some of the statements will have been run on the ksqlDB server while later statements 
 have not.
+
+You can optionally pass custom request headers to be sent with all ksqlDB requests 
+made as part of the `apply` command. In order to do so, pass the location of a
+file containing the custom request headers with the `--headers` flag:
+
+```
+$ ksql-migrations --config-file /my/migrations/project/ksql-migrations.properties apply --next --headers /my/migrations/project/request_headers.txt
+```
+
+Format your headers file with one header name and value pair on each line, 
+separated either with a colon or an equals sign. Both of the following are valid:
+```
+X-My-Custom-Header: abcdefg
+X-My-Other-Custom-Header: asdfgh
+``` 
+or
+```
+X-My-Custom-Header=abcdefg
+X-My-Other-Custom-Header=asdfgh
+```
 
 View Current Migration Status
 -----------------------------

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ClientOptions.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ClientOptions.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.client;
 
 import io.confluent.ksql.api.client.impl.ClientOptionsImpl;
+import java.util.Map;
 
 /**
  * Options for the ksqlDB {@link Client}.
@@ -144,6 +145,23 @@ public interface ClientOptions {
   ClientOptions setHttp2MultiplexingLimit(int http2MultiplexingLimit);
 
   /**
+   * Sets custom request headers to be sent with requests to the ksqlDB server.
+   * These headers are in addition to any automatic headers such as the
+   * authorization header.
+   *
+   * <p>If this method is called more than once, only the headers passed on
+   * the last invocation will be used. To update existing custom headers,
+   * use this method in combination with {@link ClientOptions#getRequestHeaders()}.
+   *
+   * <p>In case of overlap between these custom headers and automatic headers such
+   * as the authorization header, these custom headers take precedence.
+   *
+   * @param requestHeaders custom request headers
+   * @return a reference to this
+   */
+  ClientOptions setRequestHeaders(Map<String, String> requestHeaders);
+
+  /**
    * Returns the host name of the ksqlDB server to connect to.
    *
    * @return host name
@@ -254,6 +272,14 @@ public interface ClientOptions {
    * @return number of requests
    */
   int getHttp2MultiplexingLimit();
+
+  /**
+   * Returns a copy of the custom request headers to be sent with ksqlDB requests.
+   * If not set, then this method returns {@code null}.
+   *
+   * @return custom request headers
+   */
+  Map<String, String> getRequestHeaders();
 
   /**
    * Creates a copy of these {@code ClientOptions}.

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ClientOptions.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ClientOptions.java
@@ -275,7 +275,7 @@ public interface ClientOptions {
 
   /**
    * Returns a copy of the custom request headers to be sent with ksqlDB requests.
-   * If not set, then this method returns {@code null}.
+   * If not set, then this method returns an empty map.
    *
    * @return custom request headers
    */

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -555,6 +556,11 @@ public class ClientImpl implements Client {
         .exceptionHandler(cf::completeExceptionally);
     if (clientOptions.isUseBasicAuth()) {
       request = configureBasicAuth(request);
+    }
+    if (clientOptions.getRequestHeaders() != null) {
+      for (final Entry<String, String> entry : clientOptions.getRequestHeaders().entrySet()) {
+        request.putHeader(entry.getKey(), entry.getValue());
+      }
     }
     if (endRequest) {
       request.end(requestBody);

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
@@ -166,7 +166,7 @@ public class ClientOptionsImpl implements ClientOptions {
 
   @Override
   public ClientOptions setRequestHeaders(final Map<String, String> requestHeaders) {
-    this.requestHeaders = ImmutableMap.copyOf(requestHeaders);
+    this.requestHeaders = requestHeaders == null ? null : ImmutableMap.copyOf(requestHeaders);
     return this;
   }
 

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.api.client.impl;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.api.client.ClientOptions;
 import java.util.HashMap;
 import java.util.Map;
@@ -165,7 +166,7 @@ public class ClientOptionsImpl implements ClientOptions {
 
   @Override
   public ClientOptions setRequestHeaders(final Map<String, String> requestHeaders) {
-    this.requestHeaders = requestHeaders;
+    this.requestHeaders = ImmutableMap.copyOf(requestHeaders);
     return this;
   }
 
@@ -251,7 +252,7 @@ public class ClientOptionsImpl implements ClientOptions {
 
   @Override
   public Map<String, String> getRequestHeaders() {
-    return requestHeaders == null ? null : new HashMap<>(requestHeaders);
+    return requestHeaders == null ? new HashMap<>() : new HashMap<>(requestHeaders);
   }
 
   @Override

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.api.client.impl;
 
 import io.confluent.ksql.api.client.ClientOptions;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class ClientOptionsImpl implements ClientOptions {
@@ -36,6 +38,7 @@ public class ClientOptionsImpl implements ClientOptions {
   private String basicAuthPassword;
   private int executeQueryMaxResultRows = ClientOptions.DEFAULT_EXECUTE_QUERY_MAX_RESULT_ROWS;
   private int http2MultiplexingLimit = ClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
+  private Map<String, String> requestHeaders;
 
   /**
    * {@code ClientOptions} should be instantiated via {@link ClientOptions#create}, NOT via this
@@ -53,7 +56,8 @@ public class ClientOptionsImpl implements ClientOptions {
       final String trustStorePath, final String trustStorePassword,
       final String keyStorePath, final String keyStorePassword, final String keyPassword,
       final String keyAlias, final String basicAuthUsername, final String basicAuthPassword,
-      final int executeQueryMaxResultRows, final int http2MultiplexingLimit) {
+      final int executeQueryMaxResultRows, final int http2MultiplexingLimit,
+      final Map<String, String> requestHeaders) {
     this.host = Objects.requireNonNull(host);
     this.port = port;
     this.useTls = useTls;
@@ -70,6 +74,7 @@ public class ClientOptionsImpl implements ClientOptions {
     this.basicAuthPassword = basicAuthPassword;
     this.executeQueryMaxResultRows = executeQueryMaxResultRows;
     this.http2MultiplexingLimit = http2MultiplexingLimit;
+    this.requestHeaders = requestHeaders;
   }
 
   @Override
@@ -159,6 +164,12 @@ public class ClientOptionsImpl implements ClientOptions {
   }
 
   @Override
+  public ClientOptions setRequestHeaders(final Map<String, String> requestHeaders) {
+    this.requestHeaders = requestHeaders;
+    return this;
+  }
+
+  @Override
   public String getHost() {
     return host == null ? "" : host;
   }
@@ -239,6 +250,11 @@ public class ClientOptionsImpl implements ClientOptions {
   }
 
   @Override
+  public Map<String, String> getRequestHeaders() {
+    return requestHeaders == null ? null : new HashMap<>(requestHeaders);
+  }
+
+  @Override
   public ClientOptions copy() {
     return new ClientOptionsImpl(
         host, port,
@@ -247,7 +263,8 @@ public class ClientOptionsImpl implements ClientOptions {
         trustStorePath, trustStorePassword,
         keyStorePath, keyStorePassword, keyPassword, keyAlias,
         basicAuthUsername, basicAuthPassword,
-        executeQueryMaxResultRows, http2MultiplexingLimit);
+        executeQueryMaxResultRows, http2MultiplexingLimit,
+        requestHeaders);
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
@@ -275,14 +292,16 @@ public class ClientOptionsImpl implements ClientOptions {
         && Objects.equals(keyAlias, that.keyAlias)
         && Objects.equals(basicAuthUsername, that.basicAuthUsername)
         && Objects.equals(basicAuthPassword, that.basicAuthPassword)
-        && http2MultiplexingLimit == that.http2MultiplexingLimit;
+        && http2MultiplexingLimit == that.http2MultiplexingLimit
+        && Objects.equals(requestHeaders, that.requestHeaders);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(host, port, useTls, verifyHost, useAlpn, trustStorePath,
         trustStorePassword, keyStorePath, keyStorePassword, keyPassword, keyAlias,
-        basicAuthUsername, basicAuthPassword, executeQueryMaxResultRows, http2MultiplexingLimit);
+        basicAuthUsername, basicAuthPassword, executeQueryMaxResultRows, http2MultiplexingLimit,
+        requestHeaders);
   }
 
   @Override
@@ -301,8 +320,9 @@ public class ClientOptionsImpl implements ClientOptions {
         + ", keyAlias='" + keyAlias + '\''
         + ", basicAuthUsername='" + basicAuthUsername + '\''
         + ", basicAuthPassword='" + basicAuthPassword + '\''
-        + ", executeQueryMaxResultRows=" + executeQueryMaxResultRows + '\''
+        + ", executeQueryMaxResultRows=" + executeQueryMaxResultRows
         + ", http2MultiplexingLimit=" + http2MultiplexingLimit
+        + ", requestHeaders='" + requestHeaders + '\''
         + '}';
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientBasicAuthTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientBasicAuthTest.java
@@ -57,9 +57,7 @@ public class ClientBasicAuthTest extends ClientTest {
 
   @Override
   protected ClientOptions createJavaClientOptions() {
-    return ClientOptions.create()
-        .setHost("localhost")
-        .setPort(server.getListeners().get(0).getPort())
+    return super.createJavaClientOptions()
         .setBasicAuthCredentials(USER_WITH_ACCESS, USER_WITH_ACCESS_PWD);
   }
 

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -43,7 +43,6 @@ import io.confluent.ksql.api.client.QueryInfo.QueryType;
 import io.confluent.ksql.api.client.exception.KsqlClientException;
 import io.confluent.ksql.api.client.exception.KsqlException;
 import io.confluent.ksql.api.client.impl.ConnectorTypeImpl;
-import io.confluent.ksql.api.client.impl.ExecuteStatementResultImpl;
 import io.confluent.ksql.api.client.impl.StreamedQueryResultImpl;
 import io.confluent.ksql.api.client.util.ClientTestUtil;
 import io.confluent.ksql.api.client.util.ClientTestUtil.TestSubscriber;
@@ -100,6 +99,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -108,6 +108,9 @@ import java.util.stream.Collectors;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo.ConnectorState;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Test;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -138,6 +141,8 @@ public class ClientTest extends BaseApiTest {
       + "SELECT' statements. ";
   protected static final org.apache.kafka.connect.runtime.rest.entities.ConnectorType SOURCE_TYPE =
       org.apache.kafka.connect.runtime.rest.entities.ConnectorType.SOURCE;
+
+  protected static final Map<String, String> REQUEST_HEADERS = ImmutableMap.of("h1", "v1", "h2", "v2");
 
   protected Client javaClient;
 
@@ -1761,6 +1766,31 @@ public class ClientTest extends BaseApiTest {
     assertThat(testEndpoints.getLastProperties(), is(new JsonObject().put("auto.offset.reset", "earliest")));
   }
 
+  @Test
+  public void shouldSendCustomRequestHeaders() throws Exception {
+    // Given:
+    final CommandStatusEntity entity = new CommandStatusEntity(
+        "CSAS;",
+        new CommandId("STREAM", "FOO", "CREATE"),
+        new CommandStatus(
+            CommandStatus.Status.SUCCESS,
+            "Success"
+        ),
+        0L
+    );
+    testEndpoints.setKsqlEndpointResponse(Collections.singletonList(entity));
+
+    // When:
+    javaClient.executeStatement("CSAS;").get();
+
+    // Then:
+    final List<Entry<String, String>> requestHeaders =
+        testEndpoints.getLastApiSecurityContext().getRequestHeaders();
+    for (final Entry<String, String> header : REQUEST_HEADERS.entrySet()) {
+      assertThat(requestHeaders, hasItems(entry(header)));
+    }
+  }
+
   protected Client createJavaClient() {
     return Client.create(createJavaClientOptions(), vertx);
   }
@@ -1768,7 +1798,8 @@ public class ClientTest extends BaseApiTest {
   protected ClientOptions createJavaClientOptions() {
     return ClientOptions.create()
         .setHost("localhost")
-        .setPort(server.getListeners().get(0).getPort());
+        .setPort(server.getListeners().get(0).getPort())
+        .setRequestHeaders(REQUEST_HEADERS);
   }
 
   private void verifyPushQueryServerState(final String sql) {
@@ -2068,5 +2099,31 @@ public class ClientTest extends BaseApiTest {
       this.sourceDescription = sourceDescription;
       this.warnings = warnings;
     }
+  }
+
+  private static Matcher<? super Entry<String, String>> entry(
+      final Entry<String, String> entry
+  ) {
+    return new TypeSafeDiagnosingMatcher<Entry<String, String>>() {
+      @Override
+      protected boolean matchesSafely(
+          final Entry<String, String> actual,
+          final Description mismatchDescription) {
+        if (!entry.getKey().equals(actual.getKey())) {
+          return false;
+        }
+        if (!entry.getValue().equals(actual.getValue())) {
+          return false;
+        }
+        return true;
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText(String.format(
+            "key: %s. value: %s",
+            entry.getKey(), entry.getValue()));
+      }
+    };
   }
 }

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTlsTest.java
@@ -59,9 +59,7 @@ public class ClientTlsTest extends ClientTest {
 
   @Override
   protected ClientOptions createJavaClientOptions() {
-    return ClientOptions.create()
-        .setHost("localhost")
-        .setPort(server.getListeners().get(0).getPort())
+    return super.createJavaClientOptions()
         .setUseTls(true)
         .setTrustStore(TRUST_STORE_PATH)
         .setTrustStorePassword(TRUST_STORE_PASSWORD)

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientOptionsImplTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/impl/ClientOptionsImplTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.api.client.impl;
 
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.api.client.ClientOptions;
+import java.util.Collections;
 import org.junit.Test;
 
 public class ClientOptionsImplTest {
@@ -65,6 +66,9 @@ public class ClientOptionsImplTest {
         )
         .addEqualityGroup(
             ClientOptions.create().setHttp2MultiplexingLimit(5)
+        )
+        .addEqualityGroup(
+            ClientOptions.create().setRequestHeaders(Collections.singletonMap("h1", "v1"))
         )
         .testEquals();
   }

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/MigrationConfig.java
@@ -187,7 +187,8 @@ public final class MigrationConfig extends AbstractConfig {
         configs.get(SSL_KEY_PASSWORD),
         configs.get(SSL_KEY_ALIAS),
         configs.getOrDefault(SSL_ALPN, "false").equalsIgnoreCase("true"),
-        configs.getOrDefault(SSL_VERIFY_HOST, "true").equalsIgnoreCase("true")
+        configs.getOrDefault(SSL_VERIFY_HOST, "true").equalsIgnoreCase("true"),
+        null
     );
     final String serviceId;
     try {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/MigrationsUtil.java
@@ -18,10 +18,14 @@ package io.confluent.ksql.tools.migrations.util;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.api.client.Client;
 import io.confluent.ksql.api.client.ClientOptions;
+import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.tools.migrations.MigrationConfig;
 import io.confluent.ksql.tools.migrations.MigrationException;
+import io.confluent.ksql.util.KsqlException;
+import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 
 public final class MigrationsUtil {
 
@@ -31,6 +35,11 @@ public final class MigrationsUtil {
   public static final String MIGRATIONS_COMMAND = "ksql-migrations";
 
   public static Client getKsqlClient(final MigrationConfig config) throws MigrationException {
+    return getKsqlClient(config, null);
+  }
+
+  public static Client getKsqlClient(final MigrationConfig config, final String headersFile)
+      throws MigrationException {
     return getKsqlClient(
         config.getString(MigrationConfig.KSQL_SERVER_URL),
         config.getString(MigrationConfig.KSQL_BASIC_AUTH_USERNAME),
@@ -42,7 +51,8 @@ public final class MigrationsUtil {
         config.getString(MigrationConfig.SSL_KEY_PASSWORD),
         config.getString(MigrationConfig.SSL_KEY_ALIAS),
         config.getBoolean(MigrationConfig.SSL_ALPN),
-        config.getBoolean(MigrationConfig.SSL_VERIFY_HOST)
+        config.getBoolean(MigrationConfig.SSL_VERIFY_HOST),
+        loadRequestHeaders(headersFile)
     );
   }
 
@@ -59,11 +69,12 @@ public final class MigrationsUtil {
       final String sslKeyPassword,
       final String sslKeyAlias,
       final boolean sslAlpn,
-      final boolean sslVerifyHost
+      final boolean sslVerifyHost,
+      final Map<String, String> requestHeaders
   ) {
     return Client.create(createClientOptions(ksqlServerUrl, username, password,
         sslTrustStoreLocation, sslTrustStorePassword, sslKeystoreLocation, sslKeystorePassword,
-        sslKeyPassword, sslKeyAlias, sslAlpn, sslVerifyHost));
+        sslKeyPassword, sslKeyAlias, sslAlpn, sslVerifyHost, requestHeaders));
   }
 
   @VisibleForTesting
@@ -80,7 +91,8 @@ public final class MigrationsUtil {
       final String sslKeyPassword,
       final String sslKeyAlias,
       final boolean useAlpn,
-      final boolean verifyHost
+      final boolean verifyHost,
+      final Map<String, String> requestHeaders
   ) {
     final URL url;
     try {
@@ -111,6 +123,23 @@ public final class MigrationsUtil {
       options.setUseAlpn(useAlpn);
       options.setVerifyHost(verifyHost);
     }
+
+    if (requestHeaders != null) {
+      options.setRequestHeaders(requestHeaders);
+    }
+
     return options;
+  }
+
+  private static Map<String, String> loadRequestHeaders(final String headersFile) {
+    if (headersFile == null || headersFile.trim().isEmpty()) {
+      return null;
+    }
+
+    try {
+      return PropertiesUtil.loadProperties(new File(headersFile.trim()));
+    } catch (KsqlException e) {
+      throw new MigrationException("Could not parse headers file '" + headersFile + "'.");
+    }
   }
 }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -171,7 +171,7 @@ public class ApplyMigrationCommandTest {
     when(versionQueryResult.get()).thenReturn(ImmutableList.of());
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -192,7 +192,7 @@ public class ApplyMigrationCommandTest {
     when(versionQueryResult.get()).thenReturn(ImmutableList.of());
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -225,7 +225,7 @@ public class ApplyMigrationCommandTest {
     );
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -260,7 +260,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -289,7 +289,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -313,7 +313,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -333,7 +333,7 @@ public class ApplyMigrationCommandTest {
     when(versionQueryResult.get()).thenReturn(ImmutableList.of());
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -350,7 +350,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -371,7 +371,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -392,7 +392,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -416,7 +416,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -438,7 +438,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -459,7 +459,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.RUNNING);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -479,7 +479,7 @@ public class ApplyMigrationCommandTest {
     when(statementResultCf.get()).thenThrow(new ExecutionException("sql rejected", new RuntimeException()));
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -502,7 +502,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -523,7 +523,7 @@ public class ApplyMigrationCommandTest {
     assertThat(new File(migrationsDir + "/foo.sql").createNewFile(), is(true));
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -544,7 +544,7 @@ public class ApplyMigrationCommandTest {
         .thenThrow(new ExecutionException("Source not found", new RuntimeException()));
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -561,7 +561,7 @@ public class ApplyMigrationCommandTest {
     when(versionQueryResult.get()).thenReturn(ImmutableList.of());
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -582,7 +582,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -608,7 +608,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -630,7 +630,7 @@ public class ApplyMigrationCommandTest {
     givenAppliedMigration(1, NAME, MigrationState.MIGRATED);
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:
@@ -651,7 +651,7 @@ public class ApplyMigrationCommandTest {
     givenCurrentMigrationVersion("1");
 
     // When:
-    final int result = command.command(config, cfg -> ksqlClient, migrationsDir, Clock.fixed(
+    final int result = command.command(config, (cfg, headers) -> ksqlClient, migrationsDir, Clock.fixed(
         Instant.ofEpochMilli(1000), ZoneId.systemDefault()));
 
     // Then:

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/MigrationsUtilTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/MigrationsUtilTest.java
@@ -18,8 +18,11 @@ package io.confluent.ksql.tools.migrations.util;
 import static io.confluent.ksql.tools.migrations.util.MigrationsUtil.createClientOptions;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.api.client.ClientOptions;
+import java.util.Map;
 import org.junit.Test;
 
 public class MigrationsUtilTest {
@@ -32,7 +35,7 @@ public class MigrationsUtilTest {
     // Given:
     final ClientOptions clientOptions = createClientOptions(NON_TLS_URL, "user",
         "pass", null, "", null,
-        null, "", "foo", false, true);
+        null, "", "foo", false, true, null);
 
     // Then:
     assertThat(clientOptions.isUseTls(), is(false));
@@ -46,14 +49,16 @@ public class MigrationsUtilTest {
     assertThat(clientOptions.getKeyAlias(), is(""));
     assertThat(clientOptions.isUseAlpn(), is(false));
     assertThat(clientOptions.isVerifyHost(), is(true));
+    assertThat(clientOptions.getRequestHeaders(), nullValue());
   }
 
   @Test
   public void shouldCreateTlsClientOptions() {
     // Given:
+    final Map<String, String> requestHeaders = ImmutableMap.of("h1", "v1", "h2", "v2");
     final ClientOptions clientOptions = createClientOptions(TLS_URL, "user",
         "pass", "abc", null, null,
-        null, null, null, true, true);
+        null, null, null, true, true, requestHeaders);
 
     // Then:
     assertThat(clientOptions.isUseTls(), is(true));
@@ -67,5 +72,6 @@ public class MigrationsUtilTest {
     assertThat(clientOptions.getKeyAlias(), is(""));
     assertThat(clientOptions.isUseAlpn(), is(true));
     assertThat(clientOptions.isVerifyHost(), is(true));
+    assertThat(clientOptions.getRequestHeaders(), is(requestHeaders));
   }
 }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/MigrationsUtilTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/MigrationsUtilTest.java
@@ -18,10 +18,10 @@ package io.confluent.ksql.tools.migrations.util;
 import static io.confluent.ksql.tools.migrations.util.MigrationsUtil.createClientOptions;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.api.client.ClientOptions;
+import java.util.Collections;
 import java.util.Map;
 import org.junit.Test;
 
@@ -49,7 +49,7 @@ public class MigrationsUtilTest {
     assertThat(clientOptions.getKeyAlias(), is(""));
     assertThat(clientOptions.isUseAlpn(), is(false));
     assertThat(clientOptions.isVerifyHost(), is(true));
-    assertThat(clientOptions.getRequestHeaders(), nullValue());
+    assertThat(clientOptions.getRequestHeaders(), is(Collections.emptyMap()));
   }
 
   @Test


### PR DESCRIPTION
### Description 

This PR adds support for specifying custom request headers for requests issued to the ksqlDB server via the Java client, and also when applying migrations with the ksql migrations tool.

When creating a Java client instance, the new `ClientOptions#setRequestHeaders(Map<String,String>)` method can be used to set custom request headers:
```
/**
   * Sets custom request headers to be sent with requests to the ksqlDB server.
   * These headers are in addition to any automatic headers such as the
   * authorization header.
   *
   * <p>If this method is called more than once, only the headers passed on
   * the last invocation will be used. To update existing custom headers,
   * use this method in combination with {@link ClientOptions#getRequestHeaders()}.
   *
   * <p>In case of overlap between these custom headers and automatic headers such
   * as the authorization header, these custom headers take precedence.
   *
   * @param requestHeaders custom request headers
   * @return a reference to this
   */
  ClientOptions setRequestHeaders(Map<String, String> requestHeaders);
```
This PR also introduces a corresponding `ClientOptions#getRequestHeaders()` method as mentioned in the javadoc.

When using the ksql-migrations tool, you can now pass an optional `--headers` flag to the `apply` command in order to specify custom request headers to be sent with all requests to the ksqlDB server (related to applying the migration(s)):
```
ksql-migrations ... apply ... --headers /path/to/custom/headers/file.txt
```
The headers file should be formatted as a properties file. Either of the following is acceptable:
```
X-My-Custom-Header: abcdefg
X-My-Other-Custom-Header: asdfgh
```
or
```
X-My-Custom-Header=abcdefg
X-My-Other-Custom-Header=asdfgh
```

### Testing done 

Unit + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

