### PR TITLE
fix: check for the queryId in the Task ID for registering saturation metric

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -268,7 +268,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
 
   private String getQueryId(final KafkaMetric metric) {
     final String taskName = metric.metricName().tags().getOrDefault("task-id", "");
-    final Pattern namedTopologyPattern = Pattern.compile("(.*?)__(\\d*_\\d*)");
+    final Pattern namedTopologyPattern = Pattern.compile("(.*?)__\\d*_\\d*");
     final Matcher namedTopologyMatcher = namedTopologyPattern.matcher(taskName);
     if (namedTopologyMatcher.find()) {
       return namedTopologyMatcher.group(1);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -267,6 +267,13 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   }
 
   private String getQueryId(final KafkaMetric metric) {
+    final String taskName = metric.metricName().tags().getOrDefault("task-id", "");
+    final Pattern namedTopologyPattern = Pattern.compile("(.*?)__(\\d*_\\d*)");
+    final Matcher namedTopologyMatcher = namedTopologyPattern.matcher(taskName);
+    if (namedTopologyMatcher.find()) {
+      return namedTopologyMatcher.group(1);
+    }
+
     final String queryIdTag = metric.metricName().tags().getOrDefault("thread-id", "");
     final Pattern pattern = Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
     final Matcher matcher = pattern.matcher(queryIdTag);


### PR DESCRIPTION
### Description 
When registering the saturation metric we used to parse the Thread name to get the query ID. When we use shared runtimes the query ID is not in the Thread name. Instead that is in the Task ID, so we will just try to parse that to see if we can find the Query ID  first then fall back to the old approach. Then we don't have to worry about passing through a config. 

### Testing done 
Just add a unit test with no Query ID in the thread name put it is in the Task ID

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

