### PR TITLE
fix: update restore command topic tool to work with command topic configs

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -163,9 +163,9 @@ public class KsqlRestConfig extends AbstractConfig {
 
   private static final String KSQL_CONFIG_PREFIX = "ksql.";
 
-  private static final String COMMAND_CONSUMER_PREFIX =
+  public static final String COMMAND_CONSUMER_PREFIX =
       KSQL_CONFIG_PREFIX + "server.command.consumer.";
-  private static final String COMMAND_PRODUCER_PREFIX =
+  public static final String COMMAND_PRODUCER_PREFIX =
       KSQL_CONFIG_PREFIX + "server.command.producer.";
 
   public static final String ADVERTISED_LISTENER_CONFIG =

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -288,13 +288,9 @@ public class KsqlRestoreCommandTopic {
   }
 
   KsqlRestoreCommandTopic(final KsqlConfig serverConfig) {
-    final Map<String, Object> adminClientConfigs =
-      new HashMap<>(serverConfig.getKsqlAdminClientConfigProps());
-    adminClientConfigs.putAll(serverConfig.originalsWithPrefix("ksql.server.command.consumer."));
-    final Admin admin = new DefaultKafkaClientSupplier().getAdmin(adminClientConfigs);
     this.serverConfig = serverConfig;
     this.commandTopicName = ReservedInternalTopics.commandTopic(serverConfig);
-    this.topicClient = new KafkaTopicClientImpl(() -> admin);
+    this.topicClient = new KafkaTopicClientImpl(() -> createAdminClient(serverConfig));
     this.kafkaProducerSupplier = () -> transactionalProducer(serverConfig);
   }
 
@@ -450,5 +446,12 @@ public class KsqlRestoreCommandTopic {
 
   private static boolean hasKey(final JSONObject jsonObject, final String key) {
     return jsonObject != null && jsonObject.has(key);
+  }
+  
+  private Admin createAdminClient(final KsqlConfig serverConfig) {
+    final Map<String, Object> adminClientConfigs =
+      new HashMap<>(serverConfig.getKsqlAdminClientConfigProps());
+    adminClientConfigs.putAll(serverConfig.originalsWithPrefix("ksql.server.command.consumer."));
+    return new DefaultKafkaClientSupplier().getAdmin(adminClientConfigs);
   }
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/restore/KsqlRestoreCommandTopic.java
@@ -278,6 +278,7 @@ public class KsqlRestoreCommandTopic {
         ProducerConfig.ACKS_CONFIG,
         "all"
     );
+    transactionalProperties.putAll(serverConfig.originalsWithPrefix("ksql.server.command.consumer."));
 
     return new KafkaProducer<>(
         transactionalProperties,
@@ -287,13 +288,14 @@ public class KsqlRestoreCommandTopic {
   }
 
   KsqlRestoreCommandTopic(final KsqlConfig serverConfig) {
-    this(
-        serverConfig,
-        ReservedInternalTopics.commandTopic(serverConfig),
-        ServiceContextFactory.create(serverConfig,
-            () -> /* no ksql client */ null).getTopicClient(),
-        () -> transactionalProducer(serverConfig)
-    );
+    final Map<String, Object> adminClientConfigs =
+      new HashMap<>(serverConfig.getKsqlAdminClientConfigProps());
+    adminClientConfigs.putAll(serverConfig.originalsWithPrefix("ksql.server.command.consumer."));
+    final Admin admin = new DefaultKafkaClientSupplier().getAdmin(adminClientConfigs);
+    this.serverConfig = serverConfig;
+    this.commandTopicName = ReservedInternalTopics.commandTopic(serverConfig);
+    this.topicClient = new KafkaTopicClientImpl(() -> admin);
+    this.kafkaProducerSupplier = () -> transactionalProducer(serverConfig);
   }
 
   @VisibleForTesting

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicMultipleKafkasIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/integration/RestoreCommandTopicMultipleKafkasIntegrationTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.api.integration;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.integration.Retry;
+import io.confluent.ksql.rest.DefaultErrorMessages;
+import io.confluent.ksql.rest.entity.CommandId;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlWarning;
+import io.confluent.ksql.rest.entity.SourceInfo;
+import io.confluent.ksql.rest.entity.StreamsList;
+import io.confluent.ksql.rest.integration.RestIntegrationTestUtil;
+import io.confluent.ksql.rest.server.BackupReplayFile;
+import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.rest.server.computation.Command;
+import io.confluent.ksql.rest.server.computation.InternalTopicSerdes;
+import io.confluent.ksql.rest.server.restore.KsqlRestoreCommandTopic;
+import io.confluent.ksql.test.util.KsqlTestFolder;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ReservedInternalTopics;
+import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_METASTORE_BACKUP_LOCATION;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
+import static java.lang.Thread.sleep;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests covering integration tests for backup/restore the command topic when the command topic and streams/tables are on different kafkas.
+ */
+@Category({IntegrationTest.class})
+public class RestoreCommandTopicMultipleKafkasIntegrationTest {
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+  private static final IntegrationTestHarness INTERNAL_TEST_HARNESS = IntegrationTestHarness.build();
+
+  @ClassRule
+  public static final RuleChain CHAIN = RuleChain
+      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .around(TEST_HARNESS);
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = KsqlTestFolder.temporaryFolder();
+
+  private static File BACKUP_LOCATION;
+  private static TestKsqlRestApp REST_APP;
+  private String commandTopic;
+  private Path backupFile;
+  private Path propertiesFile;
+
+  @BeforeClass
+  public static void classSetUp() throws Exception {
+    BACKUP_LOCATION = TMP_FOLDER.newFolder();
+    INTERNAL_TEST_HARNESS.getKafkaCluster().start();
+
+    REST_APP = TestKsqlRestApp
+        .builder(TEST_HARNESS::kafkaBootstrapServers)
+        .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
+        .withProperty(KSQL_METASTORE_BACKUP_LOCATION, BACKUP_LOCATION.getPath())
+        .withProperty(StreamsConfig.STATE_DIR_CONFIG, "/tmp/cat/")
+        .withProperty("ksql.server.command.consumer.bootstrap.servers", INTERNAL_TEST_HARNESS.kafkaBootstrapServers())
+        .withProperty("ksql.server.command.producer.bootstrap.servers", INTERNAL_TEST_HARNESS.kafkaBootstrapServers())
+        .build();
+  }
+
+  @Before
+  public void setup() throws IOException {
+    REST_APP.start();
+
+    final KsqlConfig ksqlConfig = new KsqlConfig(REST_APP.getKsqlRestConfig().getKsqlConfigProperties());
+    commandTopic = ReservedInternalTopics.commandTopic(ksqlConfig);
+    backupFile = Files.list(BACKUP_LOCATION.toPath()).findFirst().get();
+    propertiesFile = TMP_FOLDER.newFile().toPath();
+    writeServerProperties(propertiesFile);
+  }
+
+  @After
+  public void teardown() {
+    REST_APP.stop();
+    INTERNAL_TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
+  }
+
+  @After
+  public void teardownClass() {
+    TMP_FOLDER.delete();
+  }
+
+  private static void writeServerProperties(final Path propertiesFile) throws IOException {
+    final Map<String, Object> map = REST_APP.getKsqlRestConfig().getKsqlConfigProperties();
+
+    Files.write(
+            propertiesFile,
+        map.keySet().stream()
+            .map((key -> key + "=" + map.get(key)))
+            .collect(Collectors.joining("\n"))
+            .getBytes(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE
+    );
+  }
+
+  @Test
+  public void shouldBackupAndRestoreCommandTopic() throws Exception {
+    // Given
+    TEST_HARNESS.ensureTopics("topic1", "topic2");
+
+    makeKsqlRequest("CREATE STREAM TOPIC1 (ID INT) "
+        + "WITH (KAFKA_TOPIC='topic1', VALUE_FORMAT='JSON');");
+    makeKsqlRequest("CREATE STREAM TOPIC2 (ID INT) "
+        + "WITH (KAFKA_TOPIC='topic2', VALUE_FORMAT='JSON');");
+    makeKsqlRequest("CREATE STREAM stream1 AS SELECT * FROM topic1;");
+    makeKsqlRequest("CREATE STREAM stream2 AS SELECT * FROM topic2;");
+
+    // When
+
+    // Delete the command topic and check the server is in degraded state
+    INTERNAL_TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
+    assertThatEventually("Degraded State", this::isDegradedState, is(true));
+
+    // Restore the command topic
+    KsqlRestoreCommandTopic.main(
+        new String[]{
+            "--yes",
+            "--config-file", propertiesFile.toString(),
+            backupFile.toString()
+        });
+
+    // Re-load the command topic
+    REST_APP.stop();
+    REST_APP.start();
+
+    // Then
+    final List<String> streamsNames = showStreams();
+    assertThat("Should have TOPIC1", streamsNames.contains("TOPIC1"), is(true));
+    assertThat("Should have TOPIC2", streamsNames.contains("TOPIC2"), is(true));
+    assertThat("Should have STREAM1", streamsNames.contains("STREAM1"), is(true));
+    assertThat("Should have STREAM2", streamsNames.contains("STREAM2"), is(true));
+    assertThat("Server should NOT be in degraded state", isDegradedState(), is(false));
+  }
+
+  @Test
+  public void shouldSkipIncompatibleCommands() throws Exception {
+    // Given
+    TEST_HARNESS.ensureTopics("topic3", "topic4");
+
+    makeKsqlRequest("CREATE STREAM TOPIC3 (ID INT) "
+        + "WITH (KAFKA_TOPIC='topic3', VALUE_FORMAT='JSON');");
+    makeKsqlRequest("CREATE STREAM TOPIC4 (ID INT) "
+        + "WITH (KAFKA_TOPIC='topic4', VALUE_FORMAT='JSON');");
+    makeKsqlRequest("CREATE STREAM stream3 AS SELECT * FROM topic3;");
+
+    final CommandId commandId = new CommandId("TOPIC", "entity", "CREATE");
+    final Command command = new Command(
+        "statement",
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Optional.empty(),
+        Optional.of(Command.VERSION + 1),
+        Command.VERSION + 1);
+
+    writeToBackupFile(commandId, command, backupFile);
+
+    // Delete the command topic again and restore with skip flag
+    INTERNAL_TEST_HARNESS.deleteTopics(Collections.singletonList(commandTopic));
+    REST_APP.stop();
+    KsqlRestoreCommandTopic.main(
+        new String[]{
+            "--yes",
+            "-s",
+            "--config-file", propertiesFile.toString(),
+            backupFile.toString()
+        });
+
+    // Re-load the command topic
+    REST_APP.start();
+    final List<String> streamsNames = showStreams();
+    assertThat("Should have TOPIC3", streamsNames.contains("TOPIC3"), is(true));
+    assertThat("Should have TOPIC4", streamsNames.contains("TOPIC4"), is(true));
+    assertThat("Should have STREAM3", streamsNames.contains("STREAM3"), is(true));
+    assertThat("Server should not be in degraded state", isDegradedState(), is(false));
+  }
+
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+  @Test
+  public void shouldCleanUpLeftoverStateStores() throws InterruptedException {
+    // Given:
+    File tempDir = new File("/tmp/cat/");
+    if (!tempDir.exists()){
+      tempDir.mkdirs();
+    }
+    File fakeStateStore = new File(tempDir.getAbsolutePath() + "/fakeStateStore");
+    if (!fakeStateStore.exists()){
+      fakeStateStore.mkdirs();
+    }
+    makeKsqlRequest("CREATE STREAM new_stream (ID INT, price int) "
+            + "WITH (KAFKA_TOPIC='temp_top', partitions=3, VALUE_FORMAT='JSON');");
+    makeKsqlRequest("CREATE TABLE new_stream_3 AS SELECT id, sum(price) FROM new_stream group by ID;");
+    File realStateStore = new File(tempDir.getAbsolutePath() + "/_confluent-ksql-default_query_CTAS_NEW_STREAM_3_1");
+
+    assertTrue(tempDir.exists());
+    assertTrue(fakeStateStore.exists());
+    assertTrue(realStateStore.exists());
+
+    // When:
+    REST_APP.stop();
+    REST_APP.start();
+    sleep(3000);
+
+    // Then:
+    assertFalse(fakeStateStore.exists());
+    assertTrue(realStateStore.exists());
+  }
+
+  private boolean isDegradedState() {
+    // If in degraded state, then the following command will return a warning
+    final List<KsqlEntity> response = makeKsqlRequest(
+        "Show Streams;");
+
+    final List<KsqlWarning> warnings = response.get(0).getWarnings();
+    return warnings.size() > 0 &&
+        (warnings.get(0).getMessage().contains(
+            DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_CORRUPTED_ERROR_MESSAGE) ||
+            warnings.get(0).getMessage().contains(
+                DefaultErrorMessages.COMMAND_RUNNER_DEGRADED_INCOMPATIBLE_COMMANDS_ERROR_MESSAGE));
+  }
+
+  private List<String> showStreams() {
+    return ((StreamsList)makeKsqlRequest("SHOW STREAMS;").get(0))
+        .getStreams().stream().map(SourceInfo::getName).collect(Collectors.toList());
+  }
+
+  private List<KsqlEntity> makeKsqlRequest(final String sql) {
+    return RestIntegrationTestUtil.makeKsqlRequest(REST_APP, sql);
+  }
+
+  private static void writeToBackupFile(
+      final CommandId commandId,
+      final Command command,
+      final Path backUpFileLocation
+  ) throws IOException {
+    BackupReplayFile.writable(new File(String.valueOf(backUpFileLocation)))
+        .write(new ConsumerRecord<>(
+            "",
+            0,
+            0L,
+            InternalTopicSerdes.serializer().serialize("", commandId),
+            InternalTopicSerdes.serializer().serialize("", command))
+        );
+  }
+}


### PR DESCRIPTION
### Description 
We recently updated the ksql command topic to make sure that it's using the command topic configs that can be passed in through the properties file, https://github.com/confluentinc/ksql/pull/8742. With these changes, we needed to update the restore command topic tool to make sure it's using the same configs as would be used when we create the command topic. This ensures that if the tool is used on a ksql that has its command topic on a separate kafka from the rest of its topics, the command topic will be properly recreated on the separate kafka.

### Testing done 
Added an integration test, the same tests as we currently do for the restore tool but separates the command topic onto a different kafka broker

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

