### PR TITLE
chore: Switching from shade to assembly plugin for ksqldb-benchmarks.

### DIFF
--- a/ksqldb-benchmark/pom.xml
+++ b/ksqldb-benchmark/pom.xml
@@ -131,33 +131,27 @@ questions.
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>2.0</version>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <finalName>benchmarks</finalName>
+          <archive>
+            <manifest>
+              <mainClass>org.openjdk.jmh.Main</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <appendAssemblyId>false</appendAssemblyId>
+          <attach>false</attach>
+        </configuration>
         <executions>
           <execution>
+            <id>make-assembly</id>
             <phase>package</phase>
             <goals>
-              <goal>shade</goal>
+              <goal>single</goal>
             </goals>
-            <configuration>
-              <finalName>benchmarks</finalName>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>org.openjdk.jmh.Main</mainClass>
-                </transformer>
-              </transformers>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/services/javax.annotation.processing.Processor</exclude>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -655,9 +655,6 @@
                     <artifactId>maven-assembly-plugin</artifactId>
                     <configuration>
                         <tarLongFileMode>posix</tarLongFileMode>
-                        <descriptors>
-                            <descriptor>src/assembly/package.xml</descriptor>
-                        </descriptors>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
### Description 
Switches plugins used to build the benchmarks.jar.

This will allow developers to skip all assembly work with `mvn -Dassembly.skipAssembly <goals>`