### PR TITLE
feat: add consistency levels to clients

### DIFF
--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ClientOptions.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/ClientOptions.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.api.client;
 
 import io.confluent.ksql.api.client.impl.ClientOptionsImpl;
+import io.confluent.ksql.util.ClientConfig.ConsistencyLevel;
 import java.util.Map;
 
 /**
@@ -162,6 +163,14 @@ public interface ClientOptions {
   ClientOptions setRequestHeaders(Map<String, String> requestHeaders);
 
   /**
+   * Sets the consistency level to be used for Pull queries.
+   * @param consistencyLevel custom consistency level
+   * @return a reference to this
+   */
+  ClientOptions setConsistencyLevel(ConsistencyLevel consistencyLevel);
+
+
+  /**
    * Returns the host name of the ksqlDB server to connect to.
    *
    * @return host name
@@ -287,6 +296,12 @@ public interface ClientOptions {
    * @return the copy
    */
   ClientOptions copy();
+
+  /**
+   * Returns the consistency level this client uses for Pull queries.
+   * @return consistency level
+   */
+  ConsistencyLevel getConsistencyLevel();
 
   static ClientOptions create() {
     return new ClientOptionsImpl();

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -129,7 +129,7 @@ public class ClientImpl implements Client {
       final String sql,
       final Map<String, Object> properties
   ) {
-    if (clientOptions.getConsistencyLevel() == ConsistencyLevel.MONOTONIC_READS) {
+    if (clientOptions.getConsistencyLevel() == ConsistencyLevel.MONOTONIC_SESSION) {
       requestProperties.put(
           KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR,
           serializedConsistencyVector.get());
@@ -151,7 +151,7 @@ public class ClientImpl implements Client {
       final String sql,
       final Map<String, Object> properties
   ) {
-    if (clientOptions.getConsistencyLevel() == ConsistencyLevel.MONOTONIC_READS) {
+    if (clientOptions.getConsistencyLevel() == ConsistencyLevel.MONOTONIC_SESSION) {
       requestProperties.put(
           KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR,
           serializedConsistencyVector.get());

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientImpl.java
@@ -36,7 +36,7 @@ import io.confluent.ksql.api.client.StreamedQueryResult;
 import io.confluent.ksql.api.client.TableInfo;
 import io.confluent.ksql.api.client.TopicInfo;
 import io.confluent.ksql.api.client.exception.KsqlClientException;
-import io.confluent.ksql.util.ConsistencyOffsetVector;
+import io.confluent.ksql.util.ClientConfig.ConsistencyLevel;
 import io.confluent.ksql.util.KsqlRequestConfig;
 import io.confluent.ksql.util.VertxSslOptionsFactory;
 import io.vertx.core.Context;
@@ -129,7 +129,7 @@ public class ClientImpl implements Client {
       final String sql,
       final Map<String, Object> properties
   ) {
-    if (ConsistencyOffsetVector.isConsistencyVectorEnabled(properties)) {
+    if (clientOptions.getConsistencyLevel() == ConsistencyLevel.MONOTONIC_READS) {
       requestProperties.put(
           KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR,
           serializedConsistencyVector.get());
@@ -151,7 +151,7 @@ public class ClientImpl implements Client {
       final String sql,
       final Map<String, Object> properties
   ) {
-    if (ConsistencyOffsetVector.isConsistencyVectorEnabled(properties)) {
+    if (clientOptions.getConsistencyLevel() == ConsistencyLevel.MONOTONIC_READS) {
       requestProperties.put(
           KsqlRequestConfig.KSQL_REQUEST_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR,
           serializedConsistencyVector.get());

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.api.client.impl;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.api.client.ClientOptions;
+import io.confluent.ksql.util.ClientConfig.ConsistencyLevel;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -40,6 +41,7 @@ public class ClientOptionsImpl implements ClientOptions {
   private int executeQueryMaxResultRows = ClientOptions.DEFAULT_EXECUTE_QUERY_MAX_RESULT_ROWS;
   private int http2MultiplexingLimit = ClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
   private Map<String, String> requestHeaders;
+  private ConsistencyLevel consistencyLevel;
 
   /**
    * {@code ClientOptions} should be instantiated via {@link ClientOptions#create}, NOT via this
@@ -58,7 +60,8 @@ public class ClientOptionsImpl implements ClientOptions {
       final String keyStorePath, final String keyStorePassword, final String keyPassword,
       final String keyAlias, final String basicAuthUsername, final String basicAuthPassword,
       final int executeQueryMaxResultRows, final int http2MultiplexingLimit,
-      final Map<String, String> requestHeaders) {
+      final Map<String, String> requestHeaders,
+      final ConsistencyLevel consistencyLevel) {
     this.host = Objects.requireNonNull(host);
     this.port = port;
     this.useTls = useTls;
@@ -76,6 +79,7 @@ public class ClientOptionsImpl implements ClientOptions {
     this.executeQueryMaxResultRows = executeQueryMaxResultRows;
     this.http2MultiplexingLimit = http2MultiplexingLimit;
     this.requestHeaders = requestHeaders;
+    this.consistencyLevel = consistencyLevel;
   }
 
   @Override
@@ -167,6 +171,12 @@ public class ClientOptionsImpl implements ClientOptions {
   @Override
   public ClientOptions setRequestHeaders(final Map<String, String> requestHeaders) {
     this.requestHeaders = requestHeaders == null ? null : ImmutableMap.copyOf(requestHeaders);
+    return this;
+  }
+
+  @Override
+  public ClientOptions setConsistencyLevel(final ConsistencyLevel consistencyLevel) {
+    this.consistencyLevel = consistencyLevel;
     return this;
   }
 
@@ -265,7 +275,13 @@ public class ClientOptionsImpl implements ClientOptions {
         keyStorePath, keyStorePassword, keyPassword, keyAlias,
         basicAuthUsername, basicAuthPassword,
         executeQueryMaxResultRows, http2MultiplexingLimit,
-        requestHeaders);
+        requestHeaders,
+        consistencyLevel);
+  }
+
+  @Override
+  public ConsistencyLevel getConsistencyLevel() {
+    return consistencyLevel;
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/ClientOptionsImpl.java
@@ -41,7 +41,7 @@ public class ClientOptionsImpl implements ClientOptions {
   private int executeQueryMaxResultRows = ClientOptions.DEFAULT_EXECUTE_QUERY_MAX_RESULT_ROWS;
   private int http2MultiplexingLimit = ClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
   private Map<String, String> requestHeaders;
-  private ConsistencyLevel consistencyLevel;
+  private ConsistencyLevel consistencyLevel = ConsistencyLevel.EVENTUAL;
 
   /**
    * {@code ClientOptions} should be instantiated via {@link ClientOptions#create}, NOT via this

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ConsistencyOffsetVectorFunctionalTest.java
@@ -229,7 +229,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
   public void shouldRoundTripCVWhenPullQueryHttp1() throws Exception {
     // Given
     final KsqlRestClient ksqlRestClient = REST_APP.buildKsqlClient(
-        Optional.empty(), ConsistencyLevel.MONOTONIC_READS);
+        Optional.empty(), ConsistencyLevel.MONOTONIC_SESSION);
 
     // When
     final RestResponse<StreamPublisher<StreamedRow>> response =
@@ -304,7 +304,7 @@ public class ConsistencyOffsetVectorFunctionalTest {
         .setHost("localhost")
         .setPort(REST_APP.getListeners().get(0).getPort());
     if (withConsistency)
-        clientOptions.setConsistencyLevel(ConsistencyLevel.MONOTONIC_READS);
+        clientOptions.setConsistencyLevel(ConsistencyLevel.MONOTONIC_SESSION);
     return Client.create(clientOptions, vertx);
   }
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/ClientConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/ClientConfig.java
@@ -19,6 +19,6 @@ public class ClientConfig {
 
   public enum ConsistencyLevel {
     EVENTUAL,
-    MONOTONIC_READS
+    MONOTONIC_SESSION
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/ClientConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/ClientConfig.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.util;
 public class ClientConfig {
 
   public enum ConsistencyLevel {
-    MONOTONIC_READS,
-    EVENTUAL
+    EVENTUAL,
+    MONOTONIC_READS
   }
 }

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/ClientConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/ClientConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+public class ClientConfig {
+
+  public enum ConsistencyLevel {
+    MONOTONIC_READS,
+    EVENTUAL
+  }
+}

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryConsistencyFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryConsistencyFunctionalTest.java
@@ -487,7 +487,7 @@ public class PullQueryConsistencyFunctionalTest {
         USER_CREDS);
 
     final KsqlRestClient restClient = clusterFormation.router.getApp().buildKsqlClient(
-        USER_CREDS, ConsistencyLevel.MONOTONIC_READS);
+        USER_CREDS, ConsistencyLevel.MONOTONIC_SESSION);
     final ImmutableMap<String, Object> requestProperties =
         ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryConsistencyFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryConsistencyFunctionalTest.java
@@ -63,6 +63,7 @@ import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
+import io.confluent.ksql.util.ClientConfig.ConsistencyLevel;
 import io.confluent.ksql.util.ConsistencyOffsetVector;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
@@ -485,7 +486,8 @@ public class PullQueryConsistencyFunctionalTest {
         HighAvailabilityTestUtil.lagsReported(clusterFormation.active.getHost(), Optional.of(10L), 10),
         USER_CREDS);
 
-    final KsqlRestClient restClient = clusterFormation.router.getApp().buildKsqlClient(USER_CREDS);
+    final KsqlRestClient restClient = clusterFormation.router.getApp().buildKsqlClient(
+        USER_CREDS, ConsistencyLevel.MONOTONIC_READS);
     final ImmutableMap<String, Object> requestProperties =
         ImmutableMap.of(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryIQv2FunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryIQv2FunctionalTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.integration;
 
-import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_STREAMS_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -691,8 +690,7 @@ public class PullQueryIQv2FunctionalTest {
   ) {
     final KsqlRestClient ksqlRestClient = target.buildKsqlClient(validCreds(), ConsistencyLevel.MONOTONIC_SESSION);
     final ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<String, Object>()
-        .put(KsqlRequestConfig.KSQL_DEBUG_REQUEST, true)
-        .put(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);
+        .put(KsqlRequestConfig.KSQL_DEBUG_REQUEST, true);
     final Map<String, Object> requestProperties = builder.build();
     final RestResponse<List<StreamedRow>> res =
         ksqlRestClient.makeQueryRequest(sql, null, null, requestProperties);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryIQv2FunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryIQv2FunctionalTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.serde.SerdeFeatures;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.test.util.KsqlTestFolder;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
+import io.confluent.ksql.util.ClientConfig.ConsistencyLevel;
 import io.confluent.ksql.util.ConsistencyOffsetVector;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
@@ -688,7 +689,7 @@ public class PullQueryIQv2FunctionalTest {
       final TestKsqlRestApp target,
       final String sql
   ) {
-    final KsqlRestClient ksqlRestClient = target.buildKsqlClient(validCreds());
+    final KsqlRestClient ksqlRestClient = target.buildKsqlClient(validCreds(), ConsistencyLevel.MONOTONIC_READS);
     final ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<String, Object>()
         .put(KsqlRequestConfig.KSQL_DEBUG_REQUEST, true)
         .put(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryIQv2FunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryIQv2FunctionalTest.java
@@ -689,7 +689,7 @@ public class PullQueryIQv2FunctionalTest {
       final TestKsqlRestApp target,
       final String sql
   ) {
-    final KsqlRestClient ksqlRestClient = target.buildKsqlClient(validCreds(), ConsistencyLevel.MONOTONIC_READS);
+    final KsqlRestClient ksqlRestClient = target.buildKsqlClient(validCreds(), ConsistencyLevel.MONOTONIC_SESSION);
     final ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<String, Object>()
         .put(KsqlRequestConfig.KSQL_DEBUG_REQUEST, true)
         .put(KSQL_QUERY_PULL_CONSISTENCY_OFFSET_VECTOR_ENABLED, true);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.ksql.util.ClientConfig.ConsistencyLevel;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants.KsqlQueryType;
 import io.confluent.ksql.util.ReservedInternalTopics;
@@ -198,6 +199,20 @@ public class TestKsqlRestApp extends ExternalResource {
         ImmutableMap.of(),
         credentials,
         Optional.empty()
+    );
+  }
+
+  public KsqlRestClient buildKsqlClient(
+      final Optional<BasicCredentials> credentials,
+      final ConsistencyLevel consistencyLevel
+  ) {
+    return KsqlRestClient.create(
+        getHttpListener().toString(),
+        ImmutableMap.of(),
+        ImmutableMap.of(),
+        credentials,
+        Optional.empty(),
+        consistencyLevel
     );
   }
 

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -36,7 +36,7 @@ import io.confluent.ksql.rest.entity.ServerClusterId;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.ServerMetadata;
 import io.confluent.ksql.rest.entity.StreamedRow;
-import io.confluent.ksql.util.ConsistencyOffsetVector;
+import io.confluent.ksql.util.ClientConfig.ConsistencyLevel;
 import io.confluent.ksql.util.KsqlRequestConfig;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
@@ -62,6 +62,7 @@ public final class KsqlRestClient implements Closeable {
   private final LocalProperties localProperties;
   private final AtomicReference<String> serializedConsistencyVector;
   private final Optional<BasicCredentials> ccloudApiKey;
+  private final ConsistencyLevel consistencyLevel;
 
   private List<URI> serverAddresses;
   private boolean isCCloudServer;
@@ -89,7 +90,8 @@ public final class KsqlRestClient implements Closeable {
         Optional.empty(),
         (cprops, credz, lprops) -> new KsqlClient(cprops, credz, lprops,
             new HttpClientOptions(),
-            Optional.of(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2)))
+            Optional.of(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2))),
+        ConsistencyLevel.EVENTUAL
     );
   }
 
@@ -116,7 +118,38 @@ public final class KsqlRestClient implements Closeable {
         ccloudApiKey,
         (cprops, credz, lprops) -> new KsqlClient(cprops, credz, lprops,
             new HttpClientOptions(),
-            Optional.of(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2)))
+            Optional.of(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2))),
+        ConsistencyLevel.EVENTUAL
+    );
+  }
+
+  /**
+   * @param serverAddress the address of the KSQL server to connect to.
+   * @param localProps initial set of local properties.
+   * @param clientProps properties used to build the client.
+   * @param creds optional credentials
+   * @param ccloudApiKey optional Confluent Cloud credentials for connector management
+   *                     from the ksqlDB CLI
+   * @param consistencyLevel the consistency level for pull queries
+   */
+  public static KsqlRestClient create(
+      final String serverAddress,
+      final Map<String, ?> localProps,
+      final Map<String, String> clientProps,
+      final Optional<BasicCredentials> creds,
+      final Optional<BasicCredentials> ccloudApiKey,
+      final ConsistencyLevel consistencyLevel
+  ) {
+    return create(
+        serverAddress,
+        localProps,
+        clientProps,
+        creds,
+        ccloudApiKey,
+        (cprops, credz, lprops) -> new KsqlClient(
+            cprops, credz, lprops, new HttpClientOptions(),
+            Optional.of(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_2))),
+        consistencyLevel
     );
   }
 
@@ -127,11 +160,13 @@ public final class KsqlRestClient implements Closeable {
       final Map<String, String> clientProps,
       final Optional<BasicCredentials> creds,
       final Optional<BasicCredentials> ccloudApiKey,
-      final KsqlClientSupplier clientSupplier
+      final KsqlClientSupplier clientSupplier,
+      final ConsistencyLevel consistencyLevel
   ) {
     final LocalProperties localProperties = new LocalProperties(localProps);
     final KsqlClient client = clientSupplier.get(clientProps, creds, localProperties);
-    return new KsqlRestClient(client, serverAddress, localProperties, ccloudApiKey);
+    return new KsqlRestClient(
+        client, serverAddress, localProperties, ccloudApiKey, consistencyLevel);
   }
 
   @FunctionalInterface
@@ -147,7 +182,8 @@ public final class KsqlRestClient implements Closeable {
       final KsqlClient client,
       final String serverAddress,
       final LocalProperties localProps,
-      final Optional<BasicCredentials> ccloudApiKey
+      final Optional<BasicCredentials> ccloudApiKey,
+      final ConsistencyLevel consistencyLevel
   ) {
     this.client = requireNonNull(client, "client");
     this.serverAddresses = parseServerAddresses(serverAddress);
@@ -155,6 +191,7 @@ public final class KsqlRestClient implements Closeable {
     this.ccloudApiKey = ccloudApiKey;
     this.serializedConsistencyVector = new AtomicReference<>();
     this.isCCloudServer = false;
+    this.consistencyLevel = consistencyLevel;
   }
 
   public URI getServerAddress() {
@@ -390,8 +427,11 @@ public final class KsqlRestClient implements Closeable {
   private Map<String, Object> setConsistencyVector(
       final Map<String, ?> requestProperties
   ) {
-    final Map<String, Object> requestPropertiesToSend = new HashMap<>(requestProperties);
-    if (ConsistencyOffsetVector.isConsistencyVectorEnabled(requestPropertiesToSend)) {
+    final Map<String, Object> requestPropertiesToSend = new HashMap<>();
+    if (requestProperties != null) {
+      requestPropertiesToSend.putAll(requestProperties);
+    }
+    if (consistencyLevel == ConsistencyLevel.MONOTONIC_READS) {
       final String serializedCV = serializedConsistencyVector.get();
       // KsqlRequest:serializeClassValues throws NPE for null value
       requestPropertiesToSend.put(

--- a/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksqldb-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -431,7 +431,7 @@ public final class KsqlRestClient implements Closeable {
     if (requestProperties != null) {
       requestPropertiesToSend.putAll(requestProperties);
     }
-    if (consistencyLevel == ConsistencyLevel.MONOTONIC_READS) {
+    if (consistencyLevel == ConsistencyLevel.MONOTONIC_SESSION) {
       final String serializedCV = serializedConsistencyVector.get();
       // KsqlRequest:serializeClassValues throws NPE for null value
       requestPropertiesToSend.put(

--- a/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
+++ b/ksqldb-rest-client/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.client.KsqlRestClient.KsqlClientSupplier;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
+import io.confluent.ksql.util.ClientConfig.ConsistencyLevel;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
@@ -249,7 +250,8 @@ public class KsqlRestClientTest {
         CLIENT_PROPS,
         Optional.empty(),
         ccloudApiKey,
-        clientSupplier
+        clientSupplier,
+        ConsistencyLevel.EVENTUAL
     );
   }
 


### PR DESCRIPTION
### Description 
Add two consistency levels for pull queries, `Eventual` and `Monotonic Reads`. The user can choose a consistency level when creating the client and this level will be used for all pull queries. 

### Testing done 
Updated the existing tests that exercise both levels

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

