### PR TITLE
fix: use blocking call and throw exception on failure

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -398,8 +398,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   @Override
   public void register() {
     sharedKafkaStreamsRuntime.register(
-        this,
-        queryId
+        this
     );
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -21,8 +21,8 @@ import io.confluent.ksql.util.QueryMetadataImpl.TimeBoundedQueue;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,20 +76,20 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
     try {
       if (kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
-         kafkaStreams.removeNamedTopology(queryId.toString(), false).all().get();
+        kafkaStreams.removeNamedTopology(queryId.toString(), false).all().get();
       }
       kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopologyCopy(this))
           .all()
           .get();
     }  catch (final Throwable e) {
-        final Throwable t = (e instanceof ExecutionException && e.getCause() != null)
-            ? e.getCause()
-            : e;
-        throw new IllegalStateException(String.format(
-            "Encountered an error when trying to add query %s to runtime: %s",
-            queryId,
-            getApplicationId()),
-            t);
+      final Throwable t = (e instanceof ExecutionException && e.getCause() != null)
+          ? e.getCause()
+          : e;
+      throw new IllegalStateException(String.format(
+          "Encountered an error when trying to add query %s to runtime: %s",
+          queryId,
+          getApplicationId()),
+        t);
     }
     log.info("Registered query: {}  in {} \n"
             + "Runtime {} is executing these queries: {}",

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SandboxedSharedKafkaStreamsRuntimeImpl.java
@@ -81,7 +81,7 @@ public class SandboxedSharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRu
             .all()
             .get();
       } else {
-        kafkaStreams.removeNamedTopology(queryId.toString()).all().get();
+        kafkaStreams.removeNamedTopology(queryId.toString(), false).all().get();
         kafkaStreams.addNamedTopology(binpackedPersistentQueryMetadata.getTopologyCopy(this))
             .all()
             .get();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntime.java
@@ -56,8 +56,7 @@ public abstract class SharedKafkaStreamsRuntime {
   }
 
   public abstract void register(
-      BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata,
-      QueryId queryId
+      BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata
   );
 
   public boolean isError(final QueryId queryId) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -60,9 +60,9 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void register(
-      final BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata,
-      final QueryId queryId
+      final BinPackedPersistentQueryMetadataImpl binpackedPersistentQueryMetadata
   ) {
+    final QueryId queryId = binpackedPersistentQueryMetadata.getQueryId();
     collocatedQueries.put(queryId, binpackedPersistentQueryMetadata);
     log.info("Registered query: {}  in {} \n"
                  + "Runtime {} is executing these queries: {}",

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -93,14 +93,16 @@ public class SharedKafkaStreamsRuntimeImplTest {
             streamProps
         );
 
-        sharedKafkaStreamsRuntimeImpl.register(
-            binPackedPersistentQueryMetadata,
-            queryId);
-
         when(kafkaStreamsNamedTopologyWrapper.getTopologyByName(any())).thenReturn(Optional.empty());
         when(kafkaStreamsNamedTopologyWrapper.addNamedTopology(any())).thenReturn(addNamedTopologyResult);
         when(addNamedTopologyResult.all()).thenReturn(future);
         when(binPackedPersistentQueryMetadata.getTopologyCopy(any())).thenReturn(namedTopology);
+        when(binPackedPersistentQueryMetadata.getQueryId()).thenReturn(queryId);
+        when(binPackedPersistentQueryMetadata2.getQueryId()).thenReturn(queryId2);
+
+        sharedKafkaStreamsRuntimeImpl.register(
+            binPackedPersistentQueryMetadata
+        );
     }
 
     @Test
@@ -133,8 +135,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
 
         //Should not try to add error to query2's queue
         sharedKafkaStreamsRuntimeImpl.register(
-            binPackedPersistentQueryMetadata2,
-            queryId2
+            binPackedPersistentQueryMetadata2
         );
 
         //When:
@@ -153,8 +154,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
         when(queryErrorClassifier.classify(runtimeExceptionWithNoTask)).thenReturn(Type.USER);
 
         sharedKafkaStreamsRuntimeImpl.register(
-            binPackedPersistentQueryMetadata2,
-            queryId2
+            binPackedPersistentQueryMetadata2
         );
 
         //When:
@@ -173,8 +173,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
         when(queryErrorClassifier.classify(runtimeExceptionWithTaskAndNoTopology)).thenReturn(Type.USER);
 
         sharedKafkaStreamsRuntimeImpl.register(
-            binPackedPersistentQueryMetadata2,
-            queryId2
+            binPackedPersistentQueryMetadata2
         );
 
         //When:
@@ -193,8 +192,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
         when(queryErrorClassifier.classify(runtimeExceptionWithTaskAndUnknownTopology)).thenReturn(Type.USER);
 
         sharedKafkaStreamsRuntimeImpl.register(
-            binPackedPersistentQueryMetadata2,
-            queryId2
+            binPackedPersistentQueryMetadata2
         );
 
         //When:
@@ -239,7 +237,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
     @Test
     public void shouldNotStartOrAddedToStreamsIfOnlyRegistered() {
         //Given:
-        sharedKafkaStreamsRuntimeImpl.register(binPackedPersistentQueryMetadata2, queryId2);
+        sharedKafkaStreamsRuntimeImpl.register(binPackedPersistentQueryMetadata2);
 
         //When:
         sharedKafkaStreamsRuntimeImpl.stop(queryId2, false);


### PR DESCRIPTION
### Description 
In the validation runtime we should use the blocking call so that if the future gets completed exceptionally we can fail validation. Also for COR queries we are going to validate stoping and and re-adding the topology.

Also this improves the failure message.

##

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

