### PR TITLE
chore: upgrade confluent-log4j to 1.2.17-cp9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
-            <version>1.2.17-cp6</version>
+            <version>1.2.17-cp9</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
### Description

There is a known CVE (CVE-2021-4104) for log4j12 regarding
the JMS appender. ksqlDB is not affected by the CVE since
ksqlDB does not enable the JMS appender as stated under
https://support.confluent.io/hc/en-us/articles/4412615410580-December-2021-Log4j-Vulnerabilities-Advisory

Nevertheless versions of confluent-log4j higher than 1.2.17-cp6
removed the JMSAppender class completely. Thus, it is reasonable
to upgrade the confluent-log4j to 1.2.17-cp9 (latest version at
the creation time of this commit)
