### PR TITLE
fix: Adds error handling for nested functions

### DIFF
--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -545,15 +545,15 @@ public class SqlToJavaVisitor {
         } else {
           paramType = function.parameters().get(i);
         }
-
-        joiner.add(
-            process(
-                convertArgument(arg, sqlType, paramType),
-                new Context(argumentInfos.get(i).getLambdaSqlTypeMapping()))
-            .getLeft()
-        );
+        String code = process(
+            convertArgument(arg, sqlType, paramType),
+            new Context(argumentInfos.get(i).getLambdaSqlTypeMapping()))
+            .getLeft();
+        if (arg instanceof FunctionCall) {
+          code = evaluateOrReturnNull(code, ((FunctionCall) arg).getName().text());
+        }
+        joiner.add(code);
       }
-
 
       final String argumentsString = joiner.toString();
       final String codeString = "((" + javaReturnType + ") " + instanceName

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -283,11 +283,23 @@ public class SqlToJavaVisitorTest {
     final String javaExpression = sqlToJavaVisitor.process(expression);
 
     // Then:
-    assertThat(javaExpression, is(
-        "((String) CONCAT_0.evaluate("
-            + "((String) SUBSTRING_1.evaluate(COL1, 1, 3)), "
-            + "((String) CONCAT_2.evaluate(\"-\","
-            + " ((String) SUBSTRING_3.evaluate(COL1, 4, 5))))))"));
+    final String expected = "((String) CONCAT_0.evaluate( (new Supplier<Object>() "
+        + "{@Override public Object get() { try {  return ((String) "
+        + "SUBSTRING_1.evaluate(COL1, 1, 3)); } catch (Exception e) {  "
+        + "logger.error(RecordProcessingError.recordProcessingError(    "
+        + "\"Error processing SUBSTRING\",    e instanceof InvocationTargetException? "
+        + "e.getCause() : e,    row));  return defaultValue; }}}).get(),  (new Supplier<Object>() "
+        + "{@Override public Object get() { try {  return ((String) CONCAT_2.evaluate(\"-\",  "
+        + "(new Supplier<Object>() {@Override public Object get() { try {  return ((String) "
+        + "SUBSTRING_3.evaluate(COL1, 4, 5)); } catch (Exception e) {  "
+        + "logger.error(RecordProcessingError.recordProcessingError(    "
+        + "\"Error processing SUBSTRING\",    e instanceof InvocationTargetException? "
+        + "e.getCause() : e,    row));  return defaultValue; }}}).get())); } catch (Exception e) "
+        + "{  logger.error(RecordProcessingError.recordProcessingError(    "
+        + "\"Error processing CONCAT\",    e instanceof InvocationTargetException? "
+        + "e.getCause() : e,    row));  return defaultValue; }}}).get()))";
+
+    assertThat(javaExpression, is(expected));
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_coalesce_-_with_parse_date/7.2.0_1646427911071/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_coalesce_-_with_parse_date/7.2.0_1646427911071/plan.json
@@ -1,0 +1,185 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (DATE_STRING STRING) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`DATE_STRING` STRING",
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    }
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  PARSE_DATE(INPUT.DATE_STRING, 'yyyy-MM-dd') PARSE_AS_DATE,\n  PARSE_DATE(CONCAT(INPUT.DATE_STRING, '-01-01'), 'yyyy-MM-dd') PARSE_AS_YEAR,\n  COALESCE(PARSE_DATE(INPUT.DATE_STRING, 'yyyy-MM-dd'), PARSE_DATE(CONCAT(INPUT.DATE_STRING, '-01-01'), 'yyyy-MM-dd')) PARSE_AS_EITHER\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`PARSE_AS_DATE` DATE, `PARSE_AS_YEAR` DATE, `PARSE_AS_EITHER` DATE",
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : {
+          "format" : "JSON"
+        }
+      },
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA"
+              },
+              "valueFormat" : {
+                "format" : "JSON"
+              }
+            },
+            "sourceSchema" : "`DATE_STRING` STRING",
+            "pseudoColumnVersion" : 1
+          },
+          "selectExpressions" : [ "PARSE_DATE(DATE_STRING, 'yyyy-MM-dd') AS PARSE_AS_DATE", "PARSE_DATE(CONCAT(DATE_STRING, '-01-01'), 'yyyy-MM-dd') AS PARSE_AS_YEAR", "COALESCE(PARSE_DATE(DATE_STRING, 'yyyy-MM-dd'), PARSE_DATE(CONCAT(DATE_STRING, '-01-01'), 'yyyy-MM-dd')) AS PARSE_AS_EITHER" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          }
+        },
+        "topicName" : "OUTPUT"
+      },
+      "queryId" : "CSAS_OUTPUT_0"
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "8",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.query.pull.consistency.token.enabled" : "false",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.connect.error.handler" : null,
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_coalesce_-_with_parse_date/7.2.0_1646427911071/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_coalesce_-_with_parse_date/7.2.0_1646427911071/spec.json
@@ -1,0 +1,142 @@
+{
+  "version" : "7.2.0",
+  "timestamp" : 1646427911071,
+  "path" : "query-validation-tests/null.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`DATE_STRING` STRING",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`PARSE_AS_DATE` DATE, `PARSE_AS_YEAR` DATE, `PARSE_AS_EITHER` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "coalesce - with parse_date",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "date_string" : "2003-12-24"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "date_string" : "2008-08-13"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "date_string" : "2004"
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : null,
+      "value" : {
+        "date_string" : "2012"
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "PARSE_AS_DATE" : 12410,
+        "PARSE_AS_YEAR" : 12410,
+        "PARSE_AS_EITHER" : 12410
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "parse_as_date" : 14104,
+        "parse_as_year" : 14104,
+        "parse_as_either" : 14104
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "parse_as_date" : null,
+        "parse_as_year" : 12418,
+        "parse_as_either" : 12418
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : null,
+      "value" : {
+        "parse_as_date" : null,
+        "parse_as_year" : 15340,
+        "parse_as_either" : 15340
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (date_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');", "CREATE STREAM OUTPUT AS SELECT parse_date(date_string, 'yyyy-MM-dd') as parse_as_date, parse_date(concat(date_string, '-01-01'), 'yyyy-MM-dd') as parse_as_year, coalesce(parse_date(date_string, 'yyyy-MM-dd'),  parse_date(concat(date_string, '-01-01'), 'yyyy-MM-dd')) as parse_as_either FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`DATE_STRING` STRING",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`PARSE_AS_DATE` DATE, `PARSE_AS_YEAR` DATE, `PARSE_AS_EITHER` DATE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_coalesce_-_with_parse_date/7.2.0_1646427911071/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/null_-_coalesce_-_with_parse_date/7.2.0_1646427911071/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/null.json
@@ -190,6 +190,29 @@
       }
     },
     {
+      "name": "coalesce - with parse_date",
+      "statements": [
+        "CREATE STREAM INPUT (date_string VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT parse_date(date_string, 'yyyy-MM-dd') as parse_as_date, parse_date(concat(date_string, '-01-01'), 'yyyy-MM-dd') as parse_as_year, coalesce(parse_date(date_string, 'yyyy-MM-dd'),  parse_date(concat(date_string, '-01-01'), 'yyyy-MM-dd')) as parse_as_either FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": null, "value": {"date_string": "2003-12-24"}},
+        {"topic": "test_topic", "key": null, "value": {"date_string": "2008-08-13"}},
+        {"topic": "test_topic", "key": null, "value": {"date_string": "2004"}},
+        {"topic": "test_topic", "key": null, "value": {"date_string": "2012"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": null, "value": {"PARSE_AS_DATE":  12410,
+          "PARSE_AS_YEAR": 12410, "PARSE_AS_EITHER": 12410}},
+        {"topic": "OUTPUT", "key": null, "value": {"parse_as_date":  14104,
+          "parse_as_year": 14104, "parse_as_either": 14104}},
+        {"topic": "OUTPUT", "key": null, "value": {"parse_as_date":  null,
+          "parse_as_year": 12418, "parse_as_either": 12418}},
+        {"topic": "OUTPUT", "key": null, "value": {"parse_as_date":  null,
+          "parse_as_year": 15340, "parse_as_either": 15340}}
+      ]
+    },
+    {
       "name": "if null",
       "statements": [
         "CREATE STREAM INPUT (COL0 INT KEY, COL1 STRING, COL2 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",


### PR DESCRIPTION
Addresses: https://github.com/confluentinc/ksql/issues/8324

This issue is about nested UDFs.  If a UDF has an error in processing, a null is returned.

In the case of `coalesce`, accepting a null value and doing something useful is possible.

Before this PR, the entire expression for a column was being evaluated in a single pass.  This means that
any exception would cause the entire expression to return null.

The general solution here is to wrap inner function calls with a "try-catch" which can return a null in the case of
an inner function throwing an exception.

Since such errors may represent an error in input data, the error is logged.  This handling is similar to struct and map handling.

### Testing done 
The `SqlToJavaVisitorTest` has been updated to reflect the new code for nested functions.  

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

