### PR TITLE
fix(ksql): add ifExists/ifNotExist parameters to java client connector functions

### DIFF
--- a/docs/developer-guide/ksqldb-clients/java-client.md
+++ b/docs/developer-guide/ksqldb-clients/java-client.md
@@ -731,12 +731,12 @@ Map<String, String> connectorProperties = ImmutableMap.of(
   "table.whitelist", "users",
   "key", "username"
 );
-client.createConnector("jdbc-connector", true, connectorProperties).get();
+client.createConnector("jdbc-connector", true, connectorProperties, false).get();
 ```
 
 Drop a connector:
 ```java
-client.dropConnector("jdbc-connector").get();
+client.dropConnector("jdbc-connector", true).get();
 ```
 
 List connectors:

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/Client.java
@@ -251,6 +251,22 @@ public interface Client extends Closeable {
       String connectorName, boolean isSource, Map<String, Object> properties);
 
   /**
+   * Creates a connector.
+   *
+   * <p>If a non-200 response is received from the server, the {@code CompletableFuture} will be
+   * failed.
+   *
+   * @param connectorName name of the connector
+   * @param isSource true if the connector is a source connector, false if it is a sink connector
+   * @param properties connector properties
+   * @param ifNotExists is ifNotExists is set to true, then the command won't fail if a connector
+   *                    with the same name already exists
+   * @return result of connector creation
+   */
+  CompletableFuture<Void> createConnector(
+      String connectorName, boolean isSource, Map<String, Object> properties, boolean ifNotExists);
+
+  /**
    * Drops a connector.
    *
    * <p>If a non-200 response is received from the server, the {@code CompletableFuture} will be
@@ -260,6 +276,19 @@ public interface Client extends Closeable {
    * @return a future that completes once the server response is received
    */
   CompletableFuture<Void> dropConnector(String connectorName);
+
+  /**
+   * Drops a connector.
+   *
+   * <p>If a non-200 response is received from the server, the {@code CompletableFuture} will be
+   * failed.
+   *
+   * @param connectorName name of the connector to drop
+   * @param ifExists ifExists is set to true, then the statement won't fail if the connector
+   *                 does not exist
+   * @return a future that completes once the server response is received
+   */
+  CompletableFuture<Void> dropConnector(String connectorName, boolean ifExists);
 
   /**
    * Returns a list of connectors.

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -166,12 +166,14 @@ final class AdminResponseHandlers {
 
   static boolean isCreateConnectorResponse(final JsonObject ksqlEntity) {
     return ksqlEntity.getJsonObject("info") != null
-        || ksqlEntity.getString("message").contains("already exists");
+        || (ksqlEntity.getString("message") != null
+        && ksqlEntity.getString("message").contains("already exists"));
   }
 
   static boolean isDropConnectorResponse(final JsonObject ksqlEntity) {
     return ksqlEntity.getString("connectorName") != null
-        || ksqlEntity.getString("message").contains("not exist");
+        || (ksqlEntity.getString("message") != null
+        && ksqlEntity.getString("message").contains("not exist"));
   }
 
   static boolean isConnectErrorResponse(final JsonObject ksqlEntity) {

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -165,11 +165,11 @@ final class AdminResponseHandlers {
   }
 
   static boolean isCreateConnectorResponse(final JsonObject ksqlEntity) {
-    return ksqlEntity.getJsonObject("info") != null;
+    return ksqlEntity.getJsonObject("info") != null || ksqlEntity.getString("message").contains("already exists");
   }
 
   static boolean isDropConnectorResponse(final JsonObject ksqlEntity) {
-    return ksqlEntity.getString("connectorName") != null;
+    return ksqlEntity.getString("connectorName") != null || ksqlEntity.getString("message").contains("not exist");
   }
 
   static boolean isConnectErrorResponse(final JsonObject ksqlEntity) {

--- a/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
+++ b/ksqldb-api-client/src/main/java/io/confluent/ksql/api/client/impl/AdminResponseHandlers.java
@@ -165,11 +165,13 @@ final class AdminResponseHandlers {
   }
 
   static boolean isCreateConnectorResponse(final JsonObject ksqlEntity) {
-    return ksqlEntity.getJsonObject("info") != null || ksqlEntity.getString("message").contains("already exists");
+    return ksqlEntity.getJsonObject("info") != null
+        || ksqlEntity.getString("message").contains("already exists");
   }
 
   static boolean isDropConnectorResponse(final JsonObject ksqlEntity) {
-    return ksqlEntity.getString("connectorName") != null || ksqlEntity.getString("message").contains("not exist");
+    return ksqlEntity.getString("connectorName") != null
+        || ksqlEntity.getString("message").contains("not exist");
   }
 
   static boolean isConnectErrorResponse(final JsonObject ksqlEntity) {

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/ClientTest.java
@@ -1573,6 +1573,20 @@ public class ClientTest extends BaseApiTest {
   }
 
   @Test
+  public void shouldCreateConnectorIfNotExist() throws Exception {
+    // Given
+    final CreateConnectorEntity entity = new CreateConnectorEntity("create connector;",
+        new ConnectorInfo("name", Collections.emptyMap(), Collections.emptyList(), SOURCE_TYPE));
+    testEndpoints.setKsqlEndpointResponse(Collections.singletonList(entity));
+
+    // When:
+    javaClient.createConnector("name", true, Collections.emptyMap(), true).get();
+
+    // Then:
+    assertThat(testEndpoints.getLastSql(), is("CREATE SOURCE CONNECTOR IF NOT EXISTS name WITH ();"));
+  }
+
+  @Test
   public void shouldDropConnector() throws Exception {
     // Given
     final DropConnectorEntity entity = new DropConnectorEntity("drop connector;", "name");
@@ -1583,6 +1597,19 @@ public class ClientTest extends BaseApiTest {
 
     // Then:
     assertThat(testEndpoints.getLastSql(), is("drop connector name;"));
+  }
+
+  @Test
+  public void shouldDropConnectorIfExists() throws Exception {
+    // Given
+    final DropConnectorEntity entity = new DropConnectorEntity("drop connector;", "name");
+    testEndpoints.setKsqlEndpointResponse(Collections.singletonList(entity));
+
+    // When:
+    javaClient.dropConnector("name", true).get();
+
+    // Then:
+    assertThat(testEndpoints.getLastSql(), is("drop connector if exists name;"));
   }
 
   @Test

--- a/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
+++ b/ksqldb-api-client/src/test/java/io/confluent/ksql/api/client/integration/ClientIntegrationTest.java
@@ -1074,6 +1074,13 @@ public class ClientIntegrationTest {
   }
 
   @Test
+  public void shouldNotFailToDropNonExistantConnector() throws Exception {
+    // When/Then:
+    client.dropConnector("nonExistentConnector", true).get();
+  }
+
+
+  @Test
   public void shouldCreateConnector() throws Exception {
     // When:
     client.createConnector("FOO", true, ImmutableMap.of("connector.class", MOCK_SOURCE_CLASS)).get();
@@ -1089,6 +1096,15 @@ public class ClientIntegrationTest {
         },
         is("RUNNING")
     );
+  }
+
+  @Test
+  public void shouldNotFailToCreateConnectorThatExists() throws Exception {
+    // Given:
+    givenConnectorExists();
+
+    // When/Then:
+    client.createConnector(TEST_CONNECTOR, true, ImmutableMap.of("connector.class", MOCK_SOURCE_CLASS), true).get();
   }
 
   @Test


### PR DESCRIPTION
### Description 
Adds an optional `ifExist` parameter to `dropConnector()` and `ifNotExist` to `createConnector()`

These are the java client changes needed for https://github.com/confluentinc/ksql/issues/8014. The migrations tool changes will be in another PR.

### Testing done 
Unit + integration

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

