### PR TITLE
fix(ksql): allow migrations tool to run connector commands with IF [NOT] EXISTS clauses

### DIFF
--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -435,7 +435,7 @@ public class ApplyMigrationCommand extends BaseCommand {
           ((SqlCreateConnectorStatement) command).getName(),
           ((SqlCreateConnectorStatement) command).isSource(),
           ((SqlCreateConnectorStatement) command).getProperties(),
-          ((SqlCreateConnectorStatement) command).getIfNotExist()
+          ((SqlCreateConnectorStatement) command).getIfNotExists()
       ).get();
     } else if (command instanceof SqlDropConnectorStatement) {
       ksqlClient.dropConnector(

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommand.java
@@ -434,10 +434,14 @@ public class ApplyMigrationCommand extends BaseCommand {
       ksqlClient.createConnector(
           ((SqlCreateConnectorStatement) command).getName(),
           ((SqlCreateConnectorStatement) command).isSource(),
-          ((SqlCreateConnectorStatement) command).getProperties()
+          ((SqlCreateConnectorStatement) command).getProperties(),
+          ((SqlCreateConnectorStatement) command).getIfNotExist()
       ).get();
     } else if (command instanceof SqlDropConnectorStatement) {
-      ksqlClient.dropConnector(((SqlDropConnectorStatement) command).getName()).get();
+      ksqlClient.dropConnector(
+          ((SqlDropConnectorStatement) command).getName(),
+          ((SqlDropConnectorStatement) command).getIfExists()
+      ).get();
     } else if (command instanceof SqlPropertyCommand) {
       if (((SqlPropertyCommand) command).isSetCommand()
           && ((SqlPropertyCommand) command).getValue().isPresent()) {

--- a/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
+++ b/ksqldb-tools/src/main/java/io/confluent/ksql/tools/migrations/util/CommandParser.java
@@ -61,8 +61,8 @@ public final class CommandParser {
       Pattern.CASE_INSENSITIVE);
   private static final Pattern UNSET_PROPERTY = Pattern.compile(
       "\\s*UNSET\\s+'((?:[^']*|(?:''))*)'\\s*;\\s*", Pattern.CASE_INSENSITIVE);
-  private static final Pattern DROP_CONNECTOR =
-      Pattern.compile("\\s*DROP\\s+CONNECTOR\\s+(.*?)\\s*;\\s*", Pattern.CASE_INSENSITIVE);
+  private static final Pattern DROP_CONNECTOR = Pattern.compile(
+      "\\s*DROP\\s+CONNECTOR\\s+(IF\\s+EXISTS\\s+)?(.*?)\\s*;\\s*", Pattern.CASE_INSENSITIVE);
   private static final Pattern DEFINE_VARIABLE = Pattern.compile(
       "\\s*DEFINE\\s+([a-zA-Z_][a-zA-Z0-9_@]*)\\s*=\\s*'((?:[^']*|(?:''))*)'\\s*;\\s*",
       Pattern.CASE_INSENSITIVE);
@@ -284,7 +284,8 @@ public final class CommandParser {
         preserveCase(createConnector.getName()),
         createConnector.getType() == Type.SOURCE,
         createConnector.getConfig().entrySet().stream()
-            .collect(Collectors.toMap(Entry::getKey, e -> toFieldType(e.getValue())))
+            .collect(Collectors.toMap(Entry::getKey, e -> toFieldType(e.getValue()))),
+        createConnector.ifNotExists()
     );
   }
 
@@ -293,7 +294,11 @@ public final class CommandParser {
     if (!dropConnectorMatcher.matches()) {
       throw new MigrationException("Invalid DROP CONNECTOR command: " + sql);
     }
-    return new SqlDropConnectorStatement(sql, dropConnectorMatcher.group(1));
+    return new SqlDropConnectorStatement(
+        sql,
+        dropConnectorMatcher.group(2),
+        dropConnectorMatcher.group(1) != null
+    );
   }
 
   private static SqlPropertyCommand getSetPropertyCommand(
@@ -494,17 +499,20 @@ public final class CommandParser {
     final String name;
     final boolean isSource;
     final ImmutableMap<String, Object> properties;
+    final boolean ifNotExist;
 
     SqlCreateConnectorStatement(
         final String command,
         final String name,
         final boolean isSource,
-        final Map<String, Object> properties
+        final Map<String, Object> properties,
+        final boolean ifNotExist
     ) {
       super(command);
       this.name = Objects.requireNonNull(name);
       this.isSource = isSource;
       this.properties = ImmutableMap.copyOf(Objects.requireNonNull(properties));
+      this.ifNotExist = ifNotExist;
     }
 
     public String getName() {
@@ -513,6 +521,10 @@ public final class CommandParser {
 
     public boolean isSource() {
       return isSource;
+    }
+
+    public boolean getIfNotExists() {
+      return ifNotExist;
     }
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "properties is ImmutableMap")
@@ -526,17 +538,24 @@ public final class CommandParser {
    */
   public static class SqlDropConnectorStatement extends SqlCommand {
     final String name;
+    final boolean ifExists;
 
     SqlDropConnectorStatement(
         final String command,
-        final String name
+        final String name,
+        final boolean ifExists
     ) {
       super(command);
       this.name = Objects.requireNonNull(name);
+      this.ifExists = ifExists;
     }
 
     public String getName() {
       return name;
+    }
+
+    public boolean getIfExists() {
+      return ifExists;
     }
   }
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/MigrationsTest.java
@@ -266,6 +266,7 @@ public class MigrationsTest {
         configFilePath,
         migrationsDir,
         "CREATE STREAM ${streamName} (A STRING) WITH (KAFKA_TOPIC='FOO', PARTITIONS=1, VALUE_FORMAT='JSON');\n" +
+            "DROP CONNECTOR IF EXISTS nonExistant;\n" +
             "-- let's create some connectors!!!\n" +
             "CREATE SOURCE CONNECTOR C WITH ('connector.class'='org.apache.kafka.connect.tools.MockSourceConnector');\n" +
             "DEFINE connectorName = 'D';" +
@@ -302,6 +303,7 @@ public class MigrationsTest {
             "CREATE STREAM ${variable} (ADDR ADDRESS) WITH (KAFKA_TOPIC='${variable}', PARTITIONS=1, VALUE_FORMAT='JSON');" +
             "UNDEFINE variable;" +
             "INSERT INTO HOMES VALUES (STRUCT(number := 123, street := 'sesame st', city := '${variable}'));" +
+            "CREATE SOURCE CONNECTOR IF NOT EXISTS C WITH ('connector.class'='org.apache.kafka.connect.tools.MockSourceConnector');\n" +
             "DROP TYPE ADDRESS;"
     );
 

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/commands/ApplyMigrationCommandTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.tools.migrations.commands;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
@@ -152,8 +153,10 @@ public class ApplyMigrationCommandTest {
     when(ksqlClient.describeSource(MIGRATIONS_STREAM)).thenReturn(sourceDescriptionCf);
     when(ksqlClient.describeSource(MIGRATIONS_TABLE)).thenReturn(sourceDescriptionCf);
     when(ksqlClient.describeSource("`FOO`")).thenReturn(fooDescriptionCf);
-    when(ksqlClient.createConnector("`WOOF`", false, CONNECTOR_PROPERTIES)).thenReturn(voidCf);
-    when(ksqlClient.dropConnector("WOOF")).thenReturn(voidCf);
+    when(ksqlClient.createConnector("`WOOF`", false, CONNECTOR_PROPERTIES, false)).thenReturn(voidCf);
+    when(ksqlClient.createConnector("`WOOF`", false, CONNECTOR_PROPERTIES, true)).thenReturn(voidCf);
+    when(ksqlClient.dropConnector("WOOF", false)).thenReturn(voidCf);
+    when(ksqlClient.dropConnector("WOOF", true)).thenReturn(voidCf);
     when(sourceDescriptionCf.get()).thenReturn(sourceDescription);
     when(statementResultCf.get()).thenReturn(statementResult);
     when(fooDescriptionCf.get()).thenReturn(fooDescription);
@@ -617,7 +620,7 @@ public class ApplyMigrationCommandTest {
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
     verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED,
-        () -> inOrder.verify(ksqlClient).createConnector("`WOOF`", false, CONNECTOR_PROPERTIES));
+        () -> inOrder.verify(ksqlClient).createConnector("`WOOF`", false, CONNECTOR_PROPERTIES, false));
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -639,7 +642,7 @@ public class ApplyMigrationCommandTest {
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
     verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED,
-        () -> inOrder.verify(ksqlClient).createConnector("`WOOF`", false, CONNECTOR_PROPERTIES));
+        () -> inOrder.verify(ksqlClient).createConnector("`WOOF`", false, CONNECTOR_PROPERTIES, true));
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -661,7 +664,7 @@ public class ApplyMigrationCommandTest {
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
     verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED,
-        () -> inOrder.verify(ksqlClient).dropConnector("WOOF"));
+        () -> inOrder.verify(ksqlClient).dropConnector("WOOF", false));
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }
@@ -683,7 +686,7 @@ public class ApplyMigrationCommandTest {
     assertThat(result, is(0));
     final InOrder inOrder = inOrder(ksqlClient);
     verifyMigratedVersion(inOrder, 3, "1", MigrationState.MIGRATED,
-        () -> inOrder.verify(ksqlClient).dropConnector("WOOF"));
+        () -> inOrder.verify(ksqlClient).dropConnector("WOOF", true));
     inOrder.verify(ksqlClient).close();
     inOrder.verifyNoMoreInteractions();
   }

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -387,6 +387,37 @@ public class CommandParserTest {
     assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("topic.prefix"), is("jdbc-"));
     assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("table.whitelist"), is("users"));
     assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("key"), is("username"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getIfNotExists(), is(false));
+  }
+
+  @Test
+  public void shouldParseCreateConnectorIfNotExistsStatement() {
+    // Given:
+    final String createConnector = "CREATE SOURCE CONNECTOR IF NOT EXISTS ${name} WITH(\n"
+        + "    \"connector.class\"='io.confluent.connect.jdbc.JdbcSourceConnector',\n"
+        + "    \"connection.url\"=${url},\n"
+        + "    \"mode\"='bulk',\n"
+        + "    \"topic.prefix\"='jdbc-',\n"
+        + "    \"table.whitelist\"='users',\n"
+        + "    \"key\"='username');";
+
+    // When:
+    List<SqlCommand> commands = parse(createConnector, ImmutableMap.of("url", "'jdbc:postgresql://localhost:5432/my.db'", "name", "`jdbc_connector`"));
+
+    // Then:
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0), instanceOf(SqlCreateConnectorStatement.class));
+    assertThat(commands.get(0).getCommand(), is(createConnector));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getName(), is("`jdbc_connector`"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).isSource(), is(true));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().size(), is(6));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("connector.class"), is("io.confluent.connect.jdbc.JdbcSourceConnector"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("connection.url"), is("jdbc:postgresql://localhost:5432/my.db"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("mode"), is("bulk"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("topic.prefix"), is("jdbc-"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("table.whitelist"), is("users"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getProperties().get("key"), is("username"));
+    assertThat(((SqlCreateConnectorStatement) commands.get(0)).getIfNotExists(), is(true));
   }
 
   @Test
@@ -403,6 +434,24 @@ public class CommandParserTest {
     assertThat(commands.get(0), instanceOf(SqlDropConnectorStatement.class));
     assertThat(commands.get(0).getCommand(), is(dropConnector));
     assertThat(((SqlDropConnectorStatement) commands.get(0)).getName(), is("`jdbc-connector`"));
+    assertThat(((SqlDropConnectorStatement) commands.get(0)).getIfExists(), is(false));
+  }
+
+  @Test
+  public void shouldParseDropConnectorIfExistsStatement() {
+    // Given:
+    final String dropConnector = "DRoP CONNEcTOR IF EXISTS `jdbc-connector` ;";
+
+    // When:
+    List<SqlCommand> commands = parse(dropConnector);
+
+    // Then:
+    assertThat(commands.size(), is(1));
+    assertThat(commands.get(0).getCommand(), is(dropConnector));
+    assertThat(commands.get(0), instanceOf(SqlDropConnectorStatement.class));
+    assertThat(commands.get(0).getCommand(), is(dropConnector));
+    assertThat(((SqlDropConnectorStatement) commands.get(0)).getName(), is("`jdbc-connector`"));
+    assertThat(((SqlDropConnectorStatement) commands.get(0)).getIfExists(), is(true));
   }
 
   @Test

--- a/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
+++ b/ksqldb-tools/src/test/java/io/confluent/ksql/tools/migrations/util/CommandParserTest.java
@@ -432,7 +432,6 @@ public class CommandParserTest {
     assertThat(commands.size(), is(1));
     assertThat(commands.get(0).getCommand(), is(dropConnector));
     assertThat(commands.get(0), instanceOf(SqlDropConnectorStatement.class));
-    assertThat(commands.get(0).getCommand(), is(dropConnector));
     assertThat(((SqlDropConnectorStatement) commands.get(0)).getName(), is("`jdbc-connector`"));
     assertThat(((SqlDropConnectorStatement) commands.get(0)).getIfExists(), is(false));
   }
@@ -449,7 +448,6 @@ public class CommandParserTest {
     assertThat(commands.size(), is(1));
     assertThat(commands.get(0).getCommand(), is(dropConnector));
     assertThat(commands.get(0), instanceOf(SqlDropConnectorStatement.class));
-    assertThat(commands.get(0).getCommand(), is(dropConnector));
     assertThat(((SqlDropConnectorStatement) commands.get(0)).getName(), is("`jdbc-connector`"));
     assertThat(((SqlDropConnectorStatement) commands.get(0)).getIfExists(), is(true));
   }


### PR DESCRIPTION
### Description 
Fixes #8014 

Requires #8851 to be merged for the build to pass.

### Testing done 
Unit + integration testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

