### PR TITLE
build: pull from docker internal for onprem image

### DIFF
--- a/release_stabilization.py
+++ b/release_stabilization.py
@@ -54,17 +54,17 @@ class Callbacks:
             if "rc" not in version:
                 # promote production images to dockerhub
                 for docker_repo in DOCKER_REPOS:
-                    print(f"docker pull {DOCKER_REGISTRY}{docker_repo}:{version}")
-                    subprocess.run(shlex.split(f"docker pull {DOCKER_REGISTRY}{docker_repo}:{version}"))
+                    print(f"docker pull {DOCKER_INTERNAL_REGISTRY}{docker_repo}:{version}")
+                    subprocess.run(shlex.split(f"docker pull {DOCKER_INTERNAL_REGISTRY}{docker_repo}:{version}"))
 
-                    print(f"docker tag {DOCKER_REGISTRY}{docker_repo}:{version} {docker_repo}:{version}")
-                    subprocess.run(shlex.split(f"docker tag {DOCKER_REGISTRY}{docker_repo}:{version} {docker_repo}:{version}"))
+                    print(f"docker tag {DOCKER_INTERNAL_REGISTRY}{docker_repo}:{version} {docker_repo}:{version}")
+                    subprocess.run(shlex.split(f"docker tag {DOCKER_INTERNAL_REGISTRY}{docker_repo}:{version} {docker_repo}:{version}"))
                     print(f"docker push {docker_repo}:{version}")
                     subprocess.run(shlex.split(f"docker push {docker_repo}:{version}"))
 
                     # update latest tag images on dockerhub
-                    print(f"docker tag {DOCKER_REGISTRY}{docker_repo}:{version} {docker_repo}:latest")
-                    subprocess.run(shlex.split(f"docker tag {DOCKER_REGISTRY}{docker_repo}:{version} {docker_repo}:latest"))
+                    print(f"docker tag {DOCKER_INTERNAL_REGISTRY}{docker_repo}:{version} {docker_repo}:latest")
+                    subprocess.run(shlex.split(f"docker tag {DOCKER_INTERNAL_REGISTRY}{docker_repo}:{version} {docker_repo}:latest"))
                     print(f"docker push {docker_repo}:latest")
                     subprocess.run(shlex.split(f"docker push {docker_repo}:latest"))
 


### PR DESCRIPTION
### Description 
There was an issue with publishing the on prem docker images during the 0.24 release. This was because jenkins cannot pull from `confluent-docker.jfrog.io/` due to an authentication error. It needs to instead pull from `confluent-docker-internal.jfrog.io/`, which is what this PR changes.

### Testing done 
Tested by replaying and editing the jenkins script to try both urls and confirm the behavior described above. 



