### PR TITLE
feat: Extend Udaf interface to allow for polymorphic UDAFs.

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
@@ -66,7 +66,7 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
           .map(Objects::toString)
           .collect(Collectors.joining(",")));
     }
-    return creator.createFunction(initArgs);
+    return creator.createFunction(initArgs, argTypeList);
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
@@ -94,20 +94,10 @@ class UdafFactoryInvoker implements FunctionSignature {
         ((Configurable) udaf).configure(initArgs.config());
       }
 
-      final SqlType aggregateSqlType;
-      final SqlType returnSqlType;
-
-      if (udaf.getAggregateSqlType().isPresent()) {
-        aggregateSqlType = (SqlType) udaf.getAggregateSqlType().get();
-      } else {
-        aggregateSqlType = SchemaConverters.functionToSqlConverter().toSqlType(aggregateArgType);
-      }
-
-      if (udaf.getReturnSqlType().isPresent()) {
-        returnSqlType = (SqlType) udaf.getReturnSqlType().get();
-      } else {
-        returnSqlType = SchemaConverters.functionToSqlConverter().toSqlType(aggregateReturnType);
-      }
+      final SqlType aggregateSqlType = (SqlType) udaf.getAggregateSqlType()
+          .orElse(SchemaConverters.functionToSqlConverter().toSqlType(aggregateArgType));
+      final SqlType returnSqlType = (SqlType) udaf.getReturnSqlType()
+          .orElse(SchemaConverters.functionToSqlConverter().toSqlType(aggregateReturnType));
 
       final KsqlAggregateFunction function;
       if (TableUdaf.class.isAssignableFrom(method.getReturnType())) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
@@ -97,14 +97,14 @@ class UdafFactoryInvoker implements FunctionSignature {
       final SqlType aggregateSqlType;
       final SqlType returnSqlType;
 
-      if (udaf.getAggregateSqlType() != null) {
-        aggregateSqlType = udaf.getAggregateSqlType();
+      if (udaf.getAggregateSqlType().isPresent()) {
+        aggregateSqlType = (SqlType) udaf.getAggregateSqlType().get();
       } else {
         aggregateSqlType = SchemaConverters.functionToSqlConverter().toSqlType(aggregateArgType);
       }
 
-      if (udaf.getReturnSqlType() != null) {
-        returnSqlType = udaf.getReturnSqlType();
+      if (udaf.getReturnSqlType().isPresent()) {
+        returnSqlType = (SqlType) udaf.getReturnSqlType().get();
       } else {
         returnSqlType = SchemaConverters.functionToSqlConverter().toSqlType(aggregateReturnType);
       }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
@@ -95,9 +95,10 @@ class UdafFactoryInvoker implements FunctionSignature {
       }
 
       final SqlType aggregateSqlType = (SqlType) udaf.getAggregateSqlType()
-          .orElse(SchemaConverters.functionToSqlConverter().toSqlType(aggregateArgType));
+          .orElseGet(() -> SchemaConverters.functionToSqlConverter().toSqlType(aggregateArgType));
       final SqlType returnSqlType = (SqlType) udaf.getReturnSqlType()
-          .orElse(SchemaConverters.functionToSqlConverter().toSqlType(aggregateReturnType));
+          .orElseGet(() ->
+              SchemaConverters.functionToSqlConverter().toSqlType(aggregateReturnType));
 
       final KsqlAggregateFunction function;
       if (TableUdaf.class.isAssignableFrom(method.getReturnType())) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
@@ -15,12 +15,15 @@
 
 package io.confluent.ksql.function;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.function.types.ParamType;
 import io.confluent.ksql.function.udaf.TableUdaf;
 import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -78,14 +81,32 @@ class UdafFactoryInvoker implements FunctionSignature {
     this.description = Objects.requireNonNull(description);
   }
 
+  @SuppressFBWarnings({"EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS", "REC_CATCH_EXCEPTION"})
   @SuppressWarnings("unchecked")
-  KsqlAggregateFunction createFunction(final AggregateFunctionInitArguments initArgs) {
+  KsqlAggregateFunction createFunction(final AggregateFunctionInitArguments initArgs,
+      final List<SqlArgument> argTypeList) {
     final Object[] factoryArgs = initArgs.args().toArray();
     try {
       final Udaf udaf = (Udaf)method.invoke(null, factoryArgs);
 
+      udaf.initializeTypeArguments(argTypeList);
       if (udaf instanceof Configurable) {
         ((Configurable) udaf).configure(initArgs.config());
+      }
+
+      final SqlType aggregateSqlType;
+      final SqlType returnSqlType;
+
+      if (udaf.getAggregateSqlType() != null) {
+        aggregateSqlType = udaf.getAggregateSqlType();
+      } else {
+        aggregateSqlType = SchemaConverters.functionToSqlConverter().toSqlType(aggregateArgType);
+      }
+
+      if (udaf.getReturnSqlType() != null) {
+        returnSqlType = udaf.getReturnSqlType();
+      } else {
+        returnSqlType = SchemaConverters.functionToSqlConverter().toSqlType(aggregateReturnType);
       }
 
       final KsqlAggregateFunction function;
@@ -94,8 +115,8 @@ class UdafFactoryInvoker implements FunctionSignature {
             functionName.text(),
             initArgs.udafIndex(),
             udaf,
-            SchemaConverters.functionToSqlConverter().toSqlType(aggregateArgType),
-            SchemaConverters.functionToSqlConverter().toSqlType(aggregateReturnType),
+            aggregateSqlType,
+            returnSqlType,
             params,
             description,
             metrics,
@@ -105,8 +126,8 @@ class UdafFactoryInvoker implements FunctionSignature {
             functionName.text(),
             initArgs.udafIndex(),
             udaf,
-            SchemaConverters.functionToSqlConverter().toSqlType(aggregateArgType),
-            SchemaConverters.functionToSqlConverter().toSqlType(aggregateReturnType),
+            aggregateSqlType,
+            returnSqlType,
             params,
             description,
             metrics,

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -826,7 +826,7 @@ public class UdfLoaderTest {
         "",
         "",
         "");
-    assertThat(creator.createFunction(AggregateFunctionInitArguments.EMPTY_ARGS),
+    assertThat(creator.createFunction(AggregateFunctionInitArguments.EMPTY_ARGS, Collections.EMPTY_LIST),
         not(nullValue()));
   }
 
@@ -845,7 +845,7 @@ public class UdfLoaderTest {
         0, ImmutableMap.of("ksql.functions.test_udaf.init", 100L));
 
     // When:
-    final KsqlAggregateFunction function = creator.createFunction(initArgs);
+    final KsqlAggregateFunction function = creator.createFunction(initArgs, Collections.EMPTY_LIST);
     final Object initvalue = function.getInitialValueSupplier().get();
 
     // Then:
@@ -877,7 +877,7 @@ public class UdfLoaderTest {
         "",
         "");
     final KsqlAggregateFunction function = creator
-        .createFunction(AggregateFunctionInitArguments.EMPTY_ARGS);
+        .createFunction(AggregateFunctionInitArguments.EMPTY_ARGS, Collections.EMPTY_LIST);
     assertThat(function, instanceOf(TableAggregationFunction.class));
   }
 
@@ -894,7 +894,7 @@ public class UdfLoaderTest {
         "",
         "");
     final KsqlAggregateFunction instance =
-        creator.createFunction(new AggregateFunctionInitArguments(0, "foo"));
+        creator.createFunction(new AggregateFunctionInitArguments(0, "foo"), Collections.EMPTY_LIST);
     assertThat(instance,
         not(nullValue()));
     assertThat(instance, not(instanceOf(TableAggregationFunction.class)));
@@ -915,7 +915,7 @@ public class UdfLoaderTest {
         "");
 
     final KsqlAggregateFunction<Long, Long, Long> executable =
-        creator.createFunction(AggregateFunctionInitArguments.EMPTY_ARGS);
+        creator.createFunction(AggregateFunctionInitArguments.EMPTY_ARGS, Collections.EMPTY_LIST);
 
     executable.aggregate(1L, 1L);
     executable.aggregate(1L, 1L);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
@@ -923,6 +924,26 @@ public class UdfLoaderTest {
         metrics.metricName("aggregate-test-udf-createSumLong-count",
             "ksql-udaf-test-udf-createSumLong"));
     assertThat(metric.metricValue(), equalTo(2.0));
+  }
+
+  @Test
+  public void shouldPassSqlInputTypesToUdafs() throws Exception {
+    final UdafFactoryInvoker creator
+        = createUdafLoader().createUdafFactoryInvoker(
+        TestUdaf.class.getMethod("createSumT"),
+        FunctionName.of("test-udf"),
+        "desc",
+        "",
+        "",
+        "");
+
+    final KsqlAggregateFunction<Long, Long, Long> executable =
+        creator.createFunction(AggregateFunctionInitArguments.EMPTY_ARGS,
+            Collections.singletonList(SqlArgument.of(SqlTypes.BIGINT)));
+
+    executable.aggregate(1L, 1L);
+    Long agg = executable.aggregate(1L, 1L);
+    assertThat(agg, equalTo(2L));
   }
 
   @Test(expected = KsqlException.class)

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/Udaf.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/Udaf.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.function.udaf;
 
+import io.confluent.ksql.schema.ksql.SqlArgument;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import java.util.List;
+
 /**
  * {@code Udaf} represents a custom UDAF (User Defined Aggregate Function)
  * that can be used to perform aggregations on KSQL Streams.
@@ -63,4 +67,33 @@ public interface Udaf<I, A, O> {
    * @return new value of current record
    */
   O map(A agg);
+
+  /**
+   * Some UDAFs can operate on any type.  In that case, the UDAF needs to be aware of the column
+   * type being used.  This method is called once when the UDAF is being created.
+   * Implementors may need to hold on to argument types or compute some other state to be re-used
+   * in methods like `aggregate` or `merge`.
+   * @param argTypeList The list of SqlArgument that this UDAF will receive as input.
+   */
+  default void initializeTypeArguments(List<SqlArgument> argTypeList) { }
+
+  /**
+   * Most UDAFs advertise their aggregate type statically via the Java type signature or
+   * annotations.
+   * For polymorphic UDAFs, implement this method to return the aggregate SQL Type.
+   * @return The aggregate SQL Type of type `A` returned by `aggregate` and `merge`.
+   */
+  default SqlType getAggregateSqlType() {
+    return null;
+  }
+
+  /**
+   * Most UDAFs advertise their return type statically via the Java type signature or
+   * annotations.
+   * For polymorphic UDAFs, implement this method to return the return SQL Type.
+   * @return The aggregate SQL Type of type `O` returned by `map`.
+   */
+  default SqlType getReturnSqlType() {
+    return null;
+  }
 }

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/Udaf.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/Udaf.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udaf;
 import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * {@code Udaf} represents a custom UDAF (User Defined Aggregate Function)
@@ -83,8 +84,8 @@ public interface Udaf<I, A, O> {
    * For polymorphic UDAFs, implement this method to return the aggregate SQL Type.
    * @return The aggregate SQL Type of type `A` returned by `aggregate` and `merge`.
    */
-  default SqlType getAggregateSqlType() {
-    return null;
+  default Optional<SqlType> getAggregateSqlType() {
+    return Optional.empty();
   }
 
   /**
@@ -93,7 +94,7 @@ public interface Udaf<I, A, O> {
    * For polymorphic UDAFs, implement this method to return the return SQL Type.
    * @return The aggregate SQL Type of type `O` returned by `map`.
    */
-  default SqlType getReturnSqlType() {
-    return null;
+  default Optional<SqlType> getReturnSqlType() {
+    return Optional.empty();
   }
 }

--- a/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/Udaf.java
+++ b/ksqldb-udf/src/main/java/io/confluent/ksql/function/udaf/Udaf.java
@@ -73,7 +73,7 @@ public interface Udaf<I, A, O> {
    * Some UDAFs can operate on any type.  In that case, the UDAF needs to be aware of the column
    * type being used.  This method is called once when the UDAF is being created.
    * Implementors may need to hold on to argument types or compute some other state to be re-used
-   * in methods like `aggregate` or `merge`.
+   * in methods like {@code aggregate} or {@code merge}.
    * @param argTypeList The list of SqlArgument that this UDAF will receive as input.
    */
   default void initializeTypeArguments(List<SqlArgument> argTypeList) { }
@@ -82,7 +82,7 @@ public interface Udaf<I, A, O> {
    * Most UDAFs advertise their aggregate type statically via the Java type signature or
    * annotations.
    * For polymorphic UDAFs, implement this method to return the aggregate SQL Type.
-   * @return The aggregate SQL Type of type `A` returned by `aggregate` and `merge`.
+   * @return The aggregate SQL Type
    */
   default Optional<SqlType> getAggregateSqlType() {
     return Optional.empty();
@@ -92,7 +92,7 @@ public interface Udaf<I, A, O> {
    * Most UDAFs advertise their return type statically via the Java type signature or
    * annotations.
    * For polymorphic UDAFs, implement this method to return the return SQL Type.
-   * @return The aggregate SQL Type of type `O` returned by `map`.
+   * @return The return SQL Type
    */
   default Optional<SqlType> getReturnSqlType() {
     return Optional.empty();


### PR DESCRIPTION
Various UDAFs can operate on input of any type.  This presents a challenge since ksqlDB needs to compute
the aggregate and return types of a function at runtime.

Here the `Udaf` interface is extended in order to allow for such functions to be written.

This work addresses https://github.com/confluentinc/ksql/issues/6638.

As motivation for the change, see https://github.com/confluentinc/ksql/issues/7697 and https://github.com/confluentinc/ksql/issues/5437.

### Testing done 
This change has been validated with other work-in-progress branches.  This PR only has the interface changes to focus discussion.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- Depending on discussion, docs may be updated with a separate PR.
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

