### PR TITLE
fix: Reduce query creation time with shared runtimes

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -220,15 +220,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     log.info("Attempting to start query {} in runtime {}", queryId, getApplicationId());
     if (collocatedQueries.containsKey(queryId) && !collocatedQueries.get(queryId).everStarted) {
       if (!kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
-        try {
           kafkaStreams.addNamedTopology(collocatedQueries.get(queryId).getTopology());
-        } catch (final Exception e) {
-          throw new IllegalStateException(String.format(
-                "Encountered an error when trying to start query %s in runtime: %s",
-                queryId,
-                getApplicationId()),
-              e);
-        }
       } else {
         throw new IllegalArgumentException("Cannot start because Streams is not done terminating"
                                                + " an older version of query : " + queryId);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -221,16 +221,13 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     if (collocatedQueries.containsKey(queryId) && !collocatedQueries.get(queryId).everStarted) {
       if (!kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
         try {
-          kafkaStreams.addNamedTopology(collocatedQueries.get(queryId).getTopology())
-              .all()
-              .get();
-        } catch (ExecutionException | InterruptedException e) {
-          final Throwable t = e.getCause() == null ? e : e.getCause();
+          kafkaStreams.addNamedTopology(collocatedQueries.get(queryId).getTopology());
+        } catch (final Exception e) {
           throw new IllegalStateException(String.format(
                 "Encountered an error when trying to start query %s in runtime: %s",
                 queryId,
                 getApplicationId()),
-              t);
+              e);
         }
       } else {
         throw new IllegalArgumentException("Cannot start because Streams is not done terminating"

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -220,7 +220,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     log.info("Attempting to start query {} in runtime {}", queryId, getApplicationId());
     if (collocatedQueries.containsKey(queryId) && !collocatedQueries.get(queryId).everStarted) {
       if (!kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
-          kafkaStreams.addNamedTopology(collocatedQueries.get(queryId).getTopology());
+        kafkaStreams.addNamedTopology(collocatedQueries.get(queryId).getTopology());
       } else {
         throw new IllegalArgumentException("Cannot start because Streams is not done terminating"
                                                + " an older version of query : " + queryId);


### PR DESCRIPTION
Benchmarks showed that creating 100 queries took up to 5 hours. This is likely because we currently wait on the future returned by `#addNamedTopology`, which blocks until all threads in the runtimes have ack'ed the new topology. Since this requires exiting the processing loop to check for topology updates before polling, and this depends on the configured `max.poll.interval.ms` for which we increased the default value with shared runtimes, waiting on this future can take a long time and will only increase as more queries are added.

Since we only really care about the topology being synced to the runtime's TopologyMetadata, and not whether the threads on a particular client have received it yet, we should just remove the `.all().get()` in `SharedKafkaStreamsRuntime#start(query)`

