### PR TITLE
fix: decrease default number of shared runtimes

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -583,7 +583,7 @@ public class KsqlConfig extends AbstractConfig {
       "Feature flag that enables the new planner for persistent queries. Default is false.";
 
   public static final String KSQL_SHARED_RUNTIMES_COUNT = "ksql.shared.runtimes.count";
-  public static final Integer KSQL_SHARED_RUNTIMES_COUNT_DEFAULT = 8;
+  public static final Integer KSQL_SHARED_RUNTIMES_COUNT_DEFAULT = 2;
   public static final String KSQL_SHARED_RUNTIMES_COUNT_DOC =
       "Controls how many runtimes queries are allocated over initially."
           + "this is only used when ksql.runtime.feature.shared.enabled is true.";


### PR DESCRIPTION
Since we bumped up the default number of StreamThreads per runtime to 4, we should decrease the default number of runtimes accordingly. 

The optimal number should ultimately be derived from the benchmarks, and we have a LaunchDarkly flag so we can modify the default further as more results come out, but for now we should still set the default in the code based on our initial observations.

If we start with just two runtimes, then with 4 threads each we will end up with 8 StreamThreads by default, which follows our rule of thumb for configuring the num.stream.threads (aka 2x # of cores on each node)