### PR TITLE
fix: CLI should return non-zero error code on failure

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -69,14 +69,17 @@ public final class Ksql {
       options.setPassword(readPassword());
     }
 
+    int error_code = 0;
     try {
-      new Ksql(options, System.getProperties(), KsqlRestClient::create, Cli::build).run();
+      error_code = new Ksql(options, System.getProperties(), KsqlRestClient::create, Cli::build).run();
     } catch (final Exception e) {
       final String msg = ErrorMessageUtil.buildErrorMessage(e);
       LOGGER.error(msg);
       System.err.println(msg);
       System.exit(-1);
     }
+
+    System.exit(error_code);
   }
 
   private static String readPassword() {
@@ -96,7 +99,7 @@ public final class Ksql {
     return password;
   }
 
-  void run() {
+  int run() {
     final Map<String, String> configProps = options.getConfigFile()
         .map(Ksql::loadProperties)
         .orElseGet(Collections::emptyMap);
@@ -114,16 +117,16 @@ public final class Ksql {
         cli.addSessionVariables(sessionVariables);
 
         if (options.getExecute().isPresent()) {
-          cli.runCommand(options.getExecute().get());
+          return cli.runCommand(options.getExecute().get());
         } else if (options.getScriptFile().isPresent()) {
           final File scriptFile = new File(options.getScriptFile().get());
           if (scriptFile.exists() && scriptFile.isFile()) {
-            cli.runScript(scriptFile.getPath());
+            return cli.runScript(scriptFile.getPath());
           } else {
             throw new KsqlException("No such script file: " + scriptFile.getPath());
           }
         } else {
-          cli.runInteractively();
+          return cli.runInteractively();
         }
       }
     }

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -69,9 +69,14 @@ public final class Ksql {
       options.setPassword(readPassword());
     }
 
-    int error_code = 0;
+    int errorCode = 0;
     try {
-      error_code = new Ksql(options, System.getProperties(), KsqlRestClient::create, Cli::build).run();
+      errorCode = new Ksql(
+          options,
+          System.getProperties(),
+          KsqlRestClient::create,
+          Cli::build
+      ).run();
     } catch (final Exception e) {
       final String msg = ErrorMessageUtil.buildErrorMessage(e);
       LOGGER.error(msg);
@@ -79,7 +84,7 @@ public final class Ksql {
       System.exit(-1);
     }
 
-    System.exit(error_code);
+    System.exit(errorCode);
   }
 
   private static String readPassword() {

--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -247,7 +247,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
 
   // called by '-f' command parameter
   public int runScript(final String scriptFile) {
-    int error_code = NO_ERROR;
+    int errorCode = NO_ERROR;
     RemoteServerSpecificCommand.validateClient(terminal.writer(), restClient);
 
     try {
@@ -265,7 +265,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
 
       handleLine(content);
     } catch (final Exception exception) {
-      error_code = ERROR;
+      errorCode = ERROR;
 
       LOGGER.error("An error occurred while running a script file. Error = "
           + exception.getMessage(), exception);
@@ -276,12 +276,12 @@ public class Cli implements KsqlRequestExecutor, Closeable {
 
     terminal.flush();
 
-    return error_code;
+    return errorCode;
   }
 
   // called by '-e' command parameter
   public int runCommand(final String command) {
-    int error_code = NO_ERROR;
+    int errorCode = NO_ERROR;
 
     RemoteServerSpecificCommand.validateClient(terminal.writer(), restClient);
     try {
@@ -291,7 +291,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
     } catch (final EndOfFileException exception) {
       // Ignore - only used by runInteractively() to exit the CLI
     } catch (final Exception exception) {
-      error_code = ERROR;
+      errorCode = ERROR;
       LOGGER.error("An error occurred while running a command. Error = "
           + exception.getMessage(), exception);
 
@@ -301,7 +301,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
 
     terminal.flush();
 
-    return error_code;
+    return errorCode;
   }
 
   public int runInteractively() {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -854,9 +854,10 @@ public class CliTest {
     when(mockRestClient.getServerInfo())
         .thenThrow(new KsqlRestClientException("Boom", new IOException("")));
 
-    new Cli(1L, 1L, mockRestClient, console)
+    final int error_code = new Cli(1L, 1L, mockRestClient, console)
         .runCommand("this is a command");
 
+    assertThat(error_code, is(-1));
     assertThat(terminal.getOutputString(),
         containsString("Please ensure that the URL provided is for an active KSQL server."));
   }
@@ -1228,13 +1229,14 @@ public class CliTest {
         + "partitions=1);\n").getBytes(StandardCharsets.UTF_8));
 
     // When:
-    localCli.runScript(scriptFile.getPath());
+    final int error_code = localCli.runScript(scriptFile.getPath());
 
     // Then:
     final String out = terminal.getOutputString();
     final String expected = "Statement: create stream if not exist s1(id int) "
         + "with (kafka_topic='s1', value_format='json', partitions=1);\n"
         + "Caused by: line 2:22: no viable alternative at input 'create stream if not";
+    assertThat(error_code, is(-1));
     assertThat(out, containsString(expected));
     assertThat(out, not(containsString("drop stream if exists")));
   }


### PR DESCRIPTION
### Description 
If there is an error executing a script or single command, the CLI should return error code -1 instead of 0 (no error).

Closes #7051 

### Testing done 
Extended existing unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

