### PR TITLE
feat: allow STREAMS with no key

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -36,7 +36,7 @@ public final class ImmutableProperties {
       .add(KsqlConfig.KSQL_READONLY_TOPICS_CONFIG)
       .add(KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED)
       .add(KsqlConfig.KSQL_HEADERS_COLUMNS_ENABLED)
-      //.add(KsqlConfig.KSQL_NEW_QUERY_PLANNER_ENABLED)
+      .add(KsqlConfig.KSQL_NEW_QUERY_PLANNER_ENABLED)
       .addAll(KsqlConfig.SSL_CONFIG_NAMES)
       .build();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -36,7 +36,7 @@ public final class ImmutableProperties {
       .add(KsqlConfig.KSQL_READONLY_TOPICS_CONFIG)
       .add(KsqlConfig.KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED)
       .add(KsqlConfig.KSQL_HEADERS_COLUMNS_ENABLED)
-      .add(KsqlConfig.KSQL_NEW_QUERY_PLANNER_ENABLED)
+      //.add(KsqlConfig.KSQL_NEW_QUERY_PLANNER_ENABLED)
       .addAll(KsqlConfig.SSL_CONFIG_NAMES)
       .build();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/PhysicalToExecutionPlanTranslator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/PhysicalToExecutionPlanTranslator.java
@@ -84,7 +84,10 @@ public class PhysicalToExecutionPlanTranslator implements NodeVisitor<Node<?>, E
     return ExecutionStepFactory.streamSelect(
         new Stacker().push("SELECT"),
         inputStep,
-        selectNode.keyColumnNames(),
+        // to-do: remove hack -- why do we need to pass in the source keys?
+        // -> does not seem to make sense -- might require more refactoring
+        selectNode.getInputNode().keyColumnNames(), // to-do: remove workaround
+        Optional.of(selectNode.keyColumnNames()),
         selectExpressions
     );
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/json/PlanJsonMapper.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/json/PlanJsonMapper.java
@@ -44,7 +44,7 @@ public enum PlanJsonMapper {
       .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
       .enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES)
       .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
-      .setSerializationInclusion(Include.NON_EMPTY);
+      .setSerializationInclusion(Include.NON_NULL);
 
   public ObjectMapper get() {
     return mapper.copy();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/json/PlanJsonMapper.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/json/PlanJsonMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physicalplanner/LogicalToPhysicalPlanTranslator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physicalplanner/LogicalToPhysicalPlanTranslator.java
@@ -24,9 +24,6 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalColumn;
-import io.confluent.ksql.schema.ksql.Column;
-import io.confluent.ksql.schema.ksql.LogicalColumn;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Objects;
 
 public class LogicalToPhysicalPlanTranslator

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/physicalplanner/LogicalToPhysicalPlanTranslator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/physicalplanner/LogicalToPhysicalPlanTranslator.java
@@ -24,6 +24,9 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalColumn;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.LogicalColumn;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Objects;
 
 public class LogicalToPhysicalPlanTranslator

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -151,6 +151,7 @@ public class SchemaKStream<K> {
         contextStacker,
         sourceStep,
         keyColumnNames,
+        Optional.empty(),
         selectExpressions
     );
 

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelect.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelect.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelect.java
@@ -34,17 +34,20 @@ public class StreamSelect<K> implements ExecutionStep<KStreamHolder<K>> {
   private final ExecutionStepPropertiesV1 properties;
   private final ExecutionStep<KStreamHolder<K>> source;
   private final ImmutableList<ColumnName> keyColumnNames;
+  private final Optional<ImmutableList<ColumnName>> selectedKeys;
   private final ImmutableList<SelectExpression> selectExpressions;
 
   public StreamSelect(
       final ExecutionStepPropertiesV1 props,
       final ExecutionStep<KStreamHolder<K>> source,
       final List<ColumnName> keyColumnNames,
+      final Optional<List<ColumnName>> selectedKeys,
       final List<SelectExpression> selectExpressions
   ) {
     this.properties = requireNonNull(props, "props");
     this.source = requireNonNull(source, "source");
     this.keyColumnNames = ImmutableList.copyOf(keyColumnNames);
+    this.selectedKeys = selectedKeys.map(ImmutableList::copyOf);
     this.selectExpressions = ImmutableList.copyOf(selectExpressions);
 
     if (selectExpressions.isEmpty()) {
@@ -68,10 +71,17 @@ public class StreamSelect<K> implements ExecutionStep<KStreamHolder<K>> {
       @JsonProperty(value = "properties", required = true) final ExecutionStepPropertiesV1 props,
       @JsonProperty(value = "source", required = true) final ExecutionStep<KStreamHolder<K>> source,
       @JsonProperty(value = "keyColumnNames") final Optional<List<ColumnName>> keyColumnNames,
+      @JsonProperty(value = "selectedKeys") final Optional<List<ColumnName>> selectedKeys,
       @JsonProperty(value = "selectExpressions", required = true) final
       List<SelectExpression> selectExpressions
   ) {
-    this(props, source, keyColumnNames.orElseGet(ImmutableList::of), selectExpressions);
+    this(
+        props,
+        source,
+        keyColumnNames.orElseGet(ImmutableList::of),
+        selectedKeys,
+        selectExpressions
+    );
   }
 
   @Override
@@ -88,6 +98,10 @@ public class StreamSelect<K> implements ExecutionStep<KStreamHolder<K>> {
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "keyColumnNames is ImmutableList")
   public List<ColumnName> getKeyColumnNames() {
     return keyColumnNames;
+  }
+
+  public Optional<ImmutableList<ColumnName>> getSelectedKeys() {
+    return selectedKeys;
   }
 
   @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "selectExpressions is ImmutableList")
@@ -128,11 +142,12 @@ public class StreamSelect<K> implements ExecutionStep<KStreamHolder<K>> {
     return Objects.equals(properties, that.properties)
         && Objects.equals(source, that.source)
         && Objects.equals(keyColumnNames, that.keyColumnNames)
+        && Objects.equals(selectedKeys, that.selectedKeys)
         && Objects.equals(selectExpressions, that.selectExpressions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(properties, source, keyColumnNames, selectExpressions);
+    return Objects.hash(properties, source, keyColumnNames, selectedKeys, selectExpressions);
   }
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -64,12 +64,6 @@ public final class Selection<K> {
         : keyColumnNames;
 
     final List<Column> keyCols = sourceSchema.key();
-
-//    if (keyNames.size() != keyCols.size()) {
-//      throw new IllegalArgumentException("key name count mismatch. "
-//          + "names: " + keyNames + ", "
-//          + "keys: " + keyCols);
-//    }
 
     final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
     final ImmutableList<ColumnName> selectedKeyColumns = selectedKeys.orElse(keyCols.stream()

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/transform/select/Selection.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.transform.select;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.transform.select.SelectValueMapper.SelectInfo;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -25,6 +26,7 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class Selection<K> {
@@ -35,6 +37,7 @@ public final class Selection<K> {
   public static <K> Selection<K> of(
       final LogicalSchema sourceSchema,
       final List<ColumnName> keyColumnNames,
+      final Optional<ImmutableList<ColumnName>> selectedKeys,
       final List<SelectExpression> selectExpressions,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry
@@ -46,34 +49,40 @@ public final class Selection<K> {
         functionRegistry
     );
 
-    final LogicalSchema schema = buildSchema(sourceSchema, mapper, keyColumnNames);
+    final LogicalSchema schema = buildSchema(sourceSchema, mapper, keyColumnNames, selectedKeys);
     return new Selection<>(mapper, schema);
   }
 
   private static LogicalSchema buildSchema(
       final LogicalSchema sourceSchema,
       final SelectValueMapper<?> mapper,
-      final List<ColumnName> keyColumnNames
+      final List<ColumnName> keyColumnNames,
+      final Optional<ImmutableList<ColumnName>> selectedKeys
   ) {
-    final List<ColumnName> keyNames = keyColumnNames.isEmpty()
+    final List<ColumnName> keyNames = keyColumnNames == null || keyColumnNames.isEmpty()
         ? getKeyColumnNames(sourceSchema)
         : keyColumnNames;
 
     final List<Column> keyCols = sourceSchema.key();
 
-    if (keyNames.size() != keyCols.size()) {
-      throw new IllegalArgumentException("key name count mismatch. "
-          + "names: " + keyNames + ", "
-          + "keys: " + keyCols);
-    }
+//    if (keyNames.size() != keyCols.size()) {
+//      throw new IllegalArgumentException("key name count mismatch. "
+//          + "names: " + keyNames + ", "
+//          + "keys: " + keyCols);
+//    }
 
     final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
+    final ImmutableList<ColumnName> selectedKeyColumns = selectedKeys.orElse(keyCols.stream()
+        .map(Column::name)
+        .collect(ImmutableList.toImmutableList()));
 
     for (int i = 0; i != keyCols.size(); ++i) {
-      schemaBuilder.keyColumn(
-          keyNames.get(i),
-          keyCols.get(i).type()
-      );
+      if (selectedKeyColumns.contains(keyCols.get(i).name())) {
+        schemaBuilder.keyColumn(
+            keyNames.get(i),
+            keyCols.get(i).type()
+        );
+      }
     }
 
     for (final SelectInfo select : mapper.getSelects()) {

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamSelectTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamSelectTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.name.ColumnName;
 import java.util.List;
+import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +43,8 @@ public class StreamSelectTest {
 
   private List<ColumnName> keys1;
   private List<ColumnName> keys2;
+  private Optional<List<ColumnName>> selectedKeys1;
+  private Optional<List<ColumnName>> selectedKeys2;
   private List<SelectExpression> selects1;
   private List<SelectExpression> selects2;
 
@@ -49,6 +52,8 @@ public class StreamSelectTest {
   public void setup() {
     keys1 = ImmutableList.of(mock(ColumnName.class));
     keys2 = ImmutableList.of(mock(ColumnName.class));
+    selectedKeys1 = Optional.of(ImmutableList.of(mock(ColumnName.class)));
+    selectedKeys2 = Optional.of(ImmutableList.of(mock(ColumnName.class)));
     selects1 = ImmutableList.of(mock(SelectExpression.class));
     selects2 = ImmutableList.of(mock(SelectExpression.class));
   }
@@ -57,13 +62,15 @@ public class StreamSelectTest {
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new StreamSelect<>(properties1, source1, keys1, selects1),
-            new StreamSelect<>(properties1, source1, keys1, selects1)
+            new StreamSelect<>(properties1, source1, keys1, selectedKeys1, selects1),
+            new StreamSelect<>(properties1, source1, keys1, selectedKeys1, selects1)
         )
-        .addEqualityGroup(new StreamSelect<>(properties2, source1, keys1, selects1))
-        .addEqualityGroup(new StreamSelect<>(properties1, source2, keys1, selects1))
-        .addEqualityGroup(new StreamSelect<>(properties1, source1, keys2, selects1))
-        .addEqualityGroup(new StreamSelect<>(properties1, source1, keys1, selects2))
+        .addEqualityGroup(new StreamSelect<>(properties2, source1, keys1, selectedKeys1, selects1))
+        .addEqualityGroup(new StreamSelect<>(properties1, source2, keys1, selectedKeys1, selects1))
+        .addEqualityGroup(new StreamSelect<>(properties1, source1, keys2, selectedKeys1, selects1))
+        .addEqualityGroup(new StreamSelect<>(properties1, source1, keys1, selectedKeys2, selects1))
+        .addEqualityGroup(new StreamSelect<>(properties1, source1, keys1, Optional.empty(), selects1))
+        .addEqualityGroup(new StreamSelect<>(properties1, source1, keys1, selectedKeys1, selects2))
         .testEquals();
   }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamSelectTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/plan/StreamSelectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,6 +78,7 @@ public class SelectionTest {
     selection = Selection.of(
         SCHEMA,
         ImmutableList.of(ALIASED_KEY),
+        Optional.empty(),
         SELECT_EXPRESSIONS,
         ksqlConfig,
         functionRegistry
@@ -118,6 +120,7 @@ public class SelectionTest {
     selection = Selection.of(
         SCHEMA,
         ImmutableList.of(),
+        Optional.empty(),
         SELECT_EXPRESSIONS,
         ksqlConfig,
         functionRegistry

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/select.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/select.json
@@ -1,34 +1,8 @@
 {
   "comments": [
-    "Tests covering general SELECT clause, a.k.a projection, handling",
-    "Manually tests `new query planner test` with all key combination:",
-    " - `name` only (as below)",
-    " - `id1` only",
-    " - `id2` only",
-    " - `id2, id1` (reverse order)"
+    "Tests covering general SELECT clause, a.k.a projection, handling"
   ],
   "tests": [
-    {
-      "name": "new query planner test",
-      "statements": [
-        "CREATE STREAM INPUT (id1 INT KEY, id2 INT KEY, name STRING, foo STRING) WITH (kafka_topic='test_topic', format='JSON');",
-        "CREATE STREAM OUTPUT AS SELECT name FROM INPUT;"
-      ],
-      "properties": {
-        "ksql.new.query.planner.enabled": "true"
-      },
-      "inputs": [
-        {"topic":  "test_topic", "key": {"id1": 1, "id2": 10}, "value": {"name": "a", "foo":  "b"}}
-      ],
-      "outputs": [
-        {"topic":  "OUTPUT", "key": null, "value": {"NAME": "a"}}
-      ],
-      "post": {
-        "sources": [
-          {"name": "OUTPUT", "type": "stream", "schema": "NAME STRING"}
-        ]
-      }
-    },
     {
       "name": "key column",
       "statements": [

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/select.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/select.json
@@ -1,8 +1,34 @@
 {
   "comments": [
-    "Tests covering general SELECT clause, a.k.a projection, handling"
+    "Tests covering general SELECT clause, a.k.a projection, handling",
+    "Manually tests `new query planner test` with all key combination:",
+    " - `name` only (as below)",
+    " - `id1` only",
+    " - `id2` only",
+    " - `id2, id1` (reverse order)"
   ],
   "tests": [
+    {
+      "name": "new query planner test",
+      "statements": [
+        "CREATE STREAM INPUT (id1 INT KEY, id2 INT KEY, name STRING, foo STRING) WITH (kafka_topic='test_topic', format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT name FROM INPUT;"
+      ],
+      "properties": {
+        "ksql.new.query.planner.enabled": "true"
+      },
+      "inputs": [
+        {"topic":  "test_topic", "key": {"id1": 1, "id2": 10}, "value": {"name": "a", "foo":  "b"}}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key": null, "value": {"NAME": "a"}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "NAME STRING"}
+        ]
+      }
+    },
     {
       "name": "key column",
       "statements": [

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -225,6 +225,7 @@ public final class ExecutionStepFactory {
       final QueryContext.Stacker stacker,
       final ExecutionStep<KStreamHolder<K>> source,
       final List<ColumnName> keyColumnNames,
+      final Optional<List<ColumnName>> selectedKeys,
       final List<SelectExpression> selectExpressions
   ) {
     final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(
@@ -234,6 +235,7 @@ public final class ExecutionStepFactory {
         properties,
         source,
         keyColumnNames,
+        selectedKeys,
         selectExpressions
     );
   }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.execution.streams;
 
+import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.CompiledExpression;
@@ -250,7 +251,12 @@ public final class StepSchemaResolver {
       final LogicalSchema schema,
       final StreamSelect<?> step
   ) {
-    return buildSelectSchema(schema, step.getKeyColumnNames(), step.getSelectExpressions());
+    return buildSelectSchema(
+        schema,
+        step.getKeyColumnNames(),
+        step.getSelectedKeys(),
+        step.getSelectExpressions()
+    );
   }
 
   private LogicalSchema handleStreamSelectKeyV1(
@@ -339,7 +345,12 @@ public final class StepSchemaResolver {
       final LogicalSchema schema,
       final TableSelect<?> step
   ) {
-    return buildSelectSchema(schema, step.getKeyColumnNames(), step.getSelectExpressions());
+    return buildSelectSchema(
+        schema,
+        step.getKeyColumnNames(),
+        Optional.empty(),
+        step.getSelectExpressions()
+    );
   }
 
   private LogicalSchema handleTableSelectKey(
@@ -369,11 +380,13 @@ public final class StepSchemaResolver {
   private LogicalSchema buildSelectSchema(
       final LogicalSchema schema,
       final List<ColumnName> keyColumnNames,
+      final Optional<ImmutableList<ColumnName>> selectedKeys,
       final List<SelectExpression> selectExpressions
   ) {
     return Selection.of(
         schema,
         keyColumnNames,
+        selectedKeys,
         selectExpressions,
         ksqlConfig,
         functionRegistry

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.StreamAggregate;
 import io.confluent.ksql.execution.plan.StreamWindowedAggregate;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
-import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.execution.streams.transform.KsValueTransformer;
 import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.windows.HoppingWindowExpression;
@@ -119,7 +119,7 @@ public final class StreamAggregateBuilder {
 
     final KTable<GenericKey, GenericRow> result = aggregated
         .transformValues(
-            () -> new KsTransformer<>(aggregator.getResultMapper()),
+            () -> new KsValueTransformer<>(aggregator.getResultMapper()),
             Named.as(StreamsUtil.buildOpName(
                 AggregateBuilderUtils.outputContext(aggregate)))
         );
@@ -183,7 +183,7 @@ public final class StreamAggregateBuilder {
     final KudafAggregator<Windowed<GenericKey>> aggregator = aggregateParams.getAggregator();
 
     KTable<Windowed<GenericKey>, GenericRow> reduced = aggregated.transformValues(
-        () -> new KsTransformer<>(aggregator.getResultMapper()),
+        () -> new KsValueTransformer<>(aggregator.getResultMapper()),
         Named.as(StreamsUtil.buildOpName(AggregateBuilderUtils.outputContext(aggregate)))
     );
 
@@ -196,7 +196,7 @@ public final class StreamAggregateBuilder {
         );
 
     reduced = reduced.transformValues(
-        () -> new KsTransformer<>(new WindowBoundsPopulator()),
+        () -> new KsValueTransformer<>(new WindowBoundsPopulator()),
         Named.as(StreamsUtil.buildOpName(
             AggregateBuilderUtils.windowSelectContext(aggregate)
         ))

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
@@ -19,7 +19,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamFilter;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
-import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.execution.streams.transform.KsValueTransformer;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.transform.sqlpredicate.SqlPredicate;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
@@ -77,7 +77,7 @@ public final class StreamFilterBuilder {
           final KsqlTransformer<K, Optional<GenericRow>> transformer
   ) {
     final ValueTransformerWithKey<K, GenericRow, Optional<GenericRow>> delegate =
-        new KsTransformer<>(transformer);
+        new KsValueTransformer<>(transformer);
 
     return new ValueTransformerWithKey<K, GenericRow, Iterable<GenericRow>>() {
       @Override

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -29,7 +29,7 @@ import io.confluent.ksql.execution.function.udtf.TableFunctionApplier;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamFlatMap;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
-import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.execution.streams.transform.KsValueTransformer;
 import io.confluent.ksql.execution.util.ExpressionTypeManager;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlTableFunction;
@@ -86,7 +86,9 @@ public final class StreamFlatMapBuilder {
         .build();
 
     final KStream<K, GenericRow> mapped = stream.getStream().flatTransformValues(
-        () -> new KsTransformer<>(new KudtfFlatMapper<>(tableFunctionAppliers, processingLogger)),
+        () -> new KsValueTransformer<>(
+            new KudtfFlatMapper<>(tableFunctionAppliers, processingLogger)
+        ),
         Named.as(StreamsUtil.buildOpName(queryContext))
     );
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
@@ -23,7 +23,7 @@ import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableAggregate;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
-import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.execution.streams.transform.KsValueTransformer;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.List;
@@ -84,7 +84,9 @@ public final class TableAggregateBuilder {
         aggregateParams.getUndoAggregator().get(),
         materialized
     ).transformValues(
-        () -> new KsTransformer<>(aggregateParams.<GenericKey>getAggregator().getResultMapper()),
+        () -> new KsValueTransformer<>(
+            aggregateParams.<GenericKey>getAggregator().getResultMapper()
+        ),
         Named.as(StreamsUtil.buildOpName(AggregateBuilderUtils.outputContext(aggregate)))
     );
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
@@ -20,7 +20,7 @@ import io.confluent.ksql.execution.context.QueryContext.Stacker;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableFilter;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
-import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.execution.streams.transform.KsValueTransformer;
 import io.confluent.ksql.execution.transform.sqlpredicate.SqlPredicate;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import java.util.Optional;
@@ -62,7 +62,7 @@ public final class TableFilterBuilder {
     final Stacker stacker = Stacker.of(step.getProperties().getQueryContext());
     final KTable<K, GenericRow> filtered = table.getTable()
         .transformValues(
-            () -> new KsTransformer<>(predicate.getTransformer(processingLogger)),
+            () -> new KsValueTransformer<>(predicate.getTransformer(processingLogger)),
             Named.as(StreamsUtil.buildOpName(stacker.push(PRE_PROCESS_OP).getQueryContext()))
         )
         .filter(

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSelectBuilder.java
@@ -23,7 +23,7 @@ import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableSelect;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
-import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.execution.streams.transform.KsValueTransformer;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
 import io.confluent.ksql.execution.transform.select.SelectValueMapper;
 import io.confluent.ksql.execution.transform.select.Selection;
@@ -58,6 +58,7 @@ public final class TableSelectBuilder {
     final Selection<K> selection = Selection.of(
         sourceSchema,
         step.getKeyColumnNames(),
+        Optional.empty(),
         step.getSelectExpressions(),
         buildContext.getKsqlConfig(),
         buildContext.getFunctionRegistry()
@@ -111,7 +112,7 @@ public final class TableSelectBuilder {
             );
 
         final KTable<K, GenericRow> transFormedTable = table.getTable().transformValues(
-            () -> new KsTransformer<>(selectMapper.getTransformer(logger)),
+            () -> new KsValueTransformer<>(selectMapper.getTransformer(logger)),
             materialized
         );
 
@@ -128,7 +129,7 @@ public final class TableSelectBuilder {
     }
 
     final KTable<K, GenericRow> transFormedTable = table.getTable().transformValues(
-        () -> new KsTransformer<>(selectMapper.getTransformer(logger)),
+        () -> new KsValueTransformer<>(selectMapper.getTransformer(logger)),
         Materialized.with(keySerde, valSerde),
         selectName
     );

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/TableSuppressBuilder.java
@@ -22,7 +22,7 @@ import io.confluent.ksql.execution.plan.ExecutionKeyFactory;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableSuppress;
 import io.confluent.ksql.execution.runtime.RuntimeBuildContext;
-import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.execution.streams.transform.KsValueTransformer;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.SerdeFeatures;
@@ -110,7 +110,7 @@ public final class TableSuppressBuilder {
     with the correct key and val serdes is passed on when we call suppress
      */
     final KTable<K, GenericRow> suppressed = table.getTable().transformValues(
-        (() -> new KsTransformer<>((k, v, ctx) -> v)),
+        (() -> new KsValueTransformer<>((k, v, ctx) -> v)),
         materialized
     ).suppress(
         (Suppressed<? super K>) Suppressed

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsTransformer.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsTransformer.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsTransformer.java
@@ -25,6 +25,15 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
+/**
+ * A Kafka-streams transformer
+ *
+ * <p>Maps two implementation agnostic {@link KsqlTransformer KsqlTransformers}
+ * (one for the key and one for the value) to an implementation specific {@link Transformer}.
+ *
+ * @param <KInT> the type of the key
+ * @param <KOutT> the return type for the key
+ */
 public class KsTransformer<KInT, KOutT>
     implements Transformer<KInT, GenericRow, KeyValue<KOutT, GenericRow>> {
 

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsValueTransformer.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsValueTransformer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams.transform;
+
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.transform.KsqlProcessingContext;
+import io.confluent.ksql.execution.transform.KsqlTransformer;
+import java.util.Optional;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.processor.ProcessorContext;
+
+/**
+ * A Kafka-streams transformer
+ *
+ * <p>Maps a implementation agnostic {@link KsqlTransformer} to a implementation specific {@link
+ * ValueTransformerWithKey}.
+ *
+ * @param <K> the type of the key
+ * @param <R> the return type
+ */
+public class KsValueTransformer<K, R> implements ValueTransformerWithKey<K, GenericRow, R> {
+
+  private final KsqlTransformer<K, R> delegate;
+  private Optional<KsProcessingContext> context;
+
+  public KsValueTransformer(final KsqlTransformer<K, R> delegate) {
+    this.delegate = requireNonNull(delegate, "delegate");
+    this.context = Optional.empty();
+  }
+
+  @Override
+  public void init(final ProcessorContext processorContext) {
+    this.context = Optional.of(new KsProcessingContext(processorContext));
+  }
+
+  @Override
+  public R transform(final K readOnlyKey, final GenericRow value) {
+    return delegate.transform(
+        readOnlyKey,
+        value,
+        context.orElseThrow(() -> new IllegalStateException("Not initialized"))
+    );
+  }
+
+  @Override
+  public void close() {
+  }
+
+  public static final class KsProcessingContext implements KsqlProcessingContext {
+
+    private final ProcessorContext processingContext;
+
+    public KsProcessingContext(final ProcessorContext processorContext) {
+      this.processingContext = requireNonNull(processorContext, "processorContext");
+    }
+
+    @Override
+    public long getRowTime() {
+      return processingContext.timestamp();
+    }
+  }
+}

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsValueTransformer.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsValueTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsValueTransformer.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/transform/KsValueTransformer.java
@@ -25,9 +25,9 @@ import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
 /**
- * A Kafka-streams transformer
+ * A Kafka-streams value-transformer
  *
- * <p>Maps a implementation agnostic {@link KsqlTransformer} to a implementation specific {@link
+ * <p>Maps an implementation agnostic {@link KsqlTransformer} to a implementation specific {@link
  * ValueTransformerWithKey}.
  *
  * @param <K> the type of the key

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -182,6 +182,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         streamSource,
         ImmutableList.of(ColumnName.of("NEW_KEY")),
+        Optional.empty(),
         ImmutableList.of(
             add("JUICE", "ORANGE", "APPLE"),
             ref("PLANTAIN", "BANANA"),
@@ -209,6 +210,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         streamSource,
         ImmutableList.of(),
+        Optional.empty(),
         ImmutableList.of(
             add("JUICE", "ORANGE", "APPLE"),
             ref("PLANTAIN", "BANANA"),

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectBuilderTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.schema.ksql.SystemColumns;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
+import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Named;
@@ -126,6 +127,7 @@ public class StreamSelectBuilderTest {
         properties,
         sourceStep,
         ImmutableList.of(),
+        Optional.empty(),
         SELECT_EXPRESSIONS
     );
     planBuilder = new KSPlanBuilder(
@@ -183,6 +185,7 @@ public class StreamSelectBuilderTest {
         properties,
         sourceStep,
         ImmutableList.of(ColumnName.of("NEW_KEY")),
+        Optional.empty(),
         SELECT_EXPRESSIONS
     );
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/transform/KsTransformerTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/transform/KsTransformerTest.java
@@ -49,11 +49,11 @@ public class KsTransformerTest {
   @Captor
   private ArgumentCaptor<KsqlProcessingContext> ctxCaptor;
 
-  private KsTransformer<Long, String> ksTransformer;
+  private KsValueTransformer<Long, String> ksTransformer;
 
   @Before
   public void setUp() {
-    ksTransformer = new KsTransformer<>(ksqlTransformer);
+    ksTransformer = new KsValueTransformer<>(ksqlTransformer);
     ksTransformer.init(ctx);
 
     when(ksqlTransformer.transform(any(), any(), any())).thenReturn(RESULT);
@@ -64,7 +64,7 @@ public class KsTransformerTest {
   @Test(expected = IllegalStateException.class)
   public void shouldThrowOnTransformIfNotInitialized() {
     // Given:
-    ksTransformer = new KsTransformer<>(ksqlTransformer);
+    ksTransformer = new KsValueTransformer<>(ksqlTransformer);
 
     // When:
     ksTransformer.transform(KEY, VALUE);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/transform/KsValueTransformerTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/transform/KsValueTransformerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.transform.KsqlProcessingContext;
 import io.confluent.ksql.execution.transform.KsqlTransformer;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,32 +35,28 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class KsTransformerTest {
+public class KsValueTransformerTest {
 
   private static final long KEY = 10L;
   private static final GenericRow VALUE = GenericRow.genericRow(12);
-  private static final String RESULT_KEY = "the result key";
-  private static final GenericRow RESULT_VALUE = GenericRow.genericRow("the result value");
+  private static final String RESULT = "the result";
   private static final long ROWTIME = 123456L;
 
   @Mock
-  private KsqlTransformer<Long, String> ksqlKeyTransformer;
-  @Mock
-  private KsqlTransformer<Long, GenericRow> ksqlValueTransformer;
+  private KsqlTransformer<Long, String> ksqlTransformer;
   @Mock
   private ProcessorContext ctx;
   @Captor
   private ArgumentCaptor<KsqlProcessingContext> ctxCaptor;
 
-  private KsTransformer<Long, String> ksTransformer;
+  private KsValueTransformer<Long, String> ksTransformer;
 
   @Before
   public void setUp() {
-    ksTransformer = new KsTransformer<>(ksqlKeyTransformer, ksqlValueTransformer);
+    ksTransformer = new KsValueTransformer<>(ksqlTransformer);
     ksTransformer.init(ctx);
 
-    when(ksqlKeyTransformer.transform(any(), any(), any())).thenReturn(RESULT_KEY);
-    when(ksqlValueTransformer.transform(any(), any(), any())).thenReturn(RESULT_VALUE);
+    when(ksqlTransformer.transform(any(), any(), any())).thenReturn(RESULT);
 
     when(ctx.timestamp()).thenReturn(ROWTIME);
   }
@@ -69,24 +64,19 @@ public class KsTransformerTest {
   @Test(expected = IllegalStateException.class)
   public void shouldThrowOnTransformIfNotInitialized() {
     // Given:
-    ksTransformer = new KsTransformer<>(ksqlKeyTransformer, ksqlValueTransformer);
+    ksTransformer = new KsValueTransformer<>(ksqlTransformer);
 
     // When:
     ksTransformer.transform(KEY, VALUE);
   }
 
   @Test
-  public void shouldInvokeInnerTransformers() {
+  public void shouldInvokeInnerTransformer() {
     // When:
     ksTransformer.transform(KEY, VALUE);
 
     // Then:
-    verify(ksqlKeyTransformer).transform(
-        eq(KEY),
-        eq(VALUE),
-        any()
-    );
-    verify(ksqlValueTransformer).transform(
+    verify(ksqlTransformer).transform(
         eq(KEY),
         eq(VALUE),
         any()
@@ -96,10 +86,10 @@ public class KsTransformerTest {
   @Test
   public void shouldReturnValueFromInnerTransformer() {
     // When:
-    final KeyValue<String, GenericRow> result = ksTransformer.transform(KEY, VALUE);
+    final String result = ksTransformer.transform(KEY, VALUE);
 
     // Then:
-    assertThat(result, is(KeyValue.pair(RESULT_KEY, RESULT_VALUE)));
+    assertThat(result, is(RESULT));
   }
 
   @Test
@@ -117,7 +107,7 @@ public class KsTransformerTest {
   }
 
   private KsqlProcessingContext getKsqlProcessingContext() {
-    verify(ksqlKeyTransformer).transform(
+    verify(ksqlTransformer).transform(
         any(),
         any(),
         ctxCaptor.capture()


### PR DESCRIPTION
### Description 
Previously, ksqlDB requires a CSAS statement to include key columns in
the SELECT. There is no semantic reason for this restriction and this
PR removes the key-column-requirement for CSAS statements.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

