### PR TITLE
Revert "fix: reduce query creation time with shared runtimes (#8888)"

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -220,7 +220,18 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     log.info("Attempting to start query {} in runtime {}", queryId, getApplicationId());
     if (collocatedQueries.containsKey(queryId) && !collocatedQueries.get(queryId).everStarted) {
       if (!kafkaStreams.getTopologyByName(queryId.toString()).isPresent()) {
-        kafkaStreams.addNamedTopology(collocatedQueries.get(queryId).getTopology());
+        try {
+          kafkaStreams.addNamedTopology(collocatedQueries.get(queryId).getTopology())
+              .all()
+              .get();
+        } catch (ExecutionException | InterruptedException e) {
+          final Throwable t = e.getCause() == null ? e : e.getCause();
+          throw new IllegalStateException(String.format(
+                "Encountered an error when trying to start query %s in runtime: %s",
+                queryId,
+                getApplicationId()),
+              t);
+        }
       } else {
         throw new IllegalArgumentException("Cannot start because Streams is not done terminating"
                                                + " an older version of query : " + queryId);


### PR DESCRIPTION
This reverts commit f3c58508a379543b0e545a9cb03af1e9166760c3.

The commit this is reverting was causing drop queries to block.
The behavior in streams is:
1. All threads are waiting for a non empty topology
2. A topology gets added.
3. Thread 1 updates, others do not yet
4. topology is removed Thread 1 removes and unsubscribes and goes back to waiting for a non empty topology
5. All other threads have not moved and so the remove future can never complete


### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

