### PR TITLE
fix: make sure topologies are done added before removing

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -46,7 +46,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
   private final long shutdownTimeout;
   private final QueryErrorClassifier errorClassifier;
   private final int maxQueryErrorsQueueSize;
-  private final List<KafkaFuture<Void>>  topolgogiesToAdd;
+  private final List<KafkaFuture<Void>> topolgogiesToAdd;
 
   public SharedKafkaStreamsRuntimeImpl(final KafkaStreamsBuilder kafkaStreamsBuilder,
                                        final QueryErrorClassifier errorClassifier,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.StateListener;


### PR DESCRIPTION
This commit https://github.com/confluentinc/ksql/commit/f3c58508a379543b0e545a9cb03af1e9166760c3 is  causing drop queries to block.

The behavior in streams is:
All threads are waiting for a non empty topology
A topology gets added.
Thread 1 updates, others do not yet
topology is removed Thread 1 removes and unsubscribes and goes back to waiting for a non empty topology
All other threads have not moved and so the remove future can never complete

So before all removing a topology we make sure all the adds are compelete


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

