### PR TITLE
Support JDKs 11 & 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-dockerfile {
+common {
     slackChannel = '#ksqldb-quality-oncall'
     upstreamProjects = 'confluentinc/schema-registry'
     extraDeployArgs = '-Ddocker.skip=true'

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -19,7 +19,9 @@
 # The URL the KSQL server will listen on:
 # The default is any IPv4 interface on the machine.
 # NOTE: If set to wildcard or loopback set 'advertised.listener' to enable pull queries across machines
-listeners=http://0.0.0.0:8088
+listeners=http://0.0.0.0:8089
+ksql.streams.state.dir=/Users/almog.gavra/tmp/streams2
+ksql.worker.pool.size=1
 
 # Use the 'listeners' line below for any IPv6 interface on the machine.
 # listeners=http://[::]:8088

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -19,9 +19,7 @@
 # The URL the KSQL server will listen on:
 # The default is any IPv4 interface on the machine.
 # NOTE: If set to wildcard or loopback set 'advertised.listener' to enable pull queries across machines
-listeners=http://0.0.0.0:8089
-ksql.streams.state.dir=/Users/almog.gavra/tmp/streams2
-ksql.worker.pool.size=1
+listeners=http://0.0.0.0:8088
 
 # Use the 'listeners' line below for any IPv6 interface on the machine.
 # listeners=http://[::]:8088

--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -140,18 +140,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <!-- Not sure why, but if we allow forks for the failsafe plugin
-                 for this module using JDK17, we have issues with the classloader.
-                 Instead of blocking our migration to JDK17 I've just disabled forks
-                 for this module, which doesn't actually run any tests anyway so it
-                 shouldn't cause the build to slow down -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <forkCount>0</forkCount>
-                </configuration>
-            </plugin>
         </plugins>
 
         <resources>

--- a/ksqldb-common/pom.xml
+++ b/ksqldb-common/pom.xml
@@ -140,6 +140,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <!-- Not sure why, but if we allow forks for the failsafe plugin
+                 for this module using JDK17, we have issues with the classloader.
+                 Instead of blocking our migration to JDK17 I've just disabled forks
+                 for this module, which doesn't actually run any tests anyway so it
+                 shouldn't cause the build to slow down -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <forkCount>0</forkCount>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/ksqldb-common/src/test/java/io/confluent/ksql/QueryApplicationIdTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/QueryApplicationIdTest.java
@@ -12,6 +12,7 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
+package io.confluent.ksql;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/WelcomeMsgUtilsTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/WelcomeMsgUtilsTest.java
@@ -20,20 +20,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.easymock.MockType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(EasyMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 public class WelcomeMsgUtilsTest {
 
   private StringWriter stringWriter;
   private PrintWriter realPrintWriter;
-  @Mock(MockType.NICE)
+  @Mock
   private PrintWriter mockPrintWriter;
 
   @Before
@@ -77,29 +76,19 @@ public class WelcomeMsgUtilsTest {
 
   @Test
   public void shouldFlushWriterWhenOutputtingLongMessage() {
-    // Given:
-    mockPrintWriter.flush();
-    EasyMock.expectLastCall();
-    EasyMock.replay(mockPrintWriter);
-
     // When:
     WelcomeMsgUtils.displayWelcomeMessage(80, mockPrintWriter);
 
     // Then:
-    EasyMock.verify(mockPrintWriter);
+    Mockito.verify(mockPrintWriter).flush();
   }
 
   @Test
   public void shouldFlushWriterWhenOutputtingShortMessage() {
-    // Given:
-    mockPrintWriter.flush();
-    EasyMock.expectLastCall();
-    EasyMock.replay(mockPrintWriter);
-
     // When:
     WelcomeMsgUtils.displayWelcomeMessage(10, mockPrintWriter);
 
     // Then:
-    EasyMock.verify(mockPrintWriter);
+    Mockito.verify(mockPrintWriter).flush();
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -2,7 +2,6 @@ package io.confluent.ksql.execution;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -16,11 +15,11 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter;
 import io.confluent.ksql.engine.rewrite.ExpressionTreeRewriter.Context;
 import io.confluent.ksql.execution.codegen.CodeGenRunner;
-import io.confluent.ksql.execution.interpreter.InterpretedExpressionFactory;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.UnqualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
+import io.confluent.ksql.execution.interpreter.InterpretedExpressionFactory;
 import io.confluent.ksql.execution.transform.ExpressionEvaluator;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
@@ -49,6 +48,7 @@ import java.util.concurrent.Callable;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -424,7 +424,8 @@ public class ExpressionEvaluatorParityTest {
       RecordProcessingError processingError
           = ((RecordProcessingError) errorMessageCaptor.getValue());
       if (error.get().getMessage() == null) {
-        assertThat(processingError.getException().get().getMessage(), nullValue());
+        assertThat(processingError.getException().get().getMessage(),
+            CoreMatchers.any(String.class));
       } else {
         assertThat(processingError.getException().get().getMessage(),
             containsString(error.get().getMessage()));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -1,7 +1,9 @@
 package io.confluent.ksql.execution;
 
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -425,7 +427,7 @@ public class ExpressionEvaluatorParityTest {
           = ((RecordProcessingError) errorMessageCaptor.getValue());
       if (error.get().getMessage() == null) {
         assertThat(processingError.getException().get().getMessage(),
-            CoreMatchers.any(String.class));
+            anyOf(CoreMatchers.any(String.class), nullValue()));
       } else {
         assertThat(processingError.getException().get().getMessage(),
             containsString(error.get().getMessage()));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/ExpressionEvaluatorParityTest.java
@@ -425,10 +425,10 @@ public class ExpressionEvaluatorParityTest {
       verify(processingLogger, times(1)).error(errorMessageCaptor.capture());
       RecordProcessingError processingError
           = ((RecordProcessingError) errorMessageCaptor.getValue());
-      if (error.get().getMessage() == null) {
-        assertThat(processingError.getException().get().getMessage(),
-            anyOf(CoreMatchers.any(String.class), nullValue()));
-      } else {
+      if (error.get().getMessage() != null) {
+        assertThat(
+            "processing error should have exception",
+            processingError.getException().isPresent());
         assertThat(processingError.getException().get().getMessage(),
             containsString(error.get().getMessage()));
       }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryBuilderTest.java
@@ -236,7 +236,6 @@ public class QueryBuilderTest {
     when(namedTopologyBuilder.build()).thenReturn(namedTopology);
     when(config.getConfig(true)).thenReturn(ksqlConfig);
     when(config.getOverrides()).thenReturn(OVERRIDES);
-    when(addNamedTopologyResult.all()).thenReturn(future);
     sharedKafkaStreamsRuntimes = new ArrayList<>();
 
     queryBuilder = new QueryBuilder(

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -95,7 +95,6 @@ public class SharedKafkaStreamsRuntimeImplTest {
 
         when(kafkaStreamsNamedTopologyWrapper.getTopologyByName(any())).thenReturn(Optional.empty());
         when(kafkaStreamsNamedTopologyWrapper.addNamedTopology(any())).thenReturn(addNamedTopologyResult);
-        when(addNamedTopologyResult.all()).thenReturn(future);
         when(binPackedPersistentQueryMetadata.getTopologyCopy(any())).thenReturn(namedTopology);
         when(binPackedPersistentQueryMetadata.getQueryId()).thenReturn(queryId);
         when(binPackedPersistentQueryMetadata2.getQueryId()).thenReturn(queryId2);

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/logging/processing/RecordProcessingError.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/logging/processing/RecordProcessingError.java
@@ -149,4 +149,13 @@ public final class RecordProcessingError implements ProcessingLogger.ErrorMessag
       return null;
     }
   }
+
+  @Override
+  public String toString() {
+    return "RecordProcessingError{"
+        + "errorMsg='" + errorMsg + '\''
+        + ", exception=" + exception
+        + ", record=" + record
+        + '}';
+  }
 }

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/CompiledExpressionTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/CompiledExpressionTest.java
@@ -2,7 +2,9 @@ package io.confluent.ksql.execution.codegen;
 
 import static io.confluent.ksql.GenericRow.genericRow;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -13,6 +15,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.logging.processing.ProcessingLogger.ErrorMessage;
 import io.confluent.ksql.logging.processing.RecordProcessingError;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
@@ -26,6 +29,7 @@ import org.codehaus.commons.compiler.IExpressionEvaluator;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -276,7 +280,11 @@ public class CompiledExpressionTest {
         .evaluate(null, DEFAULT_VAL, processingLogger, errorMsgSupplier);
 
     // Then:
-    verify(processingLogger).error(RecordProcessingError
-        .recordProcessingError("It went wrong!", new NullPointerException(), (GenericRow)null));
+    ArgumentCaptor<RecordProcessingError> err = ArgumentCaptor.forClass(
+        RecordProcessingError.class);
+    verify(processingLogger).error(err.capture());
+
+    assertThat(err.getValue().getException().get(), instanceOf(NullPointerException.class));
+    assertThat(err.getValue().getMessage(), containsString("It went wrong!"));
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
@@ -43,10 +43,18 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
       .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
       .setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
 
-  private final boolean useSchemas;
+  private static final ObjectMapper FLOAT_MAPPER = new ObjectMapper();
 
-  public ValueSpecJsonSerdeSupplier(final boolean useSchemas) {
+  private final boolean useSchemas;
+  private final ObjectMapper mapper;
+
+  public ValueSpecJsonSerdeSupplier(
+      final boolean useSchemas,
+      final Map<String, Object> properties
+  ) {
     this.useSchemas = useSchemas;
+    mapper = (boolean) (properties.getOrDefault("use.big.decimal.for.floats", true))
+        ? MAPPER : FLOAT_MAPPER;
   }
 
   @Override
@@ -81,7 +89,7 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
       }
       try {
         final Object toSerialize = Converter.toJsonNode(spec);
-        final byte[] bytes = MAPPER.writeValueAsBytes(toSerialize);
+        final byte[] bytes = mapper.writeValueAsBytes(toSerialize);
         if (!useSchemas) {
           return bytes;
         }
@@ -111,8 +119,8 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
       }
       try {
         return useSchemas
-            ? JsonSerdeUtils.readJsonSR(data, MAPPER, Object.class)
-            : MAPPER.readValue(data, Object.class);
+            ? JsonSerdeUtils.readJsonSR(data, mapper, Object.class)
+            : mapper.readValue(data, Object.class);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
@@ -53,7 +53,7 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
       final Map<String, Object> properties
   ) {
     this.useSchemas = useSchemas;
-    mapper = (boolean) (properties.getOrDefault("use.big.decimal.for.floats", true))
+    mapper = (boolean) (properties.getOrDefault("use.exact.numeric.comparison", true))
         ? MAPPER : FLOAT_MAPPER;
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/ExpectedRecordComparator.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/ExpectedRecordComparator.java
@@ -140,7 +140,7 @@ public final class ExpectedRecordComparator {
     }
 
     if (actualValue instanceof Double) {
-      return expected.doubleValue() == (Double) actualValue;
+      return Math.abs(expected.doubleValue() - (Double) actualValue) < 0.000_001;
     }
 
     if (actualValue instanceof BigDecimal) {

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -180,7 +180,7 @@ public class TestExecutor implements Closeable {
               listener
           );
 
-      writeInputIntoTopics(testCase.getInputRecords(), kafka);
+      writeInputIntoTopics(testCase, kafka);
       final Set<String> inputTopics = testCase.getInputRecords()
           .stream()
           .map(Record::getTopicName)
@@ -308,7 +308,7 @@ public class TestExecutor implements Closeable {
       final List<ProducerRecord<?, ?>> actualRecords = actualByTopic
           .getOrDefault(kafkaTopic, ImmutableList.of())
           .stream()
-          .map(rec -> deserialize(rec, topicInfo))
+          .map(rec -> deserialize(rec, topicInfo, testCase.properties()))
           .collect(Collectors.toList());
 
       if (validateResults) {
@@ -324,13 +324,14 @@ public class TestExecutor implements Closeable {
 
   private ProducerRecord<?, ?> deserialize(
       final ProducerRecord<byte[], byte[]> rec,
-      final TopicInfo topicInfo
+      final TopicInfo topicInfo,
+      final Map<String, Object> properties
   ) {
     final Object key;
     final Object value;
 
     try {
-      key = topicInfo.getKeyDeserializer().deserialize(rec.topic(), rec.key());
+      key = topicInfo.getKeyDeserializer(properties).deserialize(rec.topic(), rec.key());
     } catch (final Exception e) {
       throw new AssertionError("Failed to deserialize key: " + e.getMessage()
           + System.lineSeparator()
@@ -340,7 +341,7 @@ public class TestExecutor implements Closeable {
     }
 
     try {
-      value = topicInfo.getValueDeserializer().deserialize(rec.topic(), rec.value());
+      value = topicInfo.getValueDeserializer(properties).deserialize(rec.topic(), rec.value());
     } catch (final Exception e) {
       throw new AssertionError("Failed to deserialize value: " + e.getMessage()
           + System.lineSeparator()
@@ -360,7 +361,7 @@ public class TestExecutor implements Closeable {
   }
 
   private ProducerRecord<byte[], byte[]> serialize(
-      final ProducerRecord<?, ?> rec
+      final Map<String, Object> properties, final ProducerRecord<?, ?> rec
   ) {
     final TopicInfo topicInfo = topicInfoCache.get(rec.topic())
         .orElseThrow(() -> new KsqlException("No information found for topic: " + rec.topic()));
@@ -369,7 +370,7 @@ public class TestExecutor implements Closeable {
     final byte[] value;
 
     try {
-      key = topicInfo.getKeySerializer().serialize(rec.topic(), rec.key());
+      key = topicInfo.getKeySerializer(properties).serialize(rec.topic(), rec.key());
     } catch (final Exception e) {
       throw new AssertionError("Failed to serialize key: " + e.getMessage()
           + System.lineSeparator()
@@ -379,7 +380,7 @@ public class TestExecutor implements Closeable {
     }
 
     try {
-      value = topicInfo.getValueSerializer().serialize(rec.topic(), rec.value());
+      value = topicInfo.getValueSerializer(properties).serialize(rec.topic(), rec.value());
     } catch (final Exception e) {
       throw new AssertionError("Failed to serialize value: " + e.getMessage()
           + System.lineSeparator()
@@ -496,7 +497,7 @@ public class TestExecutor implements Closeable {
     for (final Record record : testCase.getInputRecords()) {
       if (testDriver.getSourceTopicNames().contains(record.getTopicName())) {
         processSingleRecord(
-            serialize(record.asProducerRecord()),
+            serialize(testCase.properties(), record.asProducerRecord()),
             testDriver,
             ImmutableSet.copyOf(kafka.getAllTopics())
         );
@@ -622,12 +623,12 @@ public class TestExecutor implements Closeable {
   }
 
   private void writeInputIntoTopics(
-      final List<Record> inputRecords,
+      final TestCase testCase,
       final StubKafkaService kafka
   ) {
-    inputRecords.stream()
+    testCase.getInputRecords().stream()
         .map(Record::asProducerRecord)
-        .map(this::serialize)
+        .map(rec -> serialize(testCase.properties(), rec))
         .forEach(kafka::writeRecord);
   }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.test.utils.SerdeUtil;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -416,9 +417,9 @@ public class TopicInfoCache {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public Serializer<Object> getKeySerializer() {
+    public Serializer<Object> getKeySerializer(final Map<String, Object> properties) {
       final SerdeSupplier<?> keySerdeSupplier = SerdeUtil
-          .getKeySerdeSupplier(keyFormat, schema);
+          .getKeySerdeSupplier(keyFormat, schema, properties);
 
       final Serializer<?> serializer = keySerdeSupplier.getSerializer(srClient, true);
 
@@ -430,9 +431,9 @@ public class TopicInfoCache {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public Serializer<Object> getValueSerializer() {
+    public Serializer<Object> getValueSerializer(final Map<String, Object> properties) {
       final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil
-          .getSerdeSupplier(FormatFactory.of(valueFormat.getFormatInfo()), schema);
+          .getSerdeSupplier(FormatFactory.of(valueFormat.getFormatInfo()), schema, properties);
 
       final Serializer<?> serializer = valueSerdeSupplier.getSerializer(srClient, false);
 
@@ -443,9 +444,9 @@ public class TopicInfoCache {
       return (Serializer) serializer;
     }
 
-    public Deserializer<?> getKeyDeserializer() {
+    public Deserializer<?> getKeyDeserializer(final Map<String, Object> properties) {
       final SerdeSupplier<?> keySerdeSupplier = SerdeUtil
-          .getKeySerdeSupplier(keyFormat, schema);
+          .getKeySerdeSupplier(keyFormat, schema, properties);
 
       final Deserializer<?> deserializer = keySerdeSupplier.getDeserializer(srClient, true);
 
@@ -463,9 +464,9 @@ public class TopicInfoCache {
       return changeLogDeserializer;
     }
 
-    public Deserializer<?> getValueDeserializer() {
+    public Deserializer<?> getValueDeserializer(final Map<String, Object> properties) {
       final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil
-          .getSerdeSupplier(FormatFactory.of(valueFormat.getFormatInfo()), schema);
+          .getSerdeSupplier(FormatFactory.of(valueFormat.getFormatInfo()), schema, properties);
 
       final Deserializer<?> deserializer = valueSerdeSupplier.getDeserializer(srClient, false);
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.test.serde.none.NoneSerdeSupplier;
 import io.confluent.ksql.test.serde.protobuf.ValueSpecProtobufSerdeSupplier;
 import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -65,13 +66,14 @@ public final class SerdeUtil {
 
   public static SerdeSupplier<?> getSerdeSupplier(
       final Format format,
-      final LogicalSchema schema
+      final LogicalSchema schema,
+      final Map<String, Object> properties
   ) {
     switch (format.name()) {
       case AvroFormat.NAME:       return new ValueSpecAvroSerdeSupplier();
       case ProtobufFormat.NAME:   return new ValueSpecProtobufSerdeSupplier();
-      case JsonFormat.NAME:       return new ValueSpecJsonSerdeSupplier(false);
-      case JsonSchemaFormat.NAME: return new ValueSpecJsonSerdeSupplier(true);
+      case JsonFormat.NAME:       return new ValueSpecJsonSerdeSupplier(false, properties);
+      case JsonSchemaFormat.NAME: return new ValueSpecJsonSerdeSupplier(true, properties);
       case DelimitedFormat.NAME:  return new StringSerdeSupplier();
       case KafkaFormat.NAME:      return new KafkaSerdeSupplier(schema);
       case NoneFormat.NAME:       return new NoneSerdeSupplier();
@@ -112,12 +114,12 @@ public final class SerdeUtil {
   @SuppressWarnings("unchecked")
   public static <T> SerdeSupplier<?> getKeySerdeSupplier(
       final KeyFormat keyFormat,
-      final LogicalSchema schema
-  ) {
+      final LogicalSchema schema,
+      final Map<String, Object> properties) {
     final SerdeSupplier<T> inner = (SerdeSupplier<T>) getSerdeSupplier(
         FormatFactory.of(keyFormat.getFormatInfo()),
-        schema
-    );
+        schema,
+        properties);
 
     if (!keyFormat.getWindowType().isPresent()) {
       return inner;

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/QueryAnonymizerTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/QueryAnonymizerTest.java
@@ -73,7 +73,6 @@ public class QueryAnonymizerTest {
 
   @RunWith(Parameterized.class)
   public static class AnonQuerySetIntersectionTestClass {
-    private static final Stream<TestCase> testCases = testFileLoader().load();
     private List<String> sqlTokens;
     private final QueryAnonymizer anon = new QueryAnonymizer();
     private final String statement;
@@ -91,7 +90,7 @@ public class QueryAnonymizerTest {
 
     @Parameterized.Parameters
     public static Collection<String> input() {
-      return testCases
+      return testFileLoader().load()
           .filter(statement -> !statement.expectedException().isPresent())
           .map(TestCase::statements)
           .flatMap(Collection::stream)

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplierTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplierTest.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.serde.json.JsonSerdeUtils;
 import io.confluent.ksql.test.tools.TestJsonMapper;
@@ -42,8 +43,8 @@ public class ValueSpecJsonSerdeSupplierTest {
 
   @Before
   public void setUp() {
-    plainSerde = new ValueSpecJsonSerdeSupplier(false);
-    srSerde = new ValueSpecJsonSerdeSupplier(true);
+    plainSerde = new ValueSpecJsonSerdeSupplier(false, ImmutableMap.of());
+    srSerde = new ValueSpecJsonSerdeSupplier(true, ImmutableMap.of());
   }
 
   @Test

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -574,7 +574,7 @@ public class TestExecutorTest {
       final List<Header> headers
   ) {
     final byte[] serializedKey = keySerializer.serialize("", key);
-    final byte[] serializeValue = new ValueSpecJsonSerdeSupplier(false)
+    final byte[] serializeValue = new ValueSpecJsonSerdeSupplier(false, ImmutableMap.of())
         .getSerializer(null, false)
         .serialize("", value);
 

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/5.5.0_1581572090139/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/5.5.0_1581572090139/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "geo distance with radius",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : "",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/5.5.0_1581572090139/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/5.5.0_1581572090139/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "geo distance with radius",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/6.0.0_1588893912655/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/6.0.0_1588893912655/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "geo distance with radius",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : "",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/6.0.0_1588893912655/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/6.0.0_1588893912655/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "geo distance with radius",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/6.0.0_1589910860273/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/6.0.0_1589910860273/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "geo distance with radius",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : "",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/6.0.0_1589910860273/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/6.0.0_1589910860273/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "geo distance with radius",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/7.1.0_1633125940924/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/7.1.0_1633125940924/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "geo distance with radius",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : null,

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/7.1.0_1633125940924/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_with_radius/7.1.0_1633125940924/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "geo distance with radius",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/5.5.0_1581572090159/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/5.5.0_1581572090159/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "geo distance without radius",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/5.5.0_1581572090159/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/5.5.0_1581572090159/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "geo distance without radius",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : "",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/6.0.0_1588893912679/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/6.0.0_1588893912679/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "geo distance without radius",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/6.0.0_1588893912679/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/6.0.0_1588893912679/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "geo distance without radius",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : "",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/6.0.0_1589910860305/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/6.0.0_1589910860305/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "geo distance without radius",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/6.0.0_1589910860305/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/6.0.0_1589910860305/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "geo distance without radius",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : "",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/7.1.0_1633125940944/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/7.1.0_1633125940944/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "geo distance without radius",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/7.1.0_1633125940944/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_geo_distance_without_radius/7.1.0_1633125940944/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "geo distance without radius",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : null,

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_small_distances_in_where/6.1.0_1592568336546/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_small_distances_in_where/6.1.0_1592568336546/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "small distances in where",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_small_distances_in_where/6.1.0_1592568336546/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_small_distances_in_where/6.1.0_1592568336546/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "small distances in where",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : null,

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_small_distances_in_where/7.1.0_1633125940981/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_small_distances_in_where/7.1.0_1633125940981/spec.json
@@ -25,7 +25,7 @@
   "testCase" : {
     "name" : "small distances in where",
     "properties": {
-      "use.big.decimal.for.floats": false
+      "use.exact.numeric.comparison": false
     },
     "inputs" : [ {
       "topic" : "test_topic",

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_small_distances_in_where/7.1.0_1633125940981/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/geodistance_-_small_distances_in_where/7.1.0_1633125940981/spec.json
@@ -24,6 +24,9 @@
   },
   "testCase" : {
     "name" : "small distances in where",
+    "properties": {
+      "use.big.decimal.for.floats": false
+    },
     "inputs" : [ {
       "topic" : "test_topic",
       "key" : null,

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/geodistance.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/geodistance.json
@@ -2,6 +2,15 @@
   "tests": [
     {
       "name": "geo distance with radius",
+      "comments": [
+        "When upgrading to JDK17, the floating point comparisons were no longer identical",
+        "to the result set of JDK8. In order to make these tests pass in both implementations",
+        "we make sure that the comparison is done using double instead of BigDecimal, which assumes",
+        "correct precision"
+      ],
+      "properties": {
+        "use.big.decimal.for.floats": false
+      },
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, LAT1 double, LON1 double, LAT2 double, LON2 double, RADIUS varchar) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM DISTANCE_STREAM AS select K, ID, geo_distance(LAT1, LON1, LAT2, LON2, RADIUS) as CALCULATED_DISTANCE from test;"
@@ -31,6 +40,9 @@
     },
     {
       "name": "geo distance without radius",
+      "properties": {
+        "use.big.decimal.for.floats": false
+      },
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, LAT1 double, LON1 double, LAT2 double, LON2 double) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM DISTANCE_STREAM AS select K, ID, geo_distance(LAT1, LON1, LAT2, LON2) as CALCULATED_DISTANCE from test;"
@@ -49,6 +61,9 @@
     {
       "name": "small distances in where",
       "issue": "https://github.com/confluentinc/ksql/issues/5636",
+      "properties": {
+        "use.big.decimal.for.floats": false
+      },
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM OUTPUT AS select GEO_DISTANCE(39.18660374, -76.73262144, 39.18660374, -76.73222145 ) AS D from INPUT WHERE  GEO_DISTANCE(39.18660374, -76.73262144, 39.18660374, -76.73222145 ) < 0.4;"

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/geodistance.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/geodistance.json
@@ -5,11 +5,10 @@
       "comments": [
         "When upgrading to JDK17, the floating point comparisons were no longer identical",
         "to the result set of JDK8. In order to make these tests pass in both implementations",
-        "we make sure that the comparison is done using double instead of BigDecimal, which assumes",
-        "correct precision"
+        "we make sure that the comparison is done using only 6 decimal places"
       ],
       "properties": {
-        "use.big.decimal.for.floats": false
+        "use.exact.numeric.comparison": false
       },
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, LAT1 double, LON1 double, LAT2 double, LON2 double, RADIUS varchar) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -41,7 +40,7 @@
     {
       "name": "geo distance without radius",
       "properties": {
-        "use.big.decimal.for.floats": false
+        "use.exact.numeric.comparison": false
       },
       "statements": [
         "CREATE STREAM TEST (K STRING KEY, ID bigint, LAT1 double, LON1 double, LAT2 double, LON2 double) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -62,7 +61,7 @@
       "name": "small distances in where",
       "issue": "https://github.com/confluentinc/ksql/issues/5636",
       "properties": {
-        "use.big.decimal.for.floats": false
+        "use.exact.numeric.comparison": false
       },
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/HeartbeatAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/HeartbeatAgentTest.java
@@ -33,10 +33,8 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.HostStatus;
 import io.confluent.ksql.util.KsqlHostInfo;
 import io.confluent.ksql.util.PersistentQueryMetadata;
-import java.util.List;
 import java.util.Map;
 import org.apache.kafka.streams.StreamsMetadata;
-import org.apache.kafka.streams.state.HostInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,19 +60,13 @@ public class HeartbeatAgentTest {
   private HostStatusListener hostStatusListener;
 
   private HeartbeatAgent heartbeatAgent;
-  private HostInfo localHostInfo;
-  private HostInfo remoteHostInfo;
   private KsqlHostInfo localHost;
   private KsqlHostInfo remoteHost;
-  private List<StreamsMetadata> allMetadata0;
-  private List<StreamsMetadata> allMetadata1;
   private Map<KsqlHostInfo, HostStatus> hostsStatus;
   private static final String LOCALHOST_URL = "http://localhost:8088";
 
   @Before
   public void setUp() {
-    localHostInfo = new HostInfo("localhost", 8088);
-    remoteHostInfo = new HostInfo("localhost", 8089);
     localHost = new KsqlHostInfo("localhost", 8088);
     remoteHost = new KsqlHostInfo("localhost", 8089);
 
@@ -88,8 +80,6 @@ public class HeartbeatAgentTest {
     hostsStatus = ImmutableMap
         .of(localHost, new HostStatus(true, 0L),
             remoteHost, new HostStatus(true, 0L));
-    allMetadata0 = ImmutableList.of(streamsMetadata0);
-    allMetadata1 = ImmutableList.of(streamsMetadata1);
   }
 
   @Test
@@ -97,12 +87,6 @@ public class HeartbeatAgentTest {
     // Given:
     heartbeatAgent.setHostsStatus(hostsStatus);
     when(ksqlEngine.getPersistentQueries()).thenReturn(ImmutableList.of(query0, query1));
-
-    when(query0.getAllStreamsHostMetadata()).thenReturn(allMetadata0);
-    when(streamsMetadata0.hostInfo()).thenReturn(localHostInfo);
-
-    when(query1.getAllStreamsHostMetadata()).thenReturn(allMetadata1);
-    when(streamsMetadata1.hostInfo()).thenReturn(remoteHostInfo);
 
     DiscoverClusterService discoverService = heartbeatAgent.new DiscoverClusterService();
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -122,10 +122,6 @@ public class KsqlRestApplicationTest {
   @Mock
   private KsqlServerPrecondition precondition2;
   @Mock
-  private ParsedStatement parsedStatement;
-  @Mock
-  private PreparedStatement<?> preparedStatement;
-  @Mock
   private Consumer<KsqlConfig> rocksDBConfigSetterHandler;
   @Mock
   private HeartbeatAgent heartbeatAgent;
@@ -168,13 +164,9 @@ public class KsqlRestApplicationTest {
     when(processingLogConfig.getBoolean(ProcessingLogConfig.TOPIC_AUTO_CREATE)).thenReturn(true);
     when(processingLogContext.getConfig()).thenReturn(processingLogConfig);
 
-    when(ksqlEngine.parse(any())).thenReturn(ImmutableList.of(parsedStatement));
-    when(ksqlEngine.prepare(any())).thenReturn((PreparedStatement) preparedStatement);
-
     when(commandQueue.getCommandTopicName()).thenReturn(CMD_TOPIC_NAME);
     when(serviceContext.getTopicClient()).thenReturn(topicClient);
-    when(topicClient.isTopicExists(CMD_TOPIC_NAME)).thenReturn(false);
-    
+
     when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn("ksql-id");
     when(ksqlConfig.getKsqlStreamConfigProps()).thenReturn(ImmutableMap.of("state.dir", "/tmp/cat"));
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/LocalCommandsTest.java
@@ -49,7 +49,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+// some tests here make sure a mocked exception isn't thrown
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class LocalCommandsTest {
   private static final String QUERY_APP_ID1 = "appId1";
   private static final String QUERY_APP_ID2 = "appId2";

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteSourceDescriptionExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/RemoteSourceDescriptionExecutorTest.java
@@ -35,6 +35,9 @@ public class RemoteSourceDescriptionExecutorTest  {
       .excludeField(
           named("fields")
               .and(inClass(SourceDescription.class))
+      ).excludeField(
+          named("windowType") // since JDK17 does not support randomizing optionals
+              .and(inClass(SourceDescription.class))
       );
   final EasyRandom objectMother = new EasyRandom(parameters);
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
@@ -16,14 +16,12 @@
 package io.confluent.ksql.rest.server.resources;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.rest.EndpointResponse;
 import io.confluent.ksql.rest.Errors;
@@ -36,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class StatusResourceTest {
 
@@ -63,15 +62,12 @@ public class StatusResourceTest {
   private StatusResource getTestStatusResource() {
     final InteractiveStatementExecutor mockStatementExecutor = mock(InteractiveStatementExecutor.class);
 
-    expect(mockStatementExecutor.getStatuses()).andReturn(mockCommandStatuses);
+    when(mockStatementExecutor.getStatuses()).thenReturn(mockCommandStatuses);
 
+    when(mockStatementExecutor.getStatus(Mockito.any(CommandId.class))).thenReturn(Optional.empty());
     for (final Map.Entry<CommandId, CommandStatus> commandEntry : mockCommandStatuses.entrySet()) {
-      expect(mockStatementExecutor.getStatus(commandEntry.getKey())).andReturn(Optional.of(commandEntry.getValue()));
+      when(mockStatementExecutor.getStatus(commandEntry.getKey())).thenReturn(Optional.of(commandEntry.getValue()));
     }
-
-    expect(mockStatementExecutor.getStatus(anyObject(CommandId.class))).andReturn(Optional.empty());
-
-    replay(mockStatementExecutor);
 
     return new StatusResource(mockStatementExecutor);
   }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -225,7 +225,6 @@ public class StreamedQueryResourceTest {
     when(queryExecutor.handleStatement(any(), any(), any(), any(), any(), any(), any(),
         anyBoolean()))
         .thenReturn(queryMetadataHolder);
-    when(pullQueryResult.getPullQueryQueue()).thenReturn(pullQueryQueue);
 
     securityContext = new KsqlSecurityContext(Optional.empty(), serviceContext);
 
@@ -407,7 +406,6 @@ public class StreamedQueryResourceTest {
     testResource.configure(new KsqlConfig(ImmutableMap.of(
         StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"
     )));
-    when(queryMetadataHolder.getPullQueryResult()).thenReturn(Optional.of(pullQueryResult));
 
     // When:
     testResource.streamQuery(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -16,8 +16,7 @@
 package io.confluent.ksql.rest.server.resources.streaming;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -86,9 +85,9 @@ public class TopicStreamWriterTest {
         "Value format: ",
         "KAFKA_STRING",
         System.lineSeparator(),
-        "rowtime: N/A, key: key-0, value: value-0",
+        "rowtime: N/A, key: key-0, value: value-0, partition: 0",
         System.lineSeparator(),
-        "rowtime: N/A, key: key-1, value: value-1",
+        "rowtime: N/A, key: key-1, value: value-1, partition: 0",
         System.lineSeparator()
     );
     out.assertWrites(expected);
@@ -119,9 +118,9 @@ public class TopicStreamWriterTest {
         "Value format: ",
         "KAFKA_STRING",
         System.lineSeparator(),
-        "rowtime: N/A, key: key-0, value: value-0",
+        "rowtime: N/A, key: key-0, value: value-0, partition: 0",
         System.lineSeparator(),
-        "rowtime: N/A, key: key-2, value: value-2",
+        "rowtime: N/A, key: key-2, value: value-2, partition: 0",
         System.lineSeparator()
     );
     out.assertWrites(expected);
@@ -152,32 +151,9 @@ public class TopicStreamWriterTest {
      *  8215412: Optimize PrintStream.println methods</a>
      */
     void assertWrites(final List<String> expected) {
-      int newlines = 0;
-      for (int i = 0; i < recordedWrites.size(); i++) {
-        final String actual = recordedWrites.get(i);
-        final int expectedOffset = i + newlines;
-        if (expected.size() <= expectedOffset) {
-          break;
-        }
-
-        if (expected.get(expectedOffset).equals(System.lineSeparator())) {
-          if (i > 0 && recordedWrites.get(i - 1).endsWith(System.lineSeparator())) {
-            newlines++;
-            continue;
-          }
-        }
-
-        assertThat(actual, containsString(expected.get(i + newlines)));
-      }
-
-      // check if the last expected row was a newline
-      if (expected.get(expected.size() - 1).equals(System.lineSeparator())
-          && !recordedWrites.get(recordedWrites.size() - 1).equalsIgnoreCase(System.lineSeparator())
-          && recordedWrites.get(recordedWrites.size() - 1).endsWith(System.lineSeparator())) {
-        newlines++;
-      }
-
-      assertThat(recordedWrites, hasSize(expected.size() - newlines));
+      assertThat(
+          String.join("", recordedWrites),
+          equalTo(String.join("", expected)));
     }
   }
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -172,6 +172,7 @@ public class TopicStreamWriterTest {
 
       // check if the last expected row was a newline
       if (expected.get(expected.size() - 1).equals(System.lineSeparator())
+          && !recordedWrites.get(recordedWrites.size() - 1).equalsIgnoreCase(System.lineSeparator())
           && recordedWrites.get(recordedWrites.size() - 1).endsWith(System.lineSeparator())) {
         newlines++;
       }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImplTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/PersistentQueryCleanupImplTest.java
@@ -94,10 +94,10 @@ public class PersistentQueryCleanupImplTest {
     final List<LoggingEvent> log = appender.getLog();
     final LoggingEvent firstLogEntry = log.get(0);
 
-    assertThat(firstLogEntry.getLevel(), is(Level.WARN));
     assertThat((String) firstLogEntry.getMessage(), is(
       "Deleted local state store for non-existing query fakeStateStore. " +
         "This is not expected and was likely due to a race condition when the query was dropped before."));
+    assertThat(firstLogEntry.getLevel(), is(Level.WARN));
   }
 
   @Test

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/timestamp/TimestampExtractionPolicyFactoryTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/timestamp/TimestampExtractionPolicyFactoryTest.java
@@ -99,8 +99,11 @@ public class TimestampExtractionPolicyFactoryTest {
     );
 
     // Then:
+    // split the assertion into two different checks to support the error message differences
+    // between JDK8 and JDK17
+    assertThat(e.getMessage(), containsString("cannot be cast"));
     assertThat(e.getMessage(), containsString(
-        "cannot be cast to org.apache.kafka.streams.processor.TimestampExtractor"));
+        "org.apache.kafka.streams.processor.TimestampExtractor"));
   }
 
   @Test

--- a/ksqldb-test-util/src/main/resources/log4j.properties
+++ b/ksqldb-test-util/src/main/resources/log4j.properties
@@ -20,6 +20,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 # help debug a flaky test
 log4j.logger.io.confluent.ksql.api.server=DEBUG
+log4j.logger.io.confluent.rest.server.HeartbeatAgent=DEBUG
 
 # Disable INFO and WARN logs from Config classes, which log out their config on each creation
 # and warnings for any unknown config:

--- a/pom.xml
+++ b/pom.xml
@@ -672,9 +672,9 @@
                 <configuration>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
-                    <compilerVersion>11</compilerVersion>
-                    <source>11</source>
-                    <target>11</target>
+                    <compilerVersion>1.8</compilerVersion>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <compilerArgs>
                         <arg>-Xlint:all,-serial,-options,-path</arg>
                         <arg>-parameters</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <really.executable.jar.version>1.5.0</really.executable.jar.version>
         <generext.version>1.0.2</generext.version>
         <avro.random.generator.version>0.2.2</avro.random.generator.version>
-        <apache.curator.version>2.9.0</apache.curator.version>
+        <apache.curator.version>5.2.0</apache.curator.version>
         <wiremock.version>2.24.0</wiremock.version>
         <clearspring-analytics.version>2.9.5</clearspring-analytics.version>
         <icu.version>67.1</icu.version>
@@ -672,9 +672,9 @@
                 <configuration>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
-                    <compilerVersion>1.8</compilerVersion>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <compilerVersion>11</compilerVersion>
+                    <source>11</source>
+                    <target>11</target>
                     <compilerArgs>
                         <arg>-Xlint:all,-serial,-options,-path</arg>
                         <arg>-parameters</arg>
@@ -701,6 +701,19 @@
                     </systemPropertyVariables>
                     <argLine>-verbose:gc -Xloggc:"${project.build.directory}/gc.log"</argLine>
                     <argLine>-Duser.timezone=UTC</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!-- we haven't yet fully migrated to JDK9 Jigsaw, but when compiling
+                    with JDKs that are >9 failsafe fails with many NoClassDefFoundErrors
+                    unless we disable this flag.
+
+                    You can also see (https://issues.apache.org/jira/browse/SUREFIRE-1809)
+                    for more details -->
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
fixes #6596

### Description 

Make the changes required to support compilation with JDK11/17. Additional notes inline. Note that we will continue to compile use JDK8 for now.

### Testing done 

Ran all the tests using:
```
Apache Maven 3.8.5 (3599d3414f046de2324203b78ddcf9b5e4388aa0)
Maven home: /usr/local/Cellar/maven/3.8.5/libexec
Java version: 17.0.2, vendor: Homebrew, runtime: /usr/local/Cellar/openjdk/17.0.2/libexec/openjdk.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "12.2.1", arch: "x86_64", family: "mac"
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

