### PR TITLE
docs: add note about prefixed kafka SSL configs

### DIFF
--- a/docs/operate-and-deploy/installation/server-config/security.md
+++ b/docs/operate-and-deploy/installation/server-config/security.md
@@ -605,6 +605,16 @@ details, and instructions on how to create suitable trust stores, please
 refer to the
 [Security Guide](https://docs.confluent.io/current/security/index.html).
 
+You can also prefix the SSL truststore configs with `ksql.streams.` in order
+to use separate trust stores for encrypted communication with Kafka and
+external communication with ksqlDB clients:
+
+```properties
+security.protocol=SSL
+ksql.streams.ssl.truststore.location=/etc/kafka/secrets/kafka.client.truststore.jks
+ksql.streams.ssl.truststore.password=confluent
+```
+
 ### Configure Kafka Authentication
 
 This configuration enables ksqlDB to connect to a secure Kafka cluster

--- a/docs/operate-and-deploy/installation/server-config/security.md
+++ b/docs/operate-and-deploy/installation/server-config/security.md
@@ -605,9 +605,9 @@ details, and instructions on how to create suitable trust stores, please
 refer to the
 [Security Guide](https://docs.confluent.io/current/security/index.html).
 
-You can also prefix the SSL truststore configs with `ksql.streams.` in order
-to use separate trust stores for encrypted communication with Kafka and
-external communication with ksqlDB clients:
+To use separate trust stores for encrypted communication with {{ site.ak }}
+and external communication with ksqlDB clients, prefix the SSL truststore configs
+with `ksql.streams.`:
 
 ```properties
 security.protocol=SSL


### PR DESCRIPTION
### Description 

ksqlDB supports using separate TLS trust stores for communication with Kafka vs external communication with ksqlDB clients, by prefixing the Kafka TLS configs with `ksql.streams.` but this is not currently documented. This PR adds docs.

See https://github.com/confluentinc/ksql/issues/8512 and https://github.com/confluentinc/ksql/pull/8514 for context.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

