### PR TITLE
docs: fix /query REST API docs to use `ksql` field

### DIFF
--- a/docs/developer-guide/api.md
+++ b/docs/developer-guide/api.md
@@ -73,7 +73,7 @@ Here's an example request that retrieves streaming data from
 curl -X "POST" "http://localhost:8088/query" \
      -H "Accept: application/vnd.ksql.v1+json" \
      -d $'{
-  "sql": "SELECT * FROM TEST_STREAM EMIT CHANGES;",
+  "ksql": "SELECT * FROM TEST_STREAM EMIT CHANGES;",
   "streamsProperties": {}
 }'
 ```


### PR DESCRIPTION
### Description 

Fixing this error that is thrown while following instructions found in the docs at https://docs.ksqldb.io/en/latest/developer-guide/api/
```
▶ curl -X "POST" "http://localhost:8088/query" \
     -H "Accept: application/vnd.ksql.v1+json" \
     -d $'{
  "sql": "SELECT * FROM TEST_STREAM EMIT CHANGES;",
  "streamsProperties": {}
}'

{"@type":"generic_error","error_code":40000,"message":"\"ksql\" field must be populated"}%
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

