### PR TITLE
docs: functional tests min version for lower bound

### DIFF
--- a/ksqldb-functional-tests/README.md
+++ b/ksqldb-functional-tests/README.md
@@ -162,7 +162,7 @@ For example:
 {
   "name": "test only valid for versions at or after 5.4",
   "versions": {
-     "max": "5.4"  
+     "min": "5.4"  
   }  
 },
 {


### PR DESCRIPTION
Fixing functional tests *min* version typo

