### PR TITLE
fix: shared runtimes calculate cache size for validation properly

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsConfig;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -15,8 +15,8 @@
 package io.confluent.ksql.query;
 
 import io.confluent.ksql.config.SessionConfig;
-import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.execution.ExecutionPlan;
+import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.streams.StreamsConfig;
-import scala.Int;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -91,23 +91,25 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
               .getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG))
           .sum();
       final Set<String> runtimes = new HashSet<>();
-      Long maxCache = -1L;
-      for (final QueryMetadata queryMetadata: running) {
+      long cacheSizeBytesPerRuntime = -1L;
+      for (final QueryMetadata queryMetadata : running) {
         if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
-          if (maxCache == -1L) {
-            maxCache = (Long) queryMetadata.getStreamsProperties()
+          if (cacheSizeBytesPerRuntime == -1L) {
+            cacheSizeBytesPerRuntime = (long) queryMetadata.getStreamsProperties()
                 .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG);
           }
           if (!runtimes.contains(queryMetadata.getQueryApplicationId())) {
             runtimes.add(queryMetadata.getQueryApplicationId());
-            usedByRunning += (Long) queryMetadata.getStreamsProperties()
+            usedByRunning += (long) queryMetadata.getStreamsProperties()
                 .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG);
           } else {
-            if (!Objects.equals(maxCache, (Long) queryMetadata.getStreamsProperties()
-                .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG))) {
+            if (cacheSizeBytesPerRuntime == (long) queryMetadata.getStreamsProperties()
+                .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)) {
               LOG.warn("Inconsistent "
                   + StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG
-                  + " in shared runtimes");
+                  + " in shared runtimes {} and {}", cacheSizeBytesPerRuntime,
+                  queryMetadata.getStreamsProperties()
+                      .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG));
             }
           }
         }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -106,7 +106,7 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
               LOG.warn("Inconsistent "
                   + StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG
                   + " in shared runtimes {} and {}", cacheSizeBytesPerRuntime,
-                  queryMetadata.getStreamsProperties()
+                    queryMetadata.getStreamsProperties()
                       .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG));
             }
           }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -92,7 +92,7 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
           .sum();
       final Set<String> runtimes = new HashSet<>();
       Long maxCache = -1L;
-      for(final QueryMetadata queryMetadata: running) {
+      for (final QueryMetadata queryMetadata: running) {
         if (queryMetadata instanceof BinPackedPersistentQueryMetadataImpl) {
           if (maxCache == -1L) {
             maxCache = (Long) queryMetadata.getStreamsProperties()
@@ -104,8 +104,10 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
                 .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG);
           } else {
             if (!Objects.equals(maxCache, (Long) queryMetadata.getStreamsProperties()
-                .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG))){
-                LOG.warn("Inconsistent " + StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG + " in shared runtimes");
+                .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG))) {
+              LOG.warn("Inconsistent "
+                  + StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG
+                  + " in shared runtimes");
             }
           }
         }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsQueryValidator.java
@@ -73,7 +73,7 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
     final long configured = getCacheMaxBytesBuffering(config);
     long usedByRunning;
     if (!config.getConfig(true).getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
-       usedByRunning = running.stream()
+      usedByRunning = running.stream()
           .mapToLong(r -> new StreamsConfig(r.getStreamsProperties())
               .getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG))
           .sum();
@@ -87,9 +87,10 @@ public class KafkaStreamsQueryValidator implements QueryValidator {
           .filter(t -> t instanceof BinPackedPersistentQueryMetadataImpl)
           .collect(HashMap<String, Long>::new,
               (r, e) ->
-                r.put(
-                    e.getQueryApplicationId(),
-                        (Long) e.getStreamsProperties().get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)),
+                  r.put(
+                      e.getQueryApplicationId(),
+                      (Long) e.getStreamsProperties()
+                          .get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)),
               (r, l) -> l.putAll(r))
           .values()
           .stream()

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.execution.ExecutionPlan;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -52,6 +53,10 @@ public class KafkaStreamsQueryValidatorTest {
   @Mock
   private  PersistentQueryMetadata persistentQueryMetadata2;
   @Mock
+  private BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata;
+  @Mock
+  private BinPackedPersistentQueryMetadataImpl binPackedPersistentQueryMetadata2;
+  @Mock
   private ExecutionPlan plan;
 
   private Collection<QueryMetadata> queries;
@@ -64,11 +69,17 @@ public class KafkaStreamsQueryValidatorTest {
     when(transientQueryMetadata2.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(20));
     when(persistentQueryMetadata1.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(10));
     when(persistentQueryMetadata2.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(20));
+    when(binPackedPersistentQueryMetadata.getQueryApplicationId()).thenReturn("runtime 1");
+    when(binPackedPersistentQueryMetadata2.getQueryApplicationId()).thenReturn("runtime 1");
+    when(binPackedPersistentQueryMetadata.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(10));
+    when(binPackedPersistentQueryMetadata2.getStreamsProperties()).thenReturn(streamPropsWithCacheLimit(10));
     queries = ImmutableList.of(
         transientQueryMetadata1,
         transientQueryMetadata2,
         persistentQueryMetadata1,
-        persistentQueryMetadata2
+        persistentQueryMetadata2,
+        binPackedPersistentQueryMetadata,
+        binPackedPersistentQueryMetadata2
     );
   }
 
@@ -125,6 +136,38 @@ public class KafkaStreamsQueryValidatorTest {
     // Given:
     final SessionConfig config = SessionConfig.of(
         new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 30)),
+        ImmutableMap.of(
+            StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 50,
+            KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 500
+        )
+    );
+
+    // When/Then:
+    assertThrows(
+        KsqlException.class,
+        () -> queryValidator.validateQuery(config, plan, queries)
+    );
+  }
+
+  @Test
+  public void shouldValidateSharedRuntimes() {
+    // Given:
+    final SessionConfig config = SessionConfig.of(
+        new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 50,
+        KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)),
+        ImmutableMap.of(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 10)
+    );
+
+    // When/Then:
+    queryValidator.validateQuery(config, plan, queries);
+  }
+
+  @Test
+  public void shouldNotValidateSharedRuntimesWhenCreatingAnewRuntimeWouldGoOverTheLimit() {
+    // Given:
+    final SessionConfig config = SessionConfig.of(
+        new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 50,
+            KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true)),
         ImmutableMap.of(
             StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 50,
             KsqlConfig.KSQL_TOTAL_CACHE_MAX_BYTES_BUFFERING, 500

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/KafkaStreamsQueryValidatorTest.java
@@ -95,7 +95,7 @@ public class KafkaStreamsQueryValidatorTest {
   @Test
   public void shouldNotThrowIfUnderLimit() {
     // Given:
-    final SessionConfig config = configWithLimits(5, OptionalLong.of(40));
+    final SessionConfig config = configWithLimits(5, OptionalLong.of(60));
 
     // When/Then (no throw)
     queryValidator.validateQuery(config, plan, queries);


### PR DESCRIPTION
### Description 
This will allow for more than 107 quereis to be made without hitting cache errors using shared runtimes. When using shared runtimes the cache can be shared among queries. When we go to see if the new query could put us over the total limit we cannot just add the query cache sizes together. Instead the queries must be grouped by runtime. Then we can see what the total usage is as the sum of the runtimes. We will assume worst case for the new query, that it will make a new runtime. This is not always the case but will prevent the runtime from being created and not having enough space. We can improve this but it would be a much more pervasive change and I think this is a strict improvement and we should get this in first regardless.

### Testing done 
added a couple of unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

