### PR TITLE
chore: better error message on ClusterAuthorizationException during INSERT VALUES

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/exception/KsqlTopicAuthorizationException.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/exception/KsqlTopicAuthorizationException.java
@@ -28,10 +28,19 @@ public class KsqlTopicAuthorizationException extends TopicAuthorizationException
   public KsqlTopicAuthorizationException(
       final AclOperation operation,
       final Collection<String> topicNames) {
-    super(String.format("Authorization denied to %s on topic(s): [%s]",
-        StringUtils.capitalize(
-            operation.toString().toLowerCase()),
-            StringUtils.join(topicNames, ", ")));
+    this(operation, topicNames, "");
+  }
+
+  public KsqlTopicAuthorizationException(
+      final AclOperation operation,
+      final Collection<String> topicNames,
+      final String additionalContext) {
+    super(
+        String.format("Authorization denied to %s on topic(s): [%s]",
+            StringUtils.capitalize(operation.toString().toLowerCase()),
+            StringUtils.join(topicNames, ", "))
+        + (additionalContext.isEmpty() ? "" : ". Caused by: " + additionalContext)
+    );
   }
 
 }

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -174,13 +174,17 @@ public class InsertValuesExecutor {
       // ClusterAuthorizationException is thrown when using idempotent producers
       // and either a topic write permission or a cluster-level idempotent write
       // permission (only applicable for broker versions no later than 2.8) is
-      // missing. In this case, we include the error message to help the user
+      // missing. In this case, we include additional context to help the user
       // distinguish this type of failure from other permissions exceptions
       // such as the ones thrown above when TopicAuthorizationException is caught.
       final Exception rootCause = new KsqlTopicAuthorizationException(
           AclOperation.WRITE,
           Collections.singletonList(dataSource.getKafkaTopicName()),
-          e.getMessage()
+          // Ideally we would forward e.getMessage() instead of the hard-coded
+          // message below, but until this error message is improved on the Kafka
+          // side, e.getMessage() is not helpful. (Today it is just "Cluster
+          // authorization failed.")
+          "The producer is not authorized to do idempotent sends"
       );
 
       throw new KsqlException(createInsertFailedExceptionMessage(insertValues), rootCause);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -184,7 +184,10 @@ public class InsertValuesExecutor {
           // message below, but until this error message is improved on the Kafka
           // side, e.getMessage() is not helpful. (Today it is just "Cluster
           // authorization failed.")
-          "The producer is not authorized to do idempotent sends"
+          "The producer is not authorized to do idempotent sends. "
+              + "Check that you have write permissions to the specified topic, "
+              + "and disable idempotent sends by setting 'enable.idempotent=false' "
+              + " if necessary."
       );
 
       throw new KsqlException(createInsertFailedExceptionMessage(insertValues), rootCause);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -725,7 +725,10 @@ public class InsertValuesExecutorTest {
     // Then:
     assertThat(e.getCause(), (hasMessage(
         containsString("Authorization denied to Write on topic(s): [" + TOPIC_NAME + "]. "
-            + "Caused by: The producer is not authorized to do idempotent sends"))));
+            + "Caused by: The producer is not authorized to do idempotent sends. "
+            + "Check that you have write permissions to the specified topic, "
+            + "and disable idempotent sends by setting 'enable.idempotent=false' "
+            + " if necessary."))));
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -713,7 +713,7 @@ public class InsertValuesExecutorTest {
             new StringLiteral("str"),
             new LongLiteral(2L))
     );
-    doThrow(new ClusterAuthorizationException("The producer is not authorized to do idempotent sends"))
+    doThrow(new ClusterAuthorizationException("Cluster authorization failed"))
         .when(producer).send(any());
 
     // When:


### PR DESCRIPTION
### Description 

AK recently enabled idempotent producers by default: https://issues.apache.org/jira/browse/KAFKA-13598. This changes the exception thrown when a producer does not have write permissions from TopicAuthorizationException (for the non-idempotent producer case) to ClusterAuthorizationException when the idempotent producer fails to initialize a transaction (because either write permissions are missing or, for broker versions no later than 2.8, because IDEMPOTENT_WRITE permissions on the cluster are missing). 

This PR updates ksql to account for the ClusterAuthorizationException case to throw a better error message when INSERT VALUES fails, similar to the special handling that exists today for TopicAuthorizationException.

### Testing done 

Added unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

