### PR TITLE
feat: limit the number of runtimes that can be created

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -588,6 +588,12 @@ public class KsqlConfig extends AbstractConfig {
       "Controls how many runtimes queries are allocated over initially."
           + "this is only used when ksql.runtime.feature.shared.enabled is true.";
 
+  public static final String KSQL_SHARED_RUNTIMES_LIMIT = "ksql.shared.runtimes.limit";
+  public static final Integer KSQL_SHARED_RUNTIMES_LIMIT_DEFAULT = 20;
+  public static final String KSQL_SHARED_RUNTIMES_LIMIT_DOC =
+      "Controls how many runtimes queries are allocated to be created."
+          + "this is only used when ksql.runtime.feature.shared.enabled is true.";
+
 
   public static final String KSQL_SUPPRESS_BUFFER_SIZE_BYTES = "ksql.suppress.buffer.size.bytes";
   public static final Long KSQL_SUPPRESS_BUFFER_SIZE_BYTES_DEFAULT = -1L;
@@ -1389,6 +1395,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_SHARED_RUNTIMES_COUNT_DEFAULT,
             Importance.MEDIUM,
             KSQL_SHARED_RUNTIMES_COUNT_DOC
+        )
+        .define(
+            KSQL_SHARED_RUNTIMES_LIMIT,
+            Type.INT,
+            KSQL_SHARED_RUNTIMES_LIMIT_DEFAULT,
+            Importance.MEDIUM,
+            KSQL_SHARED_RUNTIMES_LIMIT_DOC
         )
         .define(
             KSQL_SOURCE_TABLE_MATERIALIZATION_ENABLED,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.util.Collection;
 import java.util.HashMap;
@@ -102,6 +103,11 @@ public class RuntimeAssignor {
 
 
   private String makeNewRuntime(final KsqlConfig config) {
+    if (runtimesToSources.size() >= config.getInt(KsqlConfig.KSQL_SHARED_RUNTIMES_LIMIT)) {
+      throw new KsqlException(String.format("There are too many uses of the same topic. "
+          + "No topic for this cluster can be queried more than %s times.",
+          config.getInt(KsqlConfig.KSQL_SHARED_RUNTIMES_LIMIT)));
+    }
     final String runtime = buildSharedRuntimeId(config, true, runtimesToSources.size());
     runtimesToSources.put(runtime, new HashSet<>());
     return runtime;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
@@ -1,10 +1,12 @@
 package io.confluent.ksql.engine;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,6 +22,7 @@ import java.util.HashSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -127,6 +130,17 @@ public class RuntimeAssignorTest {
         KSQL_CONFIG
     );
     assertThat(runtime, not(equalTo(firstRuntime)));
+  }
+
+  @Test
+  public void shouldNotGetRuntimeForDifferentQueryIdAndSameSources() {
+    assertThrows(KsqlException.class, () -> runtimeAssignor.getRuntimeAndMaybeAddRuntime(
+        query2,
+        sources1,
+        new KsqlConfig(
+            ImmutableMap.of(KsqlConfig.KSQL_SHARED_RUNTIMES_COUNT, 1,
+                KsqlConfig.KSQL_SHARED_RUNTIMES_LIMIT, 1))
+    ));
   }
 
   @Test


### PR DESCRIPTION
### Description 
When a query that is issued that would cause a runtime to exceed the limit that query will fail.

### Testing done 
add a unit test in the runtime assignor

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

