### PR TITLE
fix: only make shared runtime that is chosen

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -282,6 +282,7 @@ public class QueryRegistryImpl implements QueryRegistry {
       if (sandbox) {
         throwOnNonQueryLevelConfigs(config.getOverrides());
         streams.addAll(sourceStreams.stream()
+            .filter(t -> t.getApplicationId().equals(sharedRuntimeId.get()))
             .map(SandboxedSharedKafkaStreamsRuntimeImpl::new)
             .collect(Collectors.toList()));
       }


### PR DESCRIPTION
### Description 
only create relevant runtimes for validation. Because we are now selecting runtimes in the assignor I think we don't need to make every runtime anymore. This should really speed up validation, especially when we have a topic that is queried a lot

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

