### PR TITLE
fix: Create stream fails when multiple Protobuf schema definitions exist

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
 import io.confluent.ksql.execution.expression.tree.Type;
@@ -491,6 +492,29 @@ public class DefaultSchemaInjector implements Injector {
     return statement.copyWith(newProperties);
   }
 
+  private static void throwOnMultiSchemaDefinitions(
+      final ParsedSchema schema,
+      final Format schemaFormat,
+      final boolean isKey
+  ) {
+    final List<String> schemaDefinitions = schemaFormat.getSchemaDefinitions(schema);
+    if (schemaDefinitions.size() > 1) {
+      final String schemaFullNameConfig = isKey
+          ? CommonCreateConfigs.KEY_SCHEMA_FULL_NAME
+          : CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME;
+
+      throw new KsqlException(
+          (isKey ? "Key" : "Value") + " schema has multiple schema definitions. "
+              + System.lineSeparator()
+              + System.lineSeparator()
+              + schemaDefinitions.stream().map(n -> "- " + n).collect(Collectors.joining("\n"))
+              + System.lineSeparator()
+              + System.lineSeparator()
+              + "Please specify a schema full name in the WITH clause using "
+              + schemaFullNameConfig);
+    }
+  }
+
   private static CreateSource addSchemaFields(
       final ConfiguredStatement<CreateSource> preparedStatement,
       final Optional<SchemaAndId> keySchema,
@@ -503,6 +527,20 @@ public class DefaultSchemaInjector implements Injector {
 
     final Optional<String> keySchemaName;
     final Optional<String> valueSchemaName;
+
+    if (keySchema.isPresent() && !properties.getKeySchemaFullName().isPresent()) {
+      final Format keyFormat = FormatFactory.of(
+          SourcePropertiesUtil.getKeyFormat(properties, statement.getName()));
+
+      throwOnMultiSchemaDefinitions(keySchema.get().rawSchema, keyFormat, true);
+    }
+
+    if (valueSchema.isPresent() && !properties.getValueSchemaFullName().isPresent()) {
+      final Format valueFormat = FormatFactory.of(
+          SourcePropertiesUtil.getValueFormat(properties));
+
+      throwOnMultiSchemaDefinitions(valueSchema.get().rawSchema, valueFormat, false);
+    }
 
     // Only populate key and value schema names when schema ids are explicitly provided
     if (properties.getKeySchemaId().isPresent() && keySchema.isPresent()) {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -497,8 +497,8 @@ public class DefaultSchemaInjector implements Injector {
       final Format schemaFormat,
       final boolean isKey
   ) {
-    final List<String> schemaDefinitions = schemaFormat.getSchemaDefinitions(schema);
-    if (schemaDefinitions.size() > 1) {
+    final List<String> schemaFullNames = schemaFormat.schemaFullNames(schema);
+    if (schemaFullNames.size() > 1) {
       final String schemaFullNameConfig = isKey
           ? CommonCreateConfigs.KEY_SCHEMA_FULL_NAME
           : CommonCreateConfigs.VALUE_SCHEMA_FULL_NAME;
@@ -507,7 +507,7 @@ public class DefaultSchemaInjector implements Injector {
           (isKey ? "Key" : "Value") + " schema has multiple schema definitions. "
               + System.lineSeparator()
               + System.lineSeparator()
-              + schemaDefinitions.stream().map(n -> "- " + n).collect(Collectors.joining("\n"))
+              + schemaFullNames.stream().map(n -> "- " + n).collect(Collectors.joining("\n"))
               + System.lineSeparator()
               + System.lineSeparator()
               + "Please specify a schema full name in the WITH clause using "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -106,6 +106,15 @@ public final class SchemaRegistryUtil {
     return getLatestSchema(srClient, subject).isPresent();
   }
 
+  public static Optional<Integer> getSchemaId(
+      final SchemaRegistryClient srClient,
+      final String topic,
+      final boolean isKey
+  ) {
+    final String subject = KsqlConstants.getSRSubject(topic, isKey);
+    return getLatestSchema(srClient, subject).map(SchemaMetadata::getId);
+  }
+
   public static Optional<ParsedSchema> getParsedSchema(
       final SchemaRegistryClient srClient,
       final String topic,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -106,7 +106,7 @@ public final class SchemaRegistryUtil {
     return getLatestSchema(srClient, subject).isPresent();
   }
 
-  public static Optional<Integer> getSchemaId(
+  public static Optional<Integer> getLatestSchemaId(
       final SchemaRegistryClient srClient,
       final String topic,
       final boolean isKey
@@ -115,7 +115,7 @@ public final class SchemaRegistryUtil {
     return getLatestSchema(srClient, subject).map(SchemaMetadata::getId);
   }
 
-  public static Optional<ParsedSchema> getParsedSchema(
+  public static Optional<ParsedSchema> getLatestParsedSchema(
       final SchemaRegistryClient srClient,
       final String topic,
       final boolean isKey

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
@@ -77,7 +77,7 @@ public class SchemaRegistryUtilTest {
 
     // When:
     final Optional<ParsedSchema> parsedSchema =
-        SchemaRegistryUtil.getParsedSchema(schemaRegistryClient, "bar", false);
+        SchemaRegistryUtil.getLatestParsedSchema(schemaRegistryClient, "bar", false);
 
     // Then:
     assertThat(parsedSchema.get(), equalTo(AVRO_SCHEMA));
@@ -92,7 +92,7 @@ public class SchemaRegistryUtilTest {
 
     // When:
     final Optional<Integer> schemaId =
-        SchemaRegistryUtil.getSchemaId(schemaRegistryClient, "bar", true);
+        SchemaRegistryUtil.getLatestSchemaId(schemaRegistryClient, "bar", true);
 
     // Then:
     assertThat(schemaId.get(), equalTo(123));
@@ -107,7 +107,7 @@ public class SchemaRegistryUtilTest {
 
     // When:
     final Optional<Integer> schemaId =
-        SchemaRegistryUtil.getSchemaId(schemaRegistryClient, "bar", false);
+        SchemaRegistryUtil.getLatestSchemaId(schemaRegistryClient, "bar", false);
 
     // Then:
     assertThat(schemaId.get(), equalTo(123));
@@ -125,7 +125,7 @@ public class SchemaRegistryUtilTest {
 
     // When:
     final Optional<ParsedSchema> parsedSchema =
-        SchemaRegistryUtil.getParsedSchema(schemaRegistryClient, "bar", true);
+        SchemaRegistryUtil.getLatestParsedSchema(schemaRegistryClient, "bar", true);
 
     // Then:
     assertThat(parsedSchema.get(), equalTo(AVRO_SCHEMA));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/schema/registry/SchemaRegistryUtilTest.java
@@ -84,6 +84,37 @@ public class SchemaRegistryUtilTest {
   }
 
   @Test
+  public void shouldReturnSchemaIdFromSubjectKey() throws Exception {
+    // Given:
+    when(schemaMetadata.getId()).thenReturn(123);
+    when(schemaRegistryClient.getLatestSchemaMetadata("bar-key"))
+        .thenReturn(schemaMetadata);
+
+    // When:
+    final Optional<Integer> schemaId =
+        SchemaRegistryUtil.getSchemaId(schemaRegistryClient, "bar", true);
+
+    // Then:
+    assertThat(schemaId.get(), equalTo(123));
+  }
+
+  @Test
+  public void shouldReturnSchemaIdFromSubjectValue() throws Exception {
+    // Given:
+    when(schemaMetadata.getId()).thenReturn(123);
+    when(schemaRegistryClient.getLatestSchemaMetadata("bar-value"))
+        .thenReturn(schemaMetadata);
+
+    // When:
+    final Optional<Integer> schemaId =
+        SchemaRegistryUtil.getSchemaId(schemaRegistryClient, "bar", false);
+
+    // Then:
+    assertThat(schemaId.get(), equalTo(123));
+  }
+
+
+  @Test
   public void shouldReturnParsedSchemaFromSubjectKey() throws Exception {
     // Given:
     when(schemaMetadata.getId()).thenReturn(123);

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/protobuf/ValueSpecProtobufSerdeSupplier.java
@@ -15,31 +15,24 @@
 
 package io.confluent.ksql.test.serde.protobuf;
 
-import static io.confluent.connect.protobuf.ProtobufDataConfig.SCHEMAS_CACHE_SIZE_CONFIG;
-import static io.confluent.connect.protobuf.ProtobufDataConfig.WRAPPER_FOR_RAW_PRIMITIVES_CONFIG;
-
-import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.protobuf.ProtobufConverter;
-import io.confluent.connect.protobuf.ProtobufData;
-import io.confluent.connect.protobuf.ProtobufDataConfig;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.ksql.serde.protobuf.ProtobufProperties;
+import io.confluent.ksql.serde.protobuf.ProtobufSchemaTranslator;
 import io.confluent.ksql.test.serde.ConnectSerdeSupplier;
 import org.apache.kafka.connect.data.Schema;
 
 public class ValueSpecProtobufSerdeSupplier extends ConnectSerdeSupplier<ProtobufSchema> {
 
-  private final boolean unwrapPrimitives;
+  private final ProtobufSchemaTranslator schemaTranslator;
 
-  public ValueSpecProtobufSerdeSupplier(final boolean unwrapPrimitives) {
+  public ValueSpecProtobufSerdeSupplier(final ProtobufProperties protobufProperties) {
     super(ProtobufConverter::new);
-    this.unwrapPrimitives = unwrapPrimitives;
+    this.schemaTranslator = new ProtobufSchemaTranslator(protobufProperties);
   }
 
   @Override
   protected Schema fromParsedSchema(final ProtobufSchema schema) {
-    return new ProtobufData(new ProtobufDataConfig(ImmutableMap.of(
-        SCHEMAS_CACHE_SIZE_CONFIG, 1,
-        WRAPPER_FOR_RAW_PRIMITIVES_CONFIG, unwrapPrimitives
-    ))).toConnectSchema(schema);
+    return schemaTranslator.toConnectSchema(schema);
   }
 }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
@@ -76,7 +76,7 @@ public final class SerdeUtil {
       case AvroFormat.NAME:       return new ValueSpecAvroSerdeSupplier();
       case ProtobufFormat.NAME:
         return new ValueSpecProtobufSerdeSupplier(
-            new ProtobufProperties(formatInfo.getProperties()).getUnwrapPrimitives());
+            new ProtobufProperties(formatInfo.getProperties()));
       case JsonFormat.NAME:       return new ValueSpecJsonSerdeSupplier(false, properties);
       case JsonSchemaFormat.NAME: return new ValueSpecJsonSerdeSupplier(true, properties);
       case DelimitedFormat.NAME:  return new StringSerdeSupplier();

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_from_multiple_protobuf_schema_definitions/7.3.0_1649453206637/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_from_multiple_protobuf_schema_definitions/7.3.0_1649453206637/plan.json
@@ -1,0 +1,227 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K1 STRING KEY, C1 BIGINT) WITH (FORMAT='PROTOBUF', KAFKA_TOPIC='input', KEY_SCHEMA_FULL_NAME='ProtobufKey2', VALUE_SCHEMA_FULL_NAME='ProtobufValue2');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K1` STRING KEY, `C1` BIGINT",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "ProtobufKey2",
+            "unwrapPrimitives" : "true"
+          }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "ProtobufValue2",
+            "unwrapPrimitives" : "true"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K1` STRING KEY, `C1` BIGINT",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "ProtobufKey2",
+            "unwrapPrimitives" : "true"
+          }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "ProtobufValue2",
+            "unwrapPrimitives" : "true"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : {
+                  "fullSchemaName" : "ProtobufKey2",
+                  "unwrapPrimitives" : "true"
+                }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : {
+                  "fullSchemaName" : "ProtobufValue2",
+                  "unwrapPrimitives" : "true"
+                }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K1` STRING KEY, `C1` BIGINT",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K1" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "C1 AS C1" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufKey2",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufValue2",
+              "unwrapPrimitives" : "true"
+            }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_from_multiple_protobuf_schema_definitions/7.3.0_1649453206637/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_from_multiple_protobuf_schema_definitions/7.3.0_1649453206637/spec.json
@@ -1,0 +1,146 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1649453206637,
+  "path" : "query-validation-tests/protobuf.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K1` STRING KEY, `C1` BIGINT",
+      "keyFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "ProtobufKey2",
+          "unwrapPrimitives" : "true"
+        }
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "ProtobufValue2",
+          "unwrapPrimitives" : "true"
+        }
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K1` STRING KEY, `C1` BIGINT",
+      "keyFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "ProtobufKey2",
+          "unwrapPrimitives" : "true"
+        }
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "ProtobufValue2",
+          "unwrapPrimitives" : "true"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "specify a protobuf schema from multiple protobuf schema definitions",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : {
+        "k1" : "A"
+      },
+      "value" : {
+        "c1" : 100
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K1" : "A"
+      },
+      "value" : {
+        "C1" : 100
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "keySchema" : "syntax = \"proto3\";\n\nmessage ProtobufKey1 {\n  uint32 k1 = 1;\n}\nmessage ProtobufKey2 {\n  string k1 = 1;\n}\n",
+      "valueSchema" : "syntax = \"proto3\";\n\nmessage ProtobufValue1 {\n  float c1 = 1;\n  uint32 c2 = 2;\n}\nmessage ProtobufValue2 {\n  uint32 c1 = 1;\n}\n",
+      "keyFormat" : "PROTOBUF",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "OUTPUT",
+      "keySchema" : "syntax = \"proto3\";\n\nmessage ProtobufKey2 {\n  string k1 = 1;\n}\n",
+      "valueSchema" : "syntax = \"proto3\";\n\nmessage ProtobufValue2 {\n  uint32 c1 = 1;\n}\n",
+      "keyFormat" : "PROTOBUF",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM INPUT WITH (kafka_topic='input', format='PROTOBUF', KEY_SCHEMA_FULL_NAME='ProtobufKey2', VALUE_SCHEMA_FULL_NAME='ProtobufValue2');", "CREATE STREAM OUTPUT AS SELECT * FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K1` STRING KEY, `C1` BIGINT",
+        "keyFormat" : {
+          "format" : "PROTOBUF"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K1` STRING KEY, `C1` BIGINT",
+        "keyFormat" : {
+          "format" : "PROTOBUF"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufKey2",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufValue2",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "partitions" : 1,
+          "keySchema" : "syntax = \"proto3\";\n\nmessage ProtobufKey2 {\n  string k1 = 1;\n}\n",
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ProtobufValue2 {\n  uint32 c1 = 1;\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufKey2",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufValue2",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "partitions" : 4,
+          "keySchema" : "syntax = \"proto3\";\n\nmessage ProtobufKey2 {\n  string K1 = 1;\n}\n",
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ProtobufValue2 {\n  int64 C1 = 1;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_from_multiple_protobuf_schema_definitions/7.3.0_1649453206637/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_from_multiple_protobuf_schema_definitions/7.3.0_1649453206637/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_name_with_SCHEMA_FULL_NAME/7.3.0_1649453337688/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_name_with_SCHEMA_FULL_NAME/7.3.0_1649453337688/plan.json
@@ -1,0 +1,227 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (K1 BIGINT KEY, C1 DOUBLE, C2 BIGINT) WITH (FORMAT='PROTOBUF', KAFKA_TOPIC='input', KEY_SCHEMA_FULL_NAME='ProtobufKey1', VALUE_SCHEMA_FULL_NAME='ProtobufValue1');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`K1` BIGINT KEY, `C1` DOUBLE, `C2` BIGINT",
+      "timestampColumn" : null,
+      "topicName" : "input",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "ProtobufKey1",
+            "unwrapPrimitives" : "true"
+          }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "ProtobufValue1",
+            "unwrapPrimitives" : "true"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT WITH (FORMAT='PROTOBUF', KEY_SCHEMA_FULL_NAME='ProtobufKey2', VALUE_SCHEMA_FULL_NAME='ProtobufValue2') AS SELECT *\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`K1` BIGINT KEY, `C1` DOUBLE, `C2` BIGINT",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "ProtobufKey2",
+            "unwrapPrimitives" : "true"
+          }
+        },
+        "valueFormat" : {
+          "format" : "PROTOBUF",
+          "properties" : {
+            "fullSchemaName" : "ProtobufValue2",
+            "unwrapPrimitives" : "true"
+          }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : {
+                  "fullSchemaName" : "ProtobufKey1",
+                  "unwrapPrimitives" : "true"
+                }
+              },
+              "valueFormat" : {
+                "format" : "PROTOBUF",
+                "properties" : {
+                  "fullSchemaName" : "ProtobufValue1",
+                  "unwrapPrimitives" : "true"
+                }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`K1` BIGINT KEY, `C1` DOUBLE, `C2` BIGINT",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "K1" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "C1 AS C1", "C2 AS C2" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufKey2",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufValue2",
+              "unwrapPrimitives" : "true"
+            }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_name_with_SCHEMA_FULL_NAME/7.3.0_1649453337688/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_name_with_SCHEMA_FULL_NAME/7.3.0_1649453337688/spec.json
@@ -1,0 +1,148 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1649453337688,
+  "path" : "query-validation-tests/protobuf.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`K1` BIGINT KEY, `C1` DOUBLE, `C2` BIGINT",
+      "keyFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "ProtobufKey1",
+          "unwrapPrimitives" : "true"
+        }
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "ProtobufValue1",
+          "unwrapPrimitives" : "true"
+        }
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`K1` BIGINT KEY, `C1` DOUBLE, `C2` BIGINT",
+      "keyFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "ProtobufKey2",
+          "unwrapPrimitives" : "true"
+        }
+      },
+      "valueFormat" : {
+        "format" : "PROTOBUF",
+        "properties" : {
+          "fullSchemaName" : "ProtobufValue2",
+          "unwrapPrimitives" : "true"
+        }
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "specify a protobuf schema name with SCHEMA_FULL_NAME",
+    "inputs" : [ {
+      "topic" : "input",
+      "key" : {
+        "k1" : 10
+      },
+      "value" : {
+        "c1" : 1.1234,
+        "c2" : 100
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : {
+        "K1" : 10
+      },
+      "value" : {
+        "C1" : 1.1233999729156494,
+        "C2" : 100
+      }
+    } ],
+    "topics" : [ {
+      "name" : "input",
+      "keySchema" : "syntax = \"proto3\";\n\nmessage ProtobufKey1 {\n  uint32 k1 = 1;\n}\n",
+      "valueSchema" : "syntax = \"proto3\";\n\nmessage ProtobufValue1 {\n  float c1 = 1;\n  uint32 c2 = 2;\n}\n",
+      "keyFormat" : "PROTOBUF",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 1
+    }, {
+      "name" : "OUTPUT",
+      "keySchema" : "syntax = \"proto3\";\n\nmessage ProtobufKey2 {\n  uint32 k1 = 1;\n}\n",
+      "valueSchema" : "syntax = \"proto3\";\n\nmessage ProtobufValue2 {\n  float c1 = 1;\n  uint32 c2 = 2;\n}\n",
+      "keyFormat" : "PROTOBUF",
+      "valueFormat" : "PROTOBUF",
+      "replicas" : 1,
+      "numPartitions" : 1
+    } ],
+    "statements" : [ "CREATE STREAM INPUT WITH (kafka_topic='input', format='PROTOBUF', KEY_SCHEMA_FULL_NAME='ProtobufKey1', VALUE_SCHEMA_FULL_NAME='ProtobufValue1');", "CREATE STREAM OUTPUT WITH (format='PROTOBUF', KEY_SCHEMA_FULL_NAME='ProtobufKey2', VALUE_SCHEMA_FULL_NAME='ProtobufValue2') AS SELECT * FROM input;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`K1` BIGINT KEY, `C1` DOUBLE, `C2` BIGINT",
+        "keyFormat" : {
+          "format" : "PROTOBUF"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`K1` BIGINT KEY, `C1` DOUBLE, `C2` BIGINT",
+        "keyFormat" : {
+          "format" : "PROTOBUF"
+        },
+        "valueFormat" : "PROTOBUF",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input",
+          "keyFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufKey1",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufValue1",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "partitions" : 1,
+          "keySchema" : "syntax = \"proto3\";\n\nmessage ProtobufKey1 {\n  uint32 k1 = 1;\n}\n",
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ProtobufValue1 {\n  float c1 = 1;\n  uint32 c2 = 2;\n}\n"
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufKey2",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "valueFormat" : {
+            "format" : "PROTOBUF",
+            "properties" : {
+              "fullSchemaName" : "ProtobufValue2",
+              "unwrapPrimitives" : "true"
+            }
+          },
+          "partitions" : 4,
+          "keySchema" : "syntax = \"proto3\";\n\nmessage ProtobufKey2 {\n  int64 K1 = 1;\n}\n",
+          "valueSchema" : "syntax = \"proto3\";\n\nmessage ProtobufValue2 {\n  double C1 = 1;\n  int64 C2 = 2;\n}\n"
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_name_with_SCHEMA_FULL_NAME/7.3.0_1649453337688/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/protobuf_-_specify_a_protobuf_schema_name_with_SCHEMA_FULL_NAME/7.3.0_1649453337688/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/protobuf.json
@@ -606,6 +606,81 @@
       }
     },
     {
+      "name": "specify a protobuf schema name with SCHEMA_FULL_NAME",
+      "statements": [
+        "CREATE STREAM INPUT WITH (kafka_topic='input', format='PROTOBUF', KEY_SCHEMA_FULL_NAME='ProtobufKey1', VALUE_SCHEMA_FULL_NAME='ProtobufValue1');",
+        "CREATE STREAM OUTPUT WITH (format='PROTOBUF', KEY_SCHEMA_FULL_NAME='ProtobufKey2', VALUE_SCHEMA_FULL_NAME='ProtobufValue2') AS SELECT * FROM input;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "keyFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ProtobufKey1 {uint32 k1 = 1;}",
+          "valueFormat": "PROTOBUF",
+          "valueSchema": "syntax = \"proto3\"; message ProtobufValue1 {float c1 = 1; uint32 c2 = 2;}"
+        },
+        {
+          "name": "OUTPUT",
+          "keyFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ProtobufKey2 {uint32 k1 = 1;}",
+          "valueFormat": "PROTOBUF",
+          "valueSchema": "syntax = \"proto3\"; message ProtobufValue2 {float c1 = 1; uint32 c2 = 2;}"
+        }
+      ],
+      "inputs": [
+        {"topic": "input", "key": {"k1":  10}, "value": {"c1": 1.1234, "c2": 100}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"K1":  10}, "value": {"C1": 1.1233999729156494, "C2": 100}}
+      ]
+    },
+    {
+      "name": "specify a protobuf schema from multiple protobuf schema definitions",
+      "statements": [
+        "CREATE STREAM INPUT WITH (kafka_topic='input', format='PROTOBUF', KEY_SCHEMA_FULL_NAME='ProtobufKey2', VALUE_SCHEMA_FULL_NAME='ProtobufValue2');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM input;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "keyFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ProtobufKey1 {uint32 k1 = 1;} message ProtobufKey2 {string k1 = 1;}",
+          "valueFormat": "PROTOBUF",
+          "valueSchema": "syntax = \"proto3\"; message ProtobufValue1 {float c1 = 1; uint32 c2 = 2;} message ProtobufValue2 {uint32 c1 = 1;}"
+        },
+        {
+          "name": "OUTPUT",
+          "keyFormat": "PROTOBUF",
+          "keySchema": "syntax = \"proto3\"; message ProtobufKey2 {string k1 = 1;}",
+          "valueFormat": "PROTOBUF",
+          "valueSchema": "syntax = \"proto3\"; message ProtobufValue2 {uint32 c1 = 1;}"
+        }
+      ],
+      "inputs": [
+        {"topic": "input", "key": {"k1":  "A"}, "value": {"c1": 100}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": {"K1":  "A"}, "value": {"C1": 100}}
+      ]
+    },
+    {
+      "name": "fail if protobuf schema name is not found",
+      "statements": [
+        "CREATE STREAM INPUT WITH (kafka_topic='input_topic', value_format='PROTOBUF', VALUE_SCHEMA_FULL_NAME='ProtobufValue1000');"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "valueFormat": "PROTOBUF",
+          "valueSchema": "syntax = \"proto3\"; message ProtobufValue1 {float c1 = 1; uint32 c2 = 2;} message ProtobufValue2 {uint32 c1 = 1;}"
+        }
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Schema for message values on topic 'input_topic' does not exist in the Schema Registry."
+      }
+    },
+    {
       "name": "map with non-string keys - C*",
       "comment": ["This is current limitation. PB supports INT/BIGINT keys. See https://github.com/confluentinc/ksql/issues/6177"],
       "statements": [

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -101,6 +101,8 @@ public class CreateSourcePropertiesTest {
     assertThat(properties.getReplicas(), is(Optional.empty()));
     assertThat(properties.getPartitions(), is(Optional.empty()));
     assertThat(properties.getValueSerdeFeatures(), is(SerdeFeatures.of()));
+    assertThat(properties.getKeySchemaFullName(), is(Optional.empty()));
+    assertThat(properties.getValueSchemaFullName(), is(Optional.empty()));
   }
 
   @Test

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -501,6 +501,15 @@ public class InsertValuesExecutor {
       }
     }
 
+    // The SCHEMA_ID is used by the serializer to fetch the right SR schema by id
+    if (supportedProperties.contains(ConnectProperties.SCHEMA_ID)) {
+      if (!formatInfo.getProperties().containsKey(ConnectProperties.SCHEMA_ID)) {
+        SchemaRegistryUtil.getSchemaId(srClient, topicName, isKey)
+            .ifPresent(schemaId ->
+                propertiesBuilder.put(ConnectProperties.SCHEMA_ID, String.valueOf(schemaId)));
+      }
+    }
+
     return FormatInfo.of(formatInfo.getFormat(), propertiesBuilder.build());
   }
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.GenericKey;
@@ -50,6 +49,9 @@ import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.ValueSerdeFactory;
 import io.confluent.ksql.serde.avro.AvroFormat;
 import io.confluent.ksql.serde.connect.ConnectProperties;
+import io.confluent.ksql.serde.protobuf.ProtobufFormat;
+import io.confluent.ksql.serde.protobuf.ProtobufProperties;
+import io.confluent.ksql.serde.protobuf.ProtobufSchemaTranslator;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
@@ -380,9 +382,9 @@ public class InsertValuesExecutor {
         .getSchemaTranslator(formatInfo.getProperties())
         .toParsedSchema(keySchema);
 
-    final Optional<SchemaMetadata> latest;
+    final Optional<ParsedSchema> latest;
     try {
-      latest = SchemaRegistryUtil.getLatestSchema(
+      latest = SchemaRegistryUtil.getLatestParsedSchema(
           schemaRegistryClient,
           dataSource.getKafkaTopicName(),
           true);
@@ -394,7 +396,9 @@ public class InsertValuesExecutor {
           + "operation potentially overrides existing key schema in schema registry.", e);
     }
 
-    if (latest.isPresent() && !latest.get().getSchema().equals(schema.canonicalString())) {
+    if (latest.isPresent() && !latest.get().canonicalString().equals(schema.canonicalString())) {
+      final Map<String, String> formatProps = keyFormat.getFormatInfo().getProperties();
+
       // Hack: skip comparing connect name. See https://github.com/confluentinc/ksql/issues/7211
       // Avro schema are registered in source creation time as well data insertion time.
       // CONNECT_META_DATA_CONFIG is configured to false in Avro Serializer, but it's true in
@@ -402,17 +406,36 @@ public class InsertValuesExecutor {
       // enabling it breaks lots of history QTT test which implies backward compatibility issues.
       // So we just bypass the connect name check here.
       if (format instanceof AvroFormat) {
-        final SchemaTranslator translator = format
-            .getSchemaTranslator(keyFormat.getFormatInfo().getProperties());
+        final SchemaTranslator translator = format.getSchemaTranslator(formatProps);
         translator.configure(ImmutableMap.of(AvroDataConfig.CONNECT_META_DATA_CONFIG, false));
         final ParsedSchema parsedSchema = translator.toParsedSchema(keySchema);
-        if (latest.get().getSchema().equals(parsedSchema.canonicalString())) {
+        if (latest.get().canonicalString().equals(parsedSchema.canonicalString())) {
+          return;
+        }
+      } else if (format instanceof ProtobufFormat
+          && formatProps.containsKey(ConnectProperties.FULL_SCHEMA_NAME)) {
+
+        // The SR key schema may have multiple schema definitions. The FULL_SCHEMA_NAME is used
+        // to specify one definition only. To verify the source key schema matches SR, then we
+        // extract the single schema based on the FULL_SCHEMA_NAME and then compare with the
+        // source schema.
+
+        final ProtobufSchemaTranslator protoTranslator = new ProtobufSchemaTranslator(
+            new ProtobufProperties(formatProps)
+        );
+
+        final ParsedSchema extractedSingleSchema = protoTranslator.fromConnectSchema(
+            protoTranslator.toConnectSchema(latest.get())
+        );
+
+        if (extractedSingleSchema.canonicalString().equals(schema.canonicalString())) {
           return;
         }
       }
+
       throw new KsqlException("Cannot INSERT VALUES into data source " + dataSource.getName()
           + ". ksqlDB generated schema would overwrite existing key schema."
-          + "\n\tExisting Schema: " + latest.get().getSchema()
+          + "\n\tExisting Schema: " + latest.get().canonicalString()
           + "\n\tksqlDB Generated: " + schema.canonicalString());
     }
   }
@@ -495,16 +518,18 @@ public class InsertValuesExecutor {
     // The FULL_SCHEMA_NAME allows the serializer to choose the schema definition
     if (supportedProperties.contains(ConnectProperties.FULL_SCHEMA_NAME)) {
       if (!formatInfo.getProperties().containsKey(ConnectProperties.FULL_SCHEMA_NAME)) {
-        SchemaRegistryUtil.getParsedSchema(srClient, topicName, isKey).map(ParsedSchema::name)
+        SchemaRegistryUtil.getLatestParsedSchema(srClient, topicName, isKey).map(ParsedSchema::name)
             .ifPresent(schemaName ->
                 propertiesBuilder.put(ConnectProperties.FULL_SCHEMA_NAME, schemaName));
       }
     }
 
-    // The SCHEMA_ID is used by the serializer to fetch the right SR schema by id
+    // The SCHEMA_ID is used to by the Serde factory (i.e. ProtobufSerdeFactory) to
+    // get the SR schema and extract the full schema name in case multiple schema definitions
+    // are available.
     if (supportedProperties.contains(ConnectProperties.SCHEMA_ID)) {
       if (!formatInfo.getProperties().containsKey(ConnectProperties.SCHEMA_ID)) {
-        SchemaRegistryUtil.getSchemaId(srClient, topicName, isKey)
+        SchemaRegistryUtil.getLatestSchemaId(srClient, topicName, isKey)
             .ifPresent(schemaId ->
                 propertiesBuilder.put(ConnectProperties.SCHEMA_ID, String.valueOf(schemaId)));
       }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -1169,9 +1169,7 @@ public class InsertValuesExecutorTest {
     // Then:
     verify(keySerdeFactory).create(
         FormatInfo.of(FormatFactory.AVRO.name(), ImmutableMap.of(
-            AvroProperties.FULL_SCHEMA_NAME,"io.avro.TestSchema",
-            AvroProperties.SCHEMA_ID, "1"
-        )),
+            AvroProperties.FULL_SCHEMA_NAME,"io.avro.TestSchema")),
         PersistenceSchema.from(SCHEMA.key(), SerdeFeatures.of(SerdeFeature.WRAP_SINGLES)),
         new KsqlConfig(ImmutableMap.of()),
         srClientFactory,
@@ -1182,9 +1180,7 @@ public class InsertValuesExecutorTest {
 
     verify(valueSerdeFactory).create(
         FormatInfo.of(FormatFactory.AVRO.name(), ImmutableMap.of(
-            AvroProperties.FULL_SCHEMA_NAME,"io.avro.TestSchema",
-            AvroProperties.SCHEMA_ID, "1"
-        )),
+            AvroProperties.FULL_SCHEMA_NAME,"io.avro.TestSchema")),
         PersistenceSchema.from(SCHEMA.value(), SerdeFeatures.of()),
         new KsqlConfig(ImmutableMap.of()),
         srClientFactory,

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
@@ -170,8 +170,11 @@ public interface Format {
 
   /**
    * Returns a list of schema names found in the {@code ParsedSchema}.
+   * </p>
+   * It may return an empty list if not names are found. Names are not found ont formats
+   * such as Delimited and Json (no SR) formats.
    */
-  default List<String> getSchemaDefinitions(final ParsedSchema schema) {
+  default List<String> schemaFullNames(final ParsedSchema schema) {
     return ImmutableList.of();
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/Format.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.serde;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -166,4 +167,11 @@ public interface Format {
    * @return true if the given sql type is supported
    */
   boolean supportsKeyType(SqlType type);
+
+  /**
+   * Returns a list of schema names found in the {@code ParsedSchema}.
+   */
+  default List<String> getSchemaDefinitions(final ParsedSchema schema) {
+    return ImmutableList.of();
+  }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.serde.connect;
 
+import com.google.common.collect.ImmutableList;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
@@ -258,5 +260,14 @@ public abstract class ConnectFormat implements Format {
   @Override
   public boolean supportsKeyType(final SqlType type) {
     return true;
+  }
+
+  @Override
+  public List<String> schemaFullNames(final ParsedSchema schema) {
+    if (schema.name() != null) {
+      return ImmutableList.of();
+    }
+
+    return ImmutableList.of(schema.name());
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectFormat.java
@@ -264,7 +264,7 @@ public abstract class ConnectFormat implements Format {
 
   @Override
   public List<String> schemaFullNames(final ParsedSchema schema) {
-    if (schema.name() != null) {
+    if (schema.name() == null) {
       return ImmutableList.of();
     }
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.serde.protobuf;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
@@ -87,13 +88,13 @@ public class ProtobufFormat extends ConnectFormat {
   }
 
   @Override
-  public List<String> getSchemaDefinitions(final ParsedSchema schema) {
+  public List<String> schemaFullNames(final ParsedSchema schema) {
     if (schema.rawSchema() instanceof ProtoFileElement) {
       final ProtoFileElement protoFileElement = (ProtoFileElement) schema.rawSchema();
       final String packageName = protoFileElement.getPackageName();
 
       return protoFileElement.getTypes().stream()
-          .map(typeElement -> packageName + "." + typeElement.getName())
+          .map(typeElement -> Joiner.on(".").skipNulls().join(packageName, typeElement.getName()))
           .collect(Collectors.toList());
     }
 

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufFormat.java
@@ -15,17 +15,22 @@
 
 package io.confluent.ksql.serde.protobuf;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.serde.FormatProperties;
 import io.confluent.ksql.serde.SerdeFeature;
 import io.confluent.ksql.serde.connect.ConnectFormat;
 import io.confluent.ksql.serde.connect.ConnectSchemaTranslator;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.ConnectSchema;
 
@@ -79,5 +84,19 @@ public class ProtobufFormat extends ConnectFormat {
   ) {
     return new ProtobufSerdeFactory(new ProtobufProperties(formatProps))
         .createSerde(connectSchema, config, srFactory, targetType, isKey);
+  }
+
+  @Override
+  public List<String> getSchemaDefinitions(final ParsedSchema schema) {
+    if (schema.rawSchema() instanceof ProtoFileElement) {
+      final ProtoFileElement protoFileElement = (ProtoFileElement) schema.rawSchema();
+      final String packageName = protoFileElement.getPackageName();
+
+      return protoFileElement.getTypes().stream()
+          .map(typeElement -> packageName + "." + typeElement.getName())
+          .collect(Collectors.toList());
+    }
+
+    return ImmutableList.of();
   }
 }

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
@@ -69,7 +69,7 @@ class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
 
   @Override
   public Schema toConnectSchema(final ParsedSchema schema) {
-    return protobufData.toConnectSchema((ProtobufSchema) schema);
+    return protobufData.toConnectSchema(withSchemaFullName((ProtobufSchema) schema));
   }
 
   @Override
@@ -78,6 +78,10 @@ class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
     // default naming.
     return new ProtobufData(new ProtobufDataConfig(updatedConfigs))
         .fromConnectSchema(injectSchemaFullName(schema));
+  }
+
+  private ProtobufSchema withSchemaFullName(final ProtobufSchema origSchema) {
+    return fullNameSchema.map(origSchema::copy).orElse(origSchema);
   }
 
   private Schema injectSchemaFullName(final Schema origSchema) {

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslator.java
@@ -33,7 +33,7 @@ import org.apache.kafka.connect.data.Schema;
 /**
  * Translates between Connect and Protobuf Schema Registry schema types.
  */
-class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
+public class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
 
   private final ProtobufProperties properties;
   private final Map<String, Object> baseConfigs;
@@ -42,7 +42,7 @@ class ProtobufSchemaTranslator implements ConnectSchemaTranslator {
   private Map<String, Object> updatedConfigs;
   private ProtobufData protobufData;
 
-  ProtobufSchemaTranslator(final ProtobufProperties properties) {
+  public ProtobufSchemaTranslator(final ProtobufProperties properties) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.baseConfigs = ImmutableMap.of(
         WRAPPER_FOR_RAW_PRIMITIVES_CONFIG, properties.getUnwrapPrimitives());

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/KsqlProtobufSerializerTest.java
@@ -307,7 +307,7 @@ public class KsqlProtobufSerializerTest {
     int schemaId = givenPhysicalSchema(getSRSubject(SOME_TOPIC, false),
         PROTOBUF_STRUCT_SCHEMA_WITH_MISSING_FIELD);
     final Serializer<Struct> serializer = givenSerializerForSchema(RANDOM_NAME_STRUCT_SCHEMA,
-        Struct.class, Optional.of(schemaId), Optional.of("RandomName"));
+        Struct.class, Optional.of(schemaId), Optional.empty());
 
     // When:
     final Exception e = assertThrows(

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufFormatTest.java
@@ -2,24 +2,19 @@ package io.confluent.ksql.serde.protobuf;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ProtobufFormatTest {
   private ProtobufFormat format;
-  private Map<String, String> formatProps;
 
   @Before
   public void setUp() {
     format = new ProtobufFormat();
-    formatProps = new HashMap<>();
   }
 
   @Test

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufFormatTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufFormatTest.java
@@ -1,0 +1,60 @@
+package io.confluent.ksql.serde.protobuf;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ProtobufFormatTest {
+  private ProtobufFormat format;
+  private Map<String, String> formatProps;
+
+  @Before
+  public void setUp() {
+    format = new ProtobufFormat();
+    formatProps = new HashMap<>();
+  }
+
+  @Test
+  public void shouldReturnSchemaNamesFromMultipleSchemaDefinitionsWithPackageName() {
+    // Given
+    final ProtobufSchema protoSchema = new ProtobufSchema(""
+        + "syntax = \"proto3\"; "
+        + "package examples.proto; "
+        + "message ProtobufKey1 {uint32 k1 = 1;} "
+        + "message ProtobufKey2 {string k1 = 1;}"
+    );
+
+    // When
+    final List<String> schemaNames = format.schemaFullNames(protoSchema);
+
+    // Then
+    assertThat(schemaNames, equalTo(ImmutableList.of(
+        "examples.proto.ProtobufKey1",
+        "examples.proto.ProtobufKey2"
+    )));
+  }
+
+  @Test
+  public void shouldReturnSchemaNamesFromMultipleSchemaDefinitionsWithoutPackageName() {
+    // Given
+    final ProtobufSchema protoSchema = new ProtobufSchema(""
+        + "syntax = \"proto3\"; "
+        + "message ProtobufKey1 {uint32 k1 = 1;} "
+        + "message ProtobufKey2 {string k1 = 1;}"
+    );
+
+    // When
+    final List<String> schemaNames = format.schemaFullNames(protoSchema);
+
+    // Then
+    assertThat(schemaNames, equalTo(ImmutableList.of("ProtobufKey1", "ProtobufKey2")));
+  }
+}

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslatorTest.java
@@ -20,13 +20,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableMap;
-import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 
 public class ProtobufSchemaTranslatorTest {
@@ -166,9 +164,10 @@ public class ProtobufSchemaTranslatorTest {
     final Schema connectSchema =  SchemaBuilder.struct()
         .field("id", Schema.OPTIONAL_INT64_SCHEMA)
         .field("array", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA))
-        .field("map", SchemaBuilder.map(Schema.BYTES_SCHEMA, Schema.FLOAT64_SCHEMA))
+        .field("map", SchemaBuilder.map(Schema.BYTES_SCHEMA, Schema.FLOAT64_SCHEMA).name("InternalMap"))
         .field("struct", SchemaBuilder.struct()
             .field("c1", Schema.STRING_SCHEMA)
+            .name("InternalStruct")
             .build())
         .build();
 
@@ -191,17 +190,17 @@ public class ProtobufSchemaTranslatorTest {
             "\n" +
             "  repeated string array = 2;\n" +
             "\n" +
-            "  repeated CustomerMapEntry map = 3;\n" +
+            "  repeated InternalMapEntry map = 3;\n" +
             "\n" +
-            "  Customer_struct struct = 4;\n" +
+            "  InternalStruct struct = 4;\n" +
             "\n" +
-            "  message CustomerMapEntry {\n" +
+            "  message InternalMapEntry {\n" +
             "    bytes key = 1;\n" +
             "  \n" +
             "    double value = 2;\n" +
             "  }\n" +
             "\n" +
-            "  message Customer_struct {\n" +
+            "  message InternalStruct {\n" +
             "    string c1 = 1;\n" +
             "  }\n" +
             "}\n"

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/protobuf/ProtobufSchemaTranslatorTest.java
@@ -20,9 +20,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableMap;
+import com.squareup.wire.schema.internal.parser.ProtoFileElement;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 
 public class ProtobufSchemaTranslatorTest {
@@ -108,6 +112,102 @@ public class ProtobufSchemaTranslatorTest {
     assertThat(schema.field("c5").schema().field("value").schema().type(), is(Type.STRING));
   }
 
+  @Test
+  public void shouldReturnParsedSchemaWithDefaultFullSchemaName() {
+    // Given:
+    givenWrapPrimitives();
+    final Schema connectSchema =  SchemaBuilder.struct()
+        .field("id", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("array", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA))
+        .field("map", SchemaBuilder.map(Schema.BYTES_SCHEMA, Schema.FLOAT64_SCHEMA))
+        .field("struct", SchemaBuilder.struct()
+            .field("c1", Schema.STRING_SCHEMA)
+            .build())
+        .build();
+
+    // When:
+    schemaTranslator.configure(ImmutableMap.of());
+    final ParsedSchema parsedSchema = schemaTranslator.fromConnectSchema(connectSchema);
+
+    // Then:
+    assertThat(parsedSchema.name(), is("ConnectDefault1"));
+    assertThat(((ProtobufSchema)parsedSchema).rawSchema().toSchema(), is(
+        "// Proto schema formatted by Wire, do not edit.\n" +
+            "// Source: \n" +
+            "\n" +
+            "syntax = \"proto3\";\n" +
+            "\n" +
+            "message ConnectDefault1 {\n" +
+            "  int64 id = 1;\n" +
+            "\n" +
+            "  repeated string array = 2;\n" +
+            "\n" +
+            "  repeated ConnectDefault2Entry map = 3;\n" +
+            "\n" +
+            "  ConnectDefault3 struct = 4;\n" +
+            "\n" +
+            "  message ConnectDefault2Entry {\n" +
+            "    bytes key = 1;\n" +
+            "  \n" +
+            "    double value = 2;\n" +
+            "  }\n" +
+            "\n" +
+            "  message ConnectDefault3 {\n" +
+            "    string c1 = 1;\n" +
+            "  }\n" +
+            "}\n"
+    ));
+  }
+
+  @Test
+  public void shouldReturnParsedSchemaWithFullSchemaName() {
+    // Given:
+    givenSchemaFullName("io.examples.Customer");
+    final Schema connectSchema =  SchemaBuilder.struct()
+        .field("id", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("array", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA))
+        .field("map", SchemaBuilder.map(Schema.BYTES_SCHEMA, Schema.FLOAT64_SCHEMA))
+        .field("struct", SchemaBuilder.struct()
+            .field("c1", Schema.STRING_SCHEMA)
+            .build())
+        .build();
+
+    // When:
+    schemaTranslator.configure(ImmutableMap.of());
+    final ParsedSchema parsedSchema = schemaTranslator.fromConnectSchema(connectSchema);
+
+    // Then:
+    assertThat(parsedSchema.name(), is("io.examples.Customer"));
+    assertThat(((ProtobufSchema)parsedSchema).rawSchema().toSchema(), is(
+        "// Proto schema formatted by Wire, do not edit.\n" +
+            "// Source: \n" +
+            "\n" +
+            "syntax = \"proto3\";\n" +
+            "\n" +
+            "package io.examples;\n" +
+            "\n" +
+            "message Customer {\n" +
+            "  int64 id = 1;\n" +
+            "\n" +
+            "  repeated string array = 2;\n" +
+            "\n" +
+            "  repeated CustomerMapEntry map = 3;\n" +
+            "\n" +
+            "  Customer_struct struct = 4;\n" +
+            "\n" +
+            "  message CustomerMapEntry {\n" +
+            "    bytes key = 1;\n" +
+            "  \n" +
+            "    double value = 2;\n" +
+            "  }\n" +
+            "\n" +
+            "  message Customer_struct {\n" +
+            "    string c1 = 1;\n" +
+            "  }\n" +
+            "}\n"
+    ));
+  }
+
   private void givenUnwrapPrimitives() {
     schemaTranslator = new ProtobufSchemaTranslator(new ProtobufProperties(ImmutableMap.of(
         ProtobufProperties.UNWRAP_PRIMITIVES, ProtobufProperties.UNWRAP
@@ -118,4 +218,9 @@ public class ProtobufSchemaTranslatorTest {
     schemaTranslator = new ProtobufSchemaTranslator(new ProtobufProperties(ImmutableMap.of()));
   }
 
+  private void givenSchemaFullName(final String fullSchemaName) {
+    schemaTranslator = new ProtobufSchemaTranslator(new ProtobufProperties(ImmutableMap.of(
+        ProtobufProperties.FULL_SCHEMA_NAME, fullSchemaName
+    )));
+  }
 }


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/5265

Ignore 1st commit https://github.com/confluentinc/ksql/pull/8933/commits/58e470336cc3a583872cf33f46557a1fd65acb41 which is being reviewed here -> https://github.com/confluentinc/ksql/pull/8984

This PR supports the `KEY_SCHEMA_FULL_NAME` and `VALUE_SCHEMA_FULL_NAME` properties in the `WITH` clause when creating a stream. These properties allows users to specify the full name of a protobuf schema instead of using a default name (current default is `ConnectDefault1`).

When registering a new schema, if the properties are given, then the schema will be registered in SR with the new name, i.e.
```
ksql> create stream t1(id int key, c1 double, c2 int) with (kafka_topic='t1', format='protobuf', key_schema_full_name='ProtobufKey1', value_schema_full_name='ProtobufValue1', partitions=1);

 Message        
----------------
 Stream created 
----------------

ksql> describe t1;

Name                 : T1
 Field | Type                   
--------------------------------
 ID    | INTEGER          (key) 
 C1    | DOUBLE                 
 C2    | INTEGER                
--------------------------------

$ curl -X GET http://localhost:8081/subjects/t1-key/versions/1/schema
syntax = "proto3";

message ProtobufKey1 {
  int32 ID = 1;
}

$ curl -X GET http://localhost:8081/subjects/t1-value/versions/1/schema
syntax = "proto3";

message ProtobufValue1 {
  double C1 = 1;
  int32 C2 = 2;
}
```

The KEY/VALUE properties can also be used to specify the name of the Protobuf message schema if multiple schema definitions are available in SR. i.e.
```
$ curl -X GET http://localhost:8081/subjects/s1-key/versions/2/schema
syntax = "proto3";

message ProtobufKey1 {
  int32 ID = 1;
}
message ProtobufKey2 {
  string ID = 1;
}

$ curl -X GET http://localhost:8081/subjects/s1-value/versions/2/schema
syntax = "proto3";

message ProtobufValue1 {
  double C1 = 1;
  int32 C2 = 2;
}
message ProtobufValue2 {
  int32 C1 = 1;
}

ksql> create stream s1 with (kafka_topic='s1', format='protobuf', key_schema_full_name='ProtobufKey2', value_schema_full_name='ProtobufValue2', partitions=1);

 Message        
----------------
 Stream created 
----------------

ksql> describe s1;

Name                 : S1
 Field | Type                   
--------------------------------
 ID    | VARCHAR(STRING)  (key) 
 C1    | INTEGER                
--------------------------------

ksql> drop stream s1;

ksql> create stream s1 with (kafka_topic='s1', format='protobuf', key_schema_full_name='ProtobufKey1', value_schema_full_name='ProtobufValue1', partitions=1);

 Message        
----------------
 Stream created 
----------------

ksql> describe s1;

Name                 : S1
 Field | Type                   
--------------------------------
 ID    | INTEGER          (key) 
 C1    | DOUBLE                 
 C2    | INTEGER                
--------------------------------
```

The KEY/VALUE properties are already supported for AVRO. This PR assumes those properties were meant for other formats too, but when Protobuf was implemented then these props weren't fixed.

### Testing done 
Manually. See the above examples.
I have some limitations with QTT that does not allow me to test the KEY/VALUE properties. 
Reason:
```
I can't make the multiple protobuf schema work because QTT first prepares all input/output topics and schema before executing statements, which sets up Protobuf translators without the properties specified in the CREATE statements
```


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

