### PR TITLE
feat: clean up extra runtimes so the assignment is more focused

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -102,6 +102,8 @@ public class RuntimeAssignor {
       if (runtimesToSources.get(queryMetadata.getQueryApplicationId()).isEmpty()
           && runtimesToSources.size() > numDefaultRuntimes) {
         runtimesToSources.remove(queryMetadata.getQueryApplicationId());
+        log.info("Removing runtime {} form selection of possible runtimes",
+            queryMetadata.getQueryApplicationId());
       }
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -37,11 +37,12 @@ public class RuntimeAssignor {
   private final Map<String, Collection<SourceName>> runtimesToSources;
   private final Map<QueryId, String> idToRuntime;
   private final Logger log = LoggerFactory.getLogger(RuntimeAssignor.class);
+  private final int runtimes;
 
   public RuntimeAssignor(final KsqlConfig config) {
     runtimesToSources = new HashMap<>();
     idToRuntime = new HashMap<>();
-    final int runtimes = config.getInt(KsqlConfig.KSQL_SHARED_RUNTIMES_COUNT);
+    runtimes = config.getInt(KsqlConfig.KSQL_SHARED_RUNTIMES_COUNT);
     for (int i = 0; i < runtimes; i++) {
       final String runtime = buildSharedRuntimeId(config, true, i);
       runtimesToSources.put(runtime, new HashSet<>());
@@ -49,6 +50,7 @@ public class RuntimeAssignor {
   }
 
   private RuntimeAssignor(final RuntimeAssignor other) {
+    runtimes = other.runtimes;
     this.runtimesToSources = new HashMap<>();
     this.idToRuntime = new HashMap<>(other.idToRuntime);
     for (Map.Entry<String, Collection<SourceName>> runtime
@@ -97,6 +99,10 @@ public class RuntimeAssignor {
       runtimesToSources.get(queryMetadata.getQueryApplicationId())
           .removeAll(queryMetadata.getSourceNames());
       idToRuntime.remove(queryMetadata.getQueryId());
+      if (runtimesToSources.get(queryMetadata.getQueryApplicationId()).isEmpty()
+          && runtimesToSources.size() >= runtimes) {
+        runtimesToSources.remove(queryMetadata.getQueryApplicationId());
+      }
     }
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/RuntimeAssignor.java
@@ -37,20 +37,20 @@ public class RuntimeAssignor {
   private final Map<String, Collection<SourceName>> runtimesToSources;
   private final Map<QueryId, String> idToRuntime;
   private final Logger log = LoggerFactory.getLogger(RuntimeAssignor.class);
-  private final int runtimes;
+  private final int numDefaultRuntimes;
 
   public RuntimeAssignor(final KsqlConfig config) {
     runtimesToSources = new HashMap<>();
     idToRuntime = new HashMap<>();
-    runtimes = config.getInt(KsqlConfig.KSQL_SHARED_RUNTIMES_COUNT);
-    for (int i = 0; i < runtimes; i++) {
+    numDefaultRuntimes = config.getInt(KsqlConfig.KSQL_SHARED_RUNTIMES_COUNT);
+    for (int i = 0; i < numDefaultRuntimes; i++) {
       final String runtime = buildSharedRuntimeId(config, true, i);
       runtimesToSources.put(runtime, new HashSet<>());
     }
   }
 
   private RuntimeAssignor(final RuntimeAssignor other) {
-    runtimes = other.runtimes;
+    numDefaultRuntimes = other.numDefaultRuntimes;
     this.runtimesToSources = new HashMap<>();
     this.idToRuntime = new HashMap<>(other.idToRuntime);
     for (Map.Entry<String, Collection<SourceName>> runtime
@@ -100,7 +100,7 @@ public class RuntimeAssignor {
           .removeAll(queryMetadata.getSourceNames());
       idToRuntime.remove(queryMetadata.getQueryId());
       if (runtimesToSources.get(queryMetadata.getQueryApplicationId()).isEmpty()
-          && runtimesToSources.size() >= runtimes) {
+          && runtimesToSources.size() > numDefaultRuntimes) {
         runtimesToSources.remove(queryMetadata.getQueryApplicationId());
       }
     }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/RuntimeAssignorTest.java
@@ -141,6 +141,18 @@ public class RuntimeAssignorTest {
   }
 
   @Test
+  public void shouldDropQueryAndCleanUpRuntime() {
+    runtimeAssignor.getRuntimeAndMaybeAddRuntime(
+        query2,
+        sources1,
+        KSQL_CONFIG
+    );
+    assertThat(runtimeAssignor.getRuntimesToSources().size(), equalTo(2));
+    runtimeAssignor.dropQuery(queryMetadata);
+    assertThat(runtimeAssignor.getRuntimesToSources().size(), equalTo(1));
+  }
+
+  @Test
   public void shouldRebuildAssignmentFromListOfQueries() {
     final RuntimeAssignor rebuilt = new RuntimeAssignor(KSQL_CONFIG);
     rebuilt.rebuildAssignment(Collections.singleton(queryMetadata));


### PR DESCRIPTION
### Description 
When we remove the last query from a runtime we clean it up. However we don't clean up the assignor so a new query can be assigned again. This make the assignment spread out over all the runtimes ever created instead of as few as possible.

### Testing done 
added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

