### PR TITLE
fix: clean up state when restarting runtimes to avoid errors

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -259,7 +259,8 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
         .buildNamedTopologyWrapper(streamsProperties);
     kafkaStreams = kafkaStreamsNamedTopologyWrapper;
     for (final NamedTopology topology : liveTopologies) {
-      final BinPackedPersistentQueryMetadataImpl query = collocatedQueries.get(topology.name());
+      final BinPackedPersistentQueryMetadataImpl query = collocatedQueries
+          .get(new QueryId(topology.name()));
       kafkaStreamsNamedTopologyWrapper.addNamedTopology(query.getTopologyCopy(this));
     }
     setupAndStartKafkaStreams(kafkaStreamsNamedTopologyWrapper);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -254,10 +254,11 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     final KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper = kafkaStreamsBuilder
         .buildNamedTopologyWrapper(streamsProperties);
     kafkaStreams.close();
+    kafkaStreams.cleanUp();
     kafkaStreams = kafkaStreamsNamedTopologyWrapper;
     for (final BinPackedPersistentQueryMetadataImpl query : collocatedQueries.values()) {
-      kafkaStreamsNamedTopologyWrapper.addNamedTopology(query.getTopologyCopy(this));
+      kafkaStreams.addNamedTopology(query.getTopologyCopy(this));
     }
-    setupAndStartKafkaStreams(kafkaStreamsNamedTopologyWrapper);
+    setupAndStartKafkaStreams(kafkaStreams);
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.util.QueryMetadataImpl.TimeBoundedQueue;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -35,6 +36,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -251,14 +253,15 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
   @Override
   public void restartStreamsRuntime() {
     log.info("Restarting runtime {}", getApplicationId());
+    final Collection<NamedTopology> liveTopologies = kafkaStreams.getAllTopologies();
+    kafkaStreams.close();
     final KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper = kafkaStreamsBuilder
         .buildNamedTopologyWrapper(streamsProperties);
-    kafkaStreams.close();
-    kafkaStreams.cleanUp();
     kafkaStreams = kafkaStreamsNamedTopologyWrapper;
-    for (final BinPackedPersistentQueryMetadataImpl query : collocatedQueries.values()) {
-      kafkaStreams.addNamedTopology(query.getTopologyCopy(this));
+    for (final NamedTopology topology : liveTopologies) {
+      final BinPackedPersistentQueryMetadataImpl query = collocatedQueries.get(topology.name());
+      kafkaStreamsNamedTopologyWrapper.addNamedTopology(query.getTopologyCopy(this));
     }
-    setupAndStartKafkaStreams(kafkaStreams);
+    setupAndStartKafkaStreams(kafkaStreamsNamedTopologyWrapper);
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -19,6 +19,8 @@ import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryError.Type;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
+
+import java.util.Collections;
 import java.util.HashMap;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.streams.StreamsConfig;
@@ -95,6 +97,8 @@ public class SharedKafkaStreamsRuntimeImplTest {
 
         when(kafkaStreamsNamedTopologyWrapper.getTopologyByName(any())).thenReturn(Optional.empty());
         when(kafkaStreamsNamedTopologyWrapper.addNamedTopology(any())).thenReturn(addNamedTopologyResult);
+        when(kafkaStreamsNamedTopologyWrapper.getAllTopologies()).thenReturn(Collections.singleton(namedTopology));
+        when(namedTopology.name()).thenReturn(queryId.toString());
         when(binPackedPersistentQueryMetadata.getTopologyCopy(any())).thenReturn(namedTopology);
         when(binPackedPersistentQueryMetadata.getQueryId()).thenReturn(queryId);
         when(binPackedPersistentQueryMetadata2.getQueryId()).thenReturn(queryId2);


### PR DESCRIPTION
### Description 
When running `Alter System` with many queries running we were encountering errors like 
```Stack trace: org.apache.kafka.streams.errors.StreamsException: Unable to initialize state, this can happen if multiple instances of Kafka Streams are running in the same state directory (current state directory is [/mnt/data/data/ksql-state/_confluent-ksql-pksqlc-8xo8rquery_0]
	at org.apache.kafka.streams.processor.internals.StateDirectory.initializeProcessId(StateDirectory.java:191)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:891)
	at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:874)
	at org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper.<init>(KafkaStreamsNamedTopologyWrapper.java:87)```

the clean up of state from the old runtime is not ideal but for now that might be necessary
 
### Testing done 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

