### PR TITLE
chore: better error message on ClusterAuthorizationException during INSERT VALUES (7.0.x)

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.ReservedInternalTopics;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -63,6 +64,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.serialization.Serde;
 import org.slf4j.Logger;
@@ -156,6 +158,27 @@ public class InsertValuesExecutor {
       final Exception rootCause = new KsqlTopicAuthorizationException(
           AclOperation.WRITE,
           e.unauthorizedTopics()
+      );
+
+      throw new KsqlException(createInsertFailedExceptionMessage(insertValues), rootCause);
+    } catch (final ClusterAuthorizationException e) {
+      // ClusterAuthorizationException is thrown when using idempotent producers
+      // and either a topic write permission or a cluster-level idempotent write
+      // permission (only applicable for broker versions no later than 2.8) is
+      // missing. In this case, we include additional context to help the user
+      // distinguish this type of failure from other permissions exceptions
+      // such as the ones thrown above when TopicAuthorizationException is caught.
+      final Exception rootCause = new KsqlTopicAuthorizationException(
+          AclOperation.WRITE,
+          Collections.singletonList(dataSource.getKafkaTopicName()),
+          // Ideally we would forward e.getMessage() instead of the hard-coded
+          // message below, but until this error message is improved on the Kafka
+          // side, e.getMessage() is not helpful. (Today it is just "Cluster
+          // authorization failed.")
+          "The producer is not authorized to do idempotent sends. "
+              + "Check that you have write permissions to the specified topic, "
+              + "and disable idempotent sends by setting 'enable.idempotent=false' "
+              + " if necessary."
       );
 
       throw new KsqlException(createInsertFailedExceptionMessage(insertValues), rootCause);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/exception/KsqlTopicAuthorizationException.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/exception/KsqlTopicAuthorizationException.java
@@ -28,10 +28,19 @@ public class KsqlTopicAuthorizationException extends TopicAuthorizationException
   public KsqlTopicAuthorizationException(
       final AclOperation operation,
       final Collection<String> topicNames) {
-    super(String.format("Authorization denied to %s on topic(s): [%s]",
-        StringUtils.capitalize(
-            operation.toString().toLowerCase()),
-            StringUtils.join(topicNames, ", ")));
+    this(operation, topicNames, "");
+  }
+
+  public KsqlTopicAuthorizationException(
+      final AclOperation operation,
+      final Collection<String> topicNames,
+      final String additionalContext) {
+    super(
+        String.format("Authorization denied to %s on topic(s): [%s]",
+            StringUtils.capitalize(operation.toString().toLowerCase()),
+            StringUtils.join(topicNames, ", "))
+        + (additionalContext.isEmpty() ? "" : ". Caused by: " + additionalContext)
+    );
   }
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -88,6 +88,7 @@ import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.serialization.Serde;
@@ -664,6 +665,35 @@ public class InsertValuesExecutorTest {
     // Then:
     assertThat(e.getCause(), (hasMessage(
         containsString("Authorization denied to Write on topic(s): [t1]"))));
+  }
+
+  @Test
+  public void shouldThrowOnClusterAuthorizationException() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        allAndPseudoColumnNames(SCHEMA),
+        ImmutableList.of(
+            new LongLiteral(1L),
+            new StringLiteral("str"),
+            new StringLiteral("str"),
+            new LongLiteral(2L))
+    );
+    doThrow(new ClusterAuthorizationException("Cluster authorization failed"))
+        .when(producer).send(any());
+
+    // When:
+    final Exception e = assertThrows(
+        KsqlException.class,
+        () -> executor.execute(statement, mock(SessionProperties.class), engine, serviceContext)
+    );
+
+    // Then:
+    assertThat(e.getCause(), (hasMessage(
+        containsString("Authorization denied to Write on topic(s): [" + TOPIC_NAME + "]. "
+            + "Caused by: The producer is not authorized to do idempotent sends. "
+            + "Check that you have write permissions to the specified topic, "
+            + "and disable idempotent sends by setting 'enable.idempotent=false' "
+            + " if necessary."))));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Backport https://github.com/confluentinc/ksql/pull/8927 to 7.0.x since the producer idempotency default behavior change goes back to 3.0.1 (see https://issues.apache.org/jira/browse/KAFKA-13598).

### Testing done 

Build.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

