### PR TITLE
chore: fix changelog link to 0.24.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.24.0](https://github.com/confluentinc/ksql/releases/tag/v0.24.0-ksqldb) (2022-02-11)
+## [0.24.0](https://github.com/confluentinc/ksql/releases/tag/v0.24.0) (2022-02-11)
 
 ### Features
 


### PR DESCRIPTION
### Description 

The tag linked in the changelog for v0.24.0 does not exist. This patch updates the link to the existing tag.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

