### PR TITLE
test: fix bad merge from 7.1.x

### DIFF
--- a/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -489,8 +489,8 @@ public class KsqlEngineTest {
 
     // Then:
     assertThat(queries, hasSize(2));
-    assertThat(queries.get(0).getStatementString(), containsString("create stream foo"));
-    assertThat(queries.get(1).getStatementString(), containsString("create stream bar"));
+    assertThat(queries.get(0).getStatementString(), containsString("CREATE STREAM FOO"));
+    assertThat(queries.get(1).getStatementString(), containsString("CREATE STREAM BAR"));
   }
 
   @Test(expected = KsqlStatementException.class)

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
@@ -110,7 +110,7 @@ public class TestExecutorUtilTest {
     );
     assertThat(
         asList.get(1).getPlan().getStatementText(),
-        startsWith("CREATE STREAM S1 as SELECT")
+        startsWith("CREATE STREAM S1 AS SELECT")
     );
   }
 

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -540,7 +540,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`F1` INTEGER KEY, `F2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`F1` INTEGER KEY, `F2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT AS SELECT\n TEST.F2 F2,\n TEST.F1 F1,\n (TEST.F2 + TEST.F1) KSQL_COL_0,\n COUNT(*) KSQL_COL_1\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`F1` INTEGER KEY, `F2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`F1` INTEGER KEY, `F2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT AS SELECT\n  TEST.F2 F2,\n  TEST.F1 F1,\n  (TEST.F2 + TEST.F1) KSQL_COL_0,\n  COUNT(*) KSQL_COL_1\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
       }
     },
     {
@@ -606,7 +606,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`KEY` DECIMAL(2, 1) KEY], features=[]}\nreason: The 'KAFKA' format does not support type 'DECIMAL'\nStatement: CREATE TABLE OUTPUT AS SELECT\n TEST.F2 KEY,\n COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F2\nEMIT CHANGES"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`KEY` DECIMAL(2, 1) KEY], features=[]}\nreason: The 'KAFKA' format does not support type 'DECIMAL'\nStatement: CREATE TABLE OUTPUT AS SELECT\n  TEST.F2 KEY,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F2\nEMIT CHANGES"
       }
     },
     {
@@ -688,7 +688,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`K1` INTEGER KEY, `K2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`K1` INTEGER KEY, `K2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT WITH (KEY_FORMAT='KAFKA') AS SELECT\n TEST.F1 K1,\n TEST.F2 K2,\n COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`K1` INTEGER KEY, `K2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`K1` INTEGER KEY, `K2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT WITH (KEY_FORMAT='KAFKA') AS SELECT\n  TEST.F1 K1,\n  TEST.F2 K2,\n  COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -540,7 +540,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`F1` INTEGER KEY, `F2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`F1` INTEGER KEY, `F2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT AS SELECT f2, f1, f2+f1, COUNT(*) FROM TEST GROUP BY f1, f2;"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`F1` INTEGER KEY, `F2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`F1` INTEGER KEY, `F2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT AS SELECT\n TEST.F2 F2,\n TEST.F1 F1,\n (TEST.F2 + TEST.F1) KSQL_COL_0,\n COUNT(*) KSQL_COL_1\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
       }
     },
     {
@@ -606,7 +606,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`KEY` DECIMAL(2, 1) KEY], features=[]}\nreason: The 'KAFKA' format does not support type 'DECIMAL'\nStatement: CREATE TABLE OUTPUT AS SELECT f2 AS key, COUNT(*) AS total FROM TEST GROUP BY f2;"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`KEY` DECIMAL(2, 1) KEY], features=[]}\nreason: The 'KAFKA' format does not support type 'DECIMAL'\nStatement: CREATE TABLE OUTPUT AS SELECT\n TEST.F2 KEY,\n COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F2\nEMIT CHANGES"
       }
     },
     {
@@ -688,7 +688,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`K1` INTEGER KEY, `K2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`K1` INTEGER KEY, `K2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT WITH (KEY_FORMAT='KAFKA') AS SELECT f1 AS k1, f2 AS k2, COUNT(*) AS total FROM TEST GROUP BY f1, f2;"
+        "message": "Key format does not support schema.\nformat: KAFKA\nschema: Persistence{columns=[`K1` INTEGER KEY, `K2` INTEGER KEY], features=[]}\nreason: The 'KAFKA' format only supports a single field. Got: [`K1` INTEGER KEY, `K2` INTEGER KEY]\nStatement: CREATE TABLE OUTPUT WITH (KEY_FORMAT='KAFKA') AS SELECT\n TEST.F1 K1,\n TEST.F2 K2,\n COUNT(*) TOTAL\nFROM TEST TEST\nGROUP BY TEST.F1, TEST.F2\nEMIT CHANGES"
       }
     },
     {


### PR DESCRIPTION
### Description 

The build's got a few test failures at the moment because of [this bad merge](https://github.com/confluentinc/ksql/commit/20b75ea451468d7f80f905d46e5698a3979160a2) from 7.1.x last night. This PR fixes the bad merge so tests should be green again afterwards.

### Testing done 

Build.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

