### PR TITLE
docs: update release version for custom migrations headers (MINOR)

### DIFF
--- a/docs/reference/migrations-tool-configuration.md
+++ b/docs/reference/migrations-tool-configuration.md
@@ -126,4 +126,4 @@ Specifically, the migrations directory is inferred as a directory with name
 `migrations` contained in the same directory as the migrations configuration file. 
 This is the default file structure created by the `ksql-migrations new-project` command.
 
-This configuration is available starting with ksqlDB 0.26.0.
+This configuration is available starting with ksqlDB 0.25.0.


### PR DESCRIPTION
### Description 

The PR that introduced this feature missed the original, intended 0.25 release cut so the docs said 0.26, but now that the release cut has been pushed back, the feature is actually in 0.25. This PR updates the docs accordingly.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

