### PR TITLE
docs: add note to deprecated TIMESTAMPTOSTRING for param workaround (DOCS-13327)

### DIFF
--- a/docs/developer-guide/ksqldb-reference/scalar-functions.md
+++ b/docs/developer-guide/ksqldb-reference/scalar-functions.md
@@ -2036,7 +2036,7 @@ more information on timestamp formats, see
 
 Since: 0.7.1
 
-**Deprecated since 0.17.0 (use FORMAT_TIMESTAMP)**
+**Deprecated since 0.17.0 (use [FORMAT_TIMESTAMP](#format_timestamp))**
 
 ```sql
 TIMESTAMPTOSTRING(ROWTIME, 'yyyy-MM-dd HH:mm:ss.SSS' [, TIMEZONE])
@@ -2050,3 +2050,12 @@ can be escaped with two successive single quotes, `''`, for example:
 TIMEZONE is an optional parameter, and it is a `java.util.TimeZone` ID format,
 for example, "UTC", "America/Los_Angeles", "PDT", or "Europe/London". For more
 information on timestamp formats, see [DateTimeFormatter](https://cnfl.io/java-dtf).
+
+!!! note
+    To use the [`FORMAT_TIMESTAMP`](#format_timestamp) function with a BIGINT millisecond timestamp
+    parameter, convert the millisecond value to a `TIMESTAMP` by using the
+    `FROM_UNIXTIME` function, for example:
+
+    ```sql
+    FORMAT_TIMESTAMP(FROM_UNIXTIME(unix_timestamp))
+    ```


### PR DESCRIPTION
Fixes #8957.

![image](https://user-images.githubusercontent.com/12521043/161830321-4ce4291d-30c8-4b9a-b448-dfd0a663af1a.png)
