### PR TITLE
chore: resolve configs before checking if they are query level

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import io.confluent.ksql.config.ConfigItem;
+import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.config.SessionConfig;
 import io.confluent.ksql.engine.QueryEventListener;
 import io.confluent.ksql.execution.plan.ExecutionStep;
@@ -323,7 +325,12 @@ public class QueryRegistryImpl implements QueryRegistry {
 
   private static void throwOnNonQueryLevelConfigs(final Map<String, Object> overriddenProperties) {
     final String nonQueryLevelConfigs = overriddenProperties.keySet().stream()
-        .filter(s -> !PropertiesList.QueryLevelPropertyList.contains(s))
+        .filter(s -> {
+          final KsqlConfigResolver resolver = new KsqlConfigResolver();
+          final Optional<ConfigItem> resolvedItem = resolver.resolve(s, false);
+          return resolvedItem.map(configItem ->
+              !PropertiesList.QueryLevelPropertyList.contains(configItem)).orElse(true);
+        })
         .distinct()
         .collect(Collectors.joining(","));
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -329,7 +329,7 @@ public class QueryRegistryImpl implements QueryRegistry {
           final KsqlConfigResolver resolver = new KsqlConfigResolver();
           final Optional<ConfigItem> resolvedItem = resolver.resolve(s, false);
           return resolvedItem.map(configItem ->
-              !PropertiesList.QueryLevelPropertyList.contains(configItem)).orElse(true);
+              !PropertiesList.QueryLevelPropertyList.contains(configItem.getPropertyName())).orElse(true);
         })
         .distinct()
         .collect(Collectors.joining(","));

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -329,7 +329,8 @@ public class QueryRegistryImpl implements QueryRegistry {
           final KsqlConfigResolver resolver = new KsqlConfigResolver();
           final Optional<ConfigItem> resolvedItem = resolver.resolve(s, false);
           return resolvedItem.map(configItem ->
-              !PropertiesList.QueryLevelPropertyList.contains(configItem.getPropertyName())).orElse(true);
+              !PropertiesList.QueryLevelPropertyList
+                  .contains(configItem.getPropertyName())).orElse(true);
         })
         .distinct()
         .collect(Collectors.joining(","));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -281,7 +281,6 @@ public class QueryRegistryImplTest {
       assertThat(e.getMessage(), containsString("commit.interval.ms"));
     }
     givenCreate(registry, "q1", "source", Optional.of("sink1"), CREATE_AS);
-
   }
 
   @Test

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -256,7 +256,7 @@ public class KsqlResource implements KsqlConfigurable {
       final Optional<ConfigItem> resolvedItem = resolver.resolve(property, false);
       if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
           && resolvedItem.isPresent()) {
-        if (!PropertiesList.QueryLevelPropertyList.contains(resolvedItem.get())) {
+        if (!PropertiesList.QueryLevelPropertyList.contains(resolvedItem.get().getPropertyName())) {
           throw new KsqlException(String.format("When shared runtimes are enabled, the"
               + " config %s can only be set for the entire cluster and all queries currently"
               + " running in it, and not configurable for individual queries."

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -19,6 +19,8 @@ import static java.util.regex.Pattern.compile;
 
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.config.ConfigItem;
+import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.logging.query.QueryLogger;
 import io.confluent.ksql.parser.DefaultKsqlParser;
@@ -250,8 +252,11 @@ public class KsqlResource implements KsqlConfigurable {
       final Map<String, Object> properties = new HashMap<>();
       properties.put(property, "");
       denyListPropertyValidator.validateAll(properties);
-      if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {
-        if (!PropertiesList.QueryLevelPropertyList.contains(property)) {
+      final KsqlConfigResolver resolver = new KsqlConfigResolver();
+      final Optional<ConfigItem> resolvedItem = resolver.resolve(property, false);
+      if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
+          && resolvedItem.isPresent()) {
+        if (!PropertiesList.QueryLevelPropertyList.contains(resolvedItem.get())) {
           throw new KsqlException(String.format("When shared runtimes are enabled, the"
               + " config %s can only be set for the entire cluster and all queries currently"
               + " running in it, and not configurable for individual queries."

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2554,6 +2554,21 @@ public class KsqlResourceTest {
   }
 
   @Test
+  public void shouldNotBadRequestWhenIsValidatorIsCalledWithNonQueryLevelProps() {
+    final Map<String, Object> properties = new HashMap<>();
+    properties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "");
+    givenKsqlConfigWith(ImmutableMap.of(
+        KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED, true
+    ));
+
+    // When:
+    final EndpointResponse response = ksqlResource.isValidProperty("ksql.streams.auto.offset.reset");
+
+    // Then:
+    assertThat(response.getStatus(), equalTo(200));
+  }
+
+  @Test
   public void shouldThrowOnDenyListValidatorWhenTerminateCluster() {
     final Map<String, Object> terminateStreamProperties =
         ImmutableMap.of(DELETE_TOPIC_LIST_PROP, Collections.singletonList("Foo"));


### PR DESCRIPTION
### Description 
resolve the configs before checking if they are at the query level. This way we can have the ksql.streams prefix for streams configs
### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

