### PR TITLE
feat: allow aggregations without group bys

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -32,7 +32,6 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.PartitionBy;
-import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.parser.tree.WithinExpression;
@@ -78,16 +77,13 @@ public class Analysis implements ImmutableAnalysis {
   private boolean orReplace = false;
   private final boolean rowpartitionRowoffsetEnabled;
   private boolean pullLimitClauseEnabled = true;
-  private Query query;
 
   public Analysis(
       final Optional<RefinementInfo> refinementInfo,
       final boolean rowpartitionRowoffsetEnabled,
-      final boolean pullLimitClauseEnabled,
-      final Query query
+      final boolean pullLimitClauseEnabled
   ) {
-    this(refinementInfo, SourceSchemas::new, rowpartitionRowoffsetEnabled, pullLimitClauseEnabled,
-        query);
+    this(refinementInfo, SourceSchemas::new, rowpartitionRowoffsetEnabled, pullLimitClauseEnabled);
   }
 
   @VisibleForTesting
@@ -96,14 +92,12 @@ public class Analysis implements ImmutableAnalysis {
       final BiFunction<Map<SourceName, LogicalSchema>, Boolean, SourceSchemas>
           sourceSchemasFactory,
       final boolean rowpartitionRowoffsetEnabled,
-      final boolean pullLimitClauseEnabled,
-      final Query query
+      final boolean pullLimitClauseEnabled
   ) {
     this.refinementInfo = requireNonNull(refinementInfo, "refinementInfo");
     this.sourceSchemasFactory = requireNonNull(sourceSchemasFactory, "sourceSchemasFactory");
     this.rowpartitionRowoffsetEnabled = rowpartitionRowoffsetEnabled;
     this.pullLimitClauseEnabled  = pullLimitClauseEnabled;
-    this.query = query;
   }
 
   void addSelectItem(final SelectItem selectItem) {
@@ -295,10 +289,6 @@ public class Analysis implements ImmutableAnalysis {
 
   public boolean getPullLimitClauseEnabled() {
     return pullLimitClauseEnabled;
-  }
-
-  public Query getQuery() {
-    return  query;
   }
 
   private LogicalSchema buildStreamsSchema(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -159,8 +159,7 @@ class Analyzer {
       this.analysis = new Analysis(
               query.getRefinement(),
               rowpartitionRowoffsetEnabled,
-              pullLimitClauseEnabled,
-              query
+              pullLimitClauseEnabled
           );
 
       this.persistent = persistent;
@@ -673,11 +672,8 @@ class Analyzer {
           final FunctionName functionName = functionCall.getName();
           if (metaStore.isAggregate(functionName)) {
             analysis.addAggregateFunction(functionCall);
-            // Do we need the correct location here?
-            final NodeLocation nodeLocation =
-                new NodeLocation(analysis.getQuery().getLocation().get().getLineNumber(),
-                analysis.getQuery().getLocation().get().getColumnNumber()
-                    + " GROUP BY 1".length());
+            // Since this is a dummy group by, we don't actually need a correct node location
+            final NodeLocation nodeLocation = new NodeLocation(0,0);
             analysis.setGroupBy(new GroupBy(Optional.of(nodeLocation),
                 ImmutableList.of(new IntegerLiteral(1))));
           }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -673,8 +673,8 @@ class Analyzer {
           final FunctionName functionName = functionCall.getName();
           if (metaStore.isAggregate(functionName)) {
             analysis.addAggregateFunction(functionCall);
-//             Do we need the correct location here?
-            NodeLocation nodeLocation =
+            // Do we need the correct location here?
+            final NodeLocation nodeLocation =
                 new NodeLocation(analysis.getQuery().getLocation().get().getLineNumber(),
                 analysis.getQuery().getLocation().get().getColumnNumber()
                     + " GROUP BY 1".length());

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
@@ -39,6 +39,8 @@ public interface ImmutableAnalysis {
 
   List<FunctionCall> getTableFunctions();
 
+  List<FunctionCall> getAggregateFunctions ();
+
   List<SelectItem> getSelectItems();
 
   Optional<Expression> getWhereExpression();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/ImmutableAnalysis.java
@@ -39,7 +39,7 @@ public interface ImmutableAnalysis {
 
   List<FunctionCall> getTableFunctions();
 
-  List<FunctionCall> getAggregateFunctions ();
+  List<FunctionCall> getAggregateFunctions();
 
   List<SelectItem> getSelectItems();
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/analyzer/RewrittenAnalysis.java
@@ -82,6 +82,11 @@ public class RewrittenAnalysis implements ImmutableAnalysis {
   }
 
   @Override
+  public List<FunctionCall> getAggregateFunctions() {
+    return rewriteList(original.getAggregateFunctions());
+  }
+
+  @Override
   public List<SelectItem> getSelectItems() {
     return original.getSelectItems().stream()
         .map(si -> {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -153,7 +153,7 @@ public class LogicalPlanner {
       currentNode = buildFlatMapNode(currentNode);
     }
 
-    if (analysis.getGroupBy().isPresent()) {
+    if (analysis.getGroupBy().isPresent() || !analysis.getAggregateFunctions().isEmpty()) {
       currentNode = buildAggregateNode(currentNode);
     } else {
       if (analysis.getWindowExpression().isPresent()) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
@@ -71,7 +71,7 @@ public class AnalysisTest {
 
   @Before
   public void setUp() {
-    analysis = new Analysis(Optional.of(refinementInfo), sourceSchemasFactory, ROWPARTITION_ROWOFFSET_ENABLED, true);
+    analysis = new Analysis(Optional.of(refinementInfo), sourceSchemasFactory, ROWPARTITION_ROWOFFSET_ENABLED, true, null);
 
     when(dataSource.getSchema()).thenReturn(SOURCE_SCHEMA);
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/analyzer/AnalysisTest.java
@@ -71,7 +71,7 @@ public class AnalysisTest {
 
   @Before
   public void setUp() {
-    analysis = new Analysis(Optional.of(refinementInfo), sourceSchemasFactory, ROWPARTITION_ROWOFFSET_ENABLED, true, null);
+    analysis = new Analysis(Optional.of(refinementInfo), sourceSchemasFactory, ROWPARTITION_ROWOFFSET_ENABLED, true);
 
     when(dataSource.getSchema()).thenReturn(SOURCE_SCHEMA);
   }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/count.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/count.json
@@ -19,7 +19,8 @@
         {"topic": "S2", "key": 0,"value": "2"},
         {"topic": "S2", "key": 100,"value": "1"}
       ]
-    },{
+    },
+    {
       "name": "count star",
       "statements": [
         "CREATE STREAM INPUT (ID STRING KEY, ignored STRING) WITH (kafka_topic='input_topic', value_format='DELIMITED');",

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -937,6 +937,17 @@
       }
     },
     {
+      "name": "create table as select COUNT(*) with no group by",
+      "statements": [
+        "CREATE STREAM TEST (id INT KEY, id2 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "CREATE TABLE AS SELECT statement does not support aggregate function [COUNT(ROWTIME)] without a GROUP BY clause."
+      }
+    },
+    {
       "name": "with key alias that clashes with value alias",
       "statements": [
         "CREATE STREAM TEST (ID INT KEY, data STRING) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -2306,7 +2317,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Use of aggregate function COUNT requires a GROUP BY clause"
+        "message": "Could not determine output schema for query due to error: Non-aggregate SELECT expression(s) not part of GROUP BY: D1\nEither add the column(s) to the GROUP BY or remove them from the SELECT."
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -2317,7 +2317,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Could not determine output schema for query due to error: Non-aggregate SELECT expression(s) not part of GROUP BY: D1\nEither add the column(s) to the GROUP BY or remove them from the SELECT."
+        "message": "Non-aggregate SELECT expression(s) not part of GROUP BY: D1"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/suppress.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/suppress.json
@@ -384,7 +384,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlException",
-        "message": "Use of aggregate function COUNT requires a GROUP BY clause."
+        "message": "Non-aggregate SELECT expression(s) not part of GROUP BY"
       }
     },
     {

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -674,6 +674,26 @@
       ]
     },
     {
+      "name": "multiple aggregates without GROUP BY expression",
+      "statements": [
+        "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT sum(ID),count(*) AS count FROM test EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"id": 2}, "timestamp": 10345},
+        {"topic": "test_topic", "key": 1, "value": {"id": 2}, "timestamp": 13251}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`KSQL_COL_0` INTEGER, `COUNT` BIGINT"}},
+          {"row":{"columns":[2, 1]}},
+          {"row":{"columns":[4, 2]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
       "name": "aggregate with no value columns",
       "statements": [
         "CREATE STREAM TEST (K INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -677,7 +677,7 @@
       "name": "multiple aggregates without GROUP BY expression",
       "statements": [
         "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT sum(ID),count(*) AS count FROM test EMIT CHANGES LIMIT 2;"
+        "SELECT sum(ID),count(*) AS sum, count FROM test EMIT CHANGES LIMIT 2;"
       ],
       "inputs": [
         {"topic": "test_topic", "key": 0, "value": {"id": 2}, "timestamp": 10345},
@@ -686,7 +686,7 @@
       "responses": [
         {"admin": {"@type": "currentStatus"}},
         {"query": [
-          {"header":{"schema":"`KSQL_COL_0` INTEGER, `COUNT` BIGINT"}},
+          {"header":{"schema":"`SUM` INTEGER, `COUNT` BIGINT"}},
           {"row":{"columns":[2, 1]}},
           {"row":{"columns":[4, 2]}},
           {"finalMessage":"Limit Reached"}

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -677,7 +677,7 @@
       "name": "multiple aggregates without GROUP BY expression",
       "statements": [
         "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "SELECT sum(ID),count(*) AS sum, count FROM test EMIT CHANGES LIMIT 2;"
+        "SELECT sum(ID) AS sum, count(*) AS count FROM test EMIT CHANGES LIMIT 2;"
       ],
       "inputs": [
         {"topic": "test_topic", "key": 0, "value": {"id": 2}, "timestamp": 10345},

--- a/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
+++ b/ksqldb-functional-tests/src/test/resources/rest-query-validation-tests/push-queries.json
@@ -654,6 +654,26 @@
       ]
     },
     {
+      "name": "aggregate without GROUP BY expression",
+      "statements": [
+        "CREATE STREAM TEST (K INT KEY, ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "SELECT count(*) AS count FROM test EMIT CHANGES LIMIT 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"id": 2}, "timestamp": 10345},
+        {"topic": "test_topic", "key": 1, "value": {"id": 2}, "timestamp": 13251}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`COUNT` BIGINT"}},
+          {"row":{"columns":[1]}},
+          {"row":{"columns":[2]}},
+          {"finalMessage":"Limit Reached"}
+        ]}
+      ]
+    },
+    {
       "name": "aggregate with no value columns",
       "statements": [
         "CREATE STREAM TEST (K INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",


### PR DESCRIPTION
### Description 
Helps to partially fix #430 by allowing users to create aggregations without group by clauses in push queries .

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

