### PR TITLE
fix: move create connector validation to validate phase

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
@@ -17,11 +17,8 @@ package io.confluent.ksql.services;
 
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
 
-import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.util.LimitedProxyBuilder;
 import java.util.Map;
-import org.apache.hc.core5.http.HttpStatus;
 
 /**
  * Supplies {@link ConnectClient}s to use that do not make any
@@ -36,8 +33,6 @@ final class SandboxConnectClient {
   public static ConnectClient createProxy(final ConnectClient delegate) {
     return LimitedProxyBuilder.forClass(ConnectClient.class)
         .forward("validate", methodParams(String.class, Map.class), delegate)
-        .swallow("connectors", methodParams(),
-            ConnectResponse.success(ImmutableList.of(), HttpStatus.SC_OK))
         .build();
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
@@ -18,10 +18,13 @@ package io.confluent.ksql.services;
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.util.LimitedProxyBuilder;
 import java.util.Map;
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 
 /**
  * Supplies {@link ConnectClient}s to use that do not make any
@@ -33,18 +36,16 @@ final class SandboxConnectClient {
 
   }
 
-  public static ConnectClient createProxy() {
+  public static ConnectClient createProxy(final ConnectClient delegate) {
     return LimitedProxyBuilder.forClass(ConnectClient.class)
-        .swallow("create", methodParams(String.class, Map.class),
-            ConnectResponse.failure("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
-        .swallow("describe", methodParams(String.class),
-            ConnectResponse.failure("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
+        .forward("validate", methodParams(String.class, Map.class), delegate)
         .swallow("connectors", methodParams(),
             ConnectResponse.success(ImmutableList.of(), HttpStatus.SC_OK))
-        .swallow("status", methodParams(String.class),
-            ConnectResponse.failure("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
-        .swallow("delete", methodParams(String.class),
-            ConnectResponse.success("sandbox", HttpStatus.SC_NO_CONTENT))
+        .swallow("create", methodParams(String.class, Map.class),
+            ConnectResponse.success(
+                new ConnectorInfo(
+                    "dummy", ImmutableMap.of(), ImmutableList.of(), ConnectorType.UNKNOWN),
+                HttpStatus.SC_OK))
         .build();
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
@@ -18,13 +18,10 @@ package io.confluent.ksql.services;
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.util.LimitedProxyBuilder;
 import java.util.Map;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 
 /**
  * Supplies {@link ConnectClient}s to use that do not make any
@@ -41,11 +38,6 @@ final class SandboxConnectClient {
         .forward("validate", methodParams(String.class, Map.class), delegate)
         .swallow("connectors", methodParams(),
             ConnectResponse.success(ImmutableList.of(), HttpStatus.SC_OK))
-        .swallow("create", methodParams(String.class, Map.class),
-            ConnectResponse.success(
-                new ConnectorInfo(
-                    "dummy", ImmutableMap.of(), ImmutableList.of(), ConnectorType.UNKNOWN),
-                HttpStatus.SC_OK))
         .build();
   }
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
@@ -34,7 +34,7 @@ public final class SandboxedServiceContext implements ServiceContext {
   private final KafkaTopicClient topicClient;
   private final SchemaRegistryClient srClient;
   private final KafkaClientSupplier kafkaClientSupplier;
-  private final ConnectClient connectClient;
+  private final Supplier<ConnectClient> connectClientSupplier;
   private final KafkaConsumerGroupClient consumerGroupClient;
 
   public static SandboxedServiceContext create(final ServiceContext serviceContext) {
@@ -47,8 +47,8 @@ public final class SandboxedServiceContext implements ServiceContext {
         .createProxy(serviceContext.getTopicClient(), serviceContext::getAdminClient);
     final SchemaRegistryClient schemaRegistryClient =
         SandboxedSchemaRegistryClient.createProxy(serviceContext.getSchemaRegistryClient());
-    final ConnectClient connectClient =
-        SandboxConnectClient.createProxy(serviceContext.getConnectClient()); // TODO: does this load custom configs?
+    final Supplier<ConnectClient> connectClientSupplier =
+        () -> SandboxConnectClient.createProxy(serviceContext.getConnectClient());
     final KafkaConsumerGroupClient kafkaConsumerGroupClient = SandboxedKafkaConsumerGroupClient
         .createProxy(serviceContext.getConsumerGroupClient());
 
@@ -56,7 +56,7 @@ public final class SandboxedServiceContext implements ServiceContext {
         kafkaClientSupplier,
         kafkaTopicClient,
         schemaRegistryClient,
-        connectClient,
+        connectClientSupplier,
         kafkaConsumerGroupClient);
   }
 
@@ -64,13 +64,14 @@ public final class SandboxedServiceContext implements ServiceContext {
       final KafkaClientSupplier kafkaClientSupplier,
       final KafkaTopicClient topicClient,
       final SchemaRegistryClient srClient,
-      final ConnectClient connectClient,
+      final Supplier<ConnectClient> connectClientSupplier,
       final KafkaConsumerGroupClient consumerGroupClient
   ) {
     this.kafkaClientSupplier = Objects.requireNonNull(kafkaClientSupplier, "kafkaClientSupplier");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient");
     this.srClient = Objects.requireNonNull(srClient, "srClient");
-    this.connectClient = Objects.requireNonNull(connectClient, "connectClient");
+    this.connectClientSupplier =
+        Objects.requireNonNull(connectClientSupplier, "connectClientSupplier");
     this.consumerGroupClient = Objects.requireNonNull(consumerGroupClient, "consumerGroupClient");
   }
 
@@ -102,9 +103,8 @@ public final class SandboxedServiceContext implements ServiceContext {
   }
 
   @Override
-  @SuppressFBWarnings(value = "EI_EXPOSE_REP")
   public ConnectClient getConnectClient() {
-    return connectClient;
+    return connectClientSupplier.get();
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
@@ -47,7 +47,8 @@ public final class SandboxedServiceContext implements ServiceContext {
         .createProxy(serviceContext.getTopicClient(), serviceContext::getAdminClient);
     final SchemaRegistryClient schemaRegistryClient =
         SandboxedSchemaRegistryClient.createProxy(serviceContext.getSchemaRegistryClient());
-    final ConnectClient connectClient = SandboxConnectClient.createProxy();
+    final ConnectClient connectClient =
+        SandboxConnectClient.createProxy(serviceContext.getConnectClient()); // TODO: does this load custom configs?
     final KafkaConsumerGroupClient kafkaConsumerGroupClient = SandboxedKafkaConsumerGroupClient
         .createProxy(serviceContext.getConsumerGroupClient());
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxConnectClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxConnectClientTest.java
@@ -26,8 +26,6 @@ import io.confluent.ksql.test.util.OptionalMatchers;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
-import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,18 +45,6 @@ public class SandboxConnectClientTest {
   @Before
   public void setUp() {
     sandboxClient = SandboxConnectClient.createProxy(delegate);
-  }
-
-  @Test
-  public void shouldReturnStubSuccessOnCreate() {
-    // When:
-    final ConnectResponse<ConnectorInfo> createResponse =
-        sandboxClient.create("foo", ImmutableMap.of());
-
-    // Then:
-    assertThat(createResponse.datum(), OptionalMatchers.of(is(
-        new ConnectorInfo("dummy", ImmutableMap.of(), ImmutableList.of(), ConnectorType.UNKNOWN))));
-    assertThat("expected no error", !createResponse.error().isPresent());
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxConnectClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxConnectClientTest.java
@@ -19,11 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
-import io.confluent.ksql.test.util.OptionalMatchers;
-import java.util.List;
 import java.util.Map;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.junit.Before;
@@ -45,16 +42,6 @@ public class SandboxConnectClientTest {
   @Before
   public void setUp() {
     sandboxClient = SandboxConnectClient.createProxy(delegate);
-  }
-
-  @Test
-  public void shouldReturnEmptyListOnList() {
-    // When:
-    final ConnectResponse<List<String>> listResponse = sandboxClient.connectors();
-
-    // Then:
-    assertThat(listResponse.datum(), OptionalMatchers.of(is(ImmutableList.of())));
-    assertThat("expected no error", !listResponse.error().isPresent());
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedServiceContextTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxedServiceContextTest.java
@@ -19,6 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -104,6 +106,8 @@ public final class SandboxedServiceContextTest {
     @Mock
     private SchemaRegistryClient delegateSrClient;
     @Mock
+    private ConnectClient delegateConnectClient;
+    @Mock
     private KafkaConsumerGroupClient delegateConsumerGroupClient;
     private SandboxedServiceContext sandboxedServiceContext;
 
@@ -112,6 +116,7 @@ public final class SandboxedServiceContextTest {
       when(delegate.getTopicClient()).thenReturn(delegateTopicClient);
       when(delegate.getSchemaRegistryClient()).thenReturn(delegateSrClient);
       when(delegate.getConsumerGroupClient()).thenReturn(delegateConsumerGroupClient);
+      when(delegate.getConnectClient()).thenReturn(delegateConnectClient);
 
       sandboxedServiceContext = SandboxedServiceContext.create(delegate);
     }
@@ -178,6 +183,18 @@ public final class SandboxedServiceContextTest {
 
       // Then:
       assertThat("Expected proxy class", Proxy.isProxyClass(client.getClass()));
+    }
+
+    @Test
+    public void shouldNotCreateConnectDelegateUnlessCalled() {
+      // Then: no delegate connect client called on create()
+      verify(delegate, never()).getConnectClient();
+
+      // When:
+      sandboxedServiceContext.getConnectClient();
+
+      // Then: now the delegate connect client should have been called
+      verify(delegate, times(1)).getConnectClient();
     }
 
     @Test

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server.execution;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.connect.supported.Connectors;
@@ -41,8 +42,12 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 
 public final class ConnectExecutor {
+
+  private static final ConnectorInfo DUMMY_CREATE_RESPONSE =
+      new ConnectorInfo("dummy", ImmutableMap.of(), ImmutableList.of(), ConnectorType.UNKNOWN);
 
   private ConnectExecutor() {
   }
@@ -60,12 +65,6 @@ public final class ConnectExecutor {
         statement, createConnector, client);
     if (connectorsResponse.isPresent()) {
       return StatementExecutorResponse.handled(connectorsResponse);
-    }
-
-    final List<String> errors = validate(createConnector, client);
-    if (!errors.isEmpty()) {
-      final String errorMessage = "Validation error: " + String.join("\n", errors);
-      throw new KsqlException(errorMessage);
     }
 
     final ConnectResponse<ConnectorInfo> response = client.create(
@@ -91,6 +90,33 @@ public final class ConnectExecutor {
     }
 
     throw new IllegalStateException("Either response.datum() or response.error() must be present");
+  }
+
+  public static StatementExecutorResponse validate(
+      final ConfiguredStatement<CreateConnector> statement,
+      final SessionProperties sessionProperties,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext
+  ) {
+    final CreateConnector createConnector = statement.getStatement();
+    final ConnectClient client = serviceContext.getConnectClient();
+
+    final Optional<KsqlEntity> connectorsResponse = handleIfNotExists(
+        statement, createConnector, client);
+    if (connectorsResponse.isPresent()) {
+      return StatementExecutorResponse.handled(connectorsResponse);
+    }
+
+    final List<String> errors = validate(createConnector, client);
+    if (!errors.isEmpty()) {
+      final String errorMessage = "Validation error: " + String.join("\n", errors);
+      throw new KsqlException(errorMessage);
+    }
+
+    return StatementExecutorResponse.handled(Optional.of(new CreateConnectorEntity(
+        statement.getStatementText(),
+        DUMMY_CREATE_RESPONSE
+    )));
   }
 
   private static List<String> validate(final CreateConnector createConnector,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -101,12 +101,6 @@ public final class ConnectExecutor {
     final CreateConnector createConnector = statement.getStatement();
     final ConnectClient client = serviceContext.getConnectClient();
 
-    final Optional<KsqlEntity> connectorsResponse = handleIfNotExists(
-        statement, createConnector, client);
-    if (connectorsResponse.isPresent()) {
-      return StatementExecutorResponse.handled(connectorsResponse);
-    }
-
     final List<String> errors = validate(createConnector, client);
     if (!errors.isEmpty()) {
       final String errorMessage = "Validation error: " + String.join("\n", errors);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -56,16 +56,16 @@ public final class ConnectExecutor {
     final CreateConnector createConnector = statement.getStatement();
     final ConnectClient client = serviceContext.getConnectClient();
 
-    final List<String> errors = validate(createConnector, client);
-    if (!errors.isEmpty()) {
-      final String errorMessage = "Validation error: " + String.join("\n", errors);
-      throw new KsqlException(errorMessage);
-    }
-
     final Optional<KsqlEntity> connectorsResponse = handleIfNotExists(
         statement, createConnector, client);
     if (connectorsResponse.isPresent()) {
       return StatementExecutorResponse.handled(connectorsResponse);
+    }
+
+    final List<String> errors = validate(createConnector, client);
+    if (!errors.isEmpty()) {
+      final String errorMessage = "Validation error: " + String.join("\n", errors);
+      throw new KsqlException(errorMessage);
     }
 
     final ConnectResponse<ConnectorInfo> response = client.create(

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -91,7 +91,7 @@ public enum CustomValidators {
   LIST_CONNECTORS(ListConnectors.class, StatementValidator.NO_VALIDATION),
   LIST_CONNECTOR_PLUGINS(ListConnectorPlugins.class, StatementValidator.NO_VALIDATION),
   LIST_TYPES(ListTypes.class, StatementValidator.NO_VALIDATION),
-  CREATE_CONNECTOR(CreateConnector.class, ConnectExecutor::execute),
+  CREATE_CONNECTOR(CreateConnector.class, ConnectExecutor::validate),
   DROP_CONNECTOR(DropConnector.class, StatementValidator.NO_VALIDATION),
   LIST_VARIABLES(ListVariables.class, ListVariablesExecutor::execute),
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.parser.tree.UndefineVariable;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.SessionProperties;
+import io.confluent.ksql.rest.server.execution.ConnectExecutor;
 import io.confluent.ksql.rest.server.execution.DescribeFunctionExecutor;
 import io.confluent.ksql.rest.server.execution.ExplainExecutor;
 import io.confluent.ksql.rest.server.execution.InsertValuesExecutor;
@@ -90,7 +91,7 @@ public enum CustomValidators {
   LIST_CONNECTORS(ListConnectors.class, StatementValidator.NO_VALIDATION),
   LIST_CONNECTOR_PLUGINS(ListConnectorPlugins.class, StatementValidator.NO_VALIDATION),
   LIST_TYPES(ListTypes.class, StatementValidator.NO_VALIDATION),
-  CREATE_CONNECTOR(CreateConnector.class, StatementValidator.NO_VALIDATION),
+  CREATE_CONNECTOR(CreateConnector.class, ConnectExecutor::execute),
   DROP_CONNECTOR(DropConnector.class, StatementValidator.NO_VALIDATION),
   LIST_VARIABLES(ListVariables.class, ListVariablesExecutor::execute),
 


### PR DESCRIPTION
### Description 

This PR is stacked on https://github.com/confluentinc/ksql/pull/8998. Only commits starting with `chore: move create connector validation to validate phase` need to be reviewed.

Currently, a `CREATE CONNECTOR` request has three steps performed during the execution phase, and no validation. The execution steps are, in order:
1. use the Connect client to validate configs
2. check for existing connectors, if `IF NOT EXISTS` is present in the statement
3. use the Connect client to create the connector

The fact that there's no ksql validation for `CREATE CONNECTOR` statements (validation is only performed during execution) isn't great because it means that, in the case where a `CREATE CONNECTOR` statement is issued along with other ksql statements in the same request, the entire group of statements may pass validation and ksql will begin to execute them in order, only to fail when executing `CREATE CONNECTOR`. Instead, it's preferable to validate configs with Connect during ksql engine's validate phase to fail fast.

With the changes in this PR, the new order is the following steps during the validate phase:
1. use the Connect client to validate configs

And then the following two steps during the execute phase:
1. check for existing connectors, if `IF NOT EXISTS` is present in the statement
2. use the Connect client to create the connector

Side note: ideally the `IF NOT EXISTS` handling would happen before the config validation so that we wouldn't require valid configs if the entire `CREATE CONNECTOR` statement is going to be a no-op anyway but doing so means we'd have to add the check to list connectors into the validate phase, which means it'd be repeated during the execute phase. I don't think this minor improvement is worth the additional request to Connect, so I've left it out.

### Testing done 

Unit + integration + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

