### PR TITLE
docs: cherry-pick: pin jinja2 version to 3.0.3 to fix docs build break (DOCS-13425)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+jinja2==3.0.3
 mdx_gh_links==0.2
 mdx_truly_sane_lists==1.2
 mkdocs==1.2.3


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/8945.