### PR TITLE
fix: fail validation on create connector if connector already exists

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.services;
 
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
+import static io.confluent.ksql.util.LimitedProxyBuilder.noParams;
 
 import io.confluent.ksql.util.LimitedProxyBuilder;
 import java.util.Map;
@@ -33,6 +34,7 @@ final class SandboxConnectClient {
   public static ConnectClient createProxy(final ConnectClient delegate) {
     return LimitedProxyBuilder.forClass(ConnectClient.class)
         .forward("validate", methodParams(String.class, Map.class), delegate)
+        .forward("connectors", noParams(), delegate)
         .build();
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxConnectClientTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/SandboxConnectClientTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import java.util.List;
 import java.util.Map;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.junit.Before;
@@ -36,6 +37,8 @@ public class SandboxConnectClientTest {
   private ConnectClient delegate;
   @Mock
   private ConnectResponse<ConfigInfos> mockValidateResponse;
+  @Mock
+  private ConnectResponse<List<String>> mockListResponse;
 
   private ConnectClient sandboxClient;
 
@@ -55,6 +58,18 @@ public class SandboxConnectClientTest {
 
     // Then:
     assertThat(validateResponse, is(mockValidateResponse));
+  }
+
+  @Test
+  public void shouldForwardOnList() {
+    // Given:
+    when(delegate.connectors()).thenReturn(mockListResponse);
+
+    // When:
+    final ConnectResponse<List<String>> listResponse = sandboxClient.connectors();
+
+    // Then:
+    assertThat(listResponse, is(mockListResponse));
   }
 
 }

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
@@ -258,7 +258,7 @@ public class ConnectIntegrationTest {
     assertThat("expected error response", response.isErroneous());
     final KsqlErrorMessage err = response.getErrorMessage();
     assertThat(err.getErrorCode(), is(Errors.toErrorCode(HttpStatus.SC_CONFLICT)));
-    assertThat(err.getMessage(), containsString("Failed to create connector: {\"error_code\":409,\"message\":\"Connector mock-connector already exists\"}"));
+    assertThat(err.getMessage(), containsString("Connector mock-connector already exists"));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Quick follow-up to https://github.com/confluentinc/ksql/pull/8999 (specifically, [this discussion](https://github.com/confluentinc/ksql/pull/8999#issuecomment-1095309050)): for `CREATE CONNECTOR` statements that do not include `IF NOT EXISTS` in the statement, these statements will fail if a connector with the same name already exists. Currently, this failure happens during ksql's execute phase. Ideally, the failure would occur during ksql's validation phase, in order to fail fast so that no statements (in a multi-statement request) are executed. This PR adds a check for this case during validation accordingly.

### Testing done 

Unit + integration.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

