### PR TITLE
docs: cherry-pick: move ksql.streams.max.idle.ms section to be alphabetically correct (DOCS-13443)

### DIFF
--- a/docs/reference/server-configuration.md
+++ b/docs/reference/server-configuration.md
@@ -314,19 +314,6 @@ and dropping them when they go over the threshold.
 A message will be logged every 5 seconds indicating if the rate limit
 is being hit, so an absence of this message means a complete set of logs.
 
-## `ksql.streams.max.task.idle.ms`
-
-The maximum amount of time a task will idle without processing data when
-waiting for all of its input partition buffers to contain records. This can
-help avoid potential out-of-order processing when the task has multiple input
-streams, as in a join, for example.
-
-Setting this to a nonzero value may increase latency but will improve time
-synchronization.
-
-For more information, see
-[max.task.idle.ms](https://docs.confluent.io/platform/current/streams/developer-guide/config-streams.html#max-task-idle-ms).
-
 ## `ksql.metrics.tags.custom`
 
 A list of tags to be included with emitted
@@ -587,6 +574,19 @@ For more information, see the
 [Streams parameter reference](https://docs.confluent.io/platform/current/streams/developer-guide/config-streams.html#optional-configuration-parameters)
 and
 [CACHE_MAX_BYTES_BUFFERING_CONFIG](https://docs.confluent.io/{{ site.ksqldbversion }}/streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#CACHE_MAX_BYTES_BUFFERING_CONFIG).
+
+## `ksql.streams.max.task.idle.ms`
+
+The maximum amount of time a task will idle without processing data when
+waiting for all of its input partition buffers to contain records. This can
+help avoid potential out-of-order processing when the task has multiple input
+streams, as in a join, for example.
+
+Setting this to a nonzero value may increase latency but will improve time
+synchronization.
+
+For more information, see
+[max.task.idle.ms](https://docs.confluent.io/platform/current/streams/developer-guide/config-streams.html#max-task-idle-ms).
 
 ## `ksql.streams.num.standby.replicas`
 


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/9020.