### PR TITLE
fix: remove double quotes from json_records function

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonRecords.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonRecords.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udf.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.confluent.ksql.function.FunctionCategory;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
@@ -47,7 +48,14 @@ public class JsonRecords {
     }
 
     final Map<String, String> ret = new HashMap<>(node.size());
-    node.fieldNames().forEachRemaining(k -> ret.put(k, node.get(k).toString()));
+    node.fieldNames().forEachRemaining(k -> {
+      final JsonNode value = node.get(k);
+      if (value instanceof TextNode) {
+        ret.put(k, value.textValue());
+      } else {
+        ret.put(k, value.toString());
+      }
+    });
     return ret;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonRecordsTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonRecordsTest.java
@@ -34,7 +34,7 @@ public class JsonRecordsTest {
 
     // Then:
     final Map<String, String> expected = new HashMap<String, String>() {{
-        put("a", "\"abc\"");
+        put("a", "abc");
         put("b", "{\"c\":\"a\"}");
         put("d", "1");
       }};

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_records.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/json_records.json
@@ -14,6 +14,7 @@
         {"topic": "test_topic", "key": "1", "value": {"colors_obj": "{\"Black\": 2}"}, "timestamp": 0},
         {"topic": "test_topic", "key": "1", "value": {"colors_obj": "{\"Pink\": 1, \"Yellow\": 3}"}, "timestamp": 0},
         {"topic": "test_topic", "key": "1", "value": {"colors_obj": "{\"White\": 7, \"Pink\": 8}"}, "timestamp": 0},
+        {"topic": "test_topic", "key": "1", "value": {"colors_obj": "{\"White\": \"Seven\"}"}, "timestamp": 0},
         {"topic": "test_topic", "key": "1", "value": {"colors_obj": "{}"}, "timestamp": 0},
         {"topic": "test_topic", "key": "1", "value": {"colors_obj": null, "timestamp": 0}},
         {"topic": "test_topic", "key": "1", "value": {"colors_obj": "", "timestamp": 0}}
@@ -23,6 +24,7 @@
         {"topic": "OUTPUT", "key": "1", "value": {"COLORS": {"Black": "2"}}, "timestamp": 0},
         {"topic": "OUTPUT", "key": "1", "value": {"COLORS": {"Pink": "1", "Yellow": "3"}}, "timestamp": 0},
         {"topic": "OUTPUT", "key": "1", "value": {"COLORS": {"White": "7", "Pink": "8"}}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": "1", "value": {"COLORS": {"White": "Seven"}}, "timestamp": 0},
         {"topic": "OUTPUT", "key": "1", "value": {"COLORS": {}}, "timestamp": 0}
       ]
     }


### PR DESCRIPTION
### Description 
When `JSON_RECORDS` converts a string field to a string, it adds extra quotations. For example,

```
SELECT JSON_RECORDS('{"key": "value"}') FROM SOURCE EMIT CHANGES;
> {"KSQL_COL_0": {"key": "\"value\""}}
```
This is what the user in #9000  is facing. 

### Testing done 
QTT + unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

