### PR TITLE
fix: re fetch streams for each materializationProviderBuilder

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -132,7 +132,14 @@ public final class HARouting implements AutoCloseable {
         .collect(Collectors.toMap(
             KsqlPartitionLocation::getPartition,
             loc -> loc.getNodes().stream().map(KsqlNode::getHost).collect(Collectors.toList())));
-
+    if (allLocations.isEmpty()) {
+      final MaterializationException materializationException = new MaterializationException(
+          "Unable to execute pull query as the locations are not found."
+              + " ALTER SYSTEM may not have finished."
+              + " Please wait a few minutes and try again.");
+      LOG.debug(materializationException.getMessage());
+      throw materializationException;
+    }
     if (!emptyPartitions.isEmpty()) {
       final MaterializationException materializationException = new MaterializationException(
           "Unable to execute pull query. "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/execution/pull/HARouting.java
@@ -132,14 +132,7 @@ public final class HARouting implements AutoCloseable {
         .collect(Collectors.toMap(
             KsqlPartitionLocation::getPartition,
             loc -> loc.getNodes().stream().map(KsqlNode::getHost).collect(Collectors.toList())));
-    if (allLocations.isEmpty()) {
-      final MaterializationException materializationException = new MaterializationException(
-          "Unable to execute pull query as the locations are not found."
-              + " ALTER SYSTEM may not have finished."
-              + " Please wait a few minutes and try again.");
-      LOG.debug(materializationException.getMessage());
-      throw materializationException;
-    }
+
     if (!emptyPartitions.isEmpty()) {
       final MaterializationException materializationException = new MaterializationException(
           "Unable to execute pull query. "

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -444,16 +444,7 @@ final class QueryBuilder {
     final Object result = buildQueryImplementation(physicalPlan, runtimeBuildContext);
     final NamedTopology topology = namedTopologyBuilder.build();
 
-    final Optional<MaterializationProviderBuilderFactory.MaterializationProviderBuilder>
-            materializationProviderBuilder = getMaterializationInfo(result).map(info ->
-            materializationProviderBuilderFactory.materializationProviderBuilder(
-                    info,
-                    querySchema,
-                    keyFormat,
-                    queryOverrides,
-                    applicationId,
-                    queryId.toString()
-            ));
+    final Optional<MaterializationInfo> materializationInfo = getMaterializationInfo(result);
 
     final Optional<ScalablePushRegistry> scalablePushRegistry = applyScalablePushProcessor(
         querySchema.logicalSchema(),
@@ -479,20 +470,21 @@ final class QueryBuilder {
             runtimeBuildContext.getSchemas(),
             config.getOverrides(),
             queryId,
-            materializationProviderBuilder,
+            materializationInfo,
+            materializationProviderBuilderFactory,
             physicalPlan,
             getUncaughtExceptionProcessingLogger(queryId),
             sinkDataSource,
             listener,
-            queryOverrides,
-            scalablePushRegistry,
+        scalablePushRegistry,
             (streamsRuntime) -> getNamedTopology(
                 streamsRuntime,
                 queryId,
                 applicationId,
                 queryOverrides,
                 physicalPlan
-            )
+            ),
+            keyFormat
     );
     if (real) {
       return binPackedPersistentQueryMetadata;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -128,7 +128,8 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     this.processingLogger = requireNonNull(processingLogger, "processingLogger");
     this.physicalPlan = requireNonNull(physicalPlan, "physicalPlan");
     this.resultSchema = requireNonNull(schema, "schema");
-    this.materializationProviderBuilderFactory = requireNonNull(materializationProviderBuilderFactory, "materializationProviderBuilderFactory");
+    this.materializationProviderBuilderFactory = requireNonNull(
+        materializationProviderBuilderFactory, "materializationProviderBuilderFactory");
     this.materializationInfo = requireNonNull(materializationInfo, "materializationInfo");
     this.listener = new QueryListenerWrapper(listener, scalablePushRegistry);
     this.namedTopologyBuilder = requireNonNull(namedTopologyBuilder, "namedTopologyBuilder");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -50,6 +50,7 @@ import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.LagInfo;
 import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
   private final String statementString;
   private final String executionPlan;
   private final String applicationId;
-  private final NamedTopology topology;
+  private NamedTopology topology;
   private final SharedKafkaStreamsRuntime sharedKafkaStreamsRuntime;
   private final QuerySchemas schemas;
   private final ImmutableMap<String, Object> overriddenProperties;
@@ -212,7 +213,7 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
     return materializationProviderBuilder
             .flatMap(builder -> builder.apply(
                     sharedKafkaStreamsRuntime.getKafkaStreams(),
-                    getTopologyCopy(sharedKafkaStreamsRuntime)
+                    topology
             )).map(builder -> builder.build(queryId, contextStacker));
   }
 
@@ -293,6 +294,10 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
 
   public NamedTopology getTopologyCopy(final SharedKafkaStreamsRuntime builder) {
     return namedTopologyBuilder.apply(builder);
+  }
+
+  public void updateTopology(final NamedTopology topology) {
+    this.topology = topology;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImpl.java
@@ -211,8 +211,8 @@ public class BinPackedPersistentQueryMetadataImpl implements PersistentQueryMeta
       final QueryContext.Stacker contextStacker) {
     return materializationProviderBuilder
             .flatMap(builder -> builder.apply(
-                    this.sharedKafkaStreamsRuntime.getKafkaStreams(),
-                    topology
+                    sharedKafkaStreamsRuntime.getKafkaStreams(),
+                    getTopologyCopy(sharedKafkaStreamsRuntime)
             )).map(builder -> builder.build(queryId, contextStacker));
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.StateListener;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.processor.TaskId;
@@ -247,6 +248,7 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void overrideStreamsProperties(final Map<String, Object> newProperties) {
+    newProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, streamsProperties.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
     streamsProperties = ImmutableMap.copyOf(newProperties);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -248,9 +248,9 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void overrideStreamsProperties(final Map<String, Object> newProperties) {
-//    newProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG,
-//        streamsProperties.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
-    //The application server should not be over
+    newProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG,
+        streamsProperties.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
+    //The application server should not be overwritten
     streamsProperties = ImmutableMap.copyOf(newProperties);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -248,8 +248,9 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void overrideStreamsProperties(final Map<String, Object> newProperties) {
-    newProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG,
-        streamsProperties.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
+//    newProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG,
+//        streamsProperties.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
+    //The application server should not be over
     streamsProperties = ImmutableMap.copyOf(newProperties);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -262,7 +262,8 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
     for (final NamedTopology topology : liveTopologies) {
       final BinPackedPersistentQueryMetadataImpl query = collocatedQueries
           .get(new QueryId(topology.name()));
-      kafkaStreamsNamedTopologyWrapper.addNamedTopology(query.getTopologyCopy(this));
+      query.updateTopology(query.getTopologyCopy(this));
+      kafkaStreamsNamedTopologyWrapper.addNamedTopology(query.getTopology());
     }
     setupAndStartKafkaStreams(kafkaStreamsNamedTopologyWrapper);
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImpl.java
@@ -248,7 +248,8 @@ public class SharedKafkaStreamsRuntimeImpl extends SharedKafkaStreamsRuntime {
 
   @Override
   public void overrideStreamsProperties(final Map<String, Object> newProperties) {
-    newProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG, streamsProperties.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
+    newProperties.put(StreamsConfig.APPLICATION_SERVER_CONFIG,
+        streamsProperties.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
     streamsProperties = ImmutableMap.copyOf(newProperties);
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -33,6 +35,7 @@ import io.confluent.ksql.query.MaterializationProviderBuilderFactory;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
+import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.util.QueryMetadata.Listener;
 import java.util.Map;
 import java.util.Optional;
@@ -77,14 +80,20 @@ public class BinPackedPersistentQueryMetadataImplTest {
     @Mock
     private Optional<ScalablePushRegistry> scalablePushRegistry;
     @Mock
-    private MaterializationProviderBuilderFactory.MaterializationProviderBuilder
-        materializationProviderBuilder;
+    private MaterializationProviderBuilderFactory
+        materializationProviderBuilderFactory;
     @Mock
     private KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper;
     @Mock
     private KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper2;
     @Mock
     private QueryContext.Stacker stacker;
+    @Mock
+    private KeyFormat keyFormat;
+    @Mock
+    private MaterializationInfo materializationInfo;
+    @Mock
+    private MaterializationProviderBuilderFactory.MaterializationProviderBuilder materializationProviderBuilder;
 
     private PersistentQueryMetadata query;
 
@@ -102,16 +111,20 @@ public class BinPackedPersistentQueryMetadataImplTest {
             schemas,
             overrides,
             QUERY_ID,
-            Optional.of(materializationProviderBuilder),
+            Optional.of(materializationInfo),
+            materializationProviderBuilderFactory,
             physicalPlan,
             processingLogger,
             Optional.of(sinkDataSource),
             listener,
-            streamsProperties,
             scalablePushRegistry,
-            (runtime) -> topology);
+            (runtime) -> topology,
+            keyFormat);
 
         query.initialize();
+        when(materializationProviderBuilderFactory.materializationProviderBuilder(
+            any(), any(), any(), any(), any(), any()))
+            .thenReturn(materializationProviderBuilder);
     }
 
     @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
@@ -26,8 +26,6 @@ import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.streams.materialization.Materialization;
-import io.confluent.ksql.execution.streams.materialization.ks.KsLocator;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.execution.scalablepush.ScalablePushRegistry;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/BinPackedPersistentQueryMetadataImplTest.java
@@ -15,22 +15,32 @@
 
 package io.confluent.ksql.util;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.streams.materialization.Materialization;
+import io.confluent.ksql.execution.streams.materialization.ks.KsLocator;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.execution.scalablepush.ScalablePushRegistry;
+import io.confluent.ksql.query.MaterializationProviderBuilderFactory;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.query.QuerySchemas;
 import io.confluent.ksql.util.QueryMetadata.Listener;
 import java.util.Map;
 import java.util.Optional;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
 import org.junit.Before;
 import org.junit.Test;
@@ -68,6 +78,15 @@ public class BinPackedPersistentQueryMetadataImplTest {
     private Map<String, Object> streamsProperties;
     @Mock
     private Optional<ScalablePushRegistry> scalablePushRegistry;
+    @Mock
+    private MaterializationProviderBuilderFactory.MaterializationProviderBuilder
+        materializationProviderBuilder;
+    @Mock
+    private KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper;
+    @Mock
+    private KafkaStreamsNamedTopologyWrapper kafkaStreamsNamedTopologyWrapper2;
+    @Mock
+    private QueryContext.Stacker stacker;
 
     private PersistentQueryMetadata query;
 
@@ -85,7 +104,7 @@ public class BinPackedPersistentQueryMetadataImplTest {
             schemas,
             overrides,
             QUERY_ID,
-            Optional.empty(),
+            Optional.of(materializationProviderBuilder),
             physicalPlan,
             processingLogger,
             Optional.of(sinkDataSource),
@@ -95,6 +114,19 @@ public class BinPackedPersistentQueryMetadataImplTest {
             (runtime) -> topology);
 
         query.initialize();
+    }
+
+    @Test
+    public void shouldGetStreamsFreshForMaterialization() {
+        when(sharedKafkaStreamsRuntimeImpl.getKafkaStreams())
+            .thenReturn(kafkaStreamsNamedTopologyWrapper)
+            .thenReturn(kafkaStreamsNamedTopologyWrapper2);
+        when(materializationProviderBuilder.apply(any(KafkaStreams.class), any())).thenReturn(Optional.empty());
+        query.getMaterialization(query.getQueryId(), stacker);
+        query.getMaterialization(query.getQueryId(), stacker);
+
+        verify(materializationProviderBuilder).apply(eq(kafkaStreamsNamedTopologyWrapper), any());
+        verify(materializationProviderBuilder).apply(eq(kafkaStreamsNamedTopologyWrapper2), any());
     }
 
     @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -87,6 +87,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
     public void setUp() throws Exception {
         when(kafkaStreamsBuilder.buildNamedTopologyWrapper(any())).thenReturn(kafkaStreamsNamedTopologyWrapper).thenReturn(kafkaStreamsNamedTopologyWrapper2);
         streamProps.put(StreamsConfig.APPLICATION_ID_CONFIG, "runtime");
+        streamProps.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "old");
         sharedKafkaStreamsRuntimeImpl = new SharedKafkaStreamsRuntimeImpl(
             kafkaStreamsBuilder,
             queryErrorClassifier,
@@ -112,14 +113,14 @@ public class SharedKafkaStreamsRuntimeImplTest {
     public void overrideStreamsPropertiesShouldReplaceProperties() {
         // Given:
         final Map<String, Object> newProps = new HashMap<>();
-        newProps.put("Test", "Test");
+        newProps.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "notused");
 
         // When:
         sharedKafkaStreamsRuntimeImpl.overrideStreamsProperties(newProps);
 
         // Then:
         final Map<String, Object> properties = sharedKafkaStreamsRuntimeImpl.streamsProperties;
-        assertThat(properties.get("Test"), equalTo("Test"));
+        assertThat(properties.get(StreamsConfig.APPLICATION_SERVER_CONFIG), equalTo("old"));
         assertThat(properties.size(), equalTo(1));
     }
 
@@ -232,7 +233,7 @@ public class SharedKafkaStreamsRuntimeImplTest {
 
         //Then:
         verify(kafkaStreamsNamedTopologyWrapper).close();
-        verify(kafkaStreamsNamedTopologyWrapper2).addNamedTopology(namedTopology);
+        verify(kafkaStreamsNamedTopologyWrapper2).addNamedTopology(any());
         verify(kafkaStreamsNamedTopologyWrapper2).start();
         verify(kafkaStreamsNamedTopologyWrapper2).setUncaughtExceptionHandler((StreamsUncaughtExceptionHandler) any());
     }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -131,8 +131,8 @@ public final class KsLocator implements Locator {
     if (metadata.isEmpty()) {
       final MaterializationException materializationException = new MaterializationException(
           "Cannot determine which host contains the required partitions to serve the pull query. \n"
-              + "The underlying persistent query may be restarting (e.g. as a result of ALTER SYSTEM)"
-              + "view the status of your by issuing <DESCRIBE foo>.");
+              + "The underlying persistent query may be restarting (e.g. as a result of "
+              + "ALTER SYSTEM) view the status of your by issuing <DESCRIBE foo>.");
       LOG.debug(materializationException.getMessage());
       throw materializationException;
     }

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -283,7 +283,7 @@ public final class KsLocator implements Locator {
    * @return Collection of StreamsMetadata
    */
   @VisibleForTesting
-  public Collection<StreamsMetadata> getStreamsMetadata() {
+  protected Collection<StreamsMetadata> getStreamsMetadata() {
     if (sharedRuntimesEnabled && kafkaStreams instanceof KafkaStreamsNamedTopologyWrapper) {
       return ((KafkaStreamsNamedTopologyWrapper) kafkaStreams)
           .streamsMetadataForStore(storeName, queryId);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -128,6 +128,15 @@ public final class KsLocator implements Locator {
       metadata = getMetadataForAllPartitions(filterPartitions, keySet);
     }
 
+    if (metadata.isEmpty()) {
+      final MaterializationException materializationException = new MaterializationException(
+          "Cannot determine which host contains the required partitions to serve the pull query. \n"
+              + "The underlying persistent query may be restarting (e.g. as a result of ALTER SYSTEM)"
+              + "view the status of your by issuing <DESCRIBE foo>.");
+      LOG.debug(materializationException.getMessage());
+      throw materializationException;
+    }
+
     // Go through the metadata and group them by partition.
     for (PartitionMetadata partitionMetadata : metadata) {
       LOG.debug("Handling pull query for partition {} of state store {}.",

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocator.java
@@ -283,7 +283,7 @@ public final class KsLocator implements Locator {
    * @return Collection of StreamsMetadata
    */
   @VisibleForTesting
-  protected Collection<StreamsMetadata> getStreamsMetadata() {
+  public Collection<StreamsMetadata> getStreamsMetadata() {
     if (sharedRuntimesEnabled && kafkaStreams instanceof KafkaStreamsNamedTopologyWrapper) {
       return ((KafkaStreamsNamedTopologyWrapper) kafkaStreams)
           .streamsMetadataForStore(storeName, queryId);

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -227,6 +227,29 @@ public class KsLocatorTest {
   }
 
   @Test
+  public void shouldThrowIfMetadataIsEmpty() {
+    // Given:
+    getActiveAndStandbyMetadata();
+    when(topology.describe()).thenReturn(description);
+    when(description.subtopologies()).thenReturn(ImmutableSet.of(sub1));
+    when(sub1.nodes()).thenReturn(ImmutableSet.of(source, processor));
+    when(source.topicSet()).thenReturn(ImmutableSet.of(TOPIC_NAME));
+    when(processor.stores()).thenReturn(ImmutableSet.of(STORE_NAME));
+
+    // When:
+    final Exception e = assertThrows(
+        MaterializationException.class,
+        () -> locator.locate(Collections.emptyList(), routingOptions, routingFilterFactoryActive, false)
+    );
+
+    // Then:
+    assertThat(e.getMessage(), is(
+        "Cannot determine which host contains the required partitions to serve the pull query. \n" +
+            "The underlying persistent query may be restarting (e.g. as a result of" +
+            " ALTER SYSTEM)view the status of your by issuing <DESCRIBE foo>."));
+  }
+
+  @Test
   public void shouldThrowIfRangeScanAndKeysEmpty() {
     // Given:
     getEmtpyMetadata();

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -246,7 +246,7 @@ public class KsLocatorTest {
     assertThat(e.getMessage(), is(
         "Cannot determine which host contains the required partitions to serve the pull query. \n" +
             "The underlying persistent query may be restarting (e.g. as a result of" +
-            " ALTER SYSTEM)view the status of your by issuing <DESCRIBE foo>."));
+            " ALTER SYSTEM) view the status of your by issuing <DESCRIBE foo>."));
   }
 
   @Test


### PR DESCRIPTION
### Description 
We need to re fetch the streams instance when providing the Materialization incase it was updated when changing a config.

### Testing done 
pull queries after an `ALTER SYSTEM` do not return an error with gen 2 queries

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

