### PR TITLE
fix: sum udf change exception type & classify as USER error

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 
 import static io.confluent.ksql.schema.ksql.types.SqlDecimal.validateParameters;
 
+import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.schema.ksql.types.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -258,7 +259,7 @@ public final class DecimalUtil {
     final int digits = precision - scale;
     final BigDecimal maxValue = BigDecimal.valueOf(Math.pow(10, digits));
     if (maxValue.compareTo(value.abs()) < 1) {
-      throw new ArithmeticException(
+      throw new KsqlFunctionException(
           String.format("Numeric field overflow: A field with precision %d and scale %d "
               + "must round to an absolute value less than 10^%d. Got %s",
               precision,

--- a/ksqldb-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
+++ b/ksqldb-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
 
+import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -439,7 +440,7 @@ public class DecimalUtilTest {
   public void shouldFailFitIfNotExactMatchMoreDigits() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> ensureFit(new BigDecimal("12"), DECIMAL_SCHEMA)
     );
 
@@ -464,7 +465,7 @@ public class DecimalUtilTest {
   public void shouldNotCastDecimalTooBig() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> cast(new BigDecimal(10), 2, 1)
     );
 
@@ -476,7 +477,7 @@ public class DecimalUtilTest {
   public void shouldNotCastDecimalTooNegative() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> cast(new BigDecimal(-10), 2, 1)
     );
 
@@ -488,7 +489,7 @@ public class DecimalUtilTest {
   public void shouldNotCastIntTooBig() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> cast(10, 2, 1)
     );
 
@@ -500,7 +501,7 @@ public class DecimalUtilTest {
   public void shouldNotCastIntTooNegative() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> cast(-10, 2, 1)
     );
 
@@ -512,7 +513,7 @@ public class DecimalUtilTest {
   public void shouldNotCastDoubleTooBig() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> cast(10.0, 2, 1)
     );
 
@@ -524,7 +525,7 @@ public class DecimalUtilTest {
   public void shouldNotCastDoubleTooNegative() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> cast(-10.0, 2, 1)
     );
 
@@ -536,7 +537,7 @@ public class DecimalUtilTest {
   public void shouldNotCastStringTooBig() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> cast("10", 2, 1)
     );
 
@@ -548,7 +549,7 @@ public class DecimalUtilTest {
   public void shouldNotCastStringTooNegative() {
     // When:
     final Exception e = assertThrows(
-        ArithmeticException.class,
+        KsqlFunctionException.class,
         () -> cast("-10", 2, 1)
     );
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/KSqlFunctionClassifier.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/KSqlFunctionClassifier.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.query.QueryError.Type;
+import java.util.Objects;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@code KsqlFunctionClassifier} classifies ksql function exceptions as user error
+ */
+public class KSqlFunctionClassifier implements QueryErrorClassifier {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KSqlFunctionClassifier.class);
+
+  private final String queryId;
+
+  public KSqlFunctionClassifier(final String queryId) {
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+  }
+
+  @Override
+  public Type classify(final Throwable e) {
+    Type type = Type.UNKNOWN;
+    if (e instanceof KsqlFunctionException
+        || e instanceof StreamsException
+        && ExceptionUtils.getRootCause(e) instanceof KsqlFunctionException) {
+      type = Type.USER;
+    }
+
+    if (type == Type.USER) {
+      LOG.info(
+          "Classified error as USER error based on invalid user input. Query ID: {} Exception: {}",
+          queryId,
+          e);
+    }
+
+    return type;
+  }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -641,7 +641,8 @@ final class QueryBuilder {
       final String applicationId
   ) {
     final QueryErrorClassifier userErrorClassifiers = new MissingTopicClassifier(applicationId)
-        .and(new AuthorizationClassifier(applicationId));
+        .and(new AuthorizationClassifier(applicationId))
+        .and(new KSqlFunctionClassifier(applicationId));
     return buildConfiguredClassifiers(ksqlConfig, applicationId)
         .map(userErrorClassifiers::and)
         .orElse(userErrorClassifiers);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/KsqlFunctionClassifierTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/KsqlFunctionClassifierTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.query.QueryError.Type;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlFunctionClassifierTest {
+
+  @Test
+  public void shouldClassifyWrappedKsqlFunctionExceptionAsUserError() {
+    // Given:
+    final Exception e = new StreamsException(new KsqlFunctionException("foo"));
+
+    // When:
+    final Type type = new KSqlFunctionClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldClassifyKsqlFunctionExceptionAsUserError() {
+    // Given:
+    final Exception e = new KsqlFunctionException("foo");
+
+    // When:
+    final Type type = new KSqlFunctionClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.USER));
+  }
+
+  @Test
+  public void shouldClassifyWrappedStreamsExceptionWithoutKsqlFunctionExceptionAsUnknownError() {
+    // Given:
+    final Exception e = new StreamsException(new ArithmeticException());
+
+    // When:
+    final Type type = new KSqlFunctionClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+  @Test
+  public void shouldClassifyStreamsExceptionAsUnknownError() {
+    // Given:
+    final Exception e = new StreamsException("foo");
+
+    // When:
+    final Type type = new KSqlFunctionClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+  @Test
+  public void shouldClassifyGenericExceptionAsUnknownError() {
+    // Given:
+    final Exception e = new Exception("foo");
+
+    // When:
+    final Type type = new KSqlFunctionClassifier("").classify(e);
+
+    // Then:
+    assertThat(type, is(Type.UNKNOWN));
+  }
+
+}

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/sum.json
@@ -109,6 +109,30 @@
       ]
     },
     {
+      "name": "sum decimal with overflow",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, VALUE decimal(4,1)) WITH (kafka_topic='test_topic', value_format='AVRO');",
+        "CREATE TABLE S2 as SELECT ID, sum(value) AS SUM FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0,"value": {"value": "5.4"}},
+        {"topic": "test_topic", "key": 0,"value": {"value": "100.1"}},
+        {"topic": "test_topic", "key": 100,"value": {"value": "500.9"}},
+        {"topic": "test_topic", "key": 100,"value": {"value": "300.8"}},
+        {"topic": "test_topic", "key": 100,"value": {"value": "400.5"}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0,"value": {"SUM": "005.4"}},
+        {"topic": "S2", "key": 0,"value": {"SUM": "105.5"}},
+        {"topic": "S2", "key": 100,"value": {"SUM": "500.9"}},
+        {"topic": "S2", "key": 100,"value": {"SUM": "801.7"}}
+      ],
+      "expectedException": {
+        "type": "org.apache.kafka.streams.errors.StreamsException",
+        "message": "Numeric field overflow"
+      }
+    },
+    {
       "name": "sum double map",
       "statements": [
         "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE map<varchar, double>) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
+++ b/ksqldb-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
@@ -35,7 +36,7 @@ import org.junit.Test;
 
 public class AvroDataTranslatorTest {
   @Test
-  public void shoudRenameSourceDereference() {
+  public void shouldRenameSourceDereference() {
     // Given:
     final Schema schema = SchemaBuilder.struct()
         .field("STREAM_NAME.COLUMN_NAME", Schema.OPTIONAL_INT32_SCHEMA)
@@ -187,7 +188,7 @@ public class AvroDataTranslatorTest {
   }
 
   @Test
-  public void shoudlReplacePrimitivesCorrectly() {
+  public void shouldReplacePrimitivesCorrectly() {
     // Given:
     final Schema schema = SchemaBuilder.struct()
         .field("COLUMN_NAME", Schema.OPTIONAL_INT64_SCHEMA)
@@ -305,8 +306,8 @@ public class AvroDataTranslatorTest {
         new AvroDataTranslator(ksqlSchema, AvroProperties.DEFAULT_AVRO_SCHEMA_FULL_NAME);
 
     // Then:
-    final ArithmeticException e = assertThrows(
-        ArithmeticException.class,
+    final KsqlFunctionException e = assertThrows(
+        KsqlFunctionException.class,
         () -> translator.toKsqlRow(topicSchema, new BigDecimal("123.456")));
     assertThat(
         e.getMessage(),


### PR DESCRIPTION
### Description 
Throws KsqlFunctionException instead of ArithmeticException when there is an overflow for a
DECIMAL field using a SUM function. Additionally, it classifies KSqlFunctionException as a USER
error.

### Testing done 
Added unit and integration tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

