### PR TITLE
feat: add ASSERT TOPIC command

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -661,6 +661,12 @@ public class KsqlConfig extends AbstractConfig {
   private static final boolean KSQL_ENDPOINT_MIGRATE_QUERY_DEFAULT = true;
   private static final String KSQL_ENDPOINT_MIGRATE_QUERY_DOC
       = "Migrates the /query endpoint to use the same handler as /query-stream.";
+  public static final String KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS
+      = "ksql.assert.topic.default.timeout.ms";
+  private static final int KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DEFAULT = 1000;
+  private static final String KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DOC
+      = "The default timeout for ASSERT TOPIC statements if not timeout is specified "
+      + "in the statement.";
 
   private enum ConfigGeneration {
     LEGACY,
@@ -1427,6 +1433,13 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_TRANSIENT_QUERY_CLEANUP_SERVICE_PERIOD_SECONDS_DEFAULT,
             Importance.LOW,
             KSQL_TRANSIENT_QUERY_CLEANUP_SERVICE_PERIOD_SECONDS_DOC
+        )
+        .define(
+            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS,
+            Type.INT,
+            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -89,6 +89,7 @@ statement
     | CREATE TYPE (IF NOT EXISTS)? identifier AS type                       #registerType
     | DROP TYPE (IF EXISTS)? identifier                                     #dropType
     | ALTER (STREAM | TABLE) sourceName alterOption (',' alterOption)*      #alterSource
+    | ASSERT TOPIC identifier (WITH tableProperties)? timeout?              #assertTopic
     ;
 
 assertStatement
@@ -117,6 +118,10 @@ query
 resultMaterialization
     : CHANGES
     | FINAL
+    ;
+
+timeout
+    : TIMEOUT number windowUnit
     ;
 
 alterOption
@@ -553,6 +558,7 @@ PLUGINS: 'PLUGINS';
 HEADERS: 'HEADERS';
 HEADER: 'HEADER';
 SYSTEM: 'SYSTEM';
+TIMEOUT: 'TIMEOUT';
 
 IF: 'IF';
 

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -419,6 +419,7 @@ nonReserved
     | GRACE | PERIOD
     | DEFINE | UNDEFINE | VARIABLES
     | PLUGINS | SYSTEM
+    | TIMEOUT
     ;
 
 EMIT: 'EMIT';

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -73,6 +73,7 @@ import io.confluent.ksql.parser.SqlBaseParser.ArrayConstructorContext;
 import io.confluent.ksql.parser.SqlBaseParser.AssertStreamContext;
 import io.confluent.ksql.parser.SqlBaseParser.AssertTableContext;
 import io.confluent.ksql.parser.SqlBaseParser.AssertTombstoneContext;
+import io.confluent.ksql.parser.SqlBaseParser.AssertTopicContext;
 import io.confluent.ksql.parser.SqlBaseParser.AssertValuesContext;
 import io.confluent.ksql.parser.SqlBaseParser.CreateConnectorContext;
 import io.confluent.ksql.parser.SqlBaseParser.DescribeConnectorContext;
@@ -106,6 +107,7 @@ import io.confluent.ksql.parser.tree.AlterSystemProperty;
 import io.confluent.ksql.parser.tree.AssertStatement;
 import io.confluent.ksql.parser.tree.AssertStream;
 import io.confluent.ksql.parser.tree.AssertTombstone;
+import io.confluent.ksql.parser.tree.AssertTopic;
 import io.confluent.ksql.parser.tree.AssertValues;
 import io.confluent.ksql.parser.tree.ColumnConstraints;
 import io.confluent.ksql.parser.tree.CreateConnector;
@@ -171,6 +173,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.ParserUtil;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -1394,6 +1397,21 @@ public class AstBuilder {
           ParserUtil.getIdentifierText(context.identifier()),
           typeParser.getType(context.type()),
           context.EXISTS() != null
+      );
+    }
+
+    @Override
+    public Node visitAssertTopic(final AssertTopicContext context) {
+      return new AssertTopic(
+          getLocation(context),
+          ParserUtil.getIdentifierText(context.identifier()),
+          context.WITH() == null
+              ? ImmutableMap.of()
+              : processTableProperties(context.tableProperties()),
+          context.timeout() == null
+              ? Optional.empty()
+              : Optional.of(getTimeClause(
+                  context.timeout().number(), context.timeout().windowUnit()))
       );
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertTopic.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertTopic.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.execution.expression.tree.Literal;
+import io.confluent.ksql.execution.windows.WindowTimeClause;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class AssertTopic extends Statement {
+
+  private final String topic;
+  private final ImmutableMap<String, Literal> config;
+  private final Optional<WindowTimeClause> timeout;
+
+  public AssertTopic(
+      final Optional<NodeLocation> location,
+      final String topic,
+      final Map<String, Literal> config,
+      final Optional<WindowTimeClause> timeout
+  ) {
+    super(location);
+    this.topic = Objects.requireNonNull(topic, "topic");
+    this.config = ImmutableMap.copyOf(Objects.requireNonNull(config, "config"));
+    this.timeout = Objects.requireNonNull(timeout, "timeout");
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+  public Map<String, Literal> getConfig() {
+    return config;
+  }
+
+  public Optional<WindowTimeClause> getTimeout() {
+    return timeout;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AssertTopic that = (AssertTopic) o;
+    return topic.equals(that.topic)
+        && Objects.equals(config, that.config)
+        && timeout.equals(that.timeout);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(topic, config, timeout);
+  }
+
+  @Override
+  public String toString() {
+    return "AssertTopic{"
+        + "topic=" + topic
+        + ",config=" + config
+        + ",timeout=" + timeout
+        + '}';
+  }
+}

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.parser.SqlBaseParser.SingleStatementContext;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
+import io.confluent.ksql.parser.tree.AssertTopic;
 import io.confluent.ksql.parser.tree.ColumnConstraints;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateTable;
@@ -962,5 +963,37 @@ public class AstBuilderTest {
     String actualMessage = exception.getMessage();
 
     assertEquals(expectedMessage, actualMessage);
+  }
+
+  @Test
+  public void shouldBuildAssertTopic() {
+    // Given:
+    final SingleStatementContext stmt
+        = givenQuery("ASSERT TOPIC X;");
+
+    // When:
+    final AssertTopic assertTopic = (AssertTopic) builder.buildStatement(stmt);
+
+    // Then:
+    assertThat(assertTopic.getTopic(), is("X"));
+    assertThat(assertTopic.getConfig().size(), is(0));
+    assertThat(assertTopic.getTimeout(), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldBuildAssertTopicWithConfigsAndTimeout() {
+    // Given:
+    final SingleStatementContext stmt
+        = givenQuery("ASSERT TOPIC X WITH (REPLICAS=1, partitions=1) TIMEOUT 10 SECONDS;");
+
+    // When:
+    final AssertTopic assertTopic = (AssertTopic) builder.buildStatement(stmt);
+
+    // Then:
+    assertThat(assertTopic.getTopic(), is("X"));
+    assertThat(assertTopic.getConfig().get("REPLICAS").getValue(), is(1));
+    assertThat(assertTopic.getConfig().get("partitions").getValue(), is(1));
+    assertThat(assertTopic.getTimeout().get().getTimeUnit(), is(TimeUnit.SECONDS));
+    assertThat(assertTopic.getTimeout().get().getValue(), is(10L));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertTopicTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertTopicTest.java
@@ -1,0 +1,57 @@
+package io.confluent.ksql.parser.tree;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.execution.windows.WindowTimeClause;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import org.mockito.junit.MockitoRule;
+
+public class AssertTopicTest {
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
+  public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
+  private final String SOME_TOPIC = "TOPIC";
+  private final Map SOME_CONFIG = ImmutableMap.of("partitions", 1);
+  private final WindowTimeClause SOME_TIMEOUT = new WindowTimeClause(5, TimeUnit.SECONDS);
+
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new AssertTopic(Optional.empty(), SOME_TOPIC, SOME_CONFIG, Optional.of(SOME_TIMEOUT)),
+            new AssertTopic(Optional.of(new NodeLocation(1, 1)), SOME_TOPIC, SOME_CONFIG, Optional.of(SOME_TIMEOUT)))
+        .addEqualityGroup(
+            new AssertTopic(Optional.empty(), "another topic", SOME_CONFIG, Optional.of(SOME_TIMEOUT)))
+        .addEqualityGroup(
+            new AssertTopic(Optional.empty(), SOME_TOPIC, ImmutableMap.of(), Optional.of(SOME_TIMEOUT)))
+        .addEqualityGroup(
+            new AssertTopic(Optional.empty(), SOME_TOPIC, SOME_CONFIG, Optional.empty()))
+        .testEquals();
+  }
+
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertTopicExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertTopicExecutor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import static io.confluent.ksql.rest.Errors.assertionFailedError;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS;
+
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.execution.expression.tree.Literal;
+import io.confluent.ksql.parser.tree.AssertTopic;
+import io.confluent.ksql.rest.SessionProperties;
+import io.confluent.ksql.rest.entity.AssertTopicEntity;
+import io.confluent.ksql.rest.server.resources.KsqlRestException;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.RetryUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public final class AssertTopicExecutor {
+
+  private static final int RETRY_MS = 100;
+
+  private AssertTopicExecutor() {
+
+  }
+
+  public static StatementExecutorResponse execute(
+      final ConfiguredStatement<AssertTopic> statement,
+      final SessionProperties sessionProperties,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext
+  ) {
+    final KafkaTopicClient client = serviceContext.getTopicClient();
+    final int timeout = statement.getStatement().getTimeout().isPresent()
+        ? (int) statement.getStatement().getTimeout().get().toDuration().toMillis()
+        : executionContext.getKsqlConfig().getInt(KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS);
+    try {
+      RetryUtil.retryWithBackoff(
+          timeout/RETRY_MS,
+          RETRY_MS,
+          RETRY_MS,
+          () -> assertTopic(
+              client, statement.getStatement().getTopic(), statement.getStatement().getConfig())
+      );
+    } catch (final KsqlException e) {
+      throw new KsqlRestException(assertionFailedError(e.getMessage()));
+    }
+    return StatementExecutorResponse.handled(Optional.of(
+        new AssertTopicEntity(statement.getStatementText(), statement.getStatement().getTopic())));
+  }
+
+  private static void assertTopic(
+      final KafkaTopicClient client,
+      final String topic,
+      final Map<String, Literal> config
+  ) {
+    boolean topicExists;
+    try {
+      topicExists = client.isTopicExists(topic);
+    } catch (final Exception e) {
+      throw new KsqlException("Cannot check that topic exists: " + e.getMessage());
+    }
+
+    if(topicExists) {
+      final int partitions = client.describeTopic(topic).partitions().size();
+      final int replicas = client.describeTopic(topic).partitions().get(0).replicas().size();
+      final List<String> configErrors = new ArrayList<>();
+      config.forEach((k, v) -> {
+        if (k.toLowerCase().equals("partitions")) {
+          if (!configMatches(v.getValue(), partitions)) {
+            configErrors.add(
+                createConfigError(topic, "partitions", v.getValue().toString(), partitions));
+          }
+        } else if (k.toLowerCase().equals("replicas")) {
+          if (!configMatches(v.getValue(), replicas)) {
+            configErrors.add(
+                createConfigError(topic, "replicas", v.getValue().toString(), replicas));
+          }
+        } else {
+          configErrors.add("Cannot assert unknown topic property: " + k);
+        }
+      });
+      if (configErrors.size() > 0) {
+        throw new KsqlException(String.join("\n", configErrors));
+      }
+    } else {
+      throw new KsqlException("Topic " + topic + " does not exist");
+    }
+  }
+
+  private static boolean configMatches(final Object expected, final int actual) {
+    if (expected instanceof Integer && (Integer) expected == actual) {
+      return true;
+    }
+    return false;
+  }
+
+  private static String createConfigError(
+      final String topic, final String config, final String expected, final int actual) {
+    return String.format(
+        "Mismatched configuration for topic %s: For config %s, expected %s got %d",
+        topic, config, expected, actual);
+  }
+}

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.execution;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.parser.tree.AssertTopic;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DefineVariable;
 import io.confluent.ksql.parser.tree.DescribeConnector;
@@ -72,6 +73,7 @@ public enum CustomExecutors {
   LIST_CONNECTOR_PLUGINS(ListConnectorPlugins.class, ListConnectorPluginsExecutor::execute),
   LIST_TYPES(ListTypes.class, ListTypesExecutor::execute),
   LIST_VARIABLES(ListVariables.class, ListVariablesExecutor::execute),
+  ASSERT_TOPIC(AssertTopic.class, AssertTopicExecutor::execute),
 
   SHOW_COLUMNS(ShowColumns.class, ListSourceExecutor::columns),
   EXPLAIN(Explain.class, ExplainExecutor::execute),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.validation;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.AlterSystemProperty;
+import io.confluent.ksql.parser.tree.AssertTopic;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DefineVariable;
 import io.confluent.ksql.parser.tree.DescribeConnector;
@@ -93,6 +94,7 @@ public enum CustomValidators {
   LIST_TYPES(ListTypes.class, StatementValidator.NO_VALIDATION),
   CREATE_CONNECTOR(CreateConnector.class, ConnectExecutor::validate),
   DROP_CONNECTOR(DropConnector.class, StatementValidator.NO_VALIDATION),
+  ASSERT_TOPIC(AssertTopic.class, StatementValidator.NO_VALIDATION),
   LIST_VARIABLES(ListVariables.class, ListVariablesExecutor::execute),
 
   INSERT_VALUES(InsertValues.class, new InsertValuesExecutor()::execute),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -35,6 +35,7 @@ package io.confluent.ksql.rest.integration;
   import static org.apache.kafka.common.resource.ResourceType.TOPIC;
   import static org.apache.kafka.common.resource.ResourceType.TRANSACTIONAL_ID;
   import static org.hamcrest.MatcherAssert.assertThat;
+  import static org.hamcrest.Matchers.containsString;
   import static org.hamcrest.Matchers.endsWith;
   import static org.hamcrest.Matchers.equalTo;
   import static org.hamcrest.Matchers.hasSize;
@@ -51,6 +52,7 @@ package io.confluent.ksql.rest.integration;
   import io.confluent.ksql.integration.IntegrationTestHarness;
   import io.confluent.ksql.integration.Retry;
   import io.confluent.ksql.rest.ApiJsonMapper;
+  import io.confluent.ksql.rest.entity.AssertTopicEntity;
   import io.confluent.ksql.rest.entity.CommandId;
   import io.confluent.ksql.rest.entity.CommandId.Action;
   import io.confluent.ksql.rest.entity.CommandId.Type;
@@ -84,6 +86,7 @@ package io.confluent.ksql.rest.integration;
   import io.vertx.core.http.HttpMethod;
   import io.vertx.core.http.HttpVersion;
   import io.vertx.ext.web.client.HttpResponse;
+  import java.time.Instant;
   import java.util.ArrayList;
   import java.util.Arrays;
   import java.util.Collections;
@@ -1038,6 +1041,106 @@ public class RestApiTest {
         .collect(Collectors.toList());
     assertThat(query.size(), is(1));
   }
+
+  @Test
+  public void shouldAssertTopicExists() {
+    // Given:
+    makeKsqlRequest("CREATE STREAM X AS SELECT * FROM " + PAGE_VIEW_STREAM + ";");
+
+    // When:
+    List<KsqlEntity> response = makeKsqlRequest("ASSERT TOPIC X WITH (PARTITIONS=1) TIMEOUT 2 SECONDS;");
+
+    // Then:
+    assertThat(response.size(), is(1));
+    assertThat(((AssertTopicEntity) response.get(0)).getTopicName(), is("X"));
+  }
+
+  @Test
+  public void shouldFailToAssertNonExistantTopic() {
+    assertThatEventually(() -> {
+      try {
+        makeKsqlRequest("ASSERT TOPIC X WITH (PARTITIONS=1) TIMEOUT 1 SECONDS;");
+        return "Should have thrown 'Topic does not exist' error.";
+      } catch (final Throwable t) {
+        return t.getMessage();
+      }
+    }, containsString("Topic X does not exist"));
+  }
+
+  @Test
+  public void shouldFailToAssertTopicWithWrongConfigs() {
+    // Given:
+    makeKsqlRequest("CREATE STREAM X AS SELECT * FROM " + PAGE_VIEW_STREAM + ";");
+
+    // When:
+    // Then:
+    assertThatEventually(() -> {
+      try {
+        makeKsqlRequest("ASSERT TOPIC X WITH (PARTITIONS='apples', REPLICAS=100, FAKE_CONFIG='Hello!') TIMEOUT 2 SECONDS;");
+        return "Should have thrown config mismatch error";
+      } catch (final Throwable t) {
+        return t.getMessage();
+      }
+    }, containsString(
+        "Mismatched configuration for topic X: For config partitions, expected apples got 1\n"
+            + "Mismatched configuration for topic X: For config replicas, expected 100 got 1\n"
+            + "Cannot assert unknown topic property: FAKE_CONFIG"));
+  }
+
+  @Test
+  public void shouldStopScriptOnFailedAssert() {
+    // Given:
+    makeKsqlRequest("CREATE STREAM X AS SELECT * FROM " + PAGE_VIEW_STREAM + ";");
+
+    // When:
+    // Then:
+    assertThatEventually(() -> {
+      try {
+        makeKsqlRequest("ASSERT TOPIC X WITH (PARTITIONS='apples', REPLICAS=100, FAKE_CONFIG='Hello!') TIMEOUT 2 SECONDS; CREATE STREAM Y AS SELECT * FROM X;");
+        return "Should have thrown config mismatch error";
+      } catch (final Throwable t) {
+        return t.getMessage();
+      }
+    }, containsString(
+        "Mismatched configuration for topic X: For config partitions, expected apples got 1\n"
+            + "Mismatched configuration for topic X: For config replicas, expected 100 got 1\n"
+            + "Cannot assert unknown topic property: FAKE_CONFIG"));
+    assertThat(topicExists("Y"), is(false));
+  }
+
+  @Test
+  public void shouldTimeoutTheCorrectAmountOfTime() {
+    final long start = Instant.now().getEpochSecond();
+    assertThatEventually(() -> {
+      try {
+        makeKsqlRequest("ASSERT TOPIC X WITH (PARTITIONS=1) TIMEOUT 3 SECONDS;");
+        return "Should have thrown 'Topic does not exist' error.";
+      } catch (final Throwable t) {
+        return t.getMessage();
+      }
+    }, containsString("Topic X does not exist"));
+    final long end = Instant.now().getEpochSecond();
+
+    assertThat(end - start >= 3, is(true));
+  }
+
+  @Test
+  public void shouldTimeoutTheDefaultAmountOfTime() {
+    final long start = Instant.now().getEpochSecond();
+    assertThatEventually(() -> {
+      try {
+        makeKsqlRequest("ASSERT TOPIC X WITH (PARTITIONS=1);");
+        return "Should have thrown 'Topic does not exist' error.";
+      } catch (final Throwable t) {
+        return t.getMessage();
+      }
+    }, containsString("Topic X does not exist"));
+    final long end = Instant.now().getEpochSecond();
+
+    assertThat(end - start >= 1, is(true));
+    assertThat(end - start <= 2, is(true));
+  }
+
 
   private boolean topicExists(final String topicName) {
     return getServiceContext().getTopicClient().isTopicExists(topicName);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.integration;
 import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static io.netty.handler.codec.http.HttpHeaderNames.AUTHORIZATION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpHeaderNames.EXPIRES;
 import static io.vertx.core.http.HttpMethod.POST;
 import static io.vertx.core.http.HttpVersion.HTTP_1_1;
 
@@ -555,6 +556,7 @@ public final class RestIntegrationTestUtil {
 
       mediaType.ifPresent(mt -> headers.add(ACCEPT.toString(), mt));
       contentType.ifPresent(ct -> headers.add(CONTENT_TYPE.toString(), ct));
+      headers.add(EXPIRES.toString(), "Wed, 13 Apr 2022 07:28:00 GMT");
 
       CompletableFuture<List<String>> completableFuture = new CompletableFuture<>();
 

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/AssertTopicExecutorTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/AssertTopicExecutorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.config.SessionConfig;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
+import io.confluent.ksql.execution.expression.tree.Literal;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.AssertTopic;
+import io.confluent.ksql.rest.SessionProperties;
+import io.confluent.ksql.rest.entity.AssertTopicEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.server.resources.KsqlRestException;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.connect.runtime.isolation.PluginType;
+import org.apache.kafka.connect.runtime.rest.entities.PluginInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+@RunWith(MockitoJUnitRunner.class)
+public class AssertTopicExecutorTest {
+  private static final PluginInfo INFO = new PluginInfo(
+      "org.apache.kafka.connect.file.FileStreamSinkConnector",
+      PluginType.SOURCE,
+      "2.1"
+  );
+
+  @Mock
+  private KsqlExecutionContext engine;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private KafkaTopicClient topicClient;
+  @Mock
+  private TopicDescription topicDescription;
+  @Mock
+  private TopicPartitionInfo partition;
+  private final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+
+  @Before
+  public void setUp() {
+    when(engine.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(serviceContext.getTopicClient()).thenReturn(topicClient);
+    when(topicClient.isTopicExists("topicName"))
+        .thenReturn(true);
+    when(topicClient.describeTopic("topicName"))
+        .thenReturn(topicDescription);
+    when(topicDescription.partitions())
+        .thenReturn(ImmutableList.of(partition));
+    when(partition.replicas())
+        .thenReturn(ImmutableList.of());
+  }
+
+  @Test
+  public void shouldAssertTopic() {
+    // Given:
+    final Map<String, Literal> configs = ImmutableMap.of(
+        "partitions", new IntegerLiteral(1), "replicas", new IntegerLiteral(0));
+    final AssertTopic assertTopic = new AssertTopic(Optional.empty(), "topicName", configs, Optional.empty());
+    final ConfiguredStatement<AssertTopic> statement = ConfiguredStatement
+        .of(KsqlParser.PreparedStatement.of("", assertTopic),
+            SessionConfig.of(ksqlConfig, ImmutableMap.of()));
+
+    // When:
+    final Optional<KsqlEntity> entity = AssertTopicExecutor
+        .execute(statement, mock(SessionProperties.class), engine, serviceContext).getEntity();
+
+    // Then:
+    assertThat("expected response!", entity.isPresent());
+    assertThat(((AssertTopicEntity) entity.get()).getTopicName(), is("topicName"));
+  }
+
+  @Test
+  public void shouldFailToAssertNonExistingTopic() {
+    // Given:
+    final Map<String, Literal> configs = ImmutableMap.of(
+        "partitions", new IntegerLiteral(1), "replicas", new IntegerLiteral(0));
+    final AssertTopic assertTopic = new AssertTopic(Optional.empty(), "fakeTopic", configs, Optional.empty());
+    final ConfiguredStatement<AssertTopic> statement = ConfiguredStatement
+        .of(KsqlParser.PreparedStatement.of("", assertTopic),
+            SessionConfig.of(ksqlConfig, ImmutableMap.of()));
+
+    // When:
+    final KsqlRestException e = assertThrows(KsqlRestException.class,
+        () -> AssertTopicExecutor.execute(statement, mock(SessionProperties.class), engine, serviceContext));
+
+    // Then:
+    assertThat(e.getResponse().getStatus(), is(417));
+    assertThat(((KsqlErrorMessage) e.getResponse().getEntity()).getMessage(), is("Topic fakeTopic does not exist"));
+  }
+
+  @Test
+  public void shouldFailToAssertWrongConfigs() {
+    // Given:
+    final Map<String, Literal> configs = ImmutableMap.of(
+        "partitions", new IntegerLiteral(10), "replicas", new IntegerLiteral(10), "abc", new IntegerLiteral(23));
+    final AssertTopic assertTopic = new AssertTopic(Optional.empty(), "topicName", configs, Optional.empty());
+    final ConfiguredStatement<AssertTopic> statement = ConfiguredStatement
+        .of(KsqlParser.PreparedStatement.of("", assertTopic),
+            SessionConfig.of(ksqlConfig, ImmutableMap.of()));
+
+    // When:
+    final KsqlRestException e = assertThrows(KsqlRestException.class,
+        () -> AssertTopicExecutor.execute(statement, mock(SessionProperties.class), engine, serviceContext));
+
+    // Then:
+    assertThat(e.getResponse().getStatus(), is(417));
+    assertThat(((KsqlErrorMessage) e.getResponse().getEntity()).getMessage(), is("Mismatched configuration for topic topicName: For config partitions, expected 10 got 1\n"
+        + "Mismatched configuration for topic topicName: For config replicas, expected 10 got 0\n"
+        + "Cannot assert unknown topic property: abc"));
+  }
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.RETRY_AFTER;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.EXPECTATION_FAILED;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.MISDIRECTED_REQUEST;
@@ -74,6 +75,8 @@ public final class Errors {
       toErrorCode(INTERNAL_SERVER_ERROR.code());
   
   public static final int ERROR_CODE_TOO_MANY_REQUESTS = toErrorCode(TOO_MANY_REQUESTS.code());
+
+  public static final int ERROR_CODE_ASSERTION_FAILED = toErrorCode(EXPECTATION_FAILED.code());
 
   private final ErrorMessages errorMessages;
 
@@ -216,6 +219,13 @@ public final class Errors {
       .status(TOO_MANY_REQUESTS.code())
       .entity(new KsqlErrorMessage(ERROR_CODE_TOO_MANY_REQUESTS, msg))
       .build();
+  }
+
+  public static EndpointResponse assertionFailedError(final String errorMsg) {
+    return EndpointResponse.create()
+        .status(EXPECTATION_FAILED.code())
+        .entity(new KsqlErrorMessage(ERROR_CODE_ASSERTION_FAILED, errorMsg))
+        .build();
   }
 
   public Errors(final ErrorMessages errorMessages) {

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/AssertTopicEntity.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/AssertTopicEntity.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AssertTopicEntity extends KsqlEntity {
+  private final String topicName;
+
+  public AssertTopicEntity(
+      @JsonProperty("statementText") final String statementText,
+      @JsonProperty("topicName") final String topicName
+  ) {
+    super(statementText);
+    this.topicName = Objects.requireNonNull(topicName, "topicName");
+  }
+
+  public String getTopicName() {
+    return topicName;
+  }
+
+  @Override
+  public String toString() {
+    return "AssertTopicEntity{"
+        + "topicName='" + topicName + '\''
+        + '}';
+  }
+}

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -51,7 +51,8 @@ import java.util.List;
     @JsonSubTypes.Type(value = TypeList.class, name = "type_list"),
     @JsonSubTypes.Type(value = WarningEntity.class, name = "warning_entity"),
     @JsonSubTypes.Type(value = VariablesList.class, name = "variables"),
-    @JsonSubTypes.Type(value = TerminateQueryEntity.class, name = "terminate_query")
+    @JsonSubTypes.Type(value = TerminateQueryEntity.class, name = "terminate_query"),
+    @JsonSubTypes.Type(value = AssertTopicEntity.class, name = "assert_topic")
 })
 public abstract class KsqlEntity {
   private final String statementText;


### PR DESCRIPTION
### Description 
Adds `ASSERT TOPIC` command to ksqlDB. See discussion [here](https://github.com/confluentinc/ksql/issues/8752)

### Testing done 
Unit + integration tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

