### PR TITLE
chore: fix broken build due to upstream Jackson version bump

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -57,7 +57,7 @@ public final class TopicNode {
       @JsonProperty("replicas") final Integer replicas
   ) {
     this.name = name == null ? "" : name;
-    this.avroSchema = buildAvroSchema(requireNonNull(schema, "schema"));
+    this.avroSchema = buildAvroSchema(schema == null ? NullNode.getInstance() : schema);
     this.format = format == null ? "" : format;
     this.numPartitions = numPartitions == null ? 1 : numPartitions;
     this.replicas = replicas == null ? 1 : replicas;

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.test.model;
 
-import static java.util.Objects.requireNonNull;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
Jackson was bumped upstream: https://github.com/confluentinc/common/pull/446

Version 2.13 returns `null` instead of `NullNode` (cf https://github.com/FasterXML/jackson-databind/issues/3389)

PR cannot be cherry-picked/merge into 5.5.x branch. PR for 5.5.x #9068 