### PR TITLE
chore: fix broken build due to upstream Jackson version bump

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.test.model;
 
-import static java.util.Objects.requireNonNull;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
@@ -40,7 +41,7 @@ public final class TopicNode {
       @JsonProperty("replicas") final Integer replicas
   ) {
     this.name = name == null ? "" : name;
-    this.schema = SerdeUtil.buildSchema(requireNonNull(schema, "schema"), format);
+    this.schema = SerdeUtil.buildSchema(schema == null ? NullNode.getInstance() : schema, format);
     this.numPartitions = numPartitions == null ? 1 : numPartitions;
     this.replicas = replicas == null ? 1 : replicas;
 


### PR DESCRIPTION
Jackson was bumped upstream: https://github.com/confluentinc/common/pull/446

Version 2.13 returns `null` instead of `NullNode` (cf https://github.com/FasterXML/jackson-databind/issues/3389)

PR cannot be cherry-picked/merge into 6.0.x branch. PR for 6.0.x #9069