### PR TITLE
chore: fix broken build due to upstream Jackson version bump

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.test.model;
 
-import static java.util.Objects.requireNonNull;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -52,7 +52,7 @@ public final class TopicNode {
       @JsonProperty("replicas") final Integer replicas
   ) {
     this.name = name == null ? "" : name;
-    this.schema = requireNonNull(schema, "schema");
+    this.schema = schema == null ? NullNode.getInstance() : schema;
     this.format = format;
     this.numPartitions = numPartitions == null ? 1 : numPartitions;
     this.replicas = replicas == null ? 1 : replicas;


### PR DESCRIPTION
Jackson was bumped upstream: https://github.com/confluentinc/common/pull/446

Version 2.13 returns `null` instead of `NullNode` (cf https://github.com/FasterXML/jackson-databind/issues/3389)

PR cannot be cherry-picked/merge into 6.1.x branch. PR for 6.1.x #9070