### PR TITLE
chore: fix broken master build after upstream Jackson version bump

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
@@ -215,6 +215,7 @@ public final class PostConditionsNode {
         }
 
         // CHECKSTYLE_RULES.OFF: BooleanExpressionComplexity
+        // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
         @Override
         public boolean matches(final Object item) {
           if (!(item instanceof PostTopicNode)) {
@@ -232,6 +233,7 @@ public final class PostConditionsNode {
               || valueSchema.equals(that.valueSchema));
         }
         // CHECKSTYLE_RULES.ON: BooleanExpressionComplexity
+        // CHECKSTYLE_RULES.ON: CyclomaticComplexity
       };
     }
 

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
@@ -189,8 +189,8 @@ public final class PostConditionsNode {
       this.keyFormat = requireNonNull(keyFormat, "KeyFormat");
       this.valueFormat = requireNonNull(valueFormat, "valueFormat");
       this.partitions = requireNonNull(partitions, "partitions");
-      this.keySchema = requireNonNull(keySchema, "keySchema");
-      this.valueSchema = requireNonNull(valueSchema, "valueSchema");
+      this.keySchema = keySchema == null ? NullNode.getInstance() : keySchema;
+      this.valueSchema = valueSchema == null ? NullNode.getInstance() : valueSchema;
 
       if (this.name.isEmpty()) {
         throw new InvalidFieldException("name", "empty or missing");

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
@@ -189,8 +189,8 @@ public final class PostConditionsNode {
       this.keyFormat = requireNonNull(keyFormat, "KeyFormat");
       this.valueFormat = requireNonNull(valueFormat, "valueFormat");
       this.partitions = requireNonNull(partitions, "partitions");
-      this.keySchema = keySchema == null ? NullNode.getInstance() : keySchema;
-      this.valueSchema = valueSchema == null ? NullNode.getInstance() : valueSchema;
+      this.keySchema = keySchema;
+      this.valueSchema = valueSchema;
 
       if (this.name.isEmpty()) {
         throw new InvalidFieldException("name", "empty or missing");
@@ -226,8 +226,9 @@ public final class PostConditionsNode {
               && Objects.equals(keyFormat, that.keyFormat)
               && Objects.equals(valueFormat, that.valueFormat)
               && (!partitions.isPresent() || partitions.equals(that.partitions))
-              && (keySchema instanceof NullNode || keySchema.equals(that.keySchema))
-              && (valueSchema instanceof NullNode
+              && (keySchema == null || keySchema instanceof NullNode
+              || keySchema.equals(that.keySchema))
+              && (valueSchema == null || valueSchema instanceof NullNode
               || valueSchema.equals(that.valueSchema));
         }
         // CHECKSTYLE_RULES.ON: BooleanExpressionComplexity

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -15,13 +15,9 @@
 
 package io.confluent.ksql.test.model;
 
-import static java.util.Objects.requireNonNull;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,9 +56,10 @@ public final class TopicNode {
       @JsonProperty("partitions") final Integer numPartitions,
       @JsonProperty("replicas") final Integer replicas
   ) {
+
     this.name = name == null ? "" : name;
-    this.keySchema = requireNonNull(keySchema, "keySchema");
-    this.valueSchema = requireNonNull(valueSchema, "valueSchema");
+    this.keySchema = keySchema == null ? NullNode.getInstance() : keySchema;
+    this.valueSchema = valueSchema ==  null ? NullNode.getInstance() : valueSchema;
     this.keyFormat = keyFormat;
     this.valueFormat = valueFormat;
     this.numPartitions = numPartitions == null ? 1 : numPartitions;
@@ -67,8 +70,8 @@ public final class TopicNode {
     }
 
     // Fail early:
-    SerdeUtil.buildSchema(keySchema, keyFormat);
-    SerdeUtil.buildSchema(valueSchema, valueFormat);
+    SerdeUtil.buildSchema(this.keySchema, keyFormat);
+    SerdeUtil.buildSchema(this.valueSchema, valueFormat);
   }
 
   public String getName() {

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -54,8 +54,8 @@ public final class TopicNode {
   ) {
 
     this.name = name == null ? "" : name;
-    this.keySchema = keySchema == null ? NullNode.getInstance() : keySchema;
-    this.valueSchema = valueSchema ==  null ? NullNode.getInstance() : valueSchema;
+    this.keySchema = keySchema;
+    this.valueSchema = valueSchema;
     this.keyFormat = keyFormat;
     this.valueFormat = valueFormat;
     this.numPartitions = numPartitions == null ? 1 : numPartitions;
@@ -66,8 +66,8 @@ public final class TopicNode {
     }
 
     // Fail early:
-    SerdeUtil.buildSchema(this.keySchema, keyFormat);
-    SerdeUtil.buildSchema(this.valueSchema, valueFormat);
+    SerdeUtil.buildSchema(keySchema, keyFormat);
+    SerdeUtil.buildSchema(valueSchema, valueFormat);
   }
 
   public String getName() {

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/utils/SerdeUtil.java
@@ -81,7 +81,7 @@ public final class SerdeUtil {
   }
 
   public static Optional<ParsedSchema> buildSchema(final JsonNode schema, final String format) {
-    if (schema instanceof NullNode) {
+    if (schema == null || schema instanceof NullNode) {
       return Optional.empty();
     }
 


### PR DESCRIPTION
Jackson was bumped upstream: https://github.com/confluentinc/common/pull/446

Version 2.13 returns `null` instead of `NullNode` (cf https://github.com/FasterXML/jackson-databind/issues/3389)

Should be merged to all newer branches.