### PR TITLE
docs: cherry-pick: bump docs version to 0.25.1 (DOCS-13614)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -259,7 +259,7 @@ extra:
 
         # Build-related string tokens
         kafkaversion: 3.1
-        ksqldbversion: 0.24.0
+        ksqldbversion: 0.25.1
         cprelease: 7.1.0
         releasepostbranch: 7.1.0-post
         scalaversion: 2.13


### PR DESCRIPTION
From https://github.com/confluentinc/ksql/pull/8989.