### PR TITLE
test: add timeout to future for TlsTest to avoid blocking

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/api/BaseApiTest.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
@@ -251,7 +252,7 @@ public class BaseApiTest {
     client
         .post(uri)
         .sendBuffer(requestBody, requestFuture);
-    return requestFuture.get();
+    return requestFuture.get(10_000L, TimeUnit.MILLISECONDS);
   }
 
   protected void sendPostRequest(final String uri, final Consumer<HttpRequest<Buffer>> requestSender) {


### PR DESCRIPTION
We observes some test failures:
```
org.junit.runners.model.TestTimedOutException: test timed out after 90 seconds
	at io.confluent.ksql.api.TlsTest.lambda$shouldReloadCert$0(TlsTest.java:145)
	at io.confluent.ksql.api.TlsTest.shouldReloadCert(TlsTest.java:137)
```

It seems we are blocking in the `get()` call on the future. Adding a timeout should help as it would trigger a re-try to send the request, avoiding that the test blocks and eventually times out via the `@Rule public final Timeout timeout = Timeout.seconds(90);` annotation.