### PR TITLE
feat: assert not exists topic

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -907,7 +907,8 @@ public class Console implements Closeable {
   }
 
   private void printAssertTopic(final AssertTopicEntity assertTopic) {
-    writer().printf("Topic " + assertTopic.getTopicName() + " exists.\n");
+    final String existence = assertTopic.getExists() ? " exists" : " does not exist";
+    writer().printf("Topic " + assertTopic.getTopicName() + existence + ".\n");
   }
 
   private static String argToString(final ArgumentInfo arg) {

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -1096,7 +1096,22 @@ public class ConsoleTest {
   public void shouldPrintAssertTopicResult() {
     // Given:
     final KsqlEntityList entities = new KsqlEntityList(ImmutableList.of(
-        new AssertTopicEntity("statement", "name")
+        new AssertTopicEntity("statement", "name", true)
+    ));
+
+    // When:
+    console.printKsqlEntityList(entities);
+
+    // Then:
+    final String output = terminal.getOutputString();
+    Approvals.verify(output, approvalOptions);
+  }
+
+  @Test
+  public void shouldPrintAssertNotExistsTopicResult() {
+    // Given:
+    final KsqlEntityList entities = new KsqlEntityList(ImmutableList.of(
+        new AssertTopicEntity("statement", "name", false)
     ));
 
     // When:

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.shouldPrintAssertNotExistsTopicResult.approved.json
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.shouldPrintAssertNotExistsTopicResult.approved.json
@@ -2,6 +2,6 @@
   "@type" : "assert_topic",
   "statementText" : "statement",
   "topicName" : "name",
-  "exists" : true,
+  "exists" : false,
   "warnings" : [ ]
 } ]

--- a/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.shouldPrintAssertNotExistsTopicResult.approved.tabular
+++ b/ksqldb-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.shouldPrintAssertNotExistsTopicResult.approved.tabular
@@ -1,0 +1,2 @@
+
+Topic name does not exist.

--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -89,7 +89,8 @@ statement
     | CREATE TYPE (IF NOT EXISTS)? identifier AS type                       #registerType
     | DROP TYPE (IF EXISTS)? identifier                                     #dropType
     | ALTER (STREAM | TABLE) sourceName alterOption (',' alterOption)*      #alterSource
-    | ASSERT TOPIC identifier (WITH tableProperties)? timeout?              #assertTopic
+    | ASSERT (NOT EXISTS)? TOPIC identifier
+            (WITH tableProperties)? timeout?                                #assertTopic
     ;
 
 assertStatement

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1410,7 +1410,8 @@ public class AstBuilder {
           context.timeout() == null
               ? Optional.empty()
               : Optional.of(getTimeClause(
-                  context.timeout().number(), context.timeout().windowUnit()))
+                  context.timeout().number(), context.timeout().windowUnit())),
+          context.EXISTS() == null
       );
     }
 

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertTopic.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/tree/AssertTopic.java
@@ -30,17 +30,20 @@ public class AssertTopic extends Statement {
   private final String topic;
   private final ImmutableMap<String, Literal> config;
   private final Optional<WindowTimeClause> timeout;
+  private final boolean exists;
 
   public AssertTopic(
       final Optional<NodeLocation> location,
       final String topic,
       final Map<String, Literal> config,
-      final Optional<WindowTimeClause> timeout
+      final Optional<WindowTimeClause> timeout,
+      final boolean exists
   ) {
     super(location);
     this.topic = Objects.requireNonNull(topic, "topic");
     this.config = ImmutableMap.copyOf(Objects.requireNonNull(config, "config"));
     this.timeout = Objects.requireNonNull(timeout, "timeout");
+    this.exists = exists;
   }
 
   public String getTopic() {
@@ -55,6 +58,10 @@ public class AssertTopic extends Statement {
     return timeout;
   }
 
+  public boolean checkExists() {
+    return exists;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -66,7 +73,8 @@ public class AssertTopic extends Statement {
     final AssertTopic that = (AssertTopic) o;
     return topic.equals(that.topic)
         && Objects.equals(config, that.config)
-        && timeout.equals(that.timeout);
+        && timeout.equals(that.timeout)
+        && exists == that.exists;
   }
 
   @Override
@@ -80,6 +88,7 @@ public class AssertTopic extends Statement {
         + "topic=" + topic
         + ",config=" + config
         + ",timeout=" + timeout
+        + ",exists=" + exists
         + '}';
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -978,13 +978,14 @@ public class AstBuilderTest {
     assertThat(assertTopic.getTopic(), is("X"));
     assertThat(assertTopic.getConfig().size(), is(0));
     assertThat(assertTopic.getTimeout(), is(Optional.empty()));
+    assertThat(assertTopic.checkExists(), is(true));
   }
 
   @Test
-  public void shouldBuildAssertTopicWithConfigsAndTimeout() {
+  public void shouldBuildAssertNotExistsTopicWithConfigsAndTimeout() {
     // Given:
     final SingleStatementContext stmt
-        = givenQuery("ASSERT TOPIC X WITH (REPLICAS=1, partitions=1) TIMEOUT 10 SECONDS;");
+        = givenQuery("ASSERT NOT EXISTS TOPIC X WITH (REPLICAS=1, partitions=1) TIMEOUT 10 SECONDS;");
 
     // When:
     final AssertTopic assertTopic = (AssertTopic) builder.buildStatement(stmt);
@@ -995,5 +996,6 @@ public class AstBuilderTest {
     assertThat(assertTopic.getConfig().get("PARTITIONS").getValue(), is(1));
     assertThat(assertTopic.getTimeout().get().getTimeUnit(), is(TimeUnit.SECONDS));
     assertThat(assertTopic.getTimeout().get().getValue(), is(10L));
+    assertThat(assertTopic.checkExists(), is(false));
   }
 }

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertTopicTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertTopicTest.java
@@ -43,14 +43,16 @@ public class AssertTopicTest {
   public void shouldImplementHashCodeAndEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            new AssertTopic(Optional.empty(), SOME_TOPIC, SOME_CONFIG, Optional.of(SOME_TIMEOUT)),
-            new AssertTopic(Optional.of(new NodeLocation(1, 1)), SOME_TOPIC, SOME_CONFIG, Optional.of(SOME_TIMEOUT)))
+            new AssertTopic(Optional.empty(), SOME_TOPIC, SOME_CONFIG, Optional.of(SOME_TIMEOUT), true),
+            new AssertTopic(Optional.of(new NodeLocation(1, 1)), SOME_TOPIC, SOME_CONFIG, Optional.of(SOME_TIMEOUT), true))
         .addEqualityGroup(
-            new AssertTopic(Optional.empty(), "another topic", SOME_CONFIG, Optional.of(SOME_TIMEOUT)))
+            new AssertTopic(Optional.empty(), "another topic", SOME_CONFIG, Optional.of(SOME_TIMEOUT), true))
         .addEqualityGroup(
-            new AssertTopic(Optional.empty(), SOME_TOPIC, ImmutableMap.of(), Optional.of(SOME_TIMEOUT)))
+            new AssertTopic(Optional.empty(), SOME_TOPIC, ImmutableMap.of(), Optional.of(SOME_TIMEOUT), true))
         .addEqualityGroup(
-            new AssertTopic(Optional.empty(), SOME_TOPIC, SOME_CONFIG, Optional.empty()))
+            new AssertTopic(Optional.empty(), SOME_TOPIC, SOME_CONFIG, Optional.empty(), true))
+        .addEqualityGroup(
+            new AssertTopic(Optional.empty(), SOME_TOPIC, SOME_CONFIG, Optional.of(SOME_TIMEOUT), false))
         .testEquals();
   }
 

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/AssertTopicEntity.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/AssertTopicEntity.java
@@ -22,23 +22,31 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AssertTopicEntity extends KsqlEntity {
   private final String topicName;
+  private final boolean exists;
 
   public AssertTopicEntity(
       @JsonProperty("statementText") final String statementText,
-      @JsonProperty("topicName") final String topicName
+      @JsonProperty("topicName") final String topicName,
+      @JsonProperty("exists") final boolean exists
   ) {
     super(statementText);
     this.topicName = Objects.requireNonNull(topicName, "topicName");
+    this.exists = exists;
   }
 
   public String getTopicName() {
     return topicName;
   }
 
+  public boolean getExists() {
+    return exists;
+  }
+
   @Override
   public String toString() {
     return "AssertTopicEntity{"
         + "topicName='" + topicName + '\''
+        + ", exists=" + exists
         + '}';
   }
 }


### PR DESCRIPTION
### Description 
Adds `NOT EXISTS` to `ASSERT TOPIC` which asserts that a topic doesn't exist

### Testing done 
Manual, unit+integration tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

