### PR TITLE
docs: link to main 0.26.0 changelog in built changelog topic (DOCS-13330 and DOCS-13337)

### DIFF
--- a/docs/operate-and-deploy/changelog.md
+++ b/docs/operate-and-deploy/changelog.md
@@ -10,7 +10,7 @@ Version 0.26.0
 --------------
 
 - [Announcing ksqlDB 0.26.0](https://www.confluent.io/blog/announcing-ksqldb-0-26-0/)
-- [ksqlDB v0.26.0 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0260-2022-04-07)
+- [ksqlDB v0.26.0 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0260-2022-04-28)
 
 Version 0.25.1
 --------------

--- a/docs/operate-and-deploy/changelog.md
+++ b/docs/operate-and-deploy/changelog.md
@@ -6,6 +6,12 @@ description: Lists changes to the ksqlDB codebase
 keywords: ksqldb, changelog
 ---
 
+Version 0.26.0
+--------------
+
+- [Announcing ksqlDB 0.26.0](https://www.confluent.io/blog/announcing-ksqldb-0-26-0/)
+- [ksqlDB v0.26.0 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0260-2022-04-07)
+
 Version 0.25.1
 --------------
 

--- a/docs/operate-and-deploy/changelog.md
+++ b/docs/operate-and-deploy/changelog.md
@@ -9,7 +9,6 @@ keywords: ksqldb, changelog
 Version 0.26.0
 --------------
 
-- [Announcing ksqlDB 0.26.0](https://www.confluent.io/blog/announcing-ksqldb-0-26-0/)
 - [ksqlDB v0.26.0 changelog](https://github.com/confluentinc/ksql/blob/master/CHANGELOG.md#0260-2022-04-28)
 
 Version 0.25.1


### PR DESCRIPTION
Related: https://github.com/confluentinc/ksql/pull/9080.