### PR TITLE
chore: improve variable substitution for assert statements

### DIFF
--- a/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksqldb-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -59,7 +59,7 @@ statement
     | DESCRIBE STREAMS EXTENDED?                                            #describeStreams
     | DESCRIBE FUNCTION identifier                                          #describeFunction
     | DESCRIBE CONNECTOR identifier                                         #describeConnector
-    | PRINT (identifier| STRING) printClause                                #printTopic
+    | PRINT resourceName printClause                                        #printTopic
     | (LIST | SHOW) QUERIES EXTENDED?                                       #listQueries
     | TERMINATE identifier                                                  #terminateQuery
     | TERMINATE ALL                                                         #terminateQuery
@@ -89,10 +89,10 @@ statement
     | CREATE TYPE (IF NOT EXISTS)? identifier AS type                       #registerType
     | DROP TYPE (IF EXISTS)? identifier                                     #dropType
     | ALTER (STREAM | TABLE) sourceName alterOption (',' alterOption)*      #alterSource
-    | ASSERT (NOT EXISTS)? TOPIC identifier
+    | ASSERT (NOT EXISTS)? TOPIC resourceName
             (WITH tableProperties)? timeout?                                #assertTopic
     | ASSERT (NOT EXISTS)? SCHEMA
-            (SUBJECT identifier)? (ID literal)? timeout?                    #assertSchema
+            (SUBJECT resourceName)? (ID literal)? timeout?                  #assertSchema
     ;
 
 assertStatement
@@ -104,6 +104,11 @@ assertStatement
 
 runScript
     : RUN SCRIPT STRING
+    ;
+
+resourceName
+    : identifier
+    | STRING
     ;
 
 query

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -114,6 +114,8 @@ public final class VariableSubstitutor {
       if (context.STRING() != null) {
         final String text = unquote(context.STRING().getText(), "'");
         lookupVariables(text);
+      } else {
+        visit(context.identifier());
       }
       return null;
     }

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -22,6 +22,7 @@ import static io.confluent.ksql.util.ParserUtil.unquote;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.parser.exception.ParseFailedException;
+import io.confluent.ksql.util.ParserUtil;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -107,6 +108,15 @@ public final class VariableSubstitutor {
           sanitizedValueMap.putIfAbsent(variableName, sanitize(valueMap.get(variableName)));
         }
       }
+    }
+
+    @Override
+    public Void visitResourceName(final SqlBaseParser.ResourceNameContext context) {
+      if (context.STRING() != null) {
+        final String text = unquote(context.STRING().getText(), "'");
+        lookupVariables(text);
+      }
+      return null;
     }
 
     @Override

--- a/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
+++ b/ksqldb-parser/src/main/java/io/confluent/ksql/parser/VariableSubstitutor.java
@@ -22,7 +22,6 @@ import static io.confluent.ksql.util.ParserUtil.unquote;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.parser.exception.ParseFailedException;
-import io.confluent.ksql.util.ParserUtil;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -986,13 +986,13 @@ public class AstBuilderTest {
   public void shouldBuildAssertNotExistsTopicWithConfigsAndTimeout() {
     // Given:
     final SingleStatementContext stmt
-        = givenQuery("ASSERT NOT EXISTS TOPIC X WITH (REPLICAS=1, partitions=1) TIMEOUT 10 SECONDS;");
+        = givenQuery("ASSERT NOT EXISTS TOPIC 'a-b-c' WITH (REPLICAS=1, partitions=1) TIMEOUT 10 SECONDS;");
 
     // When:
     final AssertTopic assertTopic = (AssertTopic) builder.buildStatement(stmt);
 
     // Then:
-    assertThat(assertTopic.getTopic(), is("X"));
+    assertThat(assertTopic.getTopic(), is("a-b-c"));
     assertThat(assertTopic.getConfig().get("REPLICAS").getValue(), is(1));
     assertThat(assertTopic.getConfig().get("PARTITIONS").getValue(), is(1));
     assertThat(assertTopic.getTimeout().get().getTimeUnit(), is(TimeUnit.SECONDS));
@@ -1036,13 +1036,13 @@ public class AstBuilderTest {
   public void shouldBuildAssertNotExistsWithSubjectAndId() {
     // Given:
     final SingleStatementContext stmt
-        = givenQuery("ASSERT NOT EXISTS SCHEMA SUBJECT X ID 33;");
+        = givenQuery("ASSERT NOT EXISTS SCHEMA SUBJECT 'a-b-c' ID 33;");
 
     // When:
     final AssertSchema assertSchema = (AssertSchema) builder.buildStatement(stmt);
 
     // Then:
-    assertThat(assertSchema.getSubject(), is(Optional.of("X")));
+    assertThat(assertSchema.getSubject(), is(Optional.of("a-b-c")));
     assertThat(assertSchema.getId(), is(Optional.of(33)));
     assertThat(assertSchema.getTimeout(), is(Optional.empty()));
     assertThat(assertSchema.checkExists(), is(false));

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/VariableSubstitutorTest.java
@@ -254,6 +254,22 @@ public class VariableSubstitutorTest {
     assertThat(substituted, equalTo("Happy birthday to you!"));
   }
 
+  @Test
+  public void shouldSubstituteVariablesInAssert() {
+    // Given
+    final Map<String, String> variablesMap = new ImmutableMap.Builder<String, String>() {{
+      put("name", "foo");
+    }}.build();
+
+    // When
+    final String substitutedString = VariableSubstitutor.substitute("ASSERT TOPIC '${name}';", variablesMap);
+    final String substitutedIdentifier = VariableSubstitutor.substitute("ASSERT TOPIC ${name};", variablesMap);
+
+    // Then
+    assertThat(substitutedString, equalTo("ASSERT TOPIC 'foo';"));
+    assertThat(substitutedIdentifier, equalTo("ASSERT TOPIC foo;"));
+  }
+
   private void assertReplacedStatements(
       final List<Pair<String, String>> statements,
       final Map<String, String> variablesMap


### PR DESCRIPTION
### Description 
1. Allows users to specify topic names and schema subjects using either strings or identifier names. This is important because topics and schemas are allowed to use the `-` character in names, but ksqlDB does not allow that in identifiers.
2. Allows variable substitution for quoted names. 

### Testing done 
Unit tests, manual testing. Integration testing will be included with java client changes.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

