### PR TITLE
chore: cleanup compiler warnings

### DIFF
--- a/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksqldb-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -108,6 +108,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
 
   // validators return an Optional<RuntimeException> error message representing the
   // validation error, if any.
+  @SuppressWarnings("rawtypes")
   private static final ClassHandlerMapR2<StatementContext, Cli, Void, Optional>
       STATEMENT_VALIDATORS =
           HandlerMaps
@@ -476,6 +477,7 @@ public class Cli implements KsqlRequestExecutor, Closeable {
     }
   }
 
+  @SuppressWarnings("rawtypes")
   private void handleStatements(final String line) {
     final List<ParsedStatement> statements = KSQL_PARSER.parse(line);
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/UdafFactoryInvoker.java
@@ -85,7 +85,7 @@ class UdafFactoryInvoker implements FunctionSignature {
   }
 
   @SuppressFBWarnings({"EXS_EXCEPTION_SOFTENING_NO_CONSTRAINTS", "REC_CATCH_EXCEPTION"})
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"rawtypes", "unchecked"})
   KsqlAggregateFunction createFunction(final AggregateFunctionInitArguments initArgs,
       final List<SqlArgument> argTypeList) {
     final Object[] factoryArgs = initArgs.args().toArray();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/offset/LatestByOffset.java
@@ -86,7 +86,7 @@ public final class LatestByOffset {
   @VisibleForTesting
   static <T> Udaf<T, Struct, T> latestT(
       final boolean ignoreNulls,
-      final Comparator comparator
+      final Comparator<Struct> comparator
   ) {
     return new Udaf<T, Struct, T>() {
       Schema structSchema;
@@ -149,7 +149,7 @@ public final class LatestByOffset {
   static <T> Udaf<T, List<Struct>, List<T>> latestTN(
       final int latestN,
       final boolean ignoreNulls,
-      final Comparator comparator
+      final Comparator<Struct> comparator
   ) {
     if (latestN <= 0) {
       throw new KsqlFunctionException("latestN must be 1 or greater");

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -350,7 +350,7 @@ public class DefaultSchemaInjector implements Injector {
     return result.schemaAndId.get();
   }
 
-  @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity"})
+  @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:NPathComplexity", "unchecked"})
   private static boolean shouldInferSchema(
       final Optional<Integer> schemaId,
       final ConfiguredStatement<? extends Statement> statement,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -171,7 +171,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           () -> adminClient.get().describeTopics(
               ImmutableList.of(topic),
               new DescribeTopicsOptions().includeAuthorizedOperations(true)
-          ).values().get(topic).get(),
+          ).topicNameValues().get(topic).get(),
           RetryBehaviour.ON_RETRYABLE.and(e -> !(e instanceof UnknownTopicOrPartitionException))
       );
       return true;
@@ -205,7 +205,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           () -> adminClient.get().describeTopics(
               topicNames,
               new DescribeTopicsOptions().includeAuthorizedOperations(true)
-          ).all().get(),
+          ).allTopicNames().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
     } catch (final ExecutionException e) {
       throw new KafkaResponseGetFailedException(

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetrics.java
@@ -55,8 +55,8 @@ public class PersistentQuerySaturationMetrics implements Runnable {
   private static final String STREAMS_THREAD_METRICS_GROUP = "stream-thread-metrics";
   private static final String THREAD_ID = "thread-id";
   private static final String QUERY_ID = "query-id";
-  private static Map<String, String> customTags = new HashMap<>();
 
+  private Map<String, String> customTags;
   private final Map<String, KafkaStreamsSaturation> perKafkaStreamsStats = new HashMap<>();
   private final KsqlExecutionContext engine;
   private final Supplier<Instant> time;
@@ -88,8 +88,7 @@ public class PersistentQuerySaturationMetrics implements Runnable {
     this.reporter = Objects.requireNonNull(reporter, "reporter");
     this.window = Objects.requireNonNull(window, "window");
     this.sampleMargin = Objects.requireNonNull(sampleMargin, "sampleMargin");
-    PersistentQuerySaturationMetrics.customTags =
-        Objects.requireNonNull(customTags, "customTags");
+    this.customTags = Objects.requireNonNull(customTags, "customTags");
   }
 
   @Override
@@ -167,15 +166,15 @@ public class PersistentQuerySaturationMetrics implements Runnable {
             )
         )
     );
-  }
+  }git
   
-  private static Map<String, String> getTags(final String key, final String value) {
+  private Map<String, String> getTags(final String key, final String value) {
     final Map<String, String> newTags = new HashMap<>(customTags);
     newTags.put(key, value);
     return newTags;
   }
 
-  private static final class KafkaStreamsSaturation {
+  private final class KafkaStreamsSaturation {
     private final Set<QueryId> queryIds = new HashSet<>();
     private final Map<String, ThreadSaturation> perThreadSaturation = new HashMap<>();
     private final Duration window;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetrics.java
@@ -166,7 +166,7 @@ public class PersistentQuerySaturationMetrics implements Runnable {
             )
         )
     );
-  }git
+  }
   
   private Map<String, String> getTags(final String key, final String value) {
     final Map<String, String> newTags = new HashMap<>(customTags);

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetrics.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/utilization/PersistentQuerySaturationMetrics.java
@@ -88,7 +88,8 @@ public class PersistentQuerySaturationMetrics implements Runnable {
     this.reporter = Objects.requireNonNull(reporter, "reporter");
     this.window = Objects.requireNonNull(window, "window");
     this.sampleMargin = Objects.requireNonNull(sampleMargin, "sampleMargin");
-    this.customTags = Objects.requireNonNull(customTags, "customTags");
+    PersistentQuerySaturationMetrics.customTags =
+        Objects.requireNonNull(customTags, "customTags");
   }
 
   @Override

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/execution/scalablepush/consumer/ScalablePushConsumerTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/execution/scalablepush/consumer/ScalablePushConsumerTest.java
@@ -271,6 +271,7 @@ public class ScalablePushConsumerTest {
   }
 
   @Test
+  @SuppressWarnings("resource")
   public void shouldRunConsumer_closeAsync() {
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     AtomicReference<TestScalablePushConsumer> ref = new AtomicReference<>();

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -78,7 +78,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
@@ -90,7 +89,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -142,7 +140,7 @@ public class UdfLoaderTest {
   @Test
   public void shouldLoadBadFunctionButNotLetItExit() {
     // Given:
-    final List<SqlArgument> argList =  Arrays.asList(SqlArgument.of(SqlTypes.STRING));
+    final List<SqlArgument> argList = singletonList(SqlArgument.of(SqlTypes.STRING));
     // We do need to set up the ExtensionSecurityManager for our test.
     // This is controlled by a feature flag and in this test, we just directly enable it.
     SecurityManager manager = System.getSecurityManager();
@@ -169,7 +167,7 @@ public class UdfLoaderTest {
   @Test
   public void shouldLoadBadFunctionButNotLetItExit2() {
     // Given:
-    final List<SqlArgument> argList =  Arrays.asList(SqlArgument.of(SqlTypes.STRING));
+    final List<SqlArgument> argList = singletonList(SqlArgument.of(SqlTypes.STRING));
     // We do need to set up the ExtensionSecurityManager for our test.
     // This is controlled by a feature flag and in this test, we just directly enable it.
     SecurityManager manager = System.getSecurityManager();
@@ -195,7 +193,7 @@ public class UdfLoaderTest {
     assertEquals(System.getSecurityManager(), manager);
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"rawtypes", "unchecked"})
   @Test
   public void shouldLoadUdafs() {
     final KsqlAggregateFunction instance = FUNC_REG
@@ -206,7 +204,7 @@ public class UdfLoaderTest {
     assertThat(instance.getMerger().apply(null, 2L, 3L), equalTo(5L));
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"rawtypes", "unchecked"})
   @Test
   public void shouldLoadStructUdafs() {
     final Schema schema = SchemaBuilder.struct()
@@ -238,6 +236,7 @@ public class UdfLoaderTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void shouldNotLetBadUdafsExitWithBadCreate() {
     // Given:
     // We do need to set up the ExtensionSecurityManager for our test.
@@ -250,10 +249,9 @@ public class UdfLoaderTest {
     final Exception e1 = assertThrows(
         KsqlException.class,
         () -> {
-
-          KsqlAggregateFunction function = ((KsqlAggregateFunction) FUNC_REG
+          KsqlAggregateFunction function = FUNC_REG
               .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.array(SqlTypes.INTEGER),
-                  AggregateFunctionInitArguments.EMPTY_ARGS));
+                  AggregateFunctionInitArguments.EMPTY_ARGS);
           function.aggregate("foo", 2L);
         }
     );
@@ -279,7 +277,7 @@ public class UdfLoaderTest {
         () ->
             ((Configurable)FUNC_REG
                 .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.INTEGER,
-                    AggregateFunctionInitArguments.EMPTY_ARGS)).configure(Collections.EMPTY_MAP)
+                    AggregateFunctionInitArguments.EMPTY_ARGS)).configure(Collections.emptyMap())
     );
 
     // Then:
@@ -300,14 +298,9 @@ public class UdfLoaderTest {
     // This will exit via initialize
     final Exception e3 = assertThrows(
         SecurityException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() throws Throwable {
-            FUNC_REG
-                .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.DOUBLE,
-                    AggregateFunctionInitArguments.EMPTY_ARGS).getInitialValueSupplier().get();
-          }
-        }
+        () -> FUNC_REG
+            .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.DOUBLE,
+                AggregateFunctionInitArguments.EMPTY_ARGS).getInitialValueSupplier().get()
     );
 
     // Then:
@@ -317,6 +310,7 @@ public class UdfLoaderTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void shouldNotLetBadUdafsExitWithBadMap() {
     // Given:
     // We do need to set up the ExtensionSecurityManager for our test.
@@ -340,8 +334,8 @@ public class UdfLoaderTest {
     assertEquals(System.getSecurityManager(), manager);
   }
 
-
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void shouldNotLetBadUdafsExitWithBadMerge() {
     // Given:
     // We do need to set up the ExtensionSecurityManager for our test.
@@ -376,6 +370,7 @@ public class UdfLoaderTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void shouldNotLetBadUdafsExitWithBadAggregate() {
     // Given:
     // We do need to set up the ExtensionSecurityManager for our test.
@@ -400,6 +395,7 @@ public class UdfLoaderTest {
   }
 
   @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public void shouldNotLetBadUdatsExitWithBadUnfo() {
     // Given:
     // We do need to set up the ExtensionSecurityManager for our test.
@@ -435,12 +431,10 @@ public class UdfLoaderTest {
     // This will exit due to a bad getAggregateSqlType.
     final Exception error = assertThrows(
         KsqlException.class,
-        () -> {
-          KsqlAggregateFunction func = ((KsqlAggregateFunction) FUNC_REG
-              .getAggregateFunction(FunctionName.of("bad_test_udaf"),
-                  SqlTypes.array(SqlTypes.BIGINT),
-                  AggregateFunctionInitArguments.EMPTY_ARGS));
-        }
+        () -> FUNC_REG
+            .getAggregateFunction(FunctionName.of("bad_test_udaf"),
+                SqlTypes.array(SqlTypes.BIGINT),
+                AggregateFunctionInitArguments.EMPTY_ARGS)
     );
 
     // Then:
@@ -461,11 +455,9 @@ public class UdfLoaderTest {
     // This will exit due to a bad getReturnSqlType.
     final Exception error = assertThrows(
         KsqlException.class,
-        () -> {
-          KsqlAggregateFunction func = ((KsqlAggregateFunction) FUNC_REG
-              .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.array(SqlTypes.BOOLEAN),
-                  AggregateFunctionInitArguments.EMPTY_ARGS));
-        }
+        () -> FUNC_REG
+            .getAggregateFunction(FunctionName.of("bad_test_udaf"), SqlTypes.array(SqlTypes.BOOLEAN),
+                AggregateFunctionInitArguments.EMPTY_ARGS)
     );
 
     // Then:
@@ -647,90 +639,87 @@ public class UdfLoaderTest {
   }
 
   @Test
-  public void shouldThrowOnMissingAnnotation() throws ClassNotFoundException {
+  public void shouldThrowOnMissingAnnotation() throws Exception {
     // Given:
     final MutableFunctionRegistry functionRegistry = new InternalFunctionRegistry();
     final Path udfJar = new File("src/test/resources/udf-failing-tests.jar").toPath();
-    final UdfClassLoader udfClassLoader = newClassLoader(udfJar,
-        PARENT_CLASS_LOADER,
-        resourceName -> false);
-    final Class<?> clazz = udfClassLoader.loadClass("org.damian.ksql.udf.MissingAnnotationUdf");
-    final UdfLoader udfLoader = new UdfLoader(
-        functionRegistry,
-        empty(),
-        create(EMPTY),
-        true
-    );
+    try (UdfClassLoader udfClassLoader = newClassLoader(udfJar, PARENT_CLASS_LOADER, resourceName -> false)) {
+      final Class<?> clazz = udfClassLoader.loadClass("org.damian.ksql.udf.MissingAnnotationUdf");
+      final UdfLoader udfLoader = new UdfLoader(
+          functionRegistry,
+          empty(),
+          create(EMPTY),
+          true
+      );
 
-    // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> udfLoader.loadUdfFromClass(clazz)
-    );
+      // When:
+      final Exception e = assertThrows(
+          KsqlException.class,
+          () -> udfLoader.loadUdfFromClass(clazz)
+      );
 
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "Cannot load UDF MissingAnnotation. DECIMAL return type is " +
-            "not supported without an explicit schema"));
-
+      // Then:
+      assertThat(e.getMessage(), containsString(
+          "Cannot load UDF MissingAnnotation. DECIMAL return type is " +
+              "not supported without an explicit schema"));
+    }
   }
 
   @Test
-  public void shouldThrowOnMissingSchemaProvider() throws ClassNotFoundException {
+  public void shouldThrowOnMissingSchemaProvider() throws Exception {
     // Given:
     final MutableFunctionRegistry functionRegistry = new InternalFunctionRegistry();
     final Path udfJar = new File("src/test/resources/udf-failing-tests.jar").toPath();
-    final UdfClassLoader udfClassLoader = newClassLoader(udfJar,
-        PARENT_CLASS_LOADER,
-        resourceName -> false);
-    final Class<?> clazz = udfClassLoader.loadClass("org.damian.ksql.udf.MissingSchemaProviderUdf");
-    final UdfLoader udfLoader = new UdfLoader(
-        functionRegistry,
-        empty(),
-        create(EMPTY),
-        true
-    );
+    try (final UdfClassLoader udfClassLoader = newClassLoader(udfJar, PARENT_CLASS_LOADER, resourceName -> false)) {
+      final Class<?> clazz = udfClassLoader.loadClass(
+          "org.damian.ksql.udf.MissingSchemaProviderUdf");
+      final UdfLoader udfLoader = new UdfLoader(
+          functionRegistry,
+          empty(),
+          create(EMPTY),
+          true
+      );
 
-    // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> udfLoader.loadUdfFromClass(clazz)
-    );
+      // When:
+      final Exception e = assertThrows(
+          KsqlException.class,
+          () -> udfLoader.loadUdfFromClass(clazz)
+      );
 
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "Cannot find schema provider method with name provideSchema "
-            + "and parameter List<SqlType> in class org.damian.ksql.udf."
-            + "MissingSchemaProviderUdf."));
+      // Then:
+      assertThat(e.getMessage(), containsString(
+          "Cannot find schema provider method with name provideSchema "
+              + "and parameter List<SqlType> in class org.damian.ksql.udf."
+              + "MissingSchemaProviderUdf."));
+    }
   }
 
   @Test
-  public void shouldThrowOnReturnDecimalWithoutSchemaProvider() throws ClassNotFoundException {
+  public void shouldThrowOnReturnDecimalWithoutSchemaProvider() throws Exception {
     // Given:
     final MutableFunctionRegistry functionRegistry = new InternalFunctionRegistry();
     final Path udfJar = new File("src/test/resources/udf-failing-tests.jar").toPath();
-    final UdfClassLoader udfClassLoader = newClassLoader(udfJar,
-        PARENT_CLASS_LOADER,
-        resourceName -> false);
-    final Class<?> clazz = udfClassLoader.loadClass("org.damian.ksql.udf."
-        + "ReturnDecimalWithoutSchemaProviderUdf");
-    final UdfLoader udfLoader = new UdfLoader(
-        functionRegistry,
-        empty(),
-        create(EMPTY),
-        true
-    );
+    try (final UdfClassLoader udfClassLoader = newClassLoader(udfJar, PARENT_CLASS_LOADER, resourceName -> false)) {
+      final Class<?> clazz = udfClassLoader.loadClass("org.damian.ksql.udf."
+          + "ReturnDecimalWithoutSchemaProviderUdf");
+      final UdfLoader udfLoader = new UdfLoader(
+          functionRegistry,
+          empty(),
+          create(EMPTY),
+          true
+      );
 
-    // When:
-    final Exception e = assertThrows(
-        KsqlException.class,
-        () -> udfLoader.loadUdfFromClass(clazz)
-    );
+      // When:
+      final Exception e = assertThrows(
+          KsqlException.class,
+          () -> udfLoader.loadUdfFromClass(clazz)
+      );
 
-    // Then:
-    assertThat(e.getMessage(), containsString(
-        "Cannot load UDF ReturnDecimalWithoutSchemaProvider. DECIMAL return type is not " +
-            "supported without an explicit schema"));
+      // Then:
+      assertThat(e.getMessage(), containsString(
+          "Cannot load UDF ReturnDecimalWithoutSchemaProvider. DECIMAL return type is not " +
+              "supported without an explicit schema"));
+    }
   }
 
   @Test
@@ -752,7 +741,6 @@ public class UdfLoaderTest {
 
   @Test
   public void shouldAllowClassesWithSameFQCNInDifferentUDFJars() throws Exception {
-
     final File pluginDir = tempFolder.newFolder();
     Files.copy(Paths.get("src/test/resources/udf-example.jar"),
         new File(pluginDir, "udf-example.jar").toPath());
@@ -789,9 +777,7 @@ public class UdfLoaderTest {
   @Test
   public void shouldCreateUdfFactoryWithJarPathWhenExternal() {
     final UdfFactory tostring = FUNC_REG.getUdfFactory(FunctionName.of("tostring"));
-    String expectedPath = Arrays.asList("src", "test", "resources", "udf-example.jar")
-        .stream()
-        .collect(Collectors.joining(File.separator));
+    String expectedPath = String.join(File.separator, "src", "test", "resources", "udf-example.jar");
     assertThat(tostring.getMetadata().getPath(), equalTo(expectedPath));
   }
 
@@ -1121,11 +1107,12 @@ public class UdfLoaderTest {
         "",
         "",
         "");
-    assertThat(creator.createFunction(AggregateFunctionInitArguments.EMPTY_ARGS, Collections.EMPTY_LIST),
+    assertThat(creator.createFunction(AggregateFunctionInitArguments.EMPTY_ARGS, Collections.emptyList()),
         not(nullValue()));
   }
 
   @Test
+  @SuppressWarnings("rawtypes")
   public void shouldConfigureConfigurableUdaf() throws Exception {
     // Given:
     final UdafFactoryInvoker creator
@@ -1140,7 +1127,7 @@ public class UdfLoaderTest {
         0, ImmutableMap.of("ksql.functions.test_udaf.init", 100L));
 
     // When:
-    final KsqlAggregateFunction function = creator.createFunction(initArgs, Collections.EMPTY_LIST);
+    final KsqlAggregateFunction function = creator.createFunction(initArgs, Collections.emptyList());
     final Object initvalue = function.getInitialValueSupplier().get();
 
     // Then:
@@ -1162,6 +1149,7 @@ public class UdfLoaderTest {
   }
 
   @Test
+  @SuppressWarnings("rawtypes")
   public void shouldImplementTableAggregateFunctionWhenTableUdafClass() throws Exception {
     final UdafFactoryInvoker creator
         = createUdafLoader().createUdafFactoryInvoker(
@@ -1172,11 +1160,12 @@ public class UdfLoaderTest {
         "",
         "");
     final KsqlAggregateFunction function = creator
-        .createFunction(AggregateFunctionInitArguments.EMPTY_ARGS, Collections.EMPTY_LIST);
+        .createFunction(AggregateFunctionInitArguments.EMPTY_ARGS, Collections.emptyList());
     assertThat(function, instanceOf(TableAggregationFunction.class));
   }
 
   @Test
+  @SuppressWarnings("rawtypes")
   public void shouldInvokeUdafWhenMethodHasArgs() throws Exception {
     final UdafFactoryInvoker creator
         = createUdafLoader().createUdafFactoryInvoker(
@@ -1189,7 +1178,7 @@ public class UdfLoaderTest {
         "",
         "");
     final KsqlAggregateFunction instance =
-        creator.createFunction(new AggregateFunctionInitArguments(0, "foo"), Collections.EMPTY_LIST);
+        creator.createFunction(new AggregateFunctionInitArguments(0, "foo"), Collections.emptyList());
     assertThat(instance,
         not(nullValue()));
     assertThat(instance, not(instanceOf(TableAggregationFunction.class)));
@@ -1221,6 +1210,7 @@ public class UdfLoaderTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldPassSqlInputTypesToUdafs() throws Exception {
     final UdafFactoryInvoker creator
         = createUdafLoader().createUdafFactoryInvoker(
@@ -1259,7 +1249,7 @@ public class UdfLoaderTest {
   }
 
   @Test
-  public void shouldThrowIfMissingInputTypeSchema() throws Exception {
+  public void shouldThrowIfMissingInputTypeSchema() {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
@@ -1322,7 +1312,7 @@ public class UdfLoaderTest {
   }
 
   @Test
-  public void shouldThrowIfArrayWithoutVarArgs() throws Exception {
+  public void shouldThrowIfArrayWithoutVarArgs() {
     // When:
     final Exception e = assertThrows(
         KsqlFunctionException.class,
@@ -1336,7 +1326,7 @@ public class UdfLoaderTest {
   }
 
   @Test
-  public void shouldThrowIfArrayAndVarArgs() throws Exception {
+  public void shouldThrowIfArrayAndVarArgs() {
     // When:
     final Exception e = assertThrows(
         KsqlFunctionException.class,
@@ -1367,7 +1357,7 @@ public class UdfLoaderTest {
   }
 
   @Test
-  public void shouldThrowWhenUdafReturnTypeIsntAUdaf() throws Exception {
+  public void shouldThrowWhenUdafReturnTypeIsntAUdaf() {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
@@ -1485,7 +1475,7 @@ public class UdfLoaderTest {
   }
 
   @Test
-  public void shouldThrowWhenTryingToGenerateUdafThatHasIncorrectTypes() throws Exception {
+  public void shouldThrowWhenTryingToGenerateUdafThatHasIncorrectTypes() {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
@@ -1504,7 +1494,7 @@ public class UdfLoaderTest {
   }
 
   @Test
-  public void shouldThrowWhenUdafFactoryMethodIsntStatic() throws Exception {
+  public void shouldThrowWhenUdafFactoryMethodIsntStatic() {
     // When:
     final Exception e = assertThrows(
         KsqlException.class,
@@ -1522,7 +1512,7 @@ public class UdfLoaderTest {
         "UDAF factory methods must be static public io.confluent.ksql.function.udaf.Udaf"));
   }
 
-  public String udf(final Set val) {
+  public String udf(final Set<?> val) {
     return val.toString();
   }
 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/TestUdaf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/TestUdaf.java
@@ -124,6 +124,7 @@ public final class TestUdaf {
       }
 
       @Override
+      @SuppressWarnings("unchecked")
       public void initializeTypeArguments(List<SqlArgument> argTypeList) {
         type = argTypeList.get(0).getSqlTypeOrThrow();
         if (type == SqlTypes.DOUBLE) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/BytesMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/BytesMaxKudafTest.java
@@ -94,7 +94,7 @@ public class BytesMaxKudafTest {
 
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf bytesMaxKudaf = getMaxComparableKudaf();
+    final MaxKudaf<ByteBuffer> bytesMaxKudaf = getMaxComparableKudaf();
     final Merger<GenericKey, ByteBuffer> merger = bytesMaxKudaf.getMerger();
     final String mergeResult1 = fromBytesUDF.fromBytes(
         merger.apply(
@@ -119,12 +119,13 @@ public class BytesMaxKudafTest {
     assertThat(mergeResult3, equalTo("K"));
   }
 
-  private MaxKudaf getMaxComparableKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<ByteBuffer> getMaxComparableKudaf() {
+    final KsqlAggregateFunction<ByteBuffer, ByteBuffer, ByteBuffer> aggregateFunction =
+        (KsqlAggregateFunction<ByteBuffer, ByteBuffer, ByteBuffer>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.BYTES)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<ByteBuffer>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DateMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DateMaxKudafTest.java
@@ -67,7 +67,7 @@ public class DateMaxKudafTest {
 
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf dateMaxKudaf = getMaxComparableKudaf();
+    final MaxKudaf<Date> dateMaxKudaf = getMaxComparableKudaf();
     final Merger<GenericKey, Date> merger = dateMaxKudaf.getMerger();
     final Date mergeResult1 = merger.apply(null, new Date(10), new Date(12));
     assertThat(mergeResult1, equalTo(new Date(12)));
@@ -75,15 +75,15 @@ public class DateMaxKudafTest {
     assertThat(mergeResult2, equalTo(new Date(10)));
     final Date mergeResult3 = merger.apply(null, new Date(-10), new Date(0));
     assertThat(mergeResult3, equalTo(new Date(0)));
-
   }
 
-  private MaxKudaf getMaxComparableKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<Date> getMaxComparableKudaf() {
+    final KsqlAggregateFunction<Date, Date, Date> aggregateFunction =
+        (KsqlAggregateFunction<Date, Date, Date>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.DATE)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<Date>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DecimalMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DecimalMaxKudafTest.java
@@ -68,7 +68,7 @@ public class DecimalMaxKudafTest {
 
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf decimalMaxKudaf = getMaxComparableKudaf(3);
+    final MaxKudaf<BigDecimal> decimalMaxKudaf = getMaxComparableKudaf(3);
     final Merger<GenericKey, BigDecimal> merger = decimalMaxKudaf.getMerger();
     final BigDecimal mergeResult1 = merger.apply(null, new BigDecimal(10.0), new BigDecimal(12.0));
     assertThat(mergeResult1, equalTo(new BigDecimal(12.0, new MathContext(3))));
@@ -78,13 +78,13 @@ public class DecimalMaxKudafTest {
     assertThat(mergeResult3, equalTo(new BigDecimal(0.0, new MathContext(3))));
   }
 
-
-  private MaxKudaf getMaxComparableKudaf(final int precision) {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<BigDecimal> getMaxComparableKudaf(final int precision) {
+    final KsqlAggregateFunction<BigDecimal, BigDecimal, BigDecimal> aggregateFunction =
+        (KsqlAggregateFunction<BigDecimal, BigDecimal, BigDecimal>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlDecimal.of(precision, 1)))
             , AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<BigDecimal>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
@@ -61,9 +61,10 @@ public class DoubleMaxKudafTest {
     currentMax = doubleMaxKudaf.aggregate(null, currentMax);
     assertThat(8.0, equalTo(currentMax));
   }
+
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf doubleMaxKudaf = getMaxComparableKudaf();
+    final MaxKudaf<Double> doubleMaxKudaf = getMaxComparableKudaf();
     final Merger<GenericKey, Double> merger = doubleMaxKudaf.getMerger();
     final Double mergeResult1 = merger.apply(null, 10.0, 12.0);
     assertThat(mergeResult1, equalTo(12.0));
@@ -71,15 +72,15 @@ public class DoubleMaxKudafTest {
     assertThat(mergeResult2, equalTo(10.0));
     final Double mergeResult3 = merger.apply(null, -10.0, 0.0);
     assertThat(mergeResult3, equalTo(0.0));
-
   }
 
-  private MaxKudaf getMaxComparableKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<Double> getMaxComparableKudaf() {
+    final KsqlAggregateFunction<Double, Double, Double> aggregateFunction =
+        (KsqlAggregateFunction<Double, Double, Double>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<Double>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -64,7 +64,7 @@ public class IntegerMaxKudafTest {
 
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf integerMaxKudaf = getMaxComparableKudaf();
+    final MaxKudaf<Integer> integerMaxKudaf = getMaxComparableKudaf();
     final Merger<GenericKey, Integer> merger = integerMaxKudaf.getMerger();
     final Integer mergeResult1 = merger.apply(null, 10, 12);
     assertThat(mergeResult1, equalTo(12));
@@ -72,15 +72,15 @@ public class IntegerMaxKudafTest {
     assertThat(mergeResult2, equalTo(10));
     final Integer mergeResult3 = merger.apply(null, -10, 0);
     assertThat(mergeResult3, equalTo(0));
-
   }
 
-  private MaxKudaf getMaxComparableKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<Integer> getMaxComparableKudaf() {
+    final KsqlAggregateFunction<Integer, Integer, Integer> aggregateFunction =
+        (KsqlAggregateFunction<Integer, Integer, Integer>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<Integer>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
@@ -64,7 +64,7 @@ public class LongMaxKudafTest {
 
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf longMaxKudaf = getMaxComparableKudaf();
+    final MaxKudaf<Long> longMaxKudaf = getMaxComparableKudaf();
     final Merger<GenericKey, Long> merger = longMaxKudaf.getMerger();
     final Long mergeResult1 = merger.apply(null, 10L, 12L);
     assertThat(mergeResult1, equalTo(12L));
@@ -72,15 +72,15 @@ public class LongMaxKudafTest {
     assertThat(mergeResult2, equalTo(10L));
     final Long mergeResult3 = merger.apply(null, -10L, 0L);
     assertThat(mergeResult3, equalTo(0L));
-
   }
 
-  private MaxKudaf getMaxComparableKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<Long> getMaxComparableKudaf() {
+    final KsqlAggregateFunction<Long, Long, Long> aggregateFunction =
+        (KsqlAggregateFunction<Long, Long, Long>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.BIGINT)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<Long>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/StringMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/StringMaxKudafTest.java
@@ -64,7 +64,7 @@ public class StringMaxKudafTest {
 
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf stringMaxKudaf = getMaxComparableKudaf();
+    final MaxKudaf<String> stringMaxKudaf = getMaxComparableKudaf();
     final Merger<GenericKey, String> merger = stringMaxKudaf.getMerger();
     final String mergeResult1 = merger.apply(null, "B", "D");
     assertThat(mergeResult1, equalTo("D"));
@@ -74,12 +74,13 @@ public class StringMaxKudafTest {
     assertThat(mergeResult3, equalTo("K"));
   }
 
-  private MaxKudaf getMaxComparableKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<String> getMaxComparableKudaf() {
+    final KsqlAggregateFunction<String, String , String> aggregateFunction =
+        (KsqlAggregateFunction<String, String , String>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.STRING)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<String>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/TimeMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/TimeMaxKudafTest.java
@@ -67,7 +67,7 @@ public class TimeMaxKudafTest {
 
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf timeMaxKudaf = getMaxComparableKudaf();
+    final MaxKudaf<Time> timeMaxKudaf = getMaxComparableKudaf();
     final Merger<GenericKey, Time> merger = timeMaxKudaf.getMerger();
     final Time mergeResult1 = merger.apply(null, new Time(10), new Time(12));
     assertThat(mergeResult1, equalTo(new Time(12)));
@@ -75,15 +75,14 @@ public class TimeMaxKudafTest {
     assertThat(mergeResult2, equalTo(new Time(10)));
     final Time mergeResult3 = merger.apply(null, new Time(-10), new Time(0));
     assertThat(mergeResult3, equalTo(new Time(0)));
-
   }
 
-  private MaxKudaf getMaxComparableKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<Time> getMaxComparableKudaf() {
+    final KsqlAggregateFunction<Time, Time, Time> aggregateFunction = (KsqlAggregateFunction<Time, Time, Time>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.TIME)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<Time>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/TimestampMaxKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/max/TimestampMaxKudafTest.java
@@ -67,7 +67,7 @@ public class TimestampMaxKudafTest {
 
   @Test
   public void shouldFindCorrectMaxForMerge() {
-    final MaxKudaf tsMaxKudaf = getTimestampMaxKudaf();
+    final MaxKudaf<Timestamp> tsMaxKudaf = getTimestampMaxKudaf();
     final Merger<GenericKey, Timestamp> merger = tsMaxKudaf.getMerger();
     final Timestamp mergeResult1 = merger.apply(null, new Timestamp(10), new Timestamp(12));
     assertThat(mergeResult1, equalTo(new Timestamp(12)));
@@ -75,15 +75,15 @@ public class TimestampMaxKudafTest {
     assertThat(mergeResult2, equalTo(new Timestamp(10)));
     final Timestamp mergeResult3 = merger.apply(null, new Timestamp(-10), new Timestamp(0));
     assertThat(mergeResult3, equalTo(new Timestamp(0)));
-
   }
 
-  private MaxKudaf getTimestampMaxKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MaxKudaf<Timestamp> getTimestampMaxKudaf() {
+    final KsqlAggregateFunction<Timestamp, Timestamp, Timestamp> aggregateFunction =
+        (KsqlAggregateFunction<Timestamp, Timestamp, Timestamp>) new MaxAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.TIMESTAMP)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MaxKudaf.class));
-    return  (MaxKudaf) aggregateFunction;
+    return  (MaxKudaf<Timestamp>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/BytesMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/BytesMinKudafTest.java
@@ -94,7 +94,7 @@ public class BytesMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf bytesMinKudaf = getBytesMinKudaf();
+    final MinKudaf<ByteBuffer> bytesMinKudaf = getBytesMinKudaf();
     final Merger<GenericKey, ByteBuffer> merger = bytesMinKudaf.getMerger();
     final String mergeResult1 = fromBytesUDF.fromBytes(
         merger.apply(
@@ -119,12 +119,13 @@ public class BytesMinKudafTest {
     assertThat(mergeResult3, equalTo("A"));
   }
 
-  private MinKudaf getBytesMinKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MinKudaf<ByteBuffer> getBytesMinKudaf() {
+    final KsqlAggregateFunction<ByteBuffer, ByteBuffer, ByteBuffer> aggregateFunction =
+        (KsqlAggregateFunction<ByteBuffer, ByteBuffer, ByteBuffer>) new MinAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.BYTES)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return  (MinKudaf) aggregateFunction;
+    return  (MinKudaf<ByteBuffer>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DateMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DateMinKudafTest.java
@@ -67,7 +67,7 @@ public class DateMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf dateMinKudaf = getDateMinKudaf();
+    final MinKudaf<Date> dateMinKudaf = getDateMinKudaf();
     final Merger<GenericKey, Date> merger = dateMinKudaf.getMerger();
     final Date mergeResult1 = merger.apply(null, new Date(10), new Date(12));
     assertThat(mergeResult1, equalTo(new Date(10L)));
@@ -75,15 +75,15 @@ public class DateMinKudafTest {
     assertThat(mergeResult2, equalTo(new Date(-12L)));
     final Date mergeResult3 = merger.apply(null, new Date(-10), new Date(0));
     assertThat(mergeResult3, equalTo(new Date(-10)));
-
   }
 
-
-  private MinKudaf getDateMinKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MinKudaf<Date> getDateMinKudaf() {
+    final KsqlAggregateFunction<Date, Date, Date> aggregateFunction =
+        (KsqlAggregateFunction<Date, Date, Date>) new MinAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.DATE)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return  (MinKudaf) aggregateFunction;
+    return  (MinKudaf<Date>) aggregateFunction;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DecimalMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DecimalMinKudafTest.java
@@ -68,7 +68,7 @@ public class DecimalMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf decimalMinKudaf = getDecimalMinKudaf(3);
+    final MinKudaf<BigDecimal> decimalMinKudaf = getDecimalMinKudaf(3);
     final Merger<GenericKey, BigDecimal> merger = decimalMinKudaf.getMerger();
     final BigDecimal mergeResult1 = merger.apply(null, new BigDecimal(10.0), new BigDecimal(12.0));
     assertThat(mergeResult1, equalTo(new BigDecimal(10.0, new MathContext(3))));
@@ -78,13 +78,13 @@ public class DecimalMinKudafTest {
     assertThat(mergeResult3, equalTo(new BigDecimal(-10.0, new MathContext(3))));
   }
 
-
-  private MinKudaf getDecimalMinKudaf(final int precision) {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MinKudaf<BigDecimal> getDecimalMinKudaf(final int precision) {
+    final KsqlAggregateFunction<BigDecimal, BigDecimal, BigDecimal> aggregateFunction =
+        (KsqlAggregateFunction<BigDecimal, BigDecimal, BigDecimal>) new MinAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlDecimal.of(precision, 1))),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return  (MinKudaf) aggregateFunction;
+    return  (MinKudaf<BigDecimal>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
@@ -64,7 +64,7 @@ public class DoubleMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf doubleMinKudaf = getDoubleMinKudaf();
+    final MinKudaf<Double> doubleMinKudaf = getDoubleMinKudaf();
     final Merger<GenericKey, Double> merger = doubleMinKudaf.getMerger();
     final Double mergeResult1 = merger.apply(null, 10.0, 12.0);
     assertThat(mergeResult1, equalTo(10.0));
@@ -72,15 +72,17 @@ public class DoubleMinKudafTest {
     assertThat(mergeResult2, equalTo(-12.0));
     final Double mergeResult3 = merger.apply(null, -10.0, 0.0);
     assertThat(mergeResult3, equalTo(-10.0));
-
   }
 
-
-  private MinKudaf getDoubleMinKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE)),
-            AggregateFunctionInitArguments.EMPTY_ARGS);
+  @SuppressWarnings("unchecked")
+  private MinKudaf<Double> getDoubleMinKudaf() {
+    final KsqlAggregateFunction<Double, Double, Double> aggregateFunction =
+        (KsqlAggregateFunction<Double, Double, Double>) new MinAggFunctionFactory()
+        .createAggregateFunction(
+            Collections.singletonList(SqlArgument.of(SqlTypes.DOUBLE)),
+            AggregateFunctionInitArguments.EMPTY_ARGS
+        );
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return  (MinKudaf) aggregateFunction;
+    return (MinKudaf<Double>) aggregateFunction;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -64,7 +64,7 @@ public class IntegerMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf integerMinKudaf = getIntegerMinKudaf();
+    final MinKudaf<Integer> integerMinKudaf = getIntegerMinKudaf();
     final Merger<GenericKey, Integer> merger = integerMinKudaf.getMerger();
     final Integer mergeResult1 = merger.apply(null, 10, 12);
     assertThat(mergeResult1, equalTo(10));
@@ -72,15 +72,15 @@ public class IntegerMinKudafTest {
     assertThat(mergeResult2, equalTo(-12));
     final Integer mergeResult3 = merger.apply(null, -10, 0);
     assertThat(mergeResult3, equalTo(-10));
-
   }
 
-
-  private MinKudaf getIntegerMinKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MinKudaf<Integer> getIntegerMinKudaf() {
+    final KsqlAggregateFunction<Integer, Integer, Integer> aggregateFunction =
+        (KsqlAggregateFunction<Integer, Integer, Integer>) new MinAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.INTEGER)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return  (MinKudaf) aggregateFunction;
+    return  (MinKudaf<Integer>) aggregateFunction;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
@@ -64,7 +64,7 @@ public class LongMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf longMinKudaf = getLongMinKudaf();
+    final MinKudaf<Long> longMinKudaf = getLongMinKudaf();
     final Merger<GenericKey, Long> merger = longMinKudaf.getMerger();
     final Long mergeResult1 = merger.apply(null, 10L, 12L);
     assertThat(mergeResult1, equalTo(10L));
@@ -72,15 +72,15 @@ public class LongMinKudafTest {
     assertThat(mergeResult2, equalTo(-12L));
     final Long mergeResult3 = merger.apply(null, -10L, 0L);
     assertThat(mergeResult3, equalTo(-10L));
-
   }
 
-
-  private MinKudaf getLongMinKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MinKudaf<Long> getLongMinKudaf() {
+    final KsqlAggregateFunction<Long, Long, Long> aggregateFunction =
+        (KsqlAggregateFunction<Long, Long, Long>) new MinAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.BIGINT)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return  (MinKudaf) aggregateFunction;
+    return  (MinKudaf<Long>) aggregateFunction;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/StringMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/StringMinKudafTest.java
@@ -64,7 +64,7 @@ public class StringMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf stringMinKudaf = getStringMinKudaf();
+    final MinKudaf<String> stringMinKudaf = getStringMinKudaf();
     final Merger<GenericKey, String> merger = stringMinKudaf.getMerger();
     final String mergeResult1 = merger.apply(null, "B", "D");
     assertThat(mergeResult1, equalTo("B"));
@@ -74,12 +74,13 @@ public class StringMinKudafTest {
     assertThat(mergeResult3, equalTo("A"));
   }
 
-  private MinKudaf getStringMinKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MinKudaf<String> getStringMinKudaf() {
+    final KsqlAggregateFunction<String, String , String> aggregateFunction =
+        (KsqlAggregateFunction<String, String , String>) new MinAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.STRING)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return  (MinKudaf) aggregateFunction;
+    return  (MinKudaf<String>) aggregateFunction;
   }
-
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/TimeMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/TimeMinKudafTest.java
@@ -67,7 +67,7 @@ public class TimeMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf timeMinKudaf = getTimeMinKudaf();
+    final MinKudaf<Time> timeMinKudaf = getTimeMinKudaf();
     final Merger<GenericKey, Time> merger = timeMinKudaf.getMerger();
     final Time mergeResult1 = merger.apply(null, new Time(10), new Time(12));
     assertThat(mergeResult1, equalTo(new Time(10L)));
@@ -75,15 +75,15 @@ public class TimeMinKudafTest {
     assertThat(mergeResult2, equalTo(new Time(-12L)));
     final Time mergeResult3 = merger.apply(null, new Time(-10), new Time(0));
     assertThat(mergeResult3, equalTo(new Time(-10)));
-
   }
 
-
-  private MinKudaf getTimeMinKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MinKudaf<Time> getTimeMinKudaf() {
+    final KsqlAggregateFunction<Time, Time, Time> aggregateFunction =
+        (KsqlAggregateFunction<Time, Time, Time>) new MinAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.TIME)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return (MinKudaf) aggregateFunction;
+    return (MinKudaf<Time>) aggregateFunction;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/TimestampMinKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/min/TimestampMinKudafTest.java
@@ -67,7 +67,7 @@ public class TimestampMinKudafTest {
 
   @Test
   public void shouldFindCorrectMinForMerge() {
-    final MinKudaf tsMinKudaf = getTimestampMinKudaf();
+    final MinKudaf<Timestamp> tsMinKudaf = getTimestampMinKudaf();
     final Merger<GenericKey, Timestamp> merger = tsMinKudaf.getMerger();
     final Timestamp mergeResult1 = merger.apply(null, new Timestamp(10), new Timestamp(12));
     assertThat(mergeResult1, equalTo(new Timestamp(10L)));
@@ -75,15 +75,15 @@ public class TimestampMinKudafTest {
     assertThat(mergeResult2, equalTo(new Timestamp(-12L)));
     final Timestamp mergeResult3 = merger.apply(null, new Timestamp(-10), new Timestamp(0));
     assertThat(mergeResult3, equalTo(new Timestamp(-10)));
-
   }
 
-
-  private MinKudaf getTimestampMinKudaf() {
-    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+  @SuppressWarnings("unchecked")
+  private MinKudaf<Timestamp> getTimestampMinKudaf() {
+    final KsqlAggregateFunction<Timestamp, Timestamp, Timestamp> aggregateFunction =
+        (KsqlAggregateFunction<Timestamp, Timestamp, Timestamp>) new MinAggFunctionFactory()
         .createAggregateFunction(Collections.singletonList(SqlArgument.of(SqlTypes.TIMESTAMP)),
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(MinKudaf.class));
-    return  (MinKudaf) aggregateFunction;
+    return  (MinKudaf<Timestamp>) aggregateFunction;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdtf.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/BadTestUdtf.java
@@ -115,7 +115,7 @@ public class BadTestUdtf {
   @Udtf
   public List<Boolean> listBooleanReturn(final boolean b)
       throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    Class shutdown = Class.forName("java.lang.Shutdown");
+    Class<?>shutdown = Class.forName("java.lang.Shutdown");
     Method method = shutdown.getDeclaredMethod("exit", int.class);
     method.setAccessible(true);
     method.invoke(shutdown, -10);

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/LeastTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/LeastTest.java
@@ -37,11 +37,11 @@ public class LeastTest {
   
   @Test
   public void shouldHandleNullArrays(){
-    assertThat(udf.least((Integer) null, null), is(nullValue()));
-    assertThat(udf.least((Double) null, null), is(nullValue()));
-    assertThat(udf.least((Long) null, null), is(nullValue()));
-    assertThat(udf.least((BigDecimal) null, null), is(nullValue()));
-    assertThat(udf.least((String) null, null), is(nullValue()));
+    assertThat(udf.least(null, (Integer) null), is(nullValue()));
+    assertThat(udf.least(null, (Double) null), is(nullValue()));
+    assertThat(udf.least(null, (Long) null), is(nullValue()));
+    assertThat(udf.least(null, (BigDecimal) null), is(nullValue()));
+    assertThat(udf.least(null, (String) null), is(nullValue()));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -21,14 +20,11 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricValueProvider;
 import org.apache.kafka.common.metrics.Metrics;
-import org.codehaus.janino.Java;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,6 +56,7 @@ public class StorageUtilizationMetricsReporterTest {
   private ArgumentCaptor<MetricValueProvider<?>> metricValueProvider;
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
     listener = new StorageUtilizationMetricsReporter();
     listener.configure(
@@ -67,7 +64,7 @@ public class StorageUtilizationMetricsReporterTest {
             KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG, metrics
         )
     );
-    when(metrics.metricName(any(), any(), (Map<String, String>) any())).thenAnswer(
+    when(metrics.metricName(any(), any(), any(Map.class))).thenAnswer(
       a -> new MetricName(a.getArgument(0), a.getArgument(1), "", a.getArgument(2)));
     StorageUtilizationMetricsReporter.setTags(BASE_TAGS);
   }
@@ -88,7 +85,7 @@ public class StorageUtilizationMetricsReporterTest {
     final File f = new File("/tmp/storage-test/");
     f.getParentFile().mkdirs();
     f.createNewFile();
-    listener.configureShared(f, metrics, BASE_TAGS);
+    StorageUtilizationMetricsReporter.configureShared(f, metrics, BASE_TAGS);
 
     // When:
     final Gauge<?> storageFreeGauge = verifyAndGetRegisteredMetric("node_storage_free_bytes", BASE_TAGS);
@@ -328,26 +325,26 @@ public class StorageUtilizationMetricsReporterTest {
     
     // Then:
     BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage(metrics);
-    assertTrue(maxVal.equals(BigInteger.valueOf(5)));
+    assertEquals(maxVal, BigInteger.valueOf(5));
   }
 
   @Test
   public void shouldRecordMaxTaskUsageWithNoTasks() {
     // Given:
-    when(metrics.metrics()).thenReturn(Collections.EMPTY_MAP);
+    when(metrics.metrics()).thenReturn(Collections.emptyMap());
 
     // When:
 
     // Then:
     BigInteger maxVal = StorageUtilizationMetricsReporter.getMaxTaskUsage(metrics);
-    assertTrue(maxVal.equals(BigInteger.valueOf(0)));
+    assertEquals(maxVal, BigInteger.valueOf(0));
   }
   
   @Test
   public void shouldRecordNumStatefulTasks() {
     // Given:
     final File f = new File("/tmp/storage-test/");
-    listener.configureShared(f, metrics, BASE_TAGS);
+    StorageUtilizationMetricsReporter.configureShared(f, metrics, BASE_TAGS);
     final Gauge<?> numStatefulTasksGauge = verifyAndGetRegisteredMetric("num_stateful_tasks", BASE_TAGS);
 
     // When:

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/query/QueryRegistryImplTest.java
@@ -36,7 +36,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.BinPackedPersistentQueryMetadataImpl;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
-import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.PersistentQueryMetadataImpl;
 import io.confluent.ksql.util.QueryMetadata;
@@ -90,8 +89,6 @@ public class QueryRegistryImplTest {
   private ServiceContext serviceContext;
   @Mock
   private MetaStore metaStore;
-  @Mock
-  private DataSource source;
   @Captor
   private ArgumentCaptor<QueryMetadata.Listener> queryListenerCaptor;
   @SuppressWarnings("Unused")
@@ -100,7 +97,6 @@ public class QueryRegistryImplTest {
 
   private QueryRegistryImpl registry;
 
-  @SuppressWarnings("deprecation")
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Boolean> data() {
     return Arrays.asList(
@@ -556,10 +552,10 @@ public class QueryRegistryImplTest {
   }
 
   private DataSource toSource(final String name) {
-    final DataSource source = Mockito.mock(DataSource.class);
-    return source;
+    return Mockito.mock(DataSource.class);
   }
 
+  @SuppressWarnings({"rawtypes", "unchecked"})
   private PersistentQueryMetadata givenCreate(
       final QueryRegistry registry,
       final String id,
@@ -591,9 +587,7 @@ public class QueryRegistryImplTest {
       Field sharedRuntime = BinPackedPersistentQueryMetadataImpl.class.getDeclaredField("sharedKafkaStreamsRuntime");
       sharedRuntime.setAccessible(true);
       sharedRuntime.set(newQuery, runtime);
-    } catch (NoSuchFieldException e) {
-      e.printStackTrace();
-    } catch (IllegalAccessException e) {
+    } catch (final NoSuchFieldException | IllegalAccessException e) {
       e.printStackTrace();
     }
 
@@ -658,7 +652,7 @@ public class QueryRegistryImplTest {
     return query;
   }
 
-  private TransientQueryMetadata givenStreamPull(
+  private void givenStreamPull(
       final QueryRegistry registry,
       final String id
   ) {
@@ -685,6 +679,5 @@ public class QueryRegistryImplTest {
         false,
         ImmutableMap.<TopicPartition, Long> builder().build()
     );
-    return query;
   }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -944,8 +944,8 @@ public class KafkaTopicClientImplTest {
       }
 
       final DescribeTopicsResult describeTopicsResult = mock(DescribeTopicsResult.class);
-      when(describeTopicsResult.values()).thenReturn(describe );
-      when(describeTopicsResult.all()).thenReturn(KafkaFuture.completedFuture(result));
+      when(describeTopicsResult.topicNameValues()).thenReturn(describe );
+      when(describeTopicsResult.allTopicNames()).thenReturn(KafkaFuture.completedFuture(result));
       return describeTopicsResult;
     };
   }
@@ -961,10 +961,10 @@ public class KafkaTopicClientImplTest {
           throw new IllegalStateException("Duplicate key");
         }
       }
-      when(describeTopicsResult.values()).thenReturn(map);
+      when(describeTopicsResult.topicNameValues()).thenReturn(map);
 
       final KafkaFuture<Map<String, TopicDescription>> f = failedFuture(e);
-      when(describeTopicsResult.all()).thenReturn(f);
+      when(describeTopicsResult.allTopicNames()).thenReturn(f);
       return describeTopicsResult;
     };
   }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/util/SharedKafkaStreamsRuntimeImplTest.java
@@ -15,19 +15,26 @@
 
 package io.confluent.ksql.util;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import io.confluent.ksql.query.KafkaStreamsBuilder;
 import io.confluent.ksql.query.QueryError.Type;
 import io.confluent.ksql.query.QueryErrorClassifier;
 import io.confluent.ksql.query.QueryId;
-
 import java.util.Collections;
 import java.util.HashMap;
-import org.apache.kafka.common.KafkaFuture;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.namedtopology.AddNamedTopologyResult;
-import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.processor.internals.namedtopology.KafkaStreamsNamedTopologyWrapper;
 import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
 import org.junit.Before;
@@ -35,16 +42,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SharedKafkaStreamsRuntimeImplTest {
@@ -65,12 +62,10 @@ public class SharedKafkaStreamsRuntimeImplTest {
     private NamedTopology namedTopology;
     @Mock
     private AddNamedTopologyResult addNamedTopologyResult;
-    @Mock
-    private KafkaFuture<Void> future;
 
     private final QueryId queryId = new QueryId("query-1");
     private final QueryId queryId2= new QueryId("query-2");
-    private Map<String, Object> streamProps = new HashMap();
+    private final Map<String, Object> streamProps = new HashMap<>();
 
     private final StreamsException query1Exception =
         new StreamsException("query down!", new TaskId(0, 0, queryId.toString()));

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -70,7 +70,7 @@ public final class RecordNode {
   private final JsonNode value;
   private final Optional<Long> timestamp;
   private final Optional<WindowData> window;
-  private final Optional<List<Header>> headers;
+  private final Optional<List<TestHeader>> headers;
 
   @VisibleForTesting
   RecordNode(
@@ -79,7 +79,7 @@ public final class RecordNode {
       final JsonNode value,
       final Optional<Long> timestamp,
       final Optional<WindowData> window,
-      final Optional<List<Header>> headers
+      final Optional<List<TestHeader>> headers
   ) {
     this.topicName = topicName == null ? "" : topicName;
     this.key = requireNonNull(key, "key");
@@ -225,8 +225,8 @@ public final class RecordNode {
       final Optional<WindowData> window = JsonParsingUtil
           .getOptional("window", node, jp, WindowData.class);
 
-      final Optional<List<Header>> headers = JsonParsingUtil
-          .getOptional("headers", node, jp, new TypeReference<List<Header>>() {});
+      final Optional<List<TestHeader>> headers = JsonParsingUtil
+          .getOptional("headers", node, jp, new TypeReference<List<TestHeader>>() {});
 
       return new RecordNode(
           topic, key.orElse(NullNode.getInstance()), value, timestamp, window, headers);

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.kafka.common.header.Header;
 
 @JsonDeserialize(using = RecordNode.Deserializer.class)
 @JsonSerialize(using = RecordNode.Serializer.class)
@@ -69,7 +70,7 @@ public final class RecordNode {
   private final JsonNode value;
   private final Optional<Long> timestamp;
   private final Optional<WindowData> window;
-  private final Optional<List<TestHeader>> headers;
+  private final Optional<List<Header>> headers;
 
   @VisibleForTesting
   RecordNode(
@@ -78,7 +79,7 @@ public final class RecordNode {
       final JsonNode value,
       final Optional<Long> timestamp,
       final Optional<WindowData> window,
-      final Optional<List<TestHeader>> headers
+      final Optional<List<Header>> headers
   ) {
     this.topicName = topicName == null ? "" : topicName;
     this.key = requireNonNull(key, "key");
@@ -153,6 +154,7 @@ public final class RecordNode {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private Object coerceRecord(
       final Object record,
       final ParsedSchema schema,
@@ -177,7 +179,7 @@ public final class RecordNode {
         return record;
     }
 
-    columns.stream().forEach(c -> coerceColumn(recordMap, c));
+    columns.forEach(c -> coerceColumn(recordMap, c));
     return recordMap;
   }
 
@@ -223,8 +225,8 @@ public final class RecordNode {
       final Optional<WindowData> window = JsonParsingUtil
           .getOptional("window", node, jp, WindowData.class);
 
-      final Optional<List<TestHeader>> headers = JsonParsingUtil
-          .getOptional("headers", node, jp, new TypeReference<List<TestHeader>>() {});
+      final Optional<List<Header>> headers = JsonParsingUtil
+          .getOptional("headers", node, jp, new TypeReference<List<Header>>() {});
 
       return new RecordNode(
           topic, key.orElse(NullNode.getInstance()), value, timestamp, window, headers);

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -49,7 +49,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.kafka.common.header.Header;
 
 @JsonDeserialize(using = RecordNode.Deserializer.class)
 @JsonSerialize(using = RecordNode.Serializer.class)

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/ExpectedRecordComparator.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/ExpectedRecordComparator.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableMap;
-import io.confluent.ksql.test.model.TestHeader;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -52,7 +51,7 @@ public final class ExpectedRecordComparator {
   }
 
   public static boolean matches(
-      final Header[] actualHeaders, final List<TestHeader> expectedHeaders) {
+      final Header[] actualHeaders, final List<Header> expectedHeaders) {
     if (actualHeaders.length != expectedHeaders.size()) {
       return false;
     }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/ExpectedRecordComparator.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/ExpectedRecordComparator.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.test.model.TestHeader;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -51,7 +52,7 @@ public final class ExpectedRecordComparator {
   }
 
   public static boolean matches(
-      final Header[] actualHeaders, final List<Header> expectedHeaders) {
+      final Header[] actualHeaders, final List<TestHeader> expectedHeaders) {
     if (actualHeaders.length != expectedHeaders.size()) {
       return false;
     }

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Record.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Record.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.test.model.TestHeader;
 import io.confluent.ksql.test.model.WindowData;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +40,7 @@ public class Record {
   private final WindowData window;
   private final Optional<JsonNode> jsonValue;
   private final Optional<JsonNode> jsonKey;
-  private final Optional<List<Header>> headers;
+  private final Optional<List<TestHeader>> headers;
 
   public Record(
       final String topicName,
@@ -49,7 +50,7 @@ public class Record {
       final JsonNode jsonValue,
       final Optional<Long> timestamp,
       final WindowData window,
-      final Optional<List<Header>> headers
+      final Optional<List<TestHeader>> headers
   ) {
     this.topicName = requireNonNull(topicName, "topicName");
     this.key = key;
@@ -115,7 +116,7 @@ public class Record {
   /**
    * @return expected headers, or {@link Optional#empty()} if headers can be anything.
    */
-  public Optional<List<Header>> headers() {
+  public Optional<List<TestHeader>> headers() {
     return headers;
   }
 
@@ -139,8 +140,9 @@ public class Record {
     );
   }
 
+  @SuppressWarnings("unchecked")
   public ProducerRecord<Object, Object> asProducerRecord() {
-    return new ProducerRecord<>(
+    return new ProducerRecord(
         topicName,
         0,
         timestamp.orElse(0L),

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Record.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/Record.java
@@ -19,11 +19,10 @@ import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.test.model.TestHeader;
 import io.confluent.ksql.test.model.WindowData;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.streams.kstream.Window;
@@ -40,7 +39,7 @@ public class Record {
   private final WindowData window;
   private final Optional<JsonNode> jsonValue;
   private final Optional<JsonNode> jsonKey;
-  private final Optional<List<TestHeader>> headers;
+  private final Optional<List<Header>> headers;
 
   public Record(
       final String topicName,
@@ -50,7 +49,7 @@ public class Record {
       final JsonNode jsonValue,
       final Optional<Long> timestamp,
       final WindowData window,
-      final Optional<List<TestHeader>> headers
+      final Optional<List<Header>> headers
   ) {
     this.topicName = requireNonNull(topicName, "topicName");
     this.key = key;
@@ -116,7 +115,7 @@ public class Record {
   /**
    * @return expected headers, or {@link Optional#empty()} if headers can be anything.
    */
-  public Optional<List<TestHeader>> headers() {
+  public Optional<List<Header>> headers() {
     return headers;
   }
 
@@ -124,11 +123,7 @@ public class Record {
    * @return expected headers, or {@link Optional#empty()} if headers can be anything.
    */
   public Optional<List<Header>> headersAsHeaders() {
-    return headers
-        .map(heads ->
-            heads.stream()
-                .map(testHeader -> (Header) testHeader)
-                .collect(Collectors.toList()));
+    return headers.map(ArrayList::new);
   }
 
   public Record withKeyValue(final Object key, final Object value) {
@@ -144,8 +139,8 @@ public class Record {
     );
   }
 
-  public ProducerRecord asProducerRecord() {
-    return new ProducerRecord(
+  public ProducerRecord<Object, Object> asProducerRecord() {
+    return new ProducerRecord<>(
         topicName,
         0,
         timestamp.orElse(0L),

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -56,6 +56,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.test.model.PostConditionsNode.PostTopicNode;
 import io.confluent.ksql.test.model.SchemaNode;
 import io.confluent.ksql.test.model.SourceNode;
+import io.confluent.ksql.test.model.TestHeader;
 import io.confluent.ksql.test.model.WindowData;
 import io.confluent.ksql.test.tools.TopicInfoCache.TopicInfo;
 import io.confluent.ksql.test.tools.stubs.StubKafkaClientSupplier;
@@ -669,7 +670,7 @@ public class TestExecutor implements Closeable {
         .orElseThrow(() -> new KsqlServerException(
             "could not get expected value from test record: " + expectedRecord));
     final long expectedTimestamp = expectedRecord.timestamp().orElse(actualTimestamp);
-    final List<Header> expectedHeaders = expectedRecord.headers().orElse(ImmutableList.of());
+    final List<TestHeader> expectedHeaders = expectedRecord.headers().orElse(ImmutableList.of());
 
     final AssertionError error = new AssertionError(
         "Topic '" + topicName + "', message " + messageIndex

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -56,7 +56,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.test.model.PostConditionsNode.PostTopicNode;
 import io.confluent.ksql.test.model.SchemaNode;
 import io.confluent.ksql.test.model.SourceNode;
-import io.confluent.ksql.test.model.TestHeader;
 import io.confluent.ksql.test.model.WindowData;
 import io.confluent.ksql.test.tools.TopicInfoCache.TopicInfo;
 import io.confluent.ksql.test.tools.stubs.StubKafkaClientSupplier;
@@ -525,8 +524,7 @@ public class TestExecutor implements Closeable {
     testDriver.getSourceTopic(producedRecord.topic())
         .pipeInput(new TestRecord<>(producedRecord));
 
-    testDriver.getSinkTopicName().ifPresent(topicName -> {
-      final String sinkTopicName = topicName;
+    testDriver.getSinkTopicName().ifPresent(sinkTopicName -> {
       final TestOutputTopic<byte[], byte[]> sinkTopic = testDriver.getSinkTopic(sinkTopicName);
 
       processRecordsForTopic(sinkTopic, sinkTopicName);
@@ -585,8 +583,10 @@ public class TestExecutor implements Closeable {
     );
   }
 
-  static KsqlEngine getKsqlEngine(final ServiceContext serviceContext,
-      final Optional<String> extensionDir) {
+  static KsqlEngine getKsqlEngine(
+      final ServiceContext serviceContext,
+      final Optional<String> extensionDir
+  ) {
     final FunctionRegistry functionRegistry;
     if (extensionDir.isPresent()) {
       final MutableFunctionRegistry mutable = new InternalFunctionRegistry();
@@ -632,6 +632,7 @@ public class TestExecutor implements Closeable {
         .forEach(kafka::writeRecord);
   }
 
+  @SuppressWarnings("unchecked")
   private static Object coerceRecordFields(final Object record) {
     if (!(record instanceof Map)) {
       return record;
@@ -668,7 +669,7 @@ public class TestExecutor implements Closeable {
         .orElseThrow(() -> new KsqlServerException(
             "could not get expected value from test record: " + expectedRecord));
     final long expectedTimestamp = expectedRecord.timestamp().orElse(actualTimestamp);
-    final List<TestHeader> expectedHeaders = expectedRecord.headers().orElse(ImmutableList.of());
+    final List<Header> expectedHeaders = expectedRecord.headers().orElse(ImmutableList.of());
 
     final AssertionError error = new AssertionError(
         "Topic '" + topicName + "', message " + messageIndex

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/QueryAnonymizerTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/QueryAnonymizerTest.java
@@ -20,8 +20,8 @@ import io.confluent.ksql.test.loader.JsonTestLoader;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.util.GrammarTokenExporter;
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -31,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.approvaltests.Approvals;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,7 +53,7 @@ public class QueryAnonymizerTest {
 
     String line;
     try (BufferedReader reader = new BufferedReader(
-        new InputStreamReader(new FileInputStream(QUERIES_TO_ANONYMIZE_PATH.toString()), UTF_8))) {
+        new InputStreamReader(Files.newInputStream(Paths.get(QUERIES_TO_ANONYMIZE_PATH.toString())), UTF_8))) {
       while ((line = reader.readLine()) != null) {
         statements.append(line);
       }

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.test.model.TestHeader;
 import io.confluent.ksql.test.model.WindowData;
 import java.util.List;
 import java.util.Optional;
-import org.apache.kafka.common.header.Header;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
@@ -120,7 +119,7 @@ public class RecordTest {
     );
 
     // When:
-    final List<Header> headers = record.headers().get();
+    final List<TestHeader> headers = record.headers().get();
 
     // Then:
     assertThat(headers.size(), equalTo(1));

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.test.model.TestHeader;
 import io.confluent.ksql.test.model.WindowData;
 import java.util.List;
 import java.util.Optional;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
@@ -119,7 +120,7 @@ public class RecordTest {
     );
 
     // When:
-    final List<TestHeader> headers = record.headers().get();
+    final List<Header> headers = record.headers().get();
 
     // Then:
     assertThat(headers.size(), equalTo(1));

--- a/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertTopicTest.java
+++ b/ksqldb-parser/src/test/java/io/confluent/ksql/parser/tree/AssertTopicTest.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.parser.tree;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
+import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.windows.WindowTimeClause;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Map;
@@ -25,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
-
 import org.mockito.junit.MockitoRule;
 
 public class AssertTopicTest {
@@ -34,7 +35,7 @@ public class AssertTopicTest {
   public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
   private final String SOME_TOPIC = "TOPIC";
-  private final Map SOME_CONFIG = ImmutableMap.of("partitions", 1);
+  private final Map<String, Literal> SOME_CONFIG = ImmutableMap.of("partitions", new IntegerLiteral(1));
   private final WindowTimeClause SOME_TIMEOUT = new WindowTimeClause(5, TimeUnit.SECONDS);
 
   @Test

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -30,6 +30,8 @@ import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.LagReportingMessage;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
@@ -354,9 +356,29 @@ public class ServerVerticle extends AbstractVerticle {
         .setStatusCode(TEMPORARY_REDIRECT.code()).end();
   }
 
+  private static final class VertexHandler implements Handler<AsyncResult<ServerWebSocket>> {
+    ServerWebSocket serverWebSocket;
+
+    @Override
+    public void handle(final AsyncResult<ServerWebSocket> event) {
+      serverWebSocket = event.result();
+    }
+
+    ServerWebSocket getServerWebSocket() {
+      if (serverWebSocket == null) {
+        throw new IllegalStateException();
+      }
+      return serverWebSocket;
+    }
+  }
+
   private void handleWebsocket(final RoutingContext routingContext) {
     final ApiSecurityContext apiSecurityContext = DefaultApiSecurityContext.create(routingContext);
-    final ServerWebSocket serverWebSocket = routingContext.request().upgrade();
+
+    final VertexHandler handler = new VertexHandler();
+    routingContext.request().toWebSocket(handler);
+    final ServerWebSocket serverWebSocket = handler.getServerWebSocket();
+
     endpoints
         .executeWebsocketStream(serverWebSocket, routingContext.request().params(),
             server.getWorkerExecutor(), apiSecurityContext, context);

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -26,7 +26,6 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.ServerUtil;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
-import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
@@ -66,7 +65,6 @@ public class HealthCheckAgent {
   public HealthCheckAgent(
       final SimpleKsqlClient ksqlClient,
       final KsqlRestConfig restConfig,
-      final ServiceContext serviceContext,
       final KsqlConfig ksqlConfig,
       final CommandRunner commandRunner,
       final Admin adminClient
@@ -146,7 +144,7 @@ public class HealthCheckAgent {
         healthCheckAgent.adminClient
             .describeTopics(Collections.singletonList(commandTopic),
                 new DescribeTopicsOptions().timeoutMs(DESCRIBE_TOPICS_TIMEOUT_MS))
-            .all()
+            .allTopicNames()
             .get();
 
         isHealthy = true;

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HealthCheckResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HealthCheckResource.java
@@ -73,7 +73,6 @@ public class HealthCheckResource {
             new ServerInternalKsqlClient(ksqlResource,
                 new KsqlSecurityContext(Optional.empty(), serviceContext)),
             restConfig,
-            serviceContext,
             ksqlConfig,
             commandRunner,
             adminClient),

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -106,7 +106,7 @@ public class HealthCheckAgentTest {
         "default_"
     ));
 
-    healthCheckAgent = new HealthCheckAgent(ksqlClient, restConfig, serviceContext, ksqlConfig, commandRunner, internalAdminClient);
+    healthCheckAgent = new HealthCheckAgent(ksqlClient, restConfig, ksqlConfig, commandRunner, internalAdminClient);
   }
 
   @Test

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.rest.healthcheck;
 
+import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.COMMAND_RUNNER_CHECK_NAME;
 import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.KAFKA_CHECK_NAME;
 import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.METASTORE_CHECK_NAME;
-import static io.confluent.ksql.rest.healthcheck.HealthCheckAgent.COMMAND_RUNNER_CHECK_NAME;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
@@ -36,9 +36,8 @@ import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
-import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
-import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlRequestConfig;
@@ -77,8 +76,6 @@ public class HealthCheckAgentTest {
   @Mock
   private KsqlRestConfig restConfig;
   @Mock
-  private ServiceContext serviceContext;
-  @Mock
   private Admin internalAdminClient;
   @Mock
   private CommandRunner commandRunner;
@@ -98,7 +95,7 @@ public class HealthCheckAgentTest {
 
     final DescribeTopicsResult topicsResult = mock(DescribeTopicsResult.class);
     givenDescribeTopicsReturns(topicsResult);
-    when(topicsResult.all()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
+    when(topicsResult.allTopicNames()).thenReturn(KafkaFuture.completedFuture(Collections.emptyMap()));
     when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.RUNNING);
 
     final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.integration;
 import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT;
 import static io.netty.handler.codec.http.HttpHeaderNames.AUTHORIZATION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
-import static io.netty.handler.codec.http.HttpHeaderNames.EXPIRES;
 import static io.vertx.core.http.HttpMethod.POST;
 import static io.vertx.core.http.HttpVersion.HTTP_1_1;
 
@@ -97,12 +96,12 @@ public final class RestIntegrationTestUtil {
     return makeKsqlRequest(restApp, sql, Optional.empty());
   }
 
-  public static String makeKsqlRequestWithVariables(
+  public static void makeKsqlRequestWithVariables(
       final TestKsqlRestApp restApp, final String sql, final Map<String, Object> variables) {
     final KsqlRequest request =
         new KsqlRequest(sql, ImmutableMap.of(), ImmutableMap.of(), variables, null);
 
-    return rawRestRequest(restApp, HTTP_1_1, POST, "/ksql", request, KsqlMediaType.KSQL_V1_JSON.mediaType(),
+    rawRestRequest(restApp, HTTP_1_1, POST, "/ksql", request, KsqlMediaType.KSQL_V1_JSON.mediaType(),
         Optional.empty(), Optional.empty()).body().toString();
   }
 
@@ -659,8 +658,10 @@ public final class RestIntegrationTestUtil {
     return Base64.getEncoder().encodeToString(creds.getBytes(Charset.defaultCharset()));
   }
 
-  private static String buildStreamingRequest(final String sql,
-      Optional<Map<String, Object>> overrides, Optional<Map<String, Object>> requestProperties
+  private static String buildStreamingRequest(
+      final String sql,
+      final Optional<Map<String, Object>> overrides,
+      final Optional<Map<String, Object>> requestProperties
   ) {
     KsqlRequest request = new KsqlRequest(sql, overrides.orElse(Collections.emptyMap()),
         requestProperties.orElse(Collections.emptyMap()), null);

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -295,7 +295,7 @@ public class QueryStreamWriterTest {
             ? null
             : GenericRow.genericRow(rows[i + 1]);
 
-        output.add(new KeyValueMetadata(KeyValue.keyValue(key, value)));
+        output.add(new KeyValueMetadata<>(KeyValue.keyValue(key, value)));
       }
 
       return null;
@@ -312,7 +312,7 @@ public class QueryStreamWriterTest {
             ? null
             : GenericRow.genericRow(rows[i + 1]);
 
-        output.add(new KeyValueMetadata(KeyValue.keyValue(key, value)));
+        output.add(new KeyValueMetadata<>(KeyValue.keyValue(key, value)));
       }
 
       return null;

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/FeatureFlagCheckerTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/util/FeatureFlagCheckerTest.java
@@ -70,7 +70,7 @@ public class FeatureFlagCheckerTest {
         )),
         false
     );
-    final ConfiguredStatement configuredStatement = configured(config, createStream);
+    final ConfiguredStatement<?> configuredStatement = configured(config, createStream);
 
     // When
     final Exception e = assertThrows(
@@ -104,13 +104,14 @@ public class FeatureFlagCheckerTest {
         )),
         false
     );
-    final ConfiguredStatement configuredStatement = configured(config, createStream);
+    final ConfiguredStatement<?> configuredStatement = configured(config, createStream);
 
     // When/Then
     FeatureFlagChecker.throwOnDisabledFeatures(configuredStatement);
   }
 
-  private ConfiguredStatement configured(final KsqlConfig config, final Statement statement) {
+  @SuppressWarnings("rawtypes")
+  private ConfiguredStatement<?> configured(final KsqlConfig config, final Statement statement) {
     final ConfiguredStatement mockConfigured = mock(ConfiguredStatement.class);
 
     when(mockConfigured.getStatement())

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufProperties.java
@@ -59,7 +59,7 @@ public class ProtobufProperties extends ConnectProperties {
   }
 
   public ProtobufProperties withFullSchemaName(final String name) {
-    final ImmutableMap.Builder builder = ImmutableMap.builder();
+    final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     builder.putAll(properties);
     builder.put(FULL_SCHEMA_NAME, name);
     return new ProtobufProperties(builder.build());

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSRSchemaDataTranslator.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/protobuf/ProtobufSRSchemaDataTranslator.java
@@ -40,6 +40,7 @@ public class ProtobufSRSchemaDataTranslator extends ConnectSRSchemaDataTranslato
     return compatibleWithSchema(ksqlData, getSchema());
   }
 
+  @SuppressWarnings("unchecked")
   private Object compatibleWithSchema(final Object object, final Schema schema) {
     if (object == null) {
       return object;
@@ -47,8 +48,8 @@ public class ProtobufSRSchemaDataTranslator extends ConnectSRSchemaDataTranslato
 
     switch (schema.type()) {
       case ARRAY:
-        final List<Object> ksqlArray = new ArrayList<>(((List) object).size());
-        ((List) object).forEach(
+        final List<Object> ksqlArray = new ArrayList<>(((List<Object>) object).size());
+        ((List<Object>) object).forEach(
             e -> ksqlArray.add(compatibleWithSchema(e, schema.valueSchema())));
         return ksqlArray;
       case MAP:

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableIQv2Test.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializedWindowTableIQv2Test.java
@@ -114,10 +114,6 @@ public class KsMaterializedWindowTableIQv2Test {
   private WindowStoreIterator<ValueAndTimestamp<GenericRow>> fetchIterator;
   @Mock
   private KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>> keyValueIterator;
-  @Mock
-  private QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> fetchResult;
-  @Mock
-  private QueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> keyValueResult;
 
   private KsMaterializedWindowTableIQv2 table;
   @Captor
@@ -158,11 +154,12 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldThrowIfQueryFails() {
     // Given:
-    final StateQueryResult partitionResult = new StateQueryResult();
+    final StateQueryResult<?> partitionResult = new StateQueryResult<>();
     partitionResult.addResult(PARTITION, QueryResult.forFailure(FailureReason.STORE_EXCEPTION, "Boom"));
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     // When:
     final Exception e = assertThrows(
@@ -194,11 +191,12 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldThrowIfQueryFails_fethAll() {
     // Given:
-    final StateQueryResult partitionResult = new StateQueryResult();
+    final StateQueryResult<?> partitionResult = new StateQueryResult<>();
     partitionResult.addResult(PARTITION, QueryResult.forFailure(FailureReason.STORE_EXCEPTION, "Boom"));
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     // When:
     final Exception e = assertThrows(
@@ -231,6 +229,7 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnValuesForClosedStartBounds() {
     // Given:
     final Range<Instant> start = Range.closed(
@@ -238,11 +237,11 @@ public class KsMaterializedWindowTableIQv2Test {
       NOW.plusSeconds(10)
     );
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult result = QueryResult.forResult(fetchIterator);
+    final StateQueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> result = QueryResult.forResult(fetchIterator);
     result.setPosition(POSITION);
     partitionResult.addResult(PARTITION, result);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
     when(fetchIterator.hasNext()).thenReturn(true, true, false);
 
     when(fetchIterator.next())
@@ -274,6 +273,7 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnValuesForClosedStartBounds_fetchAll() {
     // Given:
     final Range<Instant> start = Range.closed(
@@ -281,11 +281,11 @@ public class KsMaterializedWindowTableIQv2Test {
       NOW.plusSeconds(10)
     );
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(keyValueIterator);
+    final StateQueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(keyValueIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
     when(keyValueIterator.hasNext()).thenReturn(true, true, false);
 
     when(keyValueIterator.next())
@@ -324,13 +324,14 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldCloseIterator() {
     // When:
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult result = QueryResult.forResult(fetchIterator);
+    final StateQueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> result = QueryResult.forResult(fetchIterator);
     result.setPosition(POSITION);
     partitionResult.addResult(PARTITION, result);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
     when(fetchIterator.hasNext()).thenReturn(false);
 
     table.get(A_KEY, PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS);
@@ -340,13 +341,14 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldCloseIterator_fetchAll() {
     // When:
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(keyValueIterator);
+    final StateQueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(keyValueIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
     when(keyValueIterator.hasNext()).thenReturn(false);
 
     Streams.stream((table.get(PARTITION, WINDOW_START_BOUNDS, WINDOW_END_BOUNDS)
@@ -358,13 +360,14 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnEmptyIfKeyNotPresent() {
     // When:
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult result = QueryResult.forResult(fetchIterator);
+    final StateQueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> result = QueryResult.forResult(fetchIterator);
     result.setPosition(POSITION);
     partitionResult.addResult(PARTITION, result);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
     when(fetchIterator.hasNext()).thenReturn(false);
 
     final Iterator<WindowedRow> rowIterator = table.get(
@@ -375,13 +378,14 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnEmptyIfKeyNotPresent_fetchAll() {
     // When:
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(keyValueIterator);
+    final StateQueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(keyValueIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
     when(keyValueIterator.hasNext()).thenReturn(false);
 
     final Iterator<WindowedRow> rowIterator = table.get(
@@ -393,6 +397,7 @@ public class KsMaterializedWindowTableIQv2Test {
 
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnValuesForClosedEndBounds() {
     // Given:
     final Range<Instant> end = Range.closed(
@@ -405,11 +410,12 @@ public class KsMaterializedWindowTableIQv2Test {
       end.lowerEndpoint().minus(WINDOW_SIZE)
     );
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(fetchIterator);
+    final StateQueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> partitionResult =
+        new StateQueryResult<>();
+    final QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(fetchIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     when(fetchIterator.hasNext())
       .thenReturn(true)
@@ -448,6 +454,7 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnValuesForClosedEndBounds_fetchAll() {
     // Given:
     final Range<Instant> end = Range.closed(
@@ -460,11 +467,11 @@ public class KsMaterializedWindowTableIQv2Test {
       end.lowerEndpoint().minus(WINDOW_SIZE)
     );
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(keyValueIterator);
+    final StateQueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(keyValueIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     when(keyValueIterator.hasNext())
       .thenReturn(true, true, false);
@@ -505,6 +512,7 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnValuesForOpenStartBounds() {
     // Given:
     final Range<Instant> start = Range.open(
@@ -512,11 +520,12 @@ public class KsMaterializedWindowTableIQv2Test {
       NOW.plusSeconds(10)
     );
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(fetchIterator);
+    final StateQueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> partitionResult =
+        new StateQueryResult<>();
+    final QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(fetchIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     when(fetchIterator.hasNext())
       .thenReturn(true)
@@ -550,6 +559,7 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnValuesForOpenStartBounds_fetchAll() {
     // Given:
     final Range<Instant> start = Range.open(
@@ -557,11 +567,11 @@ public class KsMaterializedWindowTableIQv2Test {
       NOW.plusSeconds(10)
     );
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(keyValueIterator);
+    final StateQueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(keyValueIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     when(keyValueIterator.hasNext())
       .thenReturn(true, true, true, false);
@@ -598,6 +608,7 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnValuesForOpenEndBounds() {
     // Given:
     final Range<Instant> end = Range.open(
@@ -610,11 +621,12 @@ public class KsMaterializedWindowTableIQv2Test {
       end.upperEndpoint().minus(WINDOW_SIZE)
     );
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(fetchIterator);
+    final StateQueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> partitionResult =
+        new StateQueryResult<>();
+    final QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(fetchIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     when(fetchIterator.hasNext())
       .thenReturn(true)
@@ -650,6 +662,7 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldReturnValuesForOpenEndBounds_fetchAll() {
     // Given:
     final Range<Instant> end = Range.open(
@@ -662,11 +675,11 @@ public class KsMaterializedWindowTableIQv2Test {
       end.upperEndpoint().minus(WINDOW_SIZE)
     );
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(keyValueIterator);
+    final StateQueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(keyValueIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     when(keyValueIterator.hasNext())
       .thenReturn(true, true, true, false);
@@ -703,6 +716,7 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldMaintainResultOrder() {
     // Given:
     when(fetchIterator.hasNext())
@@ -713,11 +727,12 @@ public class KsMaterializedWindowTableIQv2Test {
 
     final Instant start = WINDOW_START_BOUNDS.lowerEndpoint();
 
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult result = QueryResult.forResult(fetchIterator);
+    final StateQueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> partitionResult =
+        new StateQueryResult<>();
+    final QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> result = QueryResult.forResult(fetchIterator);
     result.setPosition(POSITION);
     partitionResult.addResult(PARTITION, result);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     when(fetchIterator.next())
       .thenReturn(new KeyValue<>(start.toEpochMilli(), VALUE_1))
@@ -755,38 +770,41 @@ public class KsMaterializedWindowTableIQv2Test {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldSupportRangeAll() {
     // When:
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult result = QueryResult.forResult(fetchIterator);
+    final StateQueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> partitionResult =
+        new StateQueryResult<>();
+    final QueryResult<WindowStoreIterator<ValueAndTimestamp<GenericRow>>> result = QueryResult.forResult(fetchIterator);
     result.setPosition(POSITION);
     partitionResult.addResult(PARTITION, result);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     table.get(A_KEY, PARTITION, Range.all(), Range.all());
 
     // Then:
     verify(kafkaStreams).query(queryTypeCaptor.capture());
-    StateQueryRequest request = queryTypeCaptor.getValue();
+    StateQueryRequest<?> request = queryTypeCaptor.getValue();
     assertThat(request.getQuery(), instanceOf(WindowKeyQuery.class));
-    WindowKeyQuery keyQuery = (WindowKeyQuery)request.getQuery();
+    WindowKeyQuery<GenericKey,GenericRow> keyQuery = (WindowKeyQuery<GenericKey,GenericRow>) request.getQuery();
     assertThat(keyQuery.getKey(), is(A_KEY));
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void shouldSupportRangeAll_fetchAll() {
     // When:
-    final StateQueryResult partitionResult = new StateQueryResult();
-    final QueryResult queryResult = QueryResult.forResult(keyValueIterator);
+    final StateQueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> partitionResult = new StateQueryResult<>();
+    final QueryResult<KeyValueIterator<Windowed<GenericKey>, ValueAndTimestamp<GenericRow>>> queryResult = QueryResult.forResult(keyValueIterator);
     queryResult.setPosition(POSITION);
     partitionResult.addResult(PARTITION, queryResult);
-    when(kafkaStreams.query(any())).thenReturn(partitionResult);
+    when(kafkaStreams.query(any(StateQueryRequest.class))).thenReturn(partitionResult);
 
     table.get(PARTITION, Range.all(), Range.all());
 
     // Then:
     verify(kafkaStreams).query(queryTypeCaptor.capture());
-    StateQueryRequest request = queryTypeCaptor.getValue();
+    StateQueryRequest<?> request = queryTypeCaptor.getValue();
     assertThat(request.getQuery(), instanceOf(WindowRangeQuery.class));
   }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsStateStoreTest.java
@@ -78,7 +78,7 @@ public class KsStateStoreTest {
   private KsqlConfig ksqlConfig;
 
   @Captor
-  ArgumentCaptor<StoreQueryParameters> storeQueryParamCaptor;
+  ArgumentCaptor<StoreQueryParameters<?>> storeQueryParamCaptor;
 
   private KsStateStore store;
 
@@ -111,7 +111,7 @@ public class KsStateStoreTest {
 
     // Then:
     verify(kafkaStreamsNamedTopologyWrapper).store(storeQueryParamCaptor.capture());
-    List<StoreQueryParameters> keys = storeQueryParamCaptor.getAllValues();
+    List<StoreQueryParameters<?>> keys = storeQueryParamCaptor.getAllValues();
     assertThat(keys.get(0), instanceOf(NamedTopologyStoreQueryParameters.class));
   }
 


### PR DESCRIPTION
Fix type inference, avoid using deprecated methods, and suppress warnings we cannot avoid.

There are still a few type warnings that I did not suppress on purpose, because it's newer (unfinished) code (part of planner rewrite) and we should try to clean it up properly instead of suppressing those warnings.

There is also still the usage of deprecated `StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG` -- I was not sure how to address it. Any proposals?