### PR TITLE
chore: add config for assert schema timeout

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -661,11 +661,17 @@ public class KsqlConfig extends AbstractConfig {
   private static final boolean KSQL_ENDPOINT_MIGRATE_QUERY_DEFAULT = true;
   private static final String KSQL_ENDPOINT_MIGRATE_QUERY_DOC
       = "Migrates the /query endpoint to use the same handler as /query-stream.";
-  public static final String KSQL_ASSERT_DEFAULT_TIMEOUT_MS
-      = "ksql.assert.default.timeout.ms";
-  private static final int KSQL_ASSERT_DEFAULT_TIMEOUT_MS_DEFAULT = 1000;
-  private static final String KSQL_ASSERT_DEFAULT_TIMEOUT_MS_DOC
-      = "The default timeout for ASSERT TOPIC/SCHEMA statements if no timeout is specified "
+  public static final String KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS
+      = "ksql.assert.topic.default.timeout.ms";
+  private static final int KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DEFAULT = 1000;
+  private static final String KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DOC
+      = "The default timeout for ASSERT TOPIC statements if no timeout is specified "
+      + "in the statement.";
+  public static final String KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS
+      = "ksql.assert.schema.default.timeout.ms";
+  private static final int KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS_DEFAULT = 1000;
+  private static final String KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS_DOC
+      = "The default timeout for ASSERT SCHEMA statements if no timeout is specified "
       + "in the statement.";
 
   private enum ConfigGeneration {
@@ -1435,11 +1441,18 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_TRANSIENT_QUERY_CLEANUP_SERVICE_PERIOD_SECONDS_DOC
         )
         .define(
-            KSQL_ASSERT_DEFAULT_TIMEOUT_MS,
+            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS,
             Type.INT,
-            KSQL_ASSERT_DEFAULT_TIMEOUT_MS_DEFAULT,
+            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DEFAULT,
             Importance.LOW,
-            KSQL_ASSERT_DEFAULT_TIMEOUT_MS_DOC
+            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DOC
+        )
+        .define(
+            KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS,
+            Type.INT,
+            KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -661,11 +661,11 @@ public class KsqlConfig extends AbstractConfig {
   private static final boolean KSQL_ENDPOINT_MIGRATE_QUERY_DEFAULT = true;
   private static final String KSQL_ENDPOINT_MIGRATE_QUERY_DOC
       = "Migrates the /query endpoint to use the same handler as /query-stream.";
-  public static final String KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS
-      = "ksql.assert.topic.default.timeout.ms";
-  private static final int KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DEFAULT = 1000;
-  private static final String KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DOC
-      = "The default timeout for ASSERT TOPIC statements if not timeout is specified "
+  public static final String KSQL_ASSERT_DEFAULT_TIMEOUT_MS
+      = "ksql.assert.default.timeout.ms";
+  private static final int KSQL_ASSERT_DEFAULT_TIMEOUT_MS_DEFAULT = 1000;
+  private static final String KSQL_ASSERT_DEFAULT_TIMEOUT_MS_DOC
+      = "The default timeout for ASSERT TOPIC/SCHEMA statements if no timeout is specified "
       + "in the statement.";
 
   private enum ConfigGeneration {
@@ -1435,11 +1435,11 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_TRANSIENT_QUERY_CLEANUP_SERVICE_PERIOD_SECONDS_DOC
         )
         .define(
-            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS,
+            KSQL_ASSERT_DEFAULT_TIMEOUT_MS,
             Type.INT,
-            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DEFAULT,
+            KSQL_ASSERT_DEFAULT_TIMEOUT_MS_DEFAULT,
             Importance.LOW,
-            KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS_DOC
+            KSQL_ASSERT_DEFAULT_TIMEOUT_MS_DOC
         )
         .withClientSslSupport();
 

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertExecutor.java
@@ -16,9 +16,7 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static io.confluent.ksql.rest.Errors.assertionFailedError;
-import static io.confluent.ksql.util.KsqlConfig.KSQL_ASSERT_DEFAULT_TIMEOUT_MS;
 
-import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.AssertResource;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
@@ -40,14 +38,14 @@ public final class AssertExecutor {
   static StatementExecutorResponse execute(
       final String statementText,
       final AssertResource statement,
-      final KsqlExecutionContext executionContext,
+      final int defaultTimeout,
       final ServiceContext serviceContext,
       final BiConsumer<AssertResource, ServiceContext> assertResource,
       final BiFunction<String, AssertResource, KsqlEntity> createSuccessfulEntity
   ) {
     final int timeout = statement.getTimeout().isPresent()
         ? (int) statement.getTimeout().get().toDuration().toMillis()
-        : executionContext.getKsqlConfig().getInt(KSQL_ASSERT_DEFAULT_TIMEOUT_MS);
+        : defaultTimeout;
     try {
       RetryUtil.retryWithBackoff(
           timeout / RETRY_MS,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertExecutor.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static io.confluent.ksql.rest.Errors.assertionFailedError;
-import static io.confluent.ksql.util.KsqlConfig.KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ASSERT_DEFAULT_TIMEOUT_MS;
 
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.AssertResource;
@@ -47,7 +47,7 @@ public final class AssertExecutor {
   ) {
     final int timeout = statement.getTimeout().isPresent()
         ? (int) statement.getTimeout().get().toDuration().toMillis()
-        : executionContext.getKsqlConfig().getInt(KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS);
+        : executionContext.getKsqlConfig().getInt(KSQL_ASSERT_DEFAULT_TIMEOUT_MS);
     try {
       RetryUtil.retryWithBackoff(
           timeout / RETRY_MS,

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertSchemaExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertSchemaExecutor.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS;
+
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.KsqlExecutionContext;
@@ -45,7 +47,7 @@ public final class AssertSchemaExecutor {
     return AssertExecutor.execute(
         statement.getStatementText(),
         statement.getStatement(),
-        executionContext,
+        executionContext.getKsqlConfig().getInt(KSQL_ASSERT_SCHEMA_DEFAULT_TIMEOUT_MS),
         serviceContext,
         (stmt, sc) -> assertSchema(
             sc.getSchemaRegistryClient(),

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertTopicExecutor.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/AssertTopicExecutor.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import static io.confluent.ksql.util.KsqlConfig.KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS;
+
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.parser.tree.AssertTopic;
@@ -47,7 +49,7 @@ public final class AssertTopicExecutor {
   ) {
     return AssertExecutor.execute(statement.getStatementText(),
         statement.getStatement(),
-        executionContext,
+        executionContext.getKsqlConfig().getInt(KSQL_ASSERT_TOPIC_DEFAULT_TIMEOUT_MS),
         serviceContext,
         (stmt, sc) -> assertTopic(
             sc.getTopicClient(),


### PR DESCRIPTION
### Description 
~changed `ksql.assert.topic.default.timeout.ms` to `ksql.assert.default.timeout.ms ` because it covers schemas as well~

Adds a separate config for schema timeouts, `ksql.assert.schema.default.timeout.ms`

### Testing done 
should pass all tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

