### PR TITLE
chore: refactor pull query routing test into and ignore it

### DIFF
--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryRoutingFunctionalTest.java
@@ -93,6 +93,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -110,6 +111,7 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 @Category({IntegrationTest.class})
+@Ignore
 public class PullQueryRoutingFunctionalTest {
   private static final Logger LOG = LoggerFactory.getLogger(PullQueryRoutingFunctionalTest.class);
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsLocatorTest.java
@@ -140,6 +140,8 @@ public class KsLocatorTest {
   @Mock
   private RoutingFilter activeFilter;
   @Mock
+  private RoutingFilter lagFilter;
+  @Mock
   private RoutingOptions routingOptions;
   @Mock
   private TopologyDescription description;
@@ -156,8 +158,10 @@ public class KsLocatorTest {
   private KsqlNode standByNode2;
   private RoutingFilters routingStandbyFilters;
   private RoutingFilters routingActiveFilters;
+  private RoutingFilters routingLagFilters;
   private RoutingFilterFactory routingFilterFactoryActive;
   private RoutingFilterFactory routingFilterFactoryStandby;
+  private RoutingFilterFactory routingFilterFactoryLag;
 
   @Before
   public void setUp() {
@@ -178,6 +182,7 @@ public class KsLocatorTest {
 
     routingStandbyFilters = new RoutingFilters(ImmutableList.of(livenessFilter));
     routingActiveFilters = new RoutingFilters(ImmutableList.of(activeFilter, livenessFilter));
+    routingLagFilters = new RoutingFilters(ImmutableList.of(livenessFilter, lagFilter));
 
     // Only active serves query
     when(activeFilter.filter(eq(ACTIVE_HOST)))
@@ -195,10 +200,21 @@ public class KsLocatorTest {
     when(livenessFilter.filter(eq(STANDBY_HOST2)))
         .thenReturn(Host.include(STANDBY_HOST2));
 
+    // StandBy2 exceeds max allowed lag
+    when(lagFilter.filter(eq(ACTIVE_HOST)))
+        .thenReturn(Host.include(ACTIVE_HOST));
+    when(lagFilter.filter(eq(STANDBY_HOST1)))
+        .thenReturn(Host.include(STANDBY_HOST1));
+    when(lagFilter.filter(eq(STANDBY_HOST2)))
+        .thenReturn(Host.exclude(STANDBY_HOST2, "lag"));
+
+
     routingFilterFactoryActive = (routingOptions, hosts, active, applicationQueryId,
                                   storeName, partition) -> routingActiveFilters;
     routingFilterFactoryStandby = (routingOptions, hosts, active, applicationQueryId,
                                    storeName, partition) -> routingStandbyFilters;
+    routingFilterFactoryLag = (routingOptions, hosts, active, applicationQueryId,
+                                   storeName, partition) -> routingLagFilters;
   }
 
   @Test
@@ -461,6 +477,27 @@ public class KsLocatorTest {
     assertThat(nodeList.size(), is(1));
     assertThat(nodeList.stream().findFirst().get(), is(standByNode2));
   }
+
+  @Test
+  public void shouldReturnStandBy1WhenActiveDownStandby2ExceedsLag() {
+    // Given:
+    getActiveAndStandbyMetadata();
+    when(livenessFilter.filter(eq(ACTIVE_HOST)))
+        .thenReturn(Host.exclude(ACTIVE_HOST, "liveness"));
+
+    // When:
+    final List<KsqlPartitionLocation> result = locator.locate(
+        ImmutableList.of(KEY), routingOptions, routingFilterFactoryLag, false);
+
+    // Then:
+    List<KsqlNode> nodeList = result.get(0).getNodes().stream()
+        .filter(node -> node.getHost().isSelected())
+        .collect(Collectors.toList());
+    assertThat(nodeList.size(), is(1));
+    assertThat(nodeList, containsInAnyOrder(standByNode1));
+  }
+
+
 
   @Ignore
   @Test


### PR DESCRIPTION
### Description 
Refactor `PullQueryRoutingFunctionalTest` into `HaRoutingTest` and KsLocatorTest that are unit tests. `HaRouting` takes an ordered list of nodes and forwards the query in order to these nodes. This functionality is tested in `HaRoutingTest`. `KsLocator` returns an ordered list of nodes based on the routing filters such as liveness and lag. This functionality is tested in `KsLocatorTest`. Moreover, we have muckrake tests that kill nodes and test that pull queries keep succeeding  because they get forwarded to standby.

From the above, I feel it is safe to ignore the flaky `PullQueryRoutingFunctionalTest`. The only thing missing was a test in `KsLocatorTest` regarding the lag filter.

### Testing done 
Added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

