### PR TITLE
fix: move misplaced query-level configs to the correct list

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryRegistryImpl.java
@@ -329,7 +329,7 @@ public class QueryRegistryImpl implements QueryRegistry {
           final KsqlConfigResolver resolver = new KsqlConfigResolver();
           final Optional<ConfigItem> resolvedItem = resolver.resolve(s, false);
           return resolvedItem.map(configItem ->
-              !PropertiesList.QueryLevelPropertyList
+              !PropertiesList.QueryLevelProperties
                   .contains(configItem.getPropertyName())).orElse(true);
         })
         .distinct()

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -250,7 +250,7 @@ public class KsqlResource implements KsqlConfigurable {
       final Optional<ConfigItem> resolvedItem = resolver.resolve(property, false);
       if (ksqlEngine.getKsqlConfig().getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)
           && resolvedItem.isPresent()) {
-        if (!PropertiesList.QueryLevelPropertyList.contains(resolvedItem.get().getPropertyName())) {
+        if (!PropertiesList.QueryLevelProperties.contains(resolvedItem.get().getPropertyName())) {
           throw new KsqlException(String.format("When shared runtimes are enabled, the"
               + " config %s can only be set for the entire cluster and all queries currently"
               + " running in it, and not configurable for individual queries."

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -71,6 +71,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTION_TIMEO
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.ACCEPTABLE_RECOVERY_LAG_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.APPLICATION_SERVER_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.COMMIT_INTERVAL_MS_CONFIG;
@@ -88,9 +89,11 @@ import static org.apache.kafka.streams.StreamsConfig.PROCESSING_GUARANTEE_CONFIG
 import static org.apache.kafka.streams.StreamsConfig.REPLICATION_FACTOR_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.SECURITY_PROTOCOL_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.STATE_CLEANUP_DELAY_MS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.TASK_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.UPGRADE_FROM_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.WINDOW_SIZE_MS_CONFIG;
 
@@ -109,14 +112,21 @@ import java.util.Optional;
 public class PropertiesList extends KsqlEntity {
   public static final List<String> QueryLevelPropertyList = ImmutableList.of(
       AUTO_OFFSET_RESET_CONFIG,
+      BUFFERED_RECORDS_PER_PARTITION_CONFIG,
+      CACHE_MAX_BYTES_BUFFERING_CONFIG,
+      DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
+      DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
+      FAIL_ON_DESERIALIZATION_ERROR_CONFIG,
       KSQL_STRING_CASE_CONFIG_TOGGLE,
       KSQL_NESTED_ERROR_HANDLING_CONFIG,
       KSQL_QUERY_ERROR_MAX_QUEUE_SIZE,
       KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS,
       KSQL_QUERY_RETRY_BACKOFF_MAX_MS,
       KSQL_TIMESTAMP_THROW_ON_INVALID,
-      FAIL_ON_DESERIALIZATION_ERROR_CONFIG
-  );
+      MAX_TASK_IDLE_MS_CONFIG,
+      STATESTORE_CACHE_MAX_BYTES_CONFIG,
+      TASK_TIMEOUT_MS_CONFIG
+      );
 
   /**
    * List os properties that can be changes via `ALTER SYSTEM` command.
@@ -174,14 +184,10 @@ public class PropertiesList extends KsqlEntity {
       ACCEPTABLE_RECOVERY_LAG_CONFIG,
       APPLICATION_SERVER_CONFIG,
       BUILT_IN_METRICS_VERSION_CONFIG,
-      CACHE_MAX_BYTES_BUFFERING_CONFIG,
       COMMIT_INTERVAL_MS_CONFIG,
-      DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
       DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG,
       DEFAULT_KEY_SERDE_CLASS_CONFIG,
       DEFAULT_VALUE_SERDE_CLASS_CONFIG,
-      DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
-      MAX_TASK_IDLE_MS_CONFIG,
       MAX_WARMUP_REPLICAS_CONFIG,
       NUM_STANDBY_REPLICAS_CONFIG,
       POLL_MS_CONFIG,
@@ -192,7 +198,6 @@ public class PropertiesList extends KsqlEntity {
       SECURITY_PROTOCOL_CONFIG,
       STATE_CLEANUP_DELAY_MS_CONFIG,
       STATE_DIR_CONFIG,
-      TASK_TIMEOUT_MS_CONFIG,
       WINDOW_SIZE_MS_CONFIG,
       UPGRADE_FROM_CONFIG
   );

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -117,7 +117,6 @@ public class PropertiesList extends KsqlEntity {
   /**
    * The set of query-level properties that can be configured via the `SET` command. They can also
    * use the `ALTER SYSTEM` command to set a default value for queries without an explicit override.
-   * <p>
    * NOTE: IF YOU ADD A NEW CONFIG AND WANT IT TO BE CONFIGURABLE PER-QUERY YOU MUST ADD IT HERE.
    */
   @SuppressWarnings("deprecation")

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -93,7 +93,6 @@ import static org.apache.kafka.streams.StreamsConfig.STATESTORE_CACHE_MAX_BYTES_
 import static org.apache.kafka.streams.StreamsConfig.STATE_CLEANUP_DELAY_MS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.TASK_TIMEOUT_MS_CONFIG;
-import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.UPGRADE_FROM_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.WINDOW_SIZE_MS_CONFIG;
 
@@ -110,6 +109,8 @@ import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertiesList extends KsqlEntity {
+
+  @SuppressWarnings("deprecation")
   public static final List<String> QueryLevelPropertyList = ImmutableList.of(
       AUTO_OFFSET_RESET_CONFIG,
       BUFFERED_RECORDS_PER_PARTITION_CONFIG,

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -126,7 +126,7 @@ public class PropertiesList extends KsqlEntity {
       MAX_TASK_IDLE_MS_CONFIG,
       STATESTORE_CACHE_MAX_BYTES_CONFIG,
       TASK_TIMEOUT_MS_CONFIG
-      );
+  );
 
   /**
    * List os properties that can be changes via `ALTER SYSTEM` command.

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -117,7 +117,7 @@ public class PropertiesList extends KsqlEntity {
   /**
    * The set of query-level properties that can be configured via the `SET` command. They can also
    * use the `ALTER SYSTEM` command to set a default value for queries without an explicit override.
-   *
+   * <p>
    * NOTE: IF YOU ADD A NEW CONFIG AND WANT IT TO BE CONFIGURABLE PER-QUERY YOU MUST ADD IT HERE.
    */
   @SuppressWarnings("deprecation")

--- a/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksqldb-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.rest.entity;
 import static io.confluent.ksql.util.KsqlConfig.FAIL_ON_DESERIALIZATION_ERROR_CONFIG;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_NESTED_ERROR_HANDLING_CONFIG;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_ERROR_MAX_QUEUE_SIZE;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG;
+import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_PULL_TABLE_SCAN_ENABLED;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_QUERY_RETRY_BACKOFF_MAX_MS;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_STRING_CASE_CONFIG_TOGGLE;
@@ -131,6 +133,8 @@ public class PropertiesList extends KsqlEntity {
       KSQL_QUERY_ERROR_MAX_QUEUE_SIZE,
       KSQL_QUERY_RETRY_BACKOFF_INITIAL_MS,
       KSQL_QUERY_RETRY_BACKOFF_MAX_MS,
+      KSQL_QUERY_PULL_MAX_ALLOWED_OFFSET_LAG_CONFIG,
+      KSQL_QUERY_PULL_TABLE_SCAN_ENABLED,
       KSQL_TIMESTAMP_THROW_ON_INVALID,
       MAX_TASK_IDLE_MS_CONFIG,
       STATESTORE_CACHE_MAX_BYTES_CONFIG,


### PR DESCRIPTION
I noticed some configs that should be query level were missing from the `queryLevelProperties` list. Most of these are already included in the UI and were just missing here, but there are two ksql configs that I believe should be classified as query-level (see [here](https://github.com/confluentinc/ksql/pull/9143/files#r883243664))

This PR also expands & improves the javadocs.

Finally, it [fixes a small bug](https://github.com/confluentinc/ksql/pull/9144/files#diff-b956beb11421b0d6b59a03136c7fa40e577144778834e7af1479775fddd81b4dR248) where we should be checking both the query-level AND system-level properties list when validating an `ALTER SYSTEM` command, as query-level configs can be set this way but are interpreted instead as a default value.