### PR TITLE
fix: revert default `/query-stream` Content-Type to `application/vnd.ksqlapi.delimited.v1` from `application/vnd.ksql.v1+protobuf`

### DIFF
--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -142,6 +142,9 @@ public class ServerVerticle extends AbstractVerticle {
         .produces(DELIMITED_CONTENT_TYPE)
         .produces(JSON_CONTENT_TYPE)
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
+        .handler(BodyHandler.create(false))
+        .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false));
+    router.route(HttpMethod.POST, "/query-stream")
         .produces(KsqlMediaType.KSQL_V1_PROTOBUF.mediaType())
         .handler(BodyHandler.create(false))
         .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false));
@@ -178,6 +181,10 @@ public class ServerVerticle extends AbstractVerticle {
         .produces(DELIMITED_CONTENT_TYPE)
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
+        .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server, true));
+    router.route(HttpMethod.POST, "/query")
+        .handler(BodyHandler.create(false))
+        .produces(KsqlMediaType.KSQL_V1_PROTOBUF.mediaType())
         .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server, true));
     router.route(HttpMethod.GET, "/info")
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())

--- a/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
+++ b/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/ServerVerticle.java
@@ -144,6 +144,7 @@ public class ServerVerticle extends AbstractVerticle {
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .handler(BodyHandler.create(false))
         .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server, false));
+    // Add a separate route for KSQL_V1_PROTOBUF. See https://github.com/confluentinc/ksql/pull/9145
     router.route(HttpMethod.POST, "/query-stream")
         .produces(KsqlMediaType.KSQL_V1_PROTOBUF.mediaType())
         .handler(BodyHandler.create(false))
@@ -182,6 +183,7 @@ public class ServerVerticle extends AbstractVerticle {
         .produces(KsqlMediaType.KSQL_V1_JSON.mediaType())
         .produces(JSON_CONTENT_TYPE)
         .handler(new QueryStreamHandler(endpoints, connectionQueryManager, context, server, true));
+    // Add a separate route for KSQL_V1_PROTOBUF. See https://github.com/confluentinc/ksql/pull/9145
     router.route(HttpMethod.POST, "/query")
         .handler(BodyHandler.create(false))
         .produces(KsqlMediaType.KSQL_V1_PROTOBUF.mediaType())

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -1059,7 +1059,7 @@ public class RestApiTest {
   @Test
   public void shouldExecutePushQueryAllEndpointsProto() {
     ImmutableList<String> endpoints = ImmutableList.of("/query-stream", "/query");
-    final String query = String.format("SELECT COUNT, USERID from %s EMIT CHANGES LIMIT %d;", AGG_TABLE, LIMIT);;
+    final String query = String.format("SELECT COUNT, USERID from %s EMIT CHANGES LIMIT %d;", AGG_TABLE, LIMIT);
     Object requestBody;
 
     final String expectedResponse

--- a/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksqldb-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -924,6 +924,7 @@ public class RestApiTest {
   @Test
   public void shouldExecutePullQueryAllEndpointsDefaultMIME() {
     // Given:
+    final String acceptableContentType = "*/*";
     ImmutableList<String> endpoints = ImmutableList.of("/query-stream", "/query");
     final String query = String.format("SELECT COUNT, USERID from %s;", AGG_TABLE);
     Object requestBody;
@@ -956,7 +957,7 @@ public class RestApiTest {
           try {
             resp[0] = RestIntegrationTestUtil.rawRestRequest(REST_APP,
                 httpVersion, POST,
-                endpoint, finalRequestBody, "*/*",
+                endpoint, finalRequestBody, acceptableContentType,
                 Optional.empty(), Optional.empty());
             return resp[0].bodyAsString().replaceFirst("queryId\":\"[^\"]*\"", "queryId\":\"XYZ\"");
           } catch (Throwable t) {
@@ -972,6 +973,7 @@ public class RestApiTest {
   @Test
   public void shouldExecutePullQueryAllEndpointsProto() {
     // Given:
+    final String acceptableContentType = KsqlMediaType.KSQL_V1_PROTOBUF.mediaType();
     ImmutableList<String> endpoints = ImmutableList.of("/query-stream", "/query");
     final String query = String.format("SELECT COUNT, USERID from %s;", AGG_TABLE);
     Object requestBody;
@@ -1012,7 +1014,7 @@ public class RestApiTest {
             // When:
             resp[0] = RestIntegrationTestUtil.rawRestRequest(REST_APP,
                 httpVersion, POST,
-                endpoint, finalRequestBody, KsqlMediaType.KSQL_V1_PROTOBUF.mediaType(),
+                endpoint, finalRequestBody, acceptableContentType,
                 Optional.empty(), Optional.empty());
             int respSize = parseRawRestQueryResponse(resp[0].body().toString()).size();
             return respSize;
@@ -1032,6 +1034,7 @@ public class RestApiTest {
   @Test
   public void shouldExecutePullQueryAllEndpointsProtoRoundTrip() {
     // Given:
+    final String acceptableContentType = KsqlMediaType.KSQL_V1_PROTOBUF.mediaType();
     ImmutableList<String> endpoints = ImmutableList.of("/query-stream", "/query");
     final String query = String.format("SELECT * from %s;", AGG_TABLE);
     Object requestBody;
@@ -1062,7 +1065,7 @@ public class RestApiTest {
             // When:
             resp[0] = RestIntegrationTestUtil.rawRestRequest(REST_APP,
                 httpVersion, POST,
-                endpoint, finalRequestBody, KsqlMediaType.KSQL_V1_PROTOBUF.mediaType(),
+                endpoint, finalRequestBody, acceptableContentType,
                 Optional.empty(), Optional.empty());
             int respSize = parseRawRestQueryResponse(resp[0].body().toString()).size();
             return respSize;


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/pull/9103 introduced a new protobuf Content-Type: `application/vnd.ksql.v1+protobuf`.
Upon introduction, `application/vnd.ksql.v1+protobuf` accidentally became the default content type for the `/query-stream` endpoint superseding our old default `application/vnd.ksqlapi.delimited.v1`. This happened because the `/query-stream` route had an equal weighting for all the content types including the new protobuf format. When there are equal weights on all the formats, then `routingContext.getAcceptableContentType()` https://github.com/confluentinc/ksql/blob/bd9034774cf11693f751472ef168f6fe9c99515d/ksqldb-rest-app/src/main/java/io/confluent/ksql/api/server/QueryStreamHandler.java#L123 just picks the first match (which happened to be the protobuf format in our case).

We can set a weight of 0 for the protobuf format, but as far as I can tell from the Vert.x docs, there is no way to individually specify weights for the types. The next best approach is to add a separate `Route` for the protobuf format to the endpoint. By default routes are matched in the order they are added to the router [Vert.x docs](https://vertx.io/docs/vertx-web/java/#_route_order).

This PR also exposes the protobuf format on the `/query` endpoint which is a follow-up to https://github.com/confluentinc/ksql/pull/9103.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

