### PR TITLE
fix: add BYTES support for KAFKA format

### DIFF
--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
@@ -95,8 +95,6 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
         return Serdes.serdeFrom(
             new TestByteBufferSerializer(Serdes.ByteBuffer().serializer()),
             new TestByteBufferDeserializer(Serdes.ByteBuffer().deserializer())
-//            Serdes.ByteBuffer().serializer(),
-//            Serdes.ByteBuffer().deserializer()
         );
       default:
         throw new IllegalStateException("Unsupported type for KAFKA format");
@@ -198,9 +196,9 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
   /**
    * Serializer that handles coercion to {@link Double}.
    *
-   * <p>The QTT tests are written in JSON. When the input values are read from the JSON file
-   * numbers can be deserialized as an {@link Integer}, {@link Long}, or {@link BigDecimal}. The
-   * value needs converting to the correct type before serializing.
+   * <p>The QTT tests are written in JSON. When the input values are read from the JSON file, we
+   * need to convert from base64 strings to bytebuffers since JSON can't inherently represent byte
+   * arrays
    */
   private static class TestByteBufferSerializer implements Serializer<Object> {
 
@@ -321,7 +319,7 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
 
   /***
    * <p>The QTT tests are written in JSON, so we have to write a custom deserializer to convert
-   * base64 strings to bytebuffers. This is because our tests are written as JSON files,
+   * bytebuffers to base64 strings. This is because our tests are written as JSON files,
    * which can't inherently represent byte arrays
    */
   private static class TestByteBufferDeserializer implements Deserializer<Object> {

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
@@ -24,9 +24,12 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.test.TestFrameworkException;
 import io.confluent.ksql.test.serde.SerdeSupplier;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -88,6 +91,13 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
         );
       case STRING:
         return Serdes.String();
+      case BYTES:
+        return Serdes.serdeFrom(
+            new TestByteBufferSerializer(Serdes.ByteBuffer().serializer()),
+            new TestByteBufferDeserializer(Serdes.ByteBuffer().deserializer())
+//            Serdes.ByteBuffer().serializer(),
+//            Serdes.ByteBuffer().deserializer()
+        );
       default:
         throw new IllegalStateException("Unsupported type for KAFKA format");
     }
@@ -186,6 +196,53 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
   }
 
   /**
+   * Serializer that handles coercion to {@link Double}.
+   *
+   * <p>The QTT tests are written in JSON. When the input values are read from the JSON file
+   * numbers can be deserialized as an {@link Integer}, {@link Long}, or {@link BigDecimal}. The
+   * value needs converting to the correct type before serializing.
+   */
+  private static class TestByteBufferSerializer implements Serializer<Object> {
+
+    private final Serializer<ByteBuffer> inner;
+
+
+    TestByteBufferSerializer(
+        final Serializer<ByteBuffer> inner
+    ) {
+      this.inner = requireNonNull(inner, "inner");
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+      inner.configure(configs, isKey);
+    }
+
+    @Override
+    public byte[] serialize(final String topicName, final Object value) {
+      final ByteBuffer coerced = coerce(value);
+      return inner.serialize(topicName, coerced);
+    }
+
+    @Override
+    public void close() {
+      inner.close();
+    }
+
+    private ByteBuffer coerce(final Object value) {
+      if (value == null) {
+        return null;
+      }
+
+      if (value instanceof String) {
+        return ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
+      }
+
+      throw new TestFrameworkException("Can't serialize " + value + " as BYTEBUFFER");
+    }
+  }
+
+  /**
    * Deserializer that handles coercion from {@link Long} to {@link Integer}.
    *
    * <p>The QTT tests are written in JSON. When the expected values are read from the JSON file
@@ -254,6 +311,45 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
       }
 
       return BigDecimal.valueOf(deserialized);
+    }
+
+    @Override
+    public void close() {
+      inner.close();
+    }
+  }
+
+  /***
+   * <p>The QTT tests are written in JSON, so we have to write a custom deserializer to convert
+   * base64 strings to bytebuffers. This is because our tests are written as JSON files,
+   * which can't inherently represent byte arrays
+   */
+  private static class TestByteBufferDeserializer implements Deserializer<Object> {
+
+    private final Deserializer<ByteBuffer> inner;
+
+    TestByteBufferDeserializer(final Deserializer<ByteBuffer> inner) {
+      this.inner = requireNonNull(inner, "inner");
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+      inner.configure(configs, isKey);
+    }
+
+    @Override
+    public String deserialize(final String topicName, final byte[] bytes) {
+      final ByteBuffer deserialized = inner.deserialize(topicName, bytes);
+      if (deserialized == null) {
+        return null;
+      }
+
+      return new String(deserialized.array());
+    }
+
+    @Override
+    public Object deserialize(String topic, Headers headers, byte[] data) {
+      return Deserializer.super.deserialize(topic, headers, data);
     }
 
     @Override

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
@@ -340,7 +340,7 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
         return null;
       }
 
-      return new String(deserialized.array());
+      return new String(deserialized.array(), StandardCharsets.UTF_8);
     }
 
     @Override

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
@@ -194,9 +194,7 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
   }
 
   /**
-   * Serializer that handles coercion to {@link Double}.
-   *
-   * <p>The QTT tests are written in JSON. When the input values are read from the JSON file, we
+   * The QTT tests are written in JSON. When the input values are read from the JSON file, we
    * need to convert from base64 strings to bytebuffers since JSON can't inherently represent byte
    * arrays
    */
@@ -317,8 +315,8 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
     }
   }
 
-  /***
-   * <p>The QTT tests are written in JSON, so we have to write a custom deserializer to convert
+  /**
+   * The QTT tests are written in JSON, so we have to write a custom deserializer to convert
    * bytebuffers to base64 strings. This is because our tests are written as JSON files,
    * which can't inherently represent byte arrays
    */

--- a/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
+++ b/ksqldb-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
@@ -344,7 +344,7 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
     }
 
     @Override
-    public Object deserialize(String topic, Headers headers, byte[] data) {
+    public Object deserialize(final String topic, final Headers headers, final byte[] data) {
       return Deserializer.super.deserialize(topic, headers, data);
     }
 

--- a/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
+++ b/ksqldb-functional-tests/src/test/java/io/confluent/ksql/test/planned/PlannedTestGeneratorTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.test.planned;
 
-import static io.confluent.ksql.test.loader.TestLoader.KSQL_TEST_FILES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_KAFKA_in_out/7.3.0_1654811779148/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_KAFKA_in_out/7.3.0_1654811779148/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID STRING KEY, B BYTES) WITH (KAFKA_TOPIC='test', KEY_FORMAT='KAFKA', VALUE_FORMAT='KAFKA');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "timestampColumn" : null,
+      "topicName" : "test",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST2 AS SELECT *\nFROM TEST TEST\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST2",
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "timestampColumn" : null,
+      "topicName" : "TEST2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "TEST2",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "TEST2"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "test",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` STRING KEY, `B` BYTES",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "B AS B" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          }
+        },
+        "topicName" : "TEST2",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_TEST2_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_KAFKA_in_out/7.3.0_1654811779148/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_KAFKA_in_out/7.3.0_1654811779148/spec.json
@@ -1,0 +1,94 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1654811779148,
+  "path" : "query-validation-tests/bytes.json",
+  "schemas" : {
+    "CSAS_TEST2_0.TEST2" : {
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "KAFKA"
+      }
+    },
+    "CSAS_TEST2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` STRING KEY, `B` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "KAFKA"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "KAFKA in/out",
+    "inputs" : [ {
+      "topic" : "test",
+      "key" : null,
+      "value" : "dmFyaWF0aW9ucw=="
+    } ],
+    "outputs" : [ {
+      "topic" : "TEST2",
+      "key" : null,
+      "value" : "dmFyaWF0aW9ucw=="
+    } ],
+    "topics" : [ {
+      "name" : "TEST2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "test",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID STRING KEY, b BYTES) WITH (kafka_topic='test', value_format='KAFKA');", "CREATE STREAM TEST2 AS SELECT * FROM TEST;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "KAFKA",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST2",
+        "type" : "STREAM",
+        "schema" : "`ID` STRING KEY, `B` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "KAFKA",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "test",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "KAFKA"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "TEST2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "KAFKA"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_KAFKA_in_out/7.3.0_1654811779148/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/bytes_-_KAFKA_in_out/7.3.0_1654811779148/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: TEST2)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/bytes.json
@@ -15,6 +15,19 @@
       ]
     },
     {
+      "name": "KAFKA in/out",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING KEY, b BYTES) WITH (kafka_topic='test', value_format='KAFKA');",
+        "CREATE STREAM TEST2 AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "value": "dmFyaWF0aW9ucw=="}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "value": "dmFyaWF0aW9ucw=="}
+      ]
+    },
+    {
       "name": "JSON in/out",
       "statements": [
         "CREATE STREAM TEST (ID STRING KEY, b BYTES) WITH (kafka_topic='test', value_format='JSON');",

--- a/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
+++ b/ksqldb-serde/src/main/java/io/confluent/ksql/serde/kafka/KafkaSerdeFactory.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.serde.FormatFactory;
 import io.confluent.ksql.serde.SerdeUtils;
 import io.confluent.ksql.serde.voids.KsqlVoidSerde;
 import io.confluent.ksql.util.KsqlException;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -41,7 +42,8 @@ public final class KafkaSerdeFactory {
       Integer.class, Serdes.Integer(),
       Long.class, Serdes.Long(),
       Double.class, Serdes.Double(),
-      String.class, Serdes.String()
+      String.class, Serdes.String(),
+      ByteBuffer.class, Serdes.ByteBuffer()
   );
 
   private KafkaSerdeFactory() {


### PR DESCRIPTION
### Description 
Fixes #8693 by adding ByteBuffer serdes to the KafkaSerdeFactory. Added a new QTT to the bytes.json to check correct behaviour for the KAFKA format.

