### PR TITLE
chore: ignore new findbugs 4.7.0 detectors causing ksql build to fail

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -45,6 +45,16 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     <Match>
         <Bug pattern="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS"/>
     </Match>
+    <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/2040 -->
+    <Match>
+        <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+    </Match>
+    <Match>
+        <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_BASIC_EXCEPTION"/>
+    </Match>
+    <Match>
+        <Bug pattern="THROWS_METHOD_THROWS_CLAUSE_THROWABLE"/>
+    </Match>
 
     <!--
       DO NOT USE THIS EXCLUSION FILE FOR NON-GENERATED CODE

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
         <jersey-common>2.34</jersey-common>
 
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+
+        <!-- A newer mockito 4.5.1 added on https://github.com/confluentinc/common/pull/460
+             caused issues with some unit tests. This version 4.3.1 is temporary until we
+             figured out what's wrong with 4.5.1 or newer -->
+        <mockito.version>4.3.1</mockito.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
There's an issue with the recent Findbugs 4.7.0 version that introduce new detectors.
https://github.com/spotbugs/spotbugs/issues/2040

The issue seems to fail only on Java 11. This PR excludes the new detectors from findbugs.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

