### PR TITLE
chore: add ThroughputMetricsReporter for consumed/produced metrics from KIP-846

### DIFF
--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1799,9 +1799,16 @@ public class KsqlConfig extends AbstractConfig {
     return parseStringAsMap(key, value);
   }
 
-  public static Map<String, String> getStringAsMap(final String key, final Map<String, ?> configMap) {
-    final String value = ((String) configMap.get(key)).trim();
-    return parseStringAsMap(key, value);
+  public static Map<String, String> getStringAsMap(
+      final String key,
+      final Map<String, ?> configMap
+  ) {
+    final String value = (String) configMap.get(key);
+    if (value != null) {
+      return parseStringAsMap(key, value);
+    } else {
+      return Collections.emptyMap();
+    }
   }
 
   public static Map<String, String> parseStringAsMap(final String key, final String value) {

--- a/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksqldb-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -1799,6 +1799,11 @@ public class KsqlConfig extends AbstractConfig {
     return parseStringAsMap(key, value);
   }
 
+  public static Map<String, String> getStringAsMap(final String key, final Map<String, ?> configMap) {
+    final String value = ((String) configMap.get(key)).trim();
+    return parseStringAsMap(key, value);
+  }
+
   public static Map<String, String> parseStringAsMap(final String key, final String value) {
     try {
       return value.equals("")

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -52,15 +52,12 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   private static final String TASK_STORAGE_USED_BYTES = "task_storage_used_bytes";
   private static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
   private static final Pattern QUERY_ID_PATTERN =
-      Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
+      Pattern.compile("(?<=query-|transient_)(.*?)(?=-)");
 
   private Map<String, Map<String, TaskStorageMetric>> metricsSeen;
   private Metrics metricRegistry;
   private static Map<String, String> customTags = new HashMap<>();
-  private static AtomicInteger numberStatefulTasks = new AtomicInteger(0);
-
-  public StorageUtilizationMetricsReporter() {
-  }
+  private static final AtomicInteger numberStatefulTasks = new AtomicInteger(0);
 
   @Override
   public void init(final List<KafkaMetric> list) {
@@ -281,6 +278,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
     if (matcher.find()) {
       return matcher.group(1);
     } else {
+      LOGGER.error("Can't parse query id from metric {}", metric);
       throw new KsqlException("Missing query ID when reporting utilization metrics");
     }
   }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporter.java
@@ -52,7 +52,7 @@ public class StorageUtilizationMetricsReporter implements MetricsReporter {
   private static final String TASK_STORAGE_USED_BYTES = "task_storage_used_bytes";
   private static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
   private static final Pattern QUERY_ID_PATTERN =
-      Pattern.compile("(?<=query-|transient_)(.*?)(?=-)");
+      Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
 
   private Map<String, Map<String, TaskStorageMetric>> metricsSeen;
   private Metrics metricRegistry;

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -43,10 +43,10 @@ import static org.apache.kafka.common.utils.Utils.mkSet;
 public class ThroughputMetricsReporter implements MetricsReporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ThroughputMetricsReporter.class);
-    private static final String RECORDS_CONSUMED = "records-consumed";
-    private static final String BYTES_CONSUMED = "bytes-consumed";
-    private static final String RECORDS_PRODUCED = "records-produced";
-    private static final String BYTES_PRODUCED = "bytes-produced";
+    private static final String RECORDS_CONSUMED = "records-consumed-total";
+    private static final String BYTES_CONSUMED = "bytes-consumed-total";
+    private static final String RECORDS_PRODUCED = "records-produced-total";
+    private static final String BYTES_PRODUCED = "bytes-produced-total";
     private static final Set<String> THROUGHPUT_METRIC_NAMES =
         mkSet(RECORDS_CONSUMED, BYTES_CONSUMED, RECORDS_PRODUCED, BYTES_PRODUCED);
     private static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
@@ -54,7 +54,6 @@ public class ThroughputMetricsReporter implements MetricsReporter {
         Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
 
     // CHECKSTYLE_RULES.OFF: LineLength
-    //
     private static final Map<String, Map<String, Map<MetricName, ThroughputTotalMetric>>> registeredMetrics = new HashMap<>();
     // CHECKSTYLE_RULES.ON: LineLength
     private static final Map<String, String> customTags = new HashMap<>();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -20,6 +20,8 @@ import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_ID_TAG;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOPIC_LEVEL_GROUP;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOPIC_NAME_TAG;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -37,13 +39,13 @@ import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ThroughputMetricsReporter implements MetricsReporter {
   private static final Logger LOGGER = LoggerFactory.getLogger(ThroughputMetricsReporter.class);
-  private static final String TOPIC_LEVEL_GROUP = "stream-topic-metrics";
-  private static final String TOPIC_NAME_TAG = "stream-topic-metrics";
   private static final String QUERY_ID_TAG = "query-id";
   private static final String RECORDS_CONSUMED = "records-consumed-total";
   private static final String BYTES_CONSUMED = "bytes-consumed-total";

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -16,6 +16,11 @@
 package io.confluent.ksql.internal;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_ID_TAG;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOPIC_NAME_TAG;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -34,243 +39,223 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.common.utils.Utils.mkSet;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_ID_TAG;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_ID_TAG;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOPIC_NAME_TAG;
-
 public class ThroughputMetricsReporter implements MetricsReporter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThroughputMetricsReporter.class);
+  private static final String QUERY_ID_TAG = "query-id";
+  private static final String RECORDS_CONSUMED = "records-consumed-total";
+  private static final String BYTES_CONSUMED = "bytes-consumed-total";
+  private static final String RECORDS_PRODUCED = "records-produced-total";
+  private static final String BYTES_PRODUCED = "bytes-produced-total";
+  private static final Set<String> THROUGHPUT_METRIC_NAMES =
+      mkSet(RECORDS_CONSUMED, BYTES_CONSUMED, RECORDS_PRODUCED, BYTES_PRODUCED);
+  private static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
+  private static final Pattern QUERY_ID_PATTERN =
+      Pattern.compile("(?<=query-|transient_)(.*?)(?=-)");
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ThroughputMetricsReporter.class);
-    private static final String QUERY_ID_TAG = "query-id";
-    private static final String RECORDS_CONSUMED = "records-consumed-total";
-    private static final String BYTES_CONSUMED = "bytes-consumed-total";
-    private static final String RECORDS_PRODUCED = "records-produced-total";
-    private static final String BYTES_PRODUCED = "bytes-produced-total";
-    private static final Set<String> THROUGHPUT_METRIC_NAMES =
-        mkSet(RECORDS_CONSUMED, BYTES_CONSUMED, RECORDS_PRODUCED, BYTES_PRODUCED);
-    private static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
-    private static final Pattern QUERY_ID_PATTERN =
-        Pattern.compile("(?<=query-|transient_)(.*?)(?=-)");
+  private static final Map<String, Map<String, Map<MetricName, ThroughputTotalMetric>>> metrics =
+      new HashMap<>();
+  private static final Map<String, String> customTags = new HashMap<>();
+  private Metrics metricRegistry;
 
-    // CHECKSTYLE_RULES.OFF: LineLength
-    private static final Map<String, Map<String, Map<MetricName, ThroughputTotalMetric>>> registeredMetrics = new HashMap<>();
-    // CHECKSTYLE_RULES.ON: LineLength
-    private static final Map<String, String> customTags = new HashMap<>();
-    private Metrics metricRegistry;
+  @Override
+  public void init(final List<KafkaMetric> initial) {
+  }
 
-    @Override
-    public void init(final List<KafkaMetric> initial) {
+  @VisibleForTesting
+  static void reset() {
+    metrics.clear();
+  }
+
+  @Override
+  public synchronized void configure(final Map<String, ?> configMap) {
+    this.metricRegistry = (Metrics) requireNonNull(
+      configMap.get(KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG)
+    );
+    customTags.putAll(KsqlConfig.getStringAsMap(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS, configMap));
+  }
+
+  @Override
+  public void metricChange(final KafkaMetric metric) {
+    if (!THROUGHPUT_METRIC_NAMES.contains(metric.metricName().name())) {
+      return;
+    }
+    addMetric(
+        metric,
+        getQueryId(metric),
+        getTopic(metric)
+    );
+  }
+
+  private synchronized void addMetric(
+      final KafkaMetric metric,
+      final String queryId,
+      final String topic
+  ) {
+    final MetricName throughputTotalMetricName =
+          getThroughputTotalMetricName(queryId, metric.metricName());
+    LOGGER.debug("Adding metric {}", throughputTotalMetricName);
+    if (!metrics.containsKey(queryId)) {
+      metrics.put(queryId, new HashMap<>());
+    }
+    if (!metrics.get(queryId).containsKey(topic)) {
+      metrics.get(queryId).put(topic, new HashMap<>());
     }
 
-    @Override
-    public synchronized void configure(final Map<String, ?> configMap) {
-        this.metricRegistry = (Metrics) requireNonNull(
-            configMap.get(KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG)
-        );
-        customTags.putAll(KsqlConfig.getStringAsMap(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS, configMap));
+    final ThroughputTotalMetric existingThroughputMetric =
+          metrics.get(queryId).get(topic).get(throughputTotalMetricName);
+
+    if (existingThroughputMetric == null) {
+      final ThroughputTotalMetric newThroughputMetric = new ThroughputTotalMetric(metric);
+
+      metrics.get(queryId).get(topic)
+          .put(throughputTotalMetricName, newThroughputMetric);
+      metricRegistry.addMetric(
+          throughputTotalMetricName,
+          (config, now) -> newThroughputMetric.getValue()
+      );
+    } else {
+      existingThroughputMetric.add(metric);
+    }
+  }
+
+  @Override
+  public void metricRemoval(final KafkaMetric metric) {
+    if (!THROUGHPUT_METRIC_NAMES.contains(metric.metricName().name())) {
+      return;
     }
 
-    @Override
-    public void metricChange(final KafkaMetric metric) {
-        if (!THROUGHPUT_METRIC_NAMES.contains(metric.metricName().name())) {
-            return;
+    removeMetric(
+        metric,
+        getQueryId(metric),
+        getTopic(metric)
+    );
+  }
+
+  private synchronized void removeMetric(
+      final KafkaMetric metric,
+      final String queryId,
+      final String topic
+  ) {
+    final MetricName throughputTotalMetricName =
+        getThroughputTotalMetricName(queryId, metric.metricName());
+
+    LOGGER.debug("Removing metric {}", throughputTotalMetricName);
+
+    if (metrics.containsKey(queryId)
+          && metrics.get(queryId).containsKey(topic)
+          && metrics.get(queryId).get(topic).containsKey(throughputTotalMetricName)) {
+
+      final ThroughputTotalMetric throughputTotalMetric =
+          metrics.get(queryId).get(topic).get(throughputTotalMetricName);
+
+      metricRegistry.removeMetric(throughputTotalMetricName);
+      throughputTotalMetric.remove(metric.metricName());
+
+      if (throughputTotalMetric.throughputTotalMetrics.isEmpty()) {
+        metrics.get(queryId).get(topic).remove(throughputTotalMetricName);
+        if (metrics.get(queryId).get(topic).isEmpty()) {
+          metrics.get(queryId).remove(topic);
+          if (metrics.get(queryId).isEmpty()) {
+            metrics.remove(queryId);
+          }
         }
-        addMetric(
-            metric,
-            getQueryId(metric),
-            getTopic(metric)
-        );
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public Set<String> reconfigurableConfigs() {
+    return null;
+  }
+
+  @Override
+  public void validateReconfiguration(final Map<String, ?> configs) throws ConfigException {
+  }
+
+  @Override
+  public void reconfigure(final Map<String, ?> configs) {
+  }
+
+  @Override
+  public void contextChange(final MetricsContext metricsContext) {
+  }
+
+  private MetricName getThroughputTotalMetricName(
+      final String queryId,
+      final MetricName metricName
+  ) {
+    return new MetricName(
+      metricName.name(),
+      StreamsMetricsImpl.TOPIC_LEVEL_GROUP,
+      metricName.description() + " by this query",
+      getThroughputTotalMetricTags(queryId, metricName.tags())
+    );
+  }
+
+  private String getQueryId(final KafkaMetric metric) {
+    final String taskName = metric.metricName().tags().getOrDefault(TASK_ID_TAG, "");
+    final Matcher namedTopologyMatcher = NAMED_TOPOLOGY_PATTERN.matcher(taskName);
+    if (namedTopologyMatcher.find()) {
+      return namedTopologyMatcher.group(1);
     }
 
-    private synchronized void addMetric(
-        final KafkaMetric metric,
-        final String queryId,
-        final String topic
-    ) {
-        final MetricName throughputTotalMetricName =
-            getThroughputTotalMetricName(queryId, metric.metricName());
+    final String queryIdTag = metric.metricName().tags().getOrDefault(THREAD_ID_TAG, "");
+    final Matcher matcher = QUERY_ID_PATTERN.matcher(queryIdTag);
+    if (matcher.find()) {
+      return matcher.group(1);
+    } else {
+      LOGGER.error("Can't parse query id from metric {}", metric);
+      throw new KsqlException("Missing query ID when reporting total throughput metrics");
+    }
+  }
 
-        LOGGER.debug("Adding metric {}", throughputTotalMetricName);
+  private String getTopic(final KafkaMetric metric) {
+    return metric.metricName().tags().getOrDefault(TOPIC_NAME_TAG, "");
+  }
 
-        if (!registeredMetrics.containsKey(queryId)) {
-            registeredMetrics.put(queryId, new HashMap<>());
-        }
-        if (!registeredMetrics.get(queryId).containsKey(topic)) {
-            registeredMetrics.get(queryId).put(topic, new HashMap<>());
-        }
+  private Map<String, String> getThroughputTotalMetricTags(
+      final String queryId,
+      final Map<String, String> originalStreamsMetricTags
+  ) {
+    final Map<String, String> queryMetricTags = new HashMap<>(customTags);
+    queryMetricTags.putAll(originalStreamsMetricTags);
+    // Remove the taskId and processorNodeId tags as the throughput total metric sums over them
+    queryMetricTags.remove(TASK_ID_TAG);
+    queryMetricTags.remove(PROCESSOR_NODE_ID_TAG);
+    queryMetricTags.put(QUERY_ID_TAG, queryId);
+    return ImmutableMap.copyOf(queryMetricTags);
+  }
 
-        final ThroughputTotalMetric throughputMetric =
-            registeredMetrics.get(queryId).get(topic).get(throughputTotalMetricName);
+  private static class ThroughputTotalMetric {
+    final Map<MetricName, KafkaMetric> throughputTotalMetrics = new HashMap<>();
 
-        if (throughputMetric == null) {
-            final ThroughputTotalMetric newThroughputMetric =
-                new ThroughputTotalMetric(throughputTotalMetricName, metric);
-
-            registeredMetrics
-                .get(queryId)
-                .get(topic)
-                .put(throughputTotalMetricName, newThroughputMetric);
-            metricRegistry.addMetric(
-                throughputTotalMetricName,
-                (config, now) -> newThroughputMetric.getValue()
-            );
-        } else {
-            throughputMetric.add(metric);
-        }
+    ThroughputTotalMetric(final KafkaMetric metric) {
+      add(metric);
     }
 
-    @Override
-    public void metricRemoval(final KafkaMetric metric) {
-        if (!THROUGHPUT_METRIC_NAMES.contains(metric.metricName().name())) {
-            return;
-        }
-
-        removeMetric(
-            metric,
-            getQueryId(metric),
-            getTopic(metric)
-        );
+    private void add(final KafkaMetric metric) {
+      throughputTotalMetrics.put(metric.metricName(), metric);
     }
 
-    private synchronized void removeMetric(
-        final KafkaMetric metric,
-        final String queryId,
-        final String topic
-    ) {
-        final MetricName throughputTotalMetricName =
-            getThroughputTotalMetricName(queryId, metric.metricName());
-
-        LOGGER.debug("Removing metric {}", throughputTotalMetricName);
-
-        if (registeredMetrics.containsKey(queryId) &&
-            registeredMetrics.get(queryId).containsKey(topic) &&
-            registeredMetrics.get(queryId).get(topic).containsKey(throughputTotalMetricName)) {
-
-            final ThroughputTotalMetric throughputTotalMetric =
-                registeredMetrics.get(queryId).get(topic).get(throughputTotalMetricName);
-
-            metricRegistry.removeMetric(throughputTotalMetricName);
-            throughputTotalMetric.remove(throughputTotalMetricName);
-
-            if (throughputTotalMetric.metrics.isEmpty()) {
-                registeredMetrics.get(queryId).get(topic).remove(throughputTotalMetricName);
-                if (registeredMetrics.get(queryId).get(topic).isEmpty()) {
-                    registeredMetrics.get(queryId).remove(topic);
-                    if (registeredMetrics.get(queryId).isEmpty()) {
-                        registeredMetrics.remove(queryId);
-                    }
-                }
-            }
-        }
+    private void remove(final MetricName metric) {
+      throughputTotalMetrics.remove(metric);
     }
 
-    @Override
-    public void close() {
+    public Double getValue() {
+      return throughputTotalMetrics
+        .values()
+         .stream()
+         .map(m -> (Double) m.metricValue())
+        .reduce(Double::sum)
+        .orElse(0D);
     }
-
-    @Override
-    public Set<String> reconfigurableConfigs() {
-        return null;
-    }
-
-    @Override
-    public void validateReconfiguration(final Map<String, ?> configs) throws ConfigException {
-
-    }
-
-    @Override
-    public void reconfigure(final Map<String, ?> configs) {
-
-    }
-
-    @Override
-    public void contextChange(final MetricsContext metricsContext) {
-
-    }
-
-    private MetricName getThroughputTotalMetricName(
-        final String queryId,
-        final MetricName metricName
-    ) {
-        return new MetricName(
-            metricName.name(),
-            StreamsMetricsImpl.TOPIC_LEVEL_GROUP,
-            metricName.description() + " by this query",
-            getThroughputTotalMetricTags(queryId, metricName.tags())
-        );
-    }
-
-    private String getQueryId(final KafkaMetric metric) {
-        final String taskName = metric.metricName().tags().getOrDefault(TASK_ID_TAG, "");
-        final Matcher namedTopologyMatcher = NAMED_TOPOLOGY_PATTERN.matcher(taskName);
-        if (namedTopologyMatcher.find()) {
-            return namedTopologyMatcher.group(1);
-        }
-
-        final String queryIdTag = metric.metricName().tags().getOrDefault(THREAD_ID_TAG, "");
-        final Matcher matcher = QUERY_ID_PATTERN.matcher(queryIdTag);
-        if (matcher.find()) {
-            return matcher.group(1);
-        } else {
-            LOGGER.error("Can't parse query id from metric {}", metric);
-            throw new KsqlException("Missing query ID when reporting total throughput metrics");
-        }
-    }
-
-    private String getTopic(final KafkaMetric metric) {
-        return metric.metricName().tags().getOrDefault(TOPIC_NAME_TAG, "");
-    }
-
-    private Map<String, String> getThroughputTotalMetricTags(
-        final String queryId,
-        final Map<String, String> originalStreamsMetricTags
-    ) {
-        final Map<String, String> queryMetricTags = new HashMap<>(customTags);
-        queryMetricTags.putAll(originalStreamsMetricTags);
-        // Remove the taskId and processorNodeId tags as the throughput total metric sums over them
-        queryMetricTags.remove(TASK_ID_TAG);
-        queryMetricTags.remove(PROCESSOR_NODE_ID_TAG);
-        queryMetricTags.put(QUERY_ID_TAG, queryId);
-        return ImmutableMap.copyOf(queryMetricTags);
-    }
-
-    @VisibleForTesting
-    static void setTags(final Map<String, String> tags) {
-        customTags.clear();
-        customTags.putAll(tags);
-    }
-
-    private static class ThroughputTotalMetric {
-        final MetricName aggregatedTotalMetric;
-        final Map<MetricName, KafkaMetric> metrics = new HashMap<>();
-
-        ThroughputTotalMetric(final MetricName aggregatedTotalMetric, final KafkaMetric metric) {
-            this.aggregatedTotalMetric = aggregatedTotalMetric;
-            add(metric);
-        }
-
-        private void add(final KafkaMetric metric) {
-            metrics.put(metric.metricName(), metric);
-        }
-
-        private void remove(final MetricName metric) {
-            metrics.remove(metric);
-        }
-
-        public Double getValue() {
-            return metrics
-                .values()
-                .stream()
-                .map(m -> (Double) m.metricValue())
-                .reduce(Double::sum)
-                .orElse(0D);
-        }
-    }
+  }
 
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsContext;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.kafka.common.utils.Utils.mkSet;
+
+public class ThroughputMetricsReporter implements MetricsReporter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThroughputMetricsReporter.class);
+    private static final String RECORDS_CONSUMED = "records-consumed";
+    private static final String BYTES_CONSUMED = "bytes-consumed";
+    private static final String RECORDS_PRODUCED = "records-produced";
+    private static final String BYTES_PRODUCED = "bytes-produced";
+    private static final Set<String> THROUGHPUT_METRIC_NAMES =
+        mkSet(RECORDS_CONSUMED, BYTES_CONSUMED, RECORDS_PRODUCED, BYTES_PRODUCED);
+    private static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
+    private static final Pattern QUERY_ID_PATTERN =
+        Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
+
+    // CHECKSTYLE_RULES.OFF: LineLength
+    //
+    private static final Map<String, Map<String, Map<MetricName, ThroughputTotalMetric>>> registeredMetrics = new HashMap<>();
+    // CHECKSTYLE_RULES.ON: LineLength
+    private static final Map<String, String> customTags = new HashMap<>();
+    private Metrics metricRegistry;
+
+    @Override
+    public void init(final List<KafkaMetric> initial) {
+    }
+
+    @Override
+    public synchronized void configure(final Map<String, ?> configMap) {
+        this.metricRegistry = (Metrics) requireNonNull(
+            configMap.get(KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG)
+        );
+        customTags.putAll(KsqlConfig.getStringAsMap(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS, configMap));
+    }
+
+    @Override
+    public void metricChange(final KafkaMetric metric) {
+        if (!metric.metricName().group().equals(StreamsMetricsImpl.TOPIC_LEVEL_GROUP)) {
+            return;
+        }
+        addMetric(
+            metric,
+            getQueryId(metric),
+            getTopicName(metric)
+        );
+    }
+
+    @Override
+    public void metricRemoval(final KafkaMetric metric) {
+        final MetricName metricName = metric.metricName();
+        if (!THROUGHPUT_METRIC_NAMES.contains(metricName.name())) {
+            return;
+        }
+
+        removeMetric(
+            metric,
+            getQueryId(metric),
+            getTopicName(metric)
+        );
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public Set<String> reconfigurableConfigs() {
+        return null;
+    }
+
+    @Override
+    public void validateReconfiguration(final Map<String, ?> configs) throws ConfigException {
+
+    }
+
+    @Override
+    public void reconfigure(final Map<String, ?> configs) {
+
+    }
+
+    @Override
+    public void contextChange(final MetricsContext metricsContext) {
+
+    }
+
+    private synchronized void addMetric(
+        final KafkaMetric metric,
+        final String queryId,
+        final String topicName
+        ) {
+        final MetricName metricName = metric.metricName();
+        final Map<String, String> queryMetricTags = getQueryMetricTags(queryId, metric.metricName().tags());
+        final Map<String, String> topicMetricTags = getTopicMetricTags(queryMetricTags, topicName);
+
+        LOGGER.debug("Adding {} metric for query={} and topic={}", metricName.name(), queryId, topicName);
+
+        if (!registeredMetrics.containsKey(queryId)) {
+            registeredMetrics.put(queryId, new HashMap<>());
+        }
+        if (!registeredMetrics.get(queryId).containsKey(topicName)) {
+            registeredMetrics.get(queryId).put(topicName, new HashMap<>());
+        }
+
+        if (registeredMetrics.get(queryId).get(topicName).containsKey(metricName)) {
+            LOGGER.error("The {} metric has already been added for query={} and topic={}",
+                         metricName.name(), queryId, topicName);
+        }
+
+        final ThroughputTotalMetric newMetric = new ThroughputTotalMetric(
+            metricRegistry.metricName(
+                metricName.name(),
+                StreamsMetricsImpl.TOPIC_LEVEL_GROUP,
+                topicMetricTags),
+            metric);
+        registeredMetrics.get(queryId).get(topicName).put(metricName, newMetric);
+
+        metricRegistry.addMetric(
+            new MetricName(
+                metricName.name(),
+                StreamsMetricsImpl.TOPIC_LEVEL_GROUP,
+                metricName.description(),
+                queryMetricTags),
+            (config, now) -> registeredMetrics.get(queryId).get(topicName).get(metricName).getValue()
+        );
+    }
+
+    private synchronized void removeMetric(
+        final KafkaMetric metric,
+        final String queryId,
+        final String topicName
+    ) {
+        if (registeredMetrics.containsKey(queryId)) {
+            if (!registeredMetrics.get(queryId).containsKey(topicName)) {
+                metricRegistry.removeMetric(metric.metricName());
+                registeredMetrics.get(queryId).get(topicName).remove(metric.metricName());
+
+                if (registeredMetrics.get(queryId).get(topicName).size() == 0) {
+
+                }
+            }
+        }
+    }
+
+    private MetricName getMetricNameWithQueryIdTag(
+        final String queryId,
+        final String topicName,
+        final MetricName metricName
+    ) {
+        return new MetricName(
+            metricName.name(),
+            StreamsMetricsImpl.TOPIC_LEVEL_GROUP,
+            metricName.description(),
+            getTopicMetricTags(getQueryMetricTags(queryId, metricName.tags()), topicName)
+        );
+    }
+
+    private String getQueryId(final KafkaMetric metric) {
+        final String taskName = metric.metricName().tags().getOrDefault("task-id", "");
+        final Matcher namedTopologyMatcher = NAMED_TOPOLOGY_PATTERN.matcher(taskName);
+        if (namedTopologyMatcher.find()) {
+            return namedTopologyMatcher.group(1);
+        }
+
+        final String queryIdTag = metric.metricName().tags().getOrDefault("thread-id", "");
+        final Matcher matcher = QUERY_ID_PATTERN.matcher(queryIdTag);
+        if (matcher.find()) {
+            return matcher.group(1);
+        } else {
+            throw new KsqlException("Missing query ID when reporting total throughput metrics");
+        }
+    }
+
+    private String getTopicName(final KafkaMetric metric) {
+        return metric.metricName().tags().getOrDefault("topic", "");
+    }
+
+    private Map<String, String> getQueryMetricTags(
+        final String queryId,
+        final Map<String, String> metricTags
+    ) {
+        final Map<String, String> queryMetricTags = new HashMap<>(customTags);
+        queryMetricTags.putAll(metricTags);
+        queryMetricTags.put("query-id", queryId);
+        return ImmutableMap.copyOf(queryMetricTags);
+    }
+
+    private Map<String, String> getTopicMetricTags(
+        final Map<String, String> taskTags,
+        final String topic
+    ) {
+        final Map<String, String> topicMetricTags = new HashMap<>(taskTags);
+        topicMetricTags.put("topic", topic);
+        return ImmutableMap.copyOf((topicMetricTags));
+    }
+
+    @VisibleForTesting
+    static void setTags(final Map<String, String> tags) {
+        customTags.clear();
+        customTags.putAll(tags);
+    }
+
+    private static class ThroughputTotalMetric {
+        final MetricName metricName;
+        final KafkaMetric metric;
+
+        ThroughputTotalMetric(final MetricName metricName, final KafkaMetric metric) {
+            this.metricName = metricName;
+            this.metric = metric;
+        }
+
+        public double getValue() {
+            return (double) metric.metricValue();
+        }
+    }
+
+}

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -39,8 +39,6 @@ import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -53,7 +53,7 @@ public class ThroughputMetricsReporter implements MetricsReporter {
       mkSet(RECORDS_CONSUMED, BYTES_CONSUMED, RECORDS_PRODUCED, BYTES_PRODUCED);
   private static final Pattern NAMED_TOPOLOGY_PATTERN = Pattern.compile("(.*?)__\\d*_\\d*");
   private static final Pattern QUERY_ID_PATTERN =
-      Pattern.compile("(?<=query-|transient_)(.*?)(?=-)");
+      Pattern.compile("(?<=query_|transient_)(.*?)(?=-)");
 
   private static final Map<String, Map<String, Map<MetricName, ThroughputTotalMetric>>> metrics =
       new HashMap<>();

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/query/QueryBuilder.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.execution.streams.metrics.RocksDBMetricsCollector;
 import io.confluent.ksql.execution.util.KeyUtil;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.internal.StorageUtilizationMetricsReporter;
+import io.confluent.ksql.internal.ThroughputMetricsReporter;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -567,6 +568,11 @@ final class QueryBuilder {
         newStreamsProperties,
         StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG,
         StorageUtilizationMetricsReporter.class.getName()
+    );
+    updateListProperty(
+        newStreamsProperties,
+        StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG,
+        ThroughputMetricsReporter.class.getName()
     );
 
     if (config.getBoolean(KsqlConfig.KSQL_SHARED_RUNTIME_ENABLED)) {

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -39,7 +39,7 @@ public class StorageUtilizationMetricsReporterTest {
   private static final String KAFKA_METRIC_NAME = "total-sst-files-size";
   private static final String KAFKA_METRIC_GROUP = "streams-metric";
   private static final String KSQL_METRIC_GROUP = "ksqldb_utilization";
-  private static final String THREAD_ID = "_confluent_blahblah_query_CTAS_TEST_1-blahblah";
+  private static final String THREAD_ID = "_confluent_blahblah_query-CTAS_TEST_1-blahblah";
   private static final String TRANSIENT_THREAD_ID = "_confluent_blahblah_transient_blahblah_4-blahblah";
   private static final String TASK_STORAGE_METRIC = "task_storage_used_bytes";
   private static final String QUERY_STORAGE_METRIC = "query_storage_used_bytes";

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/StorageUtilizationMetricsReporterTest.java
@@ -39,7 +39,7 @@ public class StorageUtilizationMetricsReporterTest {
   private static final String KAFKA_METRIC_NAME = "total-sst-files-size";
   private static final String KAFKA_METRIC_GROUP = "streams-metric";
   private static final String KSQL_METRIC_GROUP = "ksqldb_utilization";
-  private static final String THREAD_ID = "_confluent_blahblah_query-CTAS_TEST_1-blahblah";
+  private static final String THREAD_ID = "_confluent_blahblah_query_CTAS_TEST_1-blahblah";
   private static final String TRANSIENT_THREAD_ID = "_confluent_blahblah_transient_blahblah_4-blahblah";
   private static final String TASK_STORAGE_METRIC = "task_storage_used_bytes";
   private static final String QUERY_STORAGE_METRIC = "query_storage_used_bytes";

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -3,7 +3,6 @@ package io.confluent.ksql.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -11,14 +10,13 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Measurable;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
-
-import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -261,6 +261,14 @@ public class ThroughputMetricsReporterTest {
     // Then:
     taskValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0);
     assertThat(taskValue, equalTo(2D));
+
+    final KafkaMetric metric3 = mockMetric(
+      BYTES_CONSUMED_TOTAL,
+      3D,
+      STREAMS_TAGS_PROCESSOR_2);
+    listener.metricChange(metric3);
+    taskValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0);
+    assertThat(taskValue, equalTo(5D));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -1,0 +1,338 @@
+package io.confluent.ksql.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ThroughputMetricsReporterTest {
+  private static final String RECORDS_CONSUMED_METRIC_NAME = "records-consumed-total";
+  private static final String BYTES_CONSUMED_METRIC_NAME = "bytes-consumed-total";
+  private static final String RECORDS_PRODUCED_METRIC_NAME = "records-produced-total";
+  private static final String BYTES_PRODUCED_METRIC_NAME = "bytes-produced-total";
+  private static final String QUERY_1 = "CTAS_TEST_1";
+  private static final String QUERY_2 = "CTAS_TEST_2";
+  private static final String THREAD_ID = "_confluent_blahblah_query-CTAS_TEST_1-blahblah";
+  private static final String THREAD_ID_2 = "_confluent_blahblah_query-CTAS_TEST_2-blahblah";
+  private static final String TRANSIENT_THREAD_ID = "_confluent_blahblah_transient_blahblah_4-blahblah";
+  private static final String TASK_ID_1 = "0_1";
+  private static final String TASK_ID_2 = "0_1__query-id";
+  private static final String PROCESSOR_NODE_ID = "sink-node";
+  private static final String PROCESSOR_NODE_ID_2 = "sink-node-2";
+  private static final String TOPIC_NAME = "topic";
+  private static final String TOPIC_NAME_2 = "topic-2";
+
+  private static final Map<String, String> STREAMS_TAGS_TASK_1 = ImmutableMap.of(
+      "thread-id", THREAD_ID,
+      "task-id", TASK_ID_1,
+      "processor-node-id", PROCESSOR_NODE_ID,
+      "topic-name", TOPIC_NAME
+  );
+  private static final Map<String, String> STREAMS_TAGS_TASK_2 = ImmutableMap.of(
+      "thread-id", THREAD_ID,
+      "task-id", TASK_ID_2,
+      "processor-node-id", PROCESSOR_NODE_ID,
+      "topic-name", TOPIC_NAME
+  );
+  private static final Map<String, String> STREAMS_TAGS_PROCESSOR_2 = ImmutableMap.of(
+      "thread-id", THREAD_ID,
+      "task-id", TASK_ID_2,
+      "processor-node-id", PROCESSOR_NODE_ID_2,
+      "topic-name", TOPIC_NAME
+  );
+  private static final Map<String, String> STREAMS_TAGS_TOPIC_2 = ImmutableMap.of(
+    "thread-id", THREAD_ID_2,
+    "task-id", TASK_ID_1,
+    "processor-node-id", PROCESSOR_NODE_ID,
+    "topic-name", TOPIC_NAME_2
+  );
+  private static final Map<String, String> QUERY_ONE_TAGS = ImmutableMap.of(
+      "logical_cluster_id", "lksqlc-12345",
+      "query-id", QUERY_1,
+      "thread-id", THREAD_ID,
+      "topic-name", TOPIC_NAME
+  );
+  private static final Map<String, String> QUERY_TWO_TAGS = ImmutableMap.of(
+      "logical_cluster_id", "lksqlc-12345",
+      "query-id", QUERY_2,
+      "thread-id", THREAD_ID_2,
+      "topic-name", TOPIC_NAME_2
+  );
+    
+  private ThroughputMetricsReporter listener;
+
+  @Mock
+  private Metrics metrics;
+  @Captor
+  private ArgumentCaptor<Measurable> metricValueProvider;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setUp() {
+    listener = new ThroughputMetricsReporter();
+    listener.configure(
+        ImmutableMap.of(
+            KsqlConfig.KSQL_INTERNAL_METRICS_CONFIG, metrics,
+            KsqlConfig.KSQL_CUSTOM_METRICS_TAGS, "logical_cluster_id:lksqlc-12345"
+        )
+    );
+  }
+
+  @Before
+  public void cleanUp() {
+    ThroughputMetricsReporter.reset();
+  }
+    
+  @Test
+  public void shouldAddNewMeasurableForAllThroughputMetricsTypes() {
+    // Given:
+    listener.metricChange(mockMetric(
+        BYTES_CONSUMED_METRIC_NAME,
+        1D,
+        STREAMS_TAGS_TASK_1)
+    );
+
+    listener.metricChange(mockMetric(
+      RECORDS_CONSUMED_METRIC_NAME,
+      2D,
+      STREAMS_TAGS_TASK_1)
+    );
+
+    listener.metricChange(mockMetric(
+      BYTES_PRODUCED_METRIC_NAME,
+      3D,
+      STREAMS_TAGS_TASK_1)
+    );
+
+    listener.metricChange(mockMetric(
+      RECORDS_PRODUCED_METRIC_NAME,
+      4D,
+      STREAMS_TAGS_TASK_1)
+    );
+
+    // When:
+    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    final Measurable recordsConsumed = verifyAndGetMetric(RECORDS_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    final Measurable bytesProduced = verifyAndGetMetric(BYTES_PRODUCED_METRIC_NAME, QUERY_ONE_TAGS);
+    final Measurable recordsProduced = verifyAndGetMetric(RECORDS_PRODUCED_METRIC_NAME, QUERY_ONE_TAGS);
+
+    // Then:
+    assertThat(bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L), equalTo(1D));
+    assertThat(recordsConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L), equalTo(2D));
+    assertThat(bytesProduced.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L), equalTo(3D));
+    assertThat(recordsProduced.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L), equalTo(4D));
+  }
+
+    @Test
+  public void shouldUpdateExistingMeasurable() {
+    // Given:
+    listener.metricChange(mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      2D,
+      STREAMS_TAGS_TASK_1)
+    );
+
+    Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    Object bytesConsumedValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
+    assertThat(bytesConsumedValue, equalTo(2D));
+
+    // When:
+    listener.metricChange(mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      15D,
+      STREAMS_TAGS_TASK_1)
+    );
+
+    // Then:
+    bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    bytesConsumedValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
+
+    assertThat(bytesConsumedValue, equalTo(15D));
+  }
+
+  @Test
+  public void shouldAggregateOverAllTasksAndProcessorNodes() {
+    // Given:
+    KafkaMetric m1 = mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      2D,
+      STREAMS_TAGS_TASK_1
+    );
+    KafkaMetric m2 = mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      5D,
+      STREAMS_TAGS_TASK_2
+    );
+    KafkaMetric m3 = mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      3D,
+      STREAMS_TAGS_PROCESSOR_2
+    );
+
+    // When:
+    listener.metricChange(m1);
+    listener.metricChange(m2);
+    listener.metricChange(m3);
+
+    // Then:
+    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    final Object value = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
+    assertThat(value, equalTo(10D));
+  }
+
+  @Test
+  public void shouldRemoveCorrectMetricAndReturnZero() {
+    // Given:
+    final KafkaMetric metric = mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      2D,
+      STREAMS_TAGS_TASK_1);
+    listener.metricChange(metric);
+    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+
+    final KafkaMetric metric2 = mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      5D,
+      STREAMS_TAGS_TOPIC_2);
+    listener.metricChange(metric2);
+    final Measurable bytesConsumed2 = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_TWO_TAGS);
+
+    Object value = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
+    assertThat(value, equalTo(2D));
+    Object value2 = bytesConsumed2.measure(new MetricConfig().tags(QUERY_TWO_TAGS), 0L);
+    assertThat(value2, equalTo(5D));
+
+    // When:
+    listener.metricRemoval(metric);
+
+    // Then:
+    verifyRemovedMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+
+    value = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
+    assertThat(value, equalTo(0D));
+
+    value2 = bytesConsumed2.measure(new MetricConfig().tags(QUERY_TWO_TAGS), 0L);
+    assertThat(value2, equalTo(5D));
+  }
+
+  @Test
+  public void shouldNotIncludeRemovedMetricInThroughputTotal() {
+    // Given:
+    listener.metricChange(mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      2D,
+      STREAMS_TAGS_TASK_1)
+    );
+    final KafkaMetric metric2 = mockMetric(
+      BYTES_CONSUMED_METRIC_NAME,
+      6D,
+      STREAMS_TAGS_TASK_2
+    );
+    listener.metricChange(metric2);
+    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    Object taskValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
+    assertThat(taskValue, equalTo(8D));
+
+    // When:
+    listener.metricRemoval(metric2);
+
+    // Then:
+    taskValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0);
+    assertThat(taskValue, equalTo(2D));
+  }
+
+  @Test
+  public void shouldIgnoreNonThroughputMetrics() {
+    // When:
+    listener.metricChange(mockMetric(
+      "other-metric",
+      2D,
+      QUERY_ONE_TAGS)
+    );
+
+    // Then:
+    assertThrows(AssertionError.class, () -> verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS));
+  }
+/*
+  @Test
+  public void shouldCombineTaskMetricsToQueryMetricWithSharedRuntimeQueries() {
+    // When:
+    listener.metricChange(mockMetric(
+      2D,
+      ImmutableMap.of("task-id", "CTAS_TEST_1__1_0", "thread-id", "THREAD_ID", "logical_cluster_id", "logical-id"))
+    );
+    listener.metricChange(mockMetric(
+      TOPIC_METRIC_GROUP,
+      BigInteger.valueOf(5),
+      ImmutableMap.of("task-id", "CTAS_TEST_1__1_1", "thread-id", "THREAD_ID", "logical_cluster_id", "logical-id"))
+    );
+
+    // Then:
+    final Gauge<?> queryGauge = verifyAndGetRegisteredMetric(QUERY_STORAGE_METRIC, QUERY_ONE_TAGS);
+    final Object queryValue = queryGauge.value(null, 0);
+    final Map<String, String> task1 = ImmutableMap.of("logical_cluster_id", "logical-id", "query-id", "CTAS_TEST_1", "task-id", "CTAS_TEST_1__1_0");
+    final Gauge<?> taskGaugeOne = verifyAndGetRegisteredMetric(BYTES_CONSUMED_METRIC_NAME, task1);
+    final Object taskValueOne = taskGaugeOne.value(null, 0);
+    final Map<String, String> task2 = ImmutableMap.of("logical_cluster_id", "logical-id", "query-id", "CTAS_TEST_1", "task-id", "CTAS_TEST_1__1_1");
+    final Gauge<?> taskGaugeTwo = verifyAndGetRegisteredMetric(BYTES_CONSUMED_METRIC_NAME, task2);
+    final Object taskValueTwo = taskGaugeTwo.value(null, 0);
+
+    assertThat(taskValueOne, equalTo(2D));
+    assertThat(taskValueTwo, equalTo(BigInteger.valueOf(5)));
+    assertThat(queryValue, equalTo(BigInteger.valueOf(7)));
+  }
+ */
+
+  private KafkaMetric mockMetric(
+    final String name, 
+    Object value, 
+    final Map<String, String> tags
+  ) {
+    final KafkaMetric metric = mock(KafkaMetric.class);
+    when(metric.metricName()).thenReturn(
+      new MetricName(name, "stream-topic-metrics", "", tags));
+    when(metric.metricValue()).thenReturn(value);
+    return metric;
+  }
+
+  private Measurable verifyAndGetMetric(final String name, final Map<String, String> tags) {
+    verify(metrics);
+    metrics.addMetric(
+      argThat(
+        n -> n.name().equals(name)
+            && n.tags().entrySet().equals(tags.entrySet())
+      ),
+      metricValueProvider.capture()
+    );
+    return metricValueProvider.getValue();
+  }
+
+  private void verifyRemovedMetric(final String name, final Map<String, String> tags) {
+    verify(metrics).removeMetric(
+      argThat(
+        n -> n.name().equals(name) && n.tags().equals(tags)
+      )
+    );
+  }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -27,17 +27,16 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ThroughputMetricsReporterTest {
-  private static final String RECORDS_CONSUMED_METRIC_NAME = "records-consumed-total";
-  private static final String BYTES_CONSUMED_METRIC_NAME = "bytes-consumed-total";
-  private static final String RECORDS_PRODUCED_METRIC_NAME = "records-produced-total";
-  private static final String BYTES_PRODUCED_METRIC_NAME = "bytes-produced-total";
-  private static final String QUERY_1 = "CTAS_TEST_1";
-  private static final String QUERY_2 = "CTAS_TEST_2";
-  private static final String THREAD_ID = "_confluent_blahblah_query-CTAS_TEST_1-blahblah";
-  private static final String THREAD_ID_2 = "_confluent_blahblah_query-CTAS_TEST_2-blahblah";
+  private static final String RECORDS_CONSUMED_TOTAL = "records-consumed-total";
+  private static final String BYTES_CONSUMED_TOTAL = "bytes-consumed-total";
+  private static final String RECORDS_PRODUCED_TOTAL = "records-produced-total";
+  private static final String BYTES_PRODUCED_TOTAL = "bytes-produced-total";
+  private static final String QUERY_ID = "CTAS_TEST";
+  private static final String THREAD_ID = "_confluent_blahblah_query_CTAS_TEST_1-blahblah";
+  private static final String THREAD_ID_2 = "_confluent_blahblah_query_CTAS_TEST_2-blahblah";
   private static final String TRANSIENT_THREAD_ID = "_confluent_blahblah_transient_blahblah_4-blahblah";
   private static final String TASK_ID_1 = "0_1";
-  private static final String TASK_ID_2 = "0_1__query-id";
+  private static final String TASK_ID_2 = "0_2";
   private static final String PROCESSOR_NODE_ID = "sink-node";
   private static final String PROCESSOR_NODE_ID_2 = "sink-node-2";
   private static final String TOPIC_NAME = "topic";
@@ -68,18 +67,18 @@ public class ThroughputMetricsReporterTest {
     "topic-name", TOPIC_NAME_2
   );
   private static final Map<String, String> QUERY_ONE_TAGS = ImmutableMap.of(
-      "logical_cluster_id", "lksqlc-12345",
-      "query-id", QUERY_1,
-      "thread-id", THREAD_ID,
-      "topic-name", TOPIC_NAME
+    "logical_cluster_id", "lksqlc-12345",
+    "query-id", QUERY_ID + "_1",
+    "thread-id", THREAD_ID,
+    "topic-name", TOPIC_NAME
   );
   private static final Map<String, String> QUERY_TWO_TAGS = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
-      "query-id", QUERY_2,
+      "query-id", QUERY_ID + "_2",
       "thread-id", THREAD_ID_2,
       "topic-name", TOPIC_NAME_2
   );
-    
+
   private ThroughputMetricsReporter listener;
 
   @Mock
@@ -108,34 +107,34 @@ public class ThroughputMetricsReporterTest {
   public void shouldAddNewMeasurableForAllThroughputMetricsTypes() {
     // Given:
     listener.metricChange(mockMetric(
-        BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
         1D,
         STREAMS_TAGS_TASK_1)
     );
 
     listener.metricChange(mockMetric(
-      RECORDS_CONSUMED_METRIC_NAME,
+      RECORDS_CONSUMED_TOTAL,
       2D,
       STREAMS_TAGS_TASK_1)
     );
 
     listener.metricChange(mockMetric(
-      BYTES_PRODUCED_METRIC_NAME,
+      BYTES_PRODUCED_TOTAL,
       3D,
       STREAMS_TAGS_TASK_1)
     );
 
     listener.metricChange(mockMetric(
-      RECORDS_PRODUCED_METRIC_NAME,
+      RECORDS_PRODUCED_TOTAL,
       4D,
       STREAMS_TAGS_TASK_1)
     );
 
     // When:
-    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
-    final Measurable recordsConsumed = verifyAndGetMetric(RECORDS_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
-    final Measurable bytesProduced = verifyAndGetMetric(BYTES_PRODUCED_METRIC_NAME, QUERY_ONE_TAGS);
-    final Measurable recordsProduced = verifyAndGetMetric(RECORDS_PRODUCED_METRIC_NAME, QUERY_ONE_TAGS);
+    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
+    final Measurable recordsConsumed = verifyAndGetMetric(RECORDS_CONSUMED_TOTAL, QUERY_ONE_TAGS);
+    final Measurable bytesProduced = verifyAndGetMetric(BYTES_PRODUCED_TOTAL, QUERY_ONE_TAGS);
+    final Measurable recordsProduced = verifyAndGetMetric(RECORDS_PRODUCED_TOTAL, QUERY_ONE_TAGS);
 
     // Then:
     assertThat(bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L), equalTo(1D));
@@ -144,28 +143,28 @@ public class ThroughputMetricsReporterTest {
     assertThat(recordsProduced.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L), equalTo(4D));
   }
 
-    @Test
+  @Test
   public void shouldUpdateExistingMeasurable() {
     // Given:
     listener.metricChange(mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       2D,
       STREAMS_TAGS_TASK_1)
     );
 
-    Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
     Object bytesConsumedValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
     assertThat(bytesConsumedValue, equalTo(2D));
 
     // When:
     listener.metricChange(mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       15D,
       STREAMS_TAGS_TASK_1)
     );
 
     // Then:
-    bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
     bytesConsumedValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
 
     assertThat(bytesConsumedValue, equalTo(15D));
@@ -175,17 +174,17 @@ public class ThroughputMetricsReporterTest {
   public void shouldAggregateOverAllTasksAndProcessorNodes() {
     // Given:
     KafkaMetric m1 = mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       2D,
       STREAMS_TAGS_TASK_1
     );
     KafkaMetric m2 = mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       5D,
       STREAMS_TAGS_TASK_2
     );
     KafkaMetric m3 = mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       3D,
       STREAMS_TAGS_PROCESSOR_2
     );
@@ -196,7 +195,7 @@ public class ThroughputMetricsReporterTest {
     listener.metricChange(m3);
 
     // Then:
-    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
     final Object value = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
     assertThat(value, equalTo(10D));
   }
@@ -205,18 +204,18 @@ public class ThroughputMetricsReporterTest {
   public void shouldRemoveCorrectMetricAndReturnZero() {
     // Given:
     final KafkaMetric metric = mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       2D,
       STREAMS_TAGS_TASK_1);
     listener.metricChange(metric);
-    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
 
     final KafkaMetric metric2 = mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       5D,
       STREAMS_TAGS_TOPIC_2);
     listener.metricChange(metric2);
-    final Measurable bytesConsumed2 = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_TWO_TAGS);
+    final Measurable bytesConsumed2 = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_TWO_TAGS);
 
     Object value = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
     assertThat(value, equalTo(2D));
@@ -227,7 +226,7 @@ public class ThroughputMetricsReporterTest {
     listener.metricRemoval(metric);
 
     // Then:
-    verifyRemovedMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    verifyRemovedMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
 
     value = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
     assertThat(value, equalTo(0D));
@@ -240,17 +239,17 @@ public class ThroughputMetricsReporterTest {
   public void shouldNotIncludeRemovedMetricInThroughputTotal() {
     // Given:
     listener.metricChange(mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       2D,
       STREAMS_TAGS_TASK_1)
     );
     final KafkaMetric metric2 = mockMetric(
-      BYTES_CONSUMED_METRIC_NAME,
+      BYTES_CONSUMED_TOTAL,
       6D,
       STREAMS_TAGS_TASK_2
     );
     listener.metricChange(metric2);
-    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS);
+    final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
     Object taskValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0L);
     assertThat(taskValue, equalTo(8D));
 
@@ -263,46 +262,90 @@ public class ThroughputMetricsReporterTest {
   }
 
   @Test
-  public void shouldIgnoreNonThroughputMetrics() {
+  public void shouldAggregateMetricsByQueryIdForTransientQueries() {
+    // Given:
+    final Map<String, String> transientQueryTags = ImmutableMap.of(
+      "logical_cluster_id", "lksqlc-12345",
+      "query-id", "blahblah_4",
+      "thread-id", TRANSIENT_THREAD_ID,
+      "topic-name", TOPIC_NAME
+    );
+    listener.metricChange(mockMetric(
+      BYTES_CONSUMED_TOTAL,
+      2D,
+      ImmutableMap.of(
+        "thread-id", TRANSIENT_THREAD_ID,
+        "task-id", TASK_ID_1,
+        "processor-node-id", PROCESSOR_NODE_ID,
+        "topic-name", TOPIC_NAME))
+    );
+
+    Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, transientQueryTags);
+    Object bytesConsumedValue =
+      bytesConsumed.measure(new MetricConfig().tags(transientQueryTags), 0L);
+    assertThat(bytesConsumedValue, equalTo(2D));
+
     // When:
     listener.metricChange(mockMetric(
-      "other-metric",
-      2D,
-      QUERY_ONE_TAGS)
+      BYTES_CONSUMED_TOTAL,
+      15D,
+      ImmutableMap.of(
+        "thread-id", TRANSIENT_THREAD_ID,
+        "task-id", TASK_ID_2,
+        "processor-node-id", PROCESSOR_NODE_ID,
+        "topic-name", TOPIC_NAME
+      ))
     );
 
     // Then:
-    assertThrows(AssertionError.class, () -> verifyAndGetMetric(BYTES_CONSUMED_METRIC_NAME, QUERY_ONE_TAGS));
+    bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, transientQueryTags);
+    bytesConsumedValue = bytesConsumed.measure(new MetricConfig().tags(transientQueryTags), 0L);
+
+    assertThat(bytesConsumedValue, equalTo(17D));
   }
-/*
+
   @Test
-  public void shouldCombineTaskMetricsToQueryMetricWithSharedRuntimeQueries() {
-    // When:
-    listener.metricChange(mockMetric(
-      2D,
-      ImmutableMap.of("task-id", "CTAS_TEST_1__1_0", "thread-id", "THREAD_ID", "logical_cluster_id", "logical-id"))
+  public void shouldAggregateMetricsByQueryIdInSharedRuntimes() {
+    // Given:
+    final Map<String, String> sharedRuntimeQueryTags = ImmutableMap.of(
+      "logical_cluster_id", "lksqlc-12345",
+      "query-id", "CTAS_TEST_5",
+      "thread-id", "_confluent_blahblah_query-1-blahblah",
+      "topic-name", TOPIC_NAME
     );
     listener.metricChange(mockMetric(
-      TOPIC_METRIC_GROUP,
-      BigInteger.valueOf(5),
-      ImmutableMap.of("task-id", "CTAS_TEST_1__1_1", "thread-id", "THREAD_ID", "logical_cluster_id", "logical-id"))
+      BYTES_CONSUMED_TOTAL,
+      2D,
+      ImmutableMap.of(
+        "thread-id", "_confluent_blahblah_query-1-blahblah",
+        "task-id", "CTAS_TEST_5__" + TASK_ID_1,
+        "processor-node-id", PROCESSOR_NODE_ID,
+        "topic-name", TOPIC_NAME))
+    );
+
+    Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, sharedRuntimeQueryTags);
+    Object bytesConsumedValue =
+      bytesConsumed.measure(new MetricConfig().tags(sharedRuntimeQueryTags), 0L);
+    assertThat(bytesConsumedValue, equalTo(2D));
+
+    // When:
+    listener.metricChange(mockMetric(
+      BYTES_CONSUMED_TOTAL,
+      15D,
+      ImmutableMap.of(
+        "thread-id", "_confluent_blahblah_query-1-blahblah",
+        "task-id", "CTAS_TEST_5__" + TASK_ID_2,
+        "processor-node-id", PROCESSOR_NODE_ID,
+        "topic-name", TOPIC_NAME
+      ))
     );
 
     // Then:
-    final Gauge<?> queryGauge = verifyAndGetRegisteredMetric(QUERY_STORAGE_METRIC, QUERY_ONE_TAGS);
-    final Object queryValue = queryGauge.value(null, 0);
-    final Map<String, String> task1 = ImmutableMap.of("logical_cluster_id", "logical-id", "query-id", "CTAS_TEST_1", "task-id", "CTAS_TEST_1__1_0");
-    final Gauge<?> taskGaugeOne = verifyAndGetRegisteredMetric(BYTES_CONSUMED_METRIC_NAME, task1);
-    final Object taskValueOne = taskGaugeOne.value(null, 0);
-    final Map<String, String> task2 = ImmutableMap.of("logical_cluster_id", "logical-id", "query-id", "CTAS_TEST_1", "task-id", "CTAS_TEST_1__1_1");
-    final Gauge<?> taskGaugeTwo = verifyAndGetRegisteredMetric(BYTES_CONSUMED_METRIC_NAME, task2);
-    final Object taskValueTwo = taskGaugeTwo.value(null, 0);
+    bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, sharedRuntimeQueryTags);
+    bytesConsumedValue = bytesConsumed.measure(new MetricConfig().tags(sharedRuntimeQueryTags), 0L);
 
-    assertThat(taskValueOne, equalTo(2D));
-    assertThat(taskValueTwo, equalTo(BigInteger.valueOf(5)));
-    assertThat(queryValue, equalTo(BigInteger.valueOf(7)));
+    assertThat(bytesConsumedValue, equalTo(17D));
   }
- */
 
   private KafkaMetric mockMetric(
     final String name, 

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/internal/ThroughputMetricsReporterTest.java
@@ -61,16 +61,16 @@ public class ThroughputMetricsReporterTest {
       "topic-name", TOPIC_NAME
   );
   private static final Map<String, String> STREAMS_TAGS_TOPIC_2 = ImmutableMap.of(
-    "thread-id", THREAD_ID_2,
-    "task-id", TASK_ID_1,
-    "processor-node-id", PROCESSOR_NODE_ID,
-    "topic-name", TOPIC_NAME_2
+      "thread-id", THREAD_ID_2,
+      "task-id", TASK_ID_1,
+      "processor-node-id", PROCESSOR_NODE_ID,
+      "topic-name", TOPIC_NAME_2
   );
   private static final Map<String, String> QUERY_ONE_TAGS = ImmutableMap.of(
-    "logical_cluster_id", "lksqlc-12345",
-    "query-id", QUERY_ID + "_1",
-    "thread-id", THREAD_ID,
-    "topic-name", TOPIC_NAME
+      "logical_cluster_id", "lksqlc-12345",
+      "query-id", QUERY_ID + "_1",
+      "thread-id", THREAD_ID,
+      "topic-name", TOPIC_NAME
   );
   private static final Map<String, String> QUERY_TWO_TAGS = ImmutableMap.of(
       "logical_cluster_id", "lksqlc-12345",
@@ -107,27 +107,27 @@ public class ThroughputMetricsReporterTest {
   public void shouldAddNewMeasurableForAllThroughputMetricsTypes() {
     // Given:
     listener.metricChange(mockMetric(
-      BYTES_CONSUMED_TOTAL,
+        BYTES_CONSUMED_TOTAL,
         1D,
         STREAMS_TAGS_TASK_1)
     );
 
     listener.metricChange(mockMetric(
-      RECORDS_CONSUMED_TOTAL,
-      2D,
-      STREAMS_TAGS_TASK_1)
+        RECORDS_CONSUMED_TOTAL,
+        2D,
+        STREAMS_TAGS_TASK_1)
     );
 
     listener.metricChange(mockMetric(
-      BYTES_PRODUCED_TOTAL,
-      3D,
-      STREAMS_TAGS_TASK_1)
+        BYTES_PRODUCED_TOTAL,
+        3D,
+        STREAMS_TAGS_TASK_1)
     );
 
     listener.metricChange(mockMetric(
-      RECORDS_PRODUCED_TOTAL,
-      4D,
-      STREAMS_TAGS_TASK_1)
+        RECORDS_PRODUCED_TOTAL,
+        4D,
+        STREAMS_TAGS_TASK_1)
     );
 
     // When:
@@ -147,9 +147,9 @@ public class ThroughputMetricsReporterTest {
   public void shouldUpdateExistingMeasurable() {
     // Given:
     listener.metricChange(mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      2D,
-      STREAMS_TAGS_TASK_1)
+        BYTES_CONSUMED_TOTAL,
+        2D,
+        STREAMS_TAGS_TASK_1)
     );
 
     Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
@@ -158,9 +158,9 @@ public class ThroughputMetricsReporterTest {
 
     // When:
     listener.metricChange(mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      15D,
-      STREAMS_TAGS_TASK_1)
+        BYTES_CONSUMED_TOTAL,
+        15D,
+        STREAMS_TAGS_TASK_1)
     );
 
     // Then:
@@ -174,19 +174,19 @@ public class ThroughputMetricsReporterTest {
   public void shouldAggregateOverAllTasksAndProcessorNodes() {
     // Given:
     KafkaMetric m1 = mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      2D,
-      STREAMS_TAGS_TASK_1
+        BYTES_CONSUMED_TOTAL,
+        2D,
+        STREAMS_TAGS_TASK_1
     );
     KafkaMetric m2 = mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      5D,
-      STREAMS_TAGS_TASK_2
+        BYTES_CONSUMED_TOTAL,
+        5D,
+        STREAMS_TAGS_TASK_2
     );
     KafkaMetric m3 = mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      3D,
-      STREAMS_TAGS_PROCESSOR_2
+        BYTES_CONSUMED_TOTAL,
+        3D,
+        STREAMS_TAGS_PROCESSOR_2
     );
 
     // When:
@@ -204,16 +204,16 @@ public class ThroughputMetricsReporterTest {
   public void shouldRemoveCorrectMetricAndReturnZero() {
     // Given:
     final KafkaMetric metric = mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      2D,
-      STREAMS_TAGS_TASK_1);
+        BYTES_CONSUMED_TOTAL,
+        2D,
+        STREAMS_TAGS_TASK_1);
     listener.metricChange(metric);
     final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
 
     final KafkaMetric metric2 = mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      5D,
-      STREAMS_TAGS_TOPIC_2);
+        BYTES_CONSUMED_TOTAL,
+        5D,
+        STREAMS_TAGS_TOPIC_2);
     listener.metricChange(metric2);
     final Measurable bytesConsumed2 = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_TWO_TAGS);
 
@@ -239,14 +239,14 @@ public class ThroughputMetricsReporterTest {
   public void shouldNotIncludeRemovedMetricInThroughputTotal() {
     // Given:
     listener.metricChange(mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      2D,
-      STREAMS_TAGS_TASK_1)
+        BYTES_CONSUMED_TOTAL,
+        2D,
+        STREAMS_TAGS_TASK_1)
     );
     final KafkaMetric metric2 = mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      6D,
-      STREAMS_TAGS_TASK_2
+        BYTES_CONSUMED_TOTAL,
+        6D,
+        STREAMS_TAGS_TASK_2
     );
     listener.metricChange(metric2);
     final Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, QUERY_ONE_TAGS);
@@ -261,9 +261,9 @@ public class ThroughputMetricsReporterTest {
     assertThat(taskValue, equalTo(2D));
 
     final KafkaMetric metric3 = mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      3D,
-      STREAMS_TAGS_PROCESSOR_2);
+        BYTES_CONSUMED_TOTAL,
+        3D,
+        STREAMS_TAGS_PROCESSOR_2);
     listener.metricChange(metric3);
     taskValue = bytesConsumed.measure(new MetricConfig().tags(QUERY_ONE_TAGS), 0);
     assertThat(taskValue, equalTo(5D));
@@ -273,19 +273,19 @@ public class ThroughputMetricsReporterTest {
   public void shouldAggregateMetricsByQueryIdForTransientQueries() {
     // Given:
     final Map<String, String> transientQueryTags = ImmutableMap.of(
-      "logical_cluster_id", "lksqlc-12345",
-      "query-id", "blahblah_4",
-      "thread-id", TRANSIENT_THREAD_ID,
-      "topic-name", TOPIC_NAME
+        "logical_cluster_id", "lksqlc-12345",
+        "query-id", "blahblah_4",
+        "thread-id", TRANSIENT_THREAD_ID,
+        "topic-name", TOPIC_NAME
     );
     listener.metricChange(mockMetric(
-      BYTES_CONSUMED_TOTAL,
-      2D,
-      ImmutableMap.of(
-        "thread-id", TRANSIENT_THREAD_ID,
-        "task-id", TASK_ID_1,
-        "processor-node-id", PROCESSOR_NODE_ID,
-        "topic-name", TOPIC_NAME))
+        BYTES_CONSUMED_TOTAL,
+        2D,
+        ImmutableMap.of(
+            "thread-id", TRANSIENT_THREAD_ID,
+            "task-id", TASK_ID_1,
+            "processor-node-id", PROCESSOR_NODE_ID,
+            "topic-name", TOPIC_NAME))
     );
 
     Measurable bytesConsumed = verifyAndGetMetric(BYTES_CONSUMED_TOTAL, transientQueryTags);

--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/metrics/RocksDBMetricsCollector.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/metrics/RocksDBMetricsCollector.java
@@ -257,10 +257,10 @@ public class RocksDBMetricsCollector implements MetricsReporter {
 
     boolean check() {
       final Instant now = clock.get();
-      return last.accumulateAndGet(
+      return Objects.equals(last.accumulateAndGet(
           now,
           (l, n) -> n.isAfter(l.plusSeconds(intervalSeconds)) ? n : l
-      ) == now;
+      ), now);
     }
   }
 


### PR DESCRIPTION
Introduces a ThroughputMetricsReporter to report the consumed/produced total throughput metrics added to Streams in KIP-846. 

Metrics are aggregated to spit out a total sum of records & bytes consumed/produced per topic, per query