### PR TITLE
chore: revert mockito version changes causing test issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,11 +157,6 @@
         <jersey-common>2.34</jersey-common>
 
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-
-        <!-- A newer mockito 4.5.1 added on https://github.com/confluentinc/common/pull/460
-             caused issues with some unit tests. This version 4.3.1 is temporary until we
-             figured out what's wrong with 4.5.1 or newer -->
-        <mockito.version>4.3.1</mockito.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

A previous issue with mockito 4.5.1 was causing test issues in Ksql. We had to use the lower 4.3.1 version of mockito in Ksql. These tests issues are gone with 4.6.1 which will be available in the `commos` repo soon. This PR removes the static 4.3.1 version so we can use the new one from `commons`.

Let's wait until this PR is merged https://github.com/confluentinc/common/pull/461 and tests are passing.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

