### PR TITLE
docs: protobuf content type in api index

### DIFF
--- a/docs/developer-guide/api.md
+++ b/docs/developer-guide/api.md
@@ -78,6 +78,35 @@ curl -X "POST" "http://localhost:8088/query" \
 }'
 ```
 
+A `PROTOBUF` content type where the rows are serialized in the `PROTOBUF` format
+is also supported for querying the `/query` and `/query-stream` endpoints.
+Your can specify this serialization format in the `Accept` header:
+```
+Accept: application/vnd.ksql.v1+protobuf
+```
+Here is an example curl command that issues a Pull query on a table called `CURRENTLOCATION`
+with the `PROTOBUF` content type:
+```bash
+curl -X "POST" "http://localhost:8088/query" \
+     -H "Accept: application/vnd.ksql.v1+protobuf" \
+     -d $'{
+  "ksql": "SELECT * FROM CURRENTLOCATION;",
+  "streamsProperties": {}
+}'
+```
+Response:
+```
+[{"header":{"queryId":"query_1655152127973","schema":"`PROFILEID` STRING KEY, `LA` DOUBLE, `LO` DOUBLE","protoSchema":"syntax = \"proto3\";\n\nmessage ConnectDefault1 {\n  string PROFILEID = 1;\n  double LA = 2;\n  double LO = 3;\n}\n"}},
+{"row":{"protobufBytes":"CggxOGY0ZWE4NhF90LNZ9bFCQBmASL99HYRewA=="}},
+{"row":{"protobufBytes":"Cgg0YTdjN2I0MRFAE2HD07NCQBnM7snDQoVewA=="}},
+{"row":{"protobufBytes":"Cgg0YWI1Y2JhZBGKsOHplbJCQBmMSuoENIVewA=="}},
+{"row":{"protobufBytes":"Cgg0ZGRhZDAwMBHNO07RkeRCQBk9m1Wfq5lewA=="}},
+{"row":{"protobufBytes":"Cgg4YjZlYWU1ORFtxf6ye7JCQBmMSuoENIVewA=="}},
+{"row":{"protobufBytes":"CghjMjMwOWVlYxGUh4Va0+RCQBn0/dR46ZpewA=="}}]
+```
+The `protoSchema` field in the `header` corresponds to the content of a `.proto` file that the proto compiler uses at build time. 
+Use the `protoSchema` field to deserialize the `protobufBytes` into `PROTOBUF` messages.
+
 Provide the `--basic` and `--user` options if basic HTTPS authentication is
 enabled on the cluster, as shown in the following command.
 


### PR DESCRIPTION
### Description 
Adds docs for the new `PROTOBUF` content type introduced in https://github.com/confluentinc/ksql/pull/9103

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

