### PR TITLE
chore: unpin surefire version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,8 +155,6 @@
         <netty.version>4.1.72.Final</netty.version>
         <netty-codec-http2-version>4.1.72.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
-
-        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <netty-codec-http2-version>4.1.72.Final</netty-codec-http2-version>
         <jersey-common>2.34</jersey-common>
 
-        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Fixes: https://github.com/confluentinc/ksql/issues/9060

~~We should actually not bump to `-M7` but remove the pinning -- this is just a trial PR to see it `-M7` actually works.~~

~~After the PR to common is merged (https://github.com/confluentinc/common/pull/462), this PR needs to be update to _remove_ the pinning.~~