### PR TITLE
fix: change Object#equals back to `==` to fix RocksDBMetricsCollectorTest#shouldNotUpdateIfWithinInterval

### DIFF
--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/metrics/RocksDBMetricsCollector.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/metrics/RocksDBMetricsCollector.java
@@ -257,10 +257,10 @@ public class RocksDBMetricsCollector implements MetricsReporter {
 
     boolean check() {
       final Instant now = clock.get();
-      return Objects.equals(last.accumulateAndGet(
+      return last.accumulateAndGet(
           now,
           (l, n) -> n.isAfter(l.plusSeconds(intervalSeconds)) ? n : l
-      ), now);
+      ) == now;
     }
   }
 


### PR DESCRIPTION
Oddly `RocksDBMetricsCollectorTest.shouldNotUpdateIfWithinInterval` has started failing since I changed `==` into `Objects#equals` to fix the compiler warning on the side during my ThroughMetricsReporter PR. I haven't been able to reproduce it, nor did it fail on the PR build that I merged -- still, the timing and clear relation between failing test and modified code makes me pretty suspicious.

Note that the compiler warning can actually be ignored, as `==` is indeed correct in this particular case since `accumulateAndGet` will return a reference to the actual `now` object that's passed in (if condition is true)

See https://github.com/confluentinc/ksql/pull/9187/files#r897668861