### PR TITLE
feat: Support BYTES and time types for TopKDistinct, Greatest, and Least

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
@@ -38,7 +38,7 @@ public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
   private static final AggregateFunctionInitArguments DEFAULT_INIT_ARGS =
       new AggregateFunctionInitArguments(0, 1);
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "CyclomaticComplexity"})
   @Override
   public KsqlAggregateFunction createAggregateFunction(
       final List<SqlArgument> argTypeList,

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
-
 import java.util.List;
 
 public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
@@ -15,31 +15,21 @@
 
 package io.confluent.ksql.function.udaf.topkdistinct;
 
-import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.types.ParamType;
-import io.confluent.ksql.function.types.ParamTypes;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlArgument;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
+
 import java.util.List;
 
 public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
 
   private static final String NAME = "TOPKDISTINCT";
-
-  private static final ImmutableList<List<ParamType>> SUPPORTED_TYPES = ImmutableList
-      .<List<ParamType>>builder()
-      .add(ImmutableList.of(ParamTypes.INTEGER))
-      .add(ImmutableList.of(ParamTypes.LONG))
-      .add(ImmutableList.of(ParamTypes.DOUBLE))
-      .add(ImmutableList.of(ParamTypes.STRING))
-      .add(ImmutableList.of(ParamTypes.DECIMAL))
-      .build();
 
   public TopkDistinctAggFunctionFactory() {
     super(NAME);
@@ -64,6 +54,10 @@ public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
       case DOUBLE:
       case STRING:
       case DECIMAL:
+      case BYTES:
+      case DATE:
+      case TIME:
+      case TIMESTAMP:
         return new TopkDistinctKudaf(
             NAME, initArgs.udafIndex(), tkValFromArg, argSchema,
             SchemaConverters.sqlToFunctionConverter().toFunctionType(argSchema),
@@ -80,9 +74,9 @@ public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
   }
 
   @Override
-  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "SUPPORTED_TYPES is ImmutableList")
+  @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "COMPARABLE_ARGS is ImmutableList")
   public List<List<ParamType>> supportedArgs() {
-    return SUPPORTED_TYPES;
+    return COMPARABLE_ARGS;
   }
 
   @Override

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Greatest.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Greatest.java
@@ -26,10 +26,11 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.*;
 import java.util.stream.Stream;
 
 @UdfDescription(
@@ -70,7 +71,6 @@ public class Greatest {
 
   @Udf
   public String greatest(@UdfParameter final String val, @UdfParameter final String... vals) {
-
     return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
         .filter(Objects::nonNull)
         .max(String::compareTo)
@@ -95,6 +95,42 @@ public class Greatest {
         .map(SqlArgument::getSqlTypeOrThrow)
         .reduce(DecimalUtil::widen)
         .orElse(null);
+  }
+
+  @Udf
+  public ByteBuffer greatest(@UdfParameter final ByteBuffer val, @UdfParameter final ByteBuffer... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+            .filter(Objects::nonNull)
+            .max(ByteBuffer::compareTo)
+            .orElse(null);
+  }
+
+  @Udf
+  public Date greatest(@UdfParameter final Date val, @UdfParameter final Date... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+            .filter(Objects::nonNull)
+            .max(Date::compareTo)
+            .orElse(null);
+  }
+
+  @Udf
+  public Time greatest(@UdfParameter final Time val, @UdfParameter final Time... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+            .filter(Objects::nonNull)
+            .max(Time::compareTo)
+            .orElse(null);
+  }
+
+  @Udf
+  public Timestamp greatest(@UdfParameter final Timestamp val, @UdfParameter final Timestamp... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+            .filter(Objects::nonNull)
+            .max(Timestamp::compareTo)
+            .orElse(null);
   }
 
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Greatest.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Greatest.java
@@ -30,7 +30,10 @@ import java.nio.ByteBuffer;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 @UdfDescription(
@@ -77,28 +80,9 @@ public class Greatest {
         .orElse(null);
   }
 
-  @Udf(schemaProvider = "greatestDecimalProvider")
-  public BigDecimal greatest(@UdfParameter final BigDecimal val,
-      @UdfParameter final BigDecimal... vals) {
-
-    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
-        .filter(Objects::nonNull)
-        .max(Comparator.naturalOrder())
-        .orElse(null);
-  }
-
-  @UdfSchemaProvider
-  public SqlType greatestDecimalProvider(final List<SqlArgument> params) {
-
-    return params.stream()
-        .filter(s -> s.getSqlType().isPresent())
-        .map(SqlArgument::getSqlTypeOrThrow)
-        .reduce(DecimalUtil::widen)
-        .orElse(null);
-  }
-
   @Udf
-  public ByteBuffer greatest(@UdfParameter final ByteBuffer val, @UdfParameter final ByteBuffer... vals) {
+  public ByteBuffer greatest(@UdfParameter final ByteBuffer val,
+                             @UdfParameter final ByteBuffer... vals) {
 
     return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
             .filter(Objects::nonNull)
@@ -125,12 +109,33 @@ public class Greatest {
   }
 
   @Udf
-  public Timestamp greatest(@UdfParameter final Timestamp val, @UdfParameter final Timestamp... vals) {
+  public Timestamp greatest(@UdfParameter final Timestamp val,
+                            @UdfParameter final Timestamp... vals) {
 
     return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
             .filter(Objects::nonNull)
             .max(Timestamp::compareTo)
             .orElse(null);
+  }
+
+  @Udf(schemaProvider = "greatestDecimalProvider")
+  public BigDecimal greatest(@UdfParameter final BigDecimal val,
+      @UdfParameter final BigDecimal... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+        .filter(Objects::nonNull)
+        .max(Comparator.naturalOrder())
+        .orElse(null);
+  }
+
+  @UdfSchemaProvider
+  public SqlType greatestDecimalProvider(final List<SqlArgument> params) {
+
+    return params.stream()
+        .filter(s -> s.getSqlType().isPresent())
+        .map(SqlArgument::getSqlTypeOrThrow)
+        .reduce(DecimalUtil::widen)
+        .orElse(null);
   }
 
 }

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Least.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Least.java
@@ -80,28 +80,9 @@ public class Least {
         .orElse(null);
   }
 
-  @Udf(schemaProvider = "leastDecimalProvider")
-  public BigDecimal least(@UdfParameter final BigDecimal val,
-      @UdfParameter final BigDecimal... vals) {
-
-    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
-        .filter(Objects::nonNull)
-        .min(Comparator.naturalOrder())
-        .orElse(null);
-  }
-
-  @UdfSchemaProvider
-  public SqlType leastDecimalProvider(final List<SqlArgument> params) {
-
-    return params.stream()
-        .filter(s -> s.getSqlType().isPresent())
-        .map(SqlArgument::getSqlTypeOrThrow)
-        .reduce(DecimalUtil::widen)
-        .orElse(null);
-  }
-
   @Udf
-  public ByteBuffer least(@UdfParameter final ByteBuffer val, @UdfParameter final ByteBuffer... vals) {
+  public ByteBuffer least(@UdfParameter final ByteBuffer val,
+                          @UdfParameter final ByteBuffer... vals) {
 
     return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
             .filter(Objects::nonNull)
@@ -133,6 +114,26 @@ public class Least {
     return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
             .filter(Objects::nonNull)
             .min(Timestamp::compareTo)
+            .orElse(null);
+  }
+
+  @Udf(schemaProvider = "leastDecimalProvider")
+  public BigDecimal least(@UdfParameter final BigDecimal val,
+      @UdfParameter final BigDecimal... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+        .filter(Objects::nonNull)
+        .min(Comparator.naturalOrder())
+        .orElse(null);
+  }
+
+  @UdfSchemaProvider
+  public SqlType leastDecimalProvider(final List<SqlArgument> params) {
+
+    return params.stream()
+            .filter(s -> s.getSqlType().isPresent())
+            .map(SqlArgument::getSqlTypeOrThrow)
+            .reduce(DecimalUtil::widen)
             .orElse(null);
   }
 

--- a/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Least.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/function/udf/math/Least.java
@@ -26,6 +26,10 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -94,6 +98,42 @@ public class Least {
         .map(SqlArgument::getSqlTypeOrThrow)
         .reduce(DecimalUtil::widen)
         .orElse(null);
+  }
+
+  @Udf
+  public ByteBuffer least(@UdfParameter final ByteBuffer val, @UdfParameter final ByteBuffer... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+            .filter(Objects::nonNull)
+            .min(ByteBuffer::compareTo)
+            .orElse(null);
+  }
+
+  @Udf
+  public Date least(@UdfParameter final Date val, @UdfParameter final Date... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+            .filter(Objects::nonNull)
+            .min(Date::compareTo)
+            .orElse(null);
+  }
+
+  @Udf
+  public Time least(@UdfParameter final Time val, @UdfParameter final Time... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+            .filter(Objects::nonNull)
+            .min(Time::compareTo)
+            .orElse(null);
+  }
+
+  @Udf
+  public Timestamp least(@UdfParameter final Timestamp val, @UdfParameter final Timestamp... vals) {
+
+    return (vals == null) ? null : Streams.concat(Stream.of(val), Arrays.stream(vals))
+            .filter(Objects::nonNull)
+            .min(Timestamp::compareTo)
+            .orElse(null);
   }
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/BytesTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/BytesTopKDistinctKudafTest.java
@@ -82,11 +82,11 @@ public class BytesTopKDistinctKudafTest {
                 toBytes(ImmutableList.of("A"))));
     }
 
-    private ByteBuffer toBytes(String val) {
+    private ByteBuffer toBytes(final String val) {
         return toBytesUDF.toBytes(val, BytesUtils.Encoding.ASCII.toString());
     }
 
-    private List<ByteBuffer> toBytes(List<String> vals) {
+    private List<ByteBuffer> toBytes(final List<String> vals) {
         return vals.stream().map(this::toBytes).collect(Collectors.toList());
     }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/BytesTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/BytesTopKDistinctKudafTest.java
@@ -30,77 +30,77 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class BytesTopKDistinctKudafTest {
-    private final List<String> valuesArray = ImmutableList.of("A", "D", "F", "A", "G", "H", "B", "H", "I", "E",
-            "C", "H", "I");
-    private final TopkDistinctKudaf<ByteBuffer> bytesTopkDistinctKudaf
-            = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.BYTES);
-    private ToBytes toBytesUDF;
+  private final List<String> valuesArray = ImmutableList.of("A", "D", "F", "A", "G", "H", "B", "H",
+          "I", "E", "C", "H", "I");
+  private final TopkDistinctKudaf<ByteBuffer> bytesTopkDistinctKudaf
+          = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.BYTES);
+  private ToBytes toBytesUDF;
 
-    @Before
-    public void setUp() {
-        toBytesUDF = new ToBytes();
+  @Before
+  public void setUp() {
+    toBytesUDF = new ToBytes();
+  }
+
+  @Test
+  public void shouldAggregateTopK() {
+    List<ByteBuffer> currentVal = new ArrayList<>();
+    for (final String d : valuesArray) {
+      currentVal = bytesTopkDistinctKudaf.aggregate(toBytes(d), currentVal);
     }
 
-    @Test
-    public void shouldAggregateTopK() {
-        List<ByteBuffer> currentVal = new ArrayList<>();
-        for (final String d: valuesArray) {
-            currentVal = bytesTopkDistinctKudaf.aggregate(toBytes(d), currentVal);
-        }
+    List<ByteBuffer> expected = toBytes(ImmutableList.of("I", "H", "G"));
+    assertThat("Invalid results.", currentVal, equalTo(expected));
+  }
 
-        List<ByteBuffer> expected = toBytes(ImmutableList.of("I", "H", "G"));
-        assertThat("Invalid results.", currentVal, equalTo(expected));
-    }
+  @Test
+  public void shouldAggregateTopKWithLessThanKValues() {
+    List<ByteBuffer> currentVal = new ArrayList<>();
+    currentVal = bytesTopkDistinctKudaf.aggregate(toBytes("I"), currentVal);
 
-    @Test
-    public void shouldAggregateTopKWithLessThanKValues() {
-        List<ByteBuffer> currentVal = new ArrayList<>();
-        currentVal = bytesTopkDistinctKudaf.aggregate(toBytes("I"), currentVal);
+    assertThat("Invalid results.", currentVal, equalTo(toBytes(ImmutableList.of("I"))));
+  }
 
-        assertThat("Invalid results.", currentVal, equalTo(toBytes(ImmutableList.of("I"))));
-    }
+  @Test
+  public void shouldMergeTopK() {
+    final List<ByteBuffer> array1 = toBytes(ImmutableList.of("D", "B", "A"));
+    final List<ByteBuffer> array2 = toBytes(ImmutableList.of("E", "D", "C"));
 
-    @Test
-    public void shouldMergeTopK() {
-        final List<ByteBuffer> array1 = toBytes(ImmutableList.of("D", "B", "A"));
-        final List<ByteBuffer> array2 = toBytes(ImmutableList.of("E", "D", "C"));
+    assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(toBytes(ImmutableList.of("E", "D", "C"))));
+  }
 
-        assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                toBytes(ImmutableList.of("E", "D", "C"))));
-    }
+  @Test
+  public void shouldMergeTopKWithNulls() {
+    final List<ByteBuffer> array1 = toBytes(ImmutableList.of("B", "A"));
+    final List<ByteBuffer> array2 = toBytes(ImmutableList.of("C"));
 
-    @Test
-    public void shouldMergeTopKWithNulls() {
-        final List<ByteBuffer> array1 = toBytes(ImmutableList.of("B", "A"));
-        final List<ByteBuffer> array2 = toBytes(ImmutableList.of("C"));
+    assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(toBytes(ImmutableList.of("C", "B", "A"))));
+  }
 
-        assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                toBytes(ImmutableList.of("C", "B", "A"))));
-    }
+  @Test
+  public void shouldMergeTopKWithNullsDuplicates() {
+    final List<ByteBuffer> array1 = toBytes(ImmutableList.of("B", "A"));
+    final List<ByteBuffer> array2 = toBytes(ImmutableList.of("C", "B"));
 
-    @Test
-    public void shouldMergeTopKWithNullsDuplicates() {
-        final List<ByteBuffer> array1 = toBytes(ImmutableList.of("B", "A"));
-        final List<ByteBuffer> array2 = toBytes(ImmutableList.of("C", "B"));
+    assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(toBytes(ImmutableList.of("C", "B", "A"))));
+  }
 
-        assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                toBytes(ImmutableList.of("C", "B", "A"))));
-    }
+  @Test
+  public void shouldMergeTopKWithMoreNulls() {
+    final List<ByteBuffer> array1 = toBytes(ImmutableList.of("A"));
+    final List<ByteBuffer> array2 = toBytes(ImmutableList.of("A"));
 
-    @Test
-    public void shouldMergeTopKWithMoreNulls() {
-        final List<ByteBuffer> array1 = toBytes(ImmutableList.of("A"));
-        final List<ByteBuffer> array2 = toBytes(ImmutableList.of("A"));
+    assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(toBytes(ImmutableList.of("A"))));
+  }
 
-        assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                toBytes(ImmutableList.of("A"))));
-    }
+  private ByteBuffer toBytes(final String val) {
+    return toBytesUDF.toBytes(val, BytesUtils.Encoding.ASCII.toString());
+  }
 
-    private ByteBuffer toBytes(final String val) {
-        return toBytesUDF.toBytes(val, BytesUtils.Encoding.ASCII.toString());
-    }
-
-    private List<ByteBuffer> toBytes(final List<String> vals) {
-        return vals.stream().map(this::toBytes).collect(Collectors.toList());
-    }
+  private List<ByteBuffer> toBytes(final List<String> vals) {
+    return vals.stream().map(this::toBytes).collect(Collectors.toList());
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/BytesTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/BytesTopKDistinctKudafTest.java
@@ -1,0 +1,92 @@
+package io.confluent.ksql.function.udaf.topkdistinct;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.udf.string.ToBytes;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.BytesUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BytesTopKDistinctKudafTest {
+    private final List<String> valuesArray = ImmutableList.of("A", "D", "F", "A", "G", "H", "B", "H", "I", "E",
+            "C", "H", "I");
+    private final TopkDistinctKudaf<ByteBuffer> bytesTopkDistinctKudaf
+            = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.BYTES);
+    private ToBytes toBytesUDF;
+
+    @Before
+    public void setUp() {
+        toBytesUDF = new ToBytes();
+    }
+
+    @Test
+    public void shouldAggregateTopK() {
+        List<ByteBuffer> currentVal = new ArrayList<>();
+        for (final String d: valuesArray) {
+            currentVal = bytesTopkDistinctKudaf.aggregate(toBytes(d), currentVal);
+        }
+
+        List<ByteBuffer> expected = toBytes(ImmutableList.of("I", "H", "G"));
+        assertThat("Invalid results.", currentVal, equalTo(expected));
+    }
+
+    @Test
+    public void shouldAggregateTopKWithLessThanKValues() {
+        List<ByteBuffer> currentVal = new ArrayList<>();
+        currentVal = bytesTopkDistinctKudaf.aggregate(toBytes("I"), currentVal);
+
+        assertThat("Invalid results.", currentVal, equalTo(toBytes(ImmutableList.of("I"))));
+    }
+
+    @Test
+    public void shouldMergeTopK() {
+        final List<ByteBuffer> array1 = toBytes(ImmutableList.of("D", "B", "A"));
+        final List<ByteBuffer> array2 = toBytes(ImmutableList.of("E", "D", "C"));
+
+        assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                toBytes(ImmutableList.of("E", "D", "C"))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithNulls() {
+        final List<ByteBuffer> array1 = toBytes(ImmutableList.of("B", "A"));
+        final List<ByteBuffer> array2 = toBytes(ImmutableList.of("C"));
+
+        assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                toBytes(ImmutableList.of("C", "B", "A"))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithNullsDuplicates() {
+        final List<ByteBuffer> array1 = toBytes(ImmutableList.of("B", "A"));
+        final List<ByteBuffer> array2 = toBytes(ImmutableList.of("C", "B"));
+
+        assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                toBytes(ImmutableList.of("C", "B", "A"))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithMoreNulls() {
+        final List<ByteBuffer> array1 = toBytes(ImmutableList.of("A"));
+        final List<ByteBuffer> array2 = toBytes(ImmutableList.of("A"));
+
+        assertThat("Invalid results.", bytesTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                toBytes(ImmutableList.of("A"))));
+    }
+
+    private ByteBuffer toBytes(String val) {
+        return toBytesUDF.toBytes(val, BytesUtils.Encoding.ASCII.toString());
+    }
+
+    private List<ByteBuffer> toBytes(List<String> vals) {
+        return vals.stream().map(this::toBytes).collect(Collectors.toList());
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/BytesTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/BytesTopKDistinctKudafTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import com.google.common.collect.ImmutableList;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DateTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DateTopKDistinctKudafTest.java
@@ -27,63 +27,64 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DateTopKDistinctKudafTest {
 
-    private final List<Date> valuesArray = ImmutableList.of(new Date(10), new Date(30), new Date(45), new Date(10),
-            new Date(50), new Date(60), new Date(20), new Date(60), new Date(80), new Date(35), new Date(25),
-            new Date(60), new Date(80));
-    private final TopkDistinctKudaf<Date> dateTopkDistinctKudaf
-            = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.DATE);
+  private final List<Date> valuesArray = ImmutableList.of(new Date(10), new Date(30), new Date(45),
+          new Date(10), new Date(50), new Date(60), new Date(20), new Date(60), new Date(80),
+          new Date(35), new Date(25), new Date(60), new Date(80));
+  private final TopkDistinctKudaf<Date> dateTopkDistinctKudaf
+          = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.DATE);
 
-    @Test
-    public void shouldAggregateTopK() {
-        List<Date> currentVal = new ArrayList<>();
-        for (final Date d: valuesArray) {
-            currentVal = dateTopkDistinctKudaf.aggregate(d, currentVal);
-        }
-
-        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Date(80), new Date(60), new Date(50))));
+  @Test
+  public void shouldAggregateTopK() {
+    List<Date> currentVal = new ArrayList<>();
+    for (final Date d : valuesArray) {
+      currentVal = dateTopkDistinctKudaf.aggregate(d, currentVal);
     }
 
-    @Test
-    public void shouldAggregateTopKWithLessThanKValues() {
-        List<Date> currentVal = new ArrayList<>();
-        currentVal = dateTopkDistinctKudaf.aggregate(new Date(80), currentVal);
+    assertThat("Invalid results.", currentVal,
+            equalTo(ImmutableList.of(new Date(80), new Date(60), new Date(50))));
+  }
 
-        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Date(80))));
-    }
+  @Test
+  public void shouldAggregateTopKWithLessThanKValues() {
+    List<Date> currentVal = new ArrayList<>();
+    currentVal = dateTopkDistinctKudaf.aggregate(new Date(80), currentVal);
 
-    @Test
-    public void shouldMergeTopK() {
-        final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45), new Date(25));
-        final List<Date> array2 = ImmutableList.of(new Date(60), new Date(50), new Date(48));
+    assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Date(80))));
+  }
 
-        assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Date(60), new Date(50), new Date(48))));
-    }
+  @Test
+  public void shouldMergeTopK() {
+    final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45), new Date(25));
+    final List<Date> array2 = ImmutableList.of(new Date(60), new Date(50), new Date(48));
 
-    @Test
-    public void shouldMergeTopKWithNulls() {
-        final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45));
-        final List<Date> array2 = ImmutableList.of(new Date(60));
+    assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Date(60), new Date(50), new Date(48))));
+  }
 
-        assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Date(60), new Date(50), new Date(45))));
-    }
+  @Test
+  public void shouldMergeTopKWithNulls() {
+    final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45));
+    final List<Date> array2 = ImmutableList.of(new Date(60));
 
-    @Test
-    public void shouldMergeTopKWithNullsDuplicates() {
-        final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45));
-        final List<Date> array2 = ImmutableList.of(new Date(60), new Date(50));
+    assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Date(60), new Date(50), new Date(45))));
+  }
 
-        assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Date(60), new Date(50), new Date(45))));
-    }
+  @Test
+  public void shouldMergeTopKWithNullsDuplicates() {
+    final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45));
+    final List<Date> array2 = ImmutableList.of(new Date(60), new Date(50));
 
-    @Test
-    public void shouldMergeTopKWithMoreNulls() {
-        final List<Date> array1 = ImmutableList.of(new Date(60));
-        final List<Date> array2 = ImmutableList.of(new Date(60));
+    assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Date(60), new Date(50), new Date(45))));
+  }
 
-        assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Date(60))));
-    }
+  @Test
+  public void shouldMergeTopKWithMoreNulls() {
+    final List<Date> array1 = ImmutableList.of(new Date(60));
+    final List<Date> array2 = ImmutableList.of(new Date(60));
+
+    assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Date(60))));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DateTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DateTopKDistinctKudafTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import com.google.common.collect.ImmutableList;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DateTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DateTopKDistinctKudafTest.java
@@ -1,0 +1,75 @@
+package io.confluent.ksql.function.udaf.topkdistinct;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DateTopKDistinctKudafTest {
+
+    private final List<Date> valuesArray = ImmutableList.of(new Date(10), new Date(30), new Date(45), new Date(10),
+            new Date(50), new Date(60), new Date(20), new Date(60), new Date(80), new Date(35), new Date(25),
+            new Date(60), new Date(80));
+    private final TopkDistinctKudaf<Date> dateTopkDistinctKudaf
+            = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.DATE);
+
+    @Test
+    public void shouldAggregateTopK() {
+        List<Date> currentVal = new ArrayList<>();
+        for (final Date d: valuesArray) {
+            currentVal = dateTopkDistinctKudaf.aggregate(d, currentVal);
+        }
+
+        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Date(80), new Date(60), new Date(50))));
+    }
+
+    @Test
+    public void shouldAggregateTopKWithLessThanKValues() {
+        List<Date> currentVal = new ArrayList<>();
+        currentVal = dateTopkDistinctKudaf.aggregate(new Date(80), currentVal);
+
+        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Date(80))));
+    }
+
+    @Test
+    public void shouldMergeTopK() {
+        final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45), new Date(25));
+        final List<Date> array2 = ImmutableList.of(new Date(60), new Date(50), new Date(48));
+
+        assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Date(60), new Date(50), new Date(48))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithNulls() {
+        final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45));
+        final List<Date> array2 = ImmutableList.of(new Date(60));
+
+        assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Date(60), new Date(50), new Date(45))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithNullsDuplicates() {
+        final List<Date> array1 = ImmutableList.of(new Date(50), new Date(45));
+        final List<Date> array2 = ImmutableList.of(new Date(60), new Date(50));
+
+        assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Date(60), new Date(50), new Date(45))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithMoreNulls() {
+        final List<Date> array1 = ImmutableList.of(new Date(60));
+        final List<Date> array2 = ImmutableList.of(new Date(60));
+
+        assertThat("Invalid results.", dateTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Date(60))));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimeTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimeTopKDistinctKudafTest.java
@@ -26,63 +26,64 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TimeTopKDistinctKudafTest {
-    private final List<Time> valuesArray = ImmutableList.of(new Time(10), new Time(30), new Time(45), new Time(10),
-            new Time(50), new Time(60), new Time(20), new Time(60), new Time(80), new Time(35), new Time(25),
-            new Time(60), new Time(80));
-    private final TopkDistinctKudaf<Time> timeTopkDistinctKudaf
-            = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.TIME);
+  private final List<Time> valuesArray = ImmutableList.of(new Time(10), new Time(30), new Time(45),
+          new Time(10), new Time(50), new Time(60), new Time(20), new Time(60), new Time(80),
+          new Time(35), new Time(25), new Time(60), new Time(80));
+  private final TopkDistinctKudaf<Time> timeTopkDistinctKudaf
+          = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.TIME);
 
-    @Test
-    public void shouldAggregateTopK() {
-        List<Time> currentVal = new ArrayList<>();
-        for (final Time d: valuesArray) {
-            currentVal = timeTopkDistinctKudaf.aggregate(d, currentVal);
-        }
-
-        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Time(80), new Time(60), new Time(50))));
+  @Test
+  public void shouldAggregateTopK() {
+    List<Time> currentVal = new ArrayList<>();
+    for (final Time d : valuesArray) {
+      currentVal = timeTopkDistinctKudaf.aggregate(d, currentVal);
     }
 
-    @Test
-    public void shouldAggregateTopKWithLessThanKValues() {
-        List<Time> currentVal = new ArrayList<>();
-        currentVal = timeTopkDistinctKudaf.aggregate(new Time(80), currentVal);
+    assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Time(80), new Time(60),
+            new Time(50))));
+  }
 
-        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Time(80))));
-    }
+  @Test
+  public void shouldAggregateTopKWithLessThanKValues() {
+    List<Time> currentVal = new ArrayList<>();
+    currentVal = timeTopkDistinctKudaf.aggregate(new Time(80), currentVal);
 
-    @Test
-    public void shouldMergeTopK() {
-        final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45), new Time(25));
-        final List<Time> array2 = ImmutableList.of(new Time(60), new Time(50), new Time(48));
+    assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Time(80))));
+  }
 
-        assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Time(60), new Time(50), new Time(48))));
-    }
+  @Test
+  public void shouldMergeTopK() {
+    final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45), new Time(25));
+    final List<Time> array2 = ImmutableList.of(new Time(60), new Time(50), new Time(48));
 
-    @Test
-    public void shouldMergeTopKWithNulls() {
-        final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45));
-        final List<Time> array2 = ImmutableList.of(new Time(60));
+    assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Time(60), new Time(50), new Time(48))));
+  }
 
-        assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Time(60), new Time(50), new Time(45))));
-    }
+  @Test
+  public void shouldMergeTopKWithNulls() {
+    final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45));
+    final List<Time> array2 = ImmutableList.of(new Time(60));
 
-    @Test
-    public void shouldMergeTopKWithNullsDuplicates() {
-        final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45));
-        final List<Time> array2 = ImmutableList.of(new Time(60), new Time(50));
+    assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Time(60), new Time(50), new Time(45))));
+  }
 
-        assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Time(60), new Time(50), new Time(45))));
-    }
+  @Test
+  public void shouldMergeTopKWithNullsDuplicates() {
+    final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45));
+    final List<Time> array2 = ImmutableList.of(new Time(60), new Time(50));
 
-    @Test
-    public void shouldMergeTopKWithMoreNulls() {
-        final List<Time> array1 = ImmutableList.of(new Time(60));
-        final List<Time> array2 = ImmutableList.of(new Time(60));
+    assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Time(60), new Time(50), new Time(45))));
+  }
 
-        assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Time(60))));
-    }
+  @Test
+  public void shouldMergeTopKWithMoreNulls() {
+    final List<Time> array1 = ImmutableList.of(new Time(60));
+    final List<Time> array2 = ImmutableList.of(new Time(60));
+
+    assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Time(60))));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimeTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimeTopKDistinctKudafTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import com.google.common.collect.ImmutableList;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimeTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimeTopKDistinctKudafTest.java
@@ -1,0 +1,74 @@
+package io.confluent.ksql.function.udaf.topkdistinct;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import org.junit.Test;
+
+import java.sql.Time;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TimeTopKDistinctKudafTest {
+    private final List<Time> valuesArray = ImmutableList.of(new Time(10), new Time(30), new Time(45), new Time(10),
+            new Time(50), new Time(60), new Time(20), new Time(60), new Time(80), new Time(35), new Time(25),
+            new Time(60), new Time(80));
+    private final TopkDistinctKudaf<Time> timeTopkDistinctKudaf
+            = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.TIME);
+
+    @Test
+    public void shouldAggregateTopK() {
+        List<Time> currentVal = new ArrayList<>();
+        for (final Time d: valuesArray) {
+            currentVal = timeTopkDistinctKudaf.aggregate(d, currentVal);
+        }
+
+        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Time(80), new Time(60), new Time(50))));
+    }
+
+    @Test
+    public void shouldAggregateTopKWithLessThanKValues() {
+        List<Time> currentVal = new ArrayList<>();
+        currentVal = timeTopkDistinctKudaf.aggregate(new Time(80), currentVal);
+
+        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Time(80))));
+    }
+
+    @Test
+    public void shouldMergeTopK() {
+        final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45), new Time(25));
+        final List<Time> array2 = ImmutableList.of(new Time(60), new Time(50), new Time(48));
+
+        assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Time(60), new Time(50), new Time(48))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithNulls() {
+        final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45));
+        final List<Time> array2 = ImmutableList.of(new Time(60));
+
+        assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Time(60), new Time(50), new Time(45))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithNullsDuplicates() {
+        final List<Time> array1 = ImmutableList.of(new Time(50), new Time(45));
+        final List<Time> array2 = ImmutableList.of(new Time(60), new Time(50));
+
+        assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Time(60), new Time(50), new Time(45))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithMoreNulls() {
+        final List<Time> array1 = ImmutableList.of(new Time(60));
+        final List<Time> array2 = ImmutableList.of(new Time(60));
+
+        assertThat("Invalid results.", timeTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Time(60))));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimestampTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimestampTopKDistinctKudafTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import com.google.common.collect.ImmutableList;

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimestampTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimestampTopKDistinctKudafTest.java
@@ -1,0 +1,75 @@
+package io.confluent.ksql.function.udaf.topkdistinct;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TimestampTopKDistinctKudafTest {
+    private final List<Timestamp> valuesArray = ImmutableList.of(new Timestamp(10), new Timestamp(30), new Timestamp(45),
+            new Timestamp(10), new Timestamp(50), new Timestamp(60), new Timestamp(20), new Timestamp(60), new Timestamp(80),
+            new Timestamp(35), new Timestamp(25), new Timestamp(60), new Timestamp(80));
+    private final TopkDistinctKudaf<Timestamp> timestampTopkDistinctKudaf
+            = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.TIMESTAMP);
+
+    @Test
+    public void shouldAggregateTopK() {
+        List<Timestamp> currentVal = new ArrayList<>();
+        for (final Timestamp d: valuesArray) {
+            currentVal = timestampTopkDistinctKudaf.aggregate(d, currentVal);
+        }
+
+        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Timestamp(80), new Timestamp(60),
+                new Timestamp(50))));
+    }
+
+    @Test
+    public void shouldAggregateTopKWithLessThanKValues() {
+        List<Timestamp> currentVal = new ArrayList<>();
+        currentVal = timestampTopkDistinctKudaf.aggregate(new Timestamp(80), currentVal);
+
+        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Timestamp(80))));
+    }
+
+    @Test
+    public void shouldMergeTopK() {
+        final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45), new Timestamp(25));
+        final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(48));
+
+        assertThat("Invalid results.", timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(48))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithNulls() {
+        final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45));
+        final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60));
+
+        assertThat("Invalid results.", timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(45))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithNullsDuplicates() {
+        final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45));
+        final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60), new Timestamp(50));
+
+        assertThat("Invalid results.", timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(45))));
+    }
+
+    @Test
+    public void shouldMergeTopKWithMoreNulls() {
+        final List<Timestamp> array1 = ImmutableList.of(new Timestamp(60));
+        final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60));
+
+        assertThat("Invalid results.", timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
+                ImmutableList.of(new Timestamp(60))));
+    }
+}

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimestampTopKDistinctKudafTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TimestampTopKDistinctKudafTest.java
@@ -26,64 +26,71 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TimestampTopKDistinctKudafTest {
-    private final List<Timestamp> valuesArray = ImmutableList.of(new Timestamp(10), new Timestamp(30), new Timestamp(45),
-            new Timestamp(10), new Timestamp(50), new Timestamp(60), new Timestamp(20), new Timestamp(60), new Timestamp(80),
-            new Timestamp(35), new Timestamp(25), new Timestamp(60), new Timestamp(80));
-    private final TopkDistinctKudaf<Timestamp> timestampTopkDistinctKudaf
-            = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.TIMESTAMP);
+  private final List<Timestamp> valuesArray = ImmutableList.of(new Timestamp(10),
+          new Timestamp(30), new Timestamp(45), new Timestamp(10), new Timestamp(50),
+          new Timestamp(60), new Timestamp(20), new Timestamp(60), new Timestamp(80),
+          new Timestamp(35), new Timestamp(25), new Timestamp(60), new Timestamp(80));
+  private final TopkDistinctKudaf<Timestamp> timestampTopkDistinctKudaf
+          = TopKDistinctTestUtils.getTopKDistinctKudaf(3, SqlTypes.TIMESTAMP);
 
-    @Test
-    public void shouldAggregateTopK() {
-        List<Timestamp> currentVal = new ArrayList<>();
-        for (final Timestamp d: valuesArray) {
-            currentVal = timestampTopkDistinctKudaf.aggregate(d, currentVal);
-        }
-
-        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Timestamp(80), new Timestamp(60),
-                new Timestamp(50))));
+  @Test
+  public void shouldAggregateTopK() {
+    List<Timestamp> currentVal = new ArrayList<>();
+    for (final Timestamp d : valuesArray) {
+      currentVal = timestampTopkDistinctKudaf.aggregate(d, currentVal);
     }
 
-    @Test
-    public void shouldAggregateTopKWithLessThanKValues() {
-        List<Timestamp> currentVal = new ArrayList<>();
-        currentVal = timestampTopkDistinctKudaf.aggregate(new Timestamp(80), currentVal);
+    assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(
+            new Timestamp(80), new Timestamp(60), new Timestamp(50))));
+  }
 
-        assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Timestamp(80))));
-    }
+  @Test
+  public void shouldAggregateTopKWithLessThanKValues() {
+    List<Timestamp> currentVal = new ArrayList<>();
+    currentVal = timestampTopkDistinctKudaf.aggregate(new Timestamp(80), currentVal);
 
-    @Test
-    public void shouldMergeTopK() {
-        final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45), new Timestamp(25));
-        final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(48));
+    assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(new Timestamp(80))));
+  }
 
-        assertThat("Invalid results.", timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(48))));
-    }
+  @Test
+  public void shouldMergeTopK() {
+    final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45),
+            new Timestamp(25));
+    final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60), new Timestamp(50),
+            new Timestamp(48));
 
-    @Test
-    public void shouldMergeTopKWithNulls() {
-        final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45));
-        final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60));
+    assertThat("Invalid results.",
+            timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(48))));
+  }
 
-        assertThat("Invalid results.", timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(45))));
-    }
+  @Test
+  public void shouldMergeTopKWithNulls() {
+    final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45));
+    final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60));
 
-    @Test
-    public void shouldMergeTopKWithNullsDuplicates() {
-        final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45));
-        final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60), new Timestamp(50));
+    assertThat("Invalid results.",
+            timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(45))));
+  }
 
-        assertThat("Invalid results.", timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(45))));
-    }
+  @Test
+  public void shouldMergeTopKWithNullsDuplicates() {
+    final List<Timestamp> array1 = ImmutableList.of(new Timestamp(50), new Timestamp(45));
+    final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60), new Timestamp(50));
 
-    @Test
-    public void shouldMergeTopKWithMoreNulls() {
-        final List<Timestamp> array1 = ImmutableList.of(new Timestamp(60));
-        final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60));
+    assertThat("Invalid results.",
+            timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Timestamp(60), new Timestamp(50), new Timestamp(45))));
+  }
 
-        assertThat("Invalid results.", timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2), equalTo(
-                ImmutableList.of(new Timestamp(60))));
-    }
+  @Test
+  public void shouldMergeTopKWithMoreNulls() {
+    final List<Timestamp> array1 = ImmutableList.of(new Timestamp(60));
+    final List<Timestamp> array2 = ImmutableList.of(new Timestamp(60));
+
+    assertThat("Invalid results.",
+            timestampTopkDistinctKudaf.getMerger().apply(null, array1, array2),
+            equalTo(ImmutableList.of(new Timestamp(60))));
+  }
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/GreatestTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/GreatestTest.java
@@ -5,52 +5,81 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+
+import io.confluent.ksql.function.udf.string.ToBytes;
+import io.confluent.ksql.util.BytesUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 public class GreatestTest {
 
-  private Greatest udf;
+  private Greatest greatestUDF;
+  private ToBytes toBytesUDF;
 
   @Before
   public void setUp() {
-    udf = new Greatest();
+    greatestUDF = new Greatest();
+    toBytesUDF = new ToBytes();
   }
 
   @Test
   public void shouldWorkWithoutImplicitCasting(){
-    assertThat(udf.greatest(0, 1, -1, 2, -2), is(2));
-    assertThat(udf.greatest(0L, 1L, -1L, 2L, -2L), is(2L));
-    assertThat(udf.greatest(0D, .1, -.1, .2, -.2), is(.2));
-    assertThat(udf.greatest(new BigDecimal("0"), new BigDecimal(".1"), new BigDecimal("-.1"), new BigDecimal(".2"), new BigDecimal("-.2")), is(new BigDecimal(".2")));
-    assertThat(udf.greatest("apple", "banana", "bzzz"), is("bzzz"));
+    assertThat(greatestUDF.greatest(0, 1, -1, 2, -2), is(2));
+    assertThat(greatestUDF.greatest(0L, 1L, -1L, 2L, -2L), is(2L));
+    assertThat(greatestUDF.greatest(0D, .1, -.1, .2, -.2), is(.2));
+    assertThat(greatestUDF.greatest(new BigDecimal("0"), new BigDecimal(".1"), new BigDecimal("-.1"), new BigDecimal(".2"), new BigDecimal("-.2")), is(new BigDecimal(".2")));
+    assertThat(greatestUDF.greatest("apple", "banana", "bzzz"), is("bzzz"));
+    assertThat(greatestUDF.greatest(toBytes("apple"), toBytes("banana"), toBytes("aardvark")), is(toBytes("banana")));
+    assertThat(greatestUDF.greatest(new Date(10), new Date(0), new Date(-5), new Date(100), new Date(2)), is(new Date(100)));
+    assertThat(greatestUDF.greatest(new Time(10), new Time(0), new Time(-5), new Time(100), new Time(2)), is(new Time(100)));
+    assertThat(greatestUDF.greatest(new Timestamp(10), new Timestamp(0), new Timestamp(-5), new Timestamp(100), new Timestamp(2)), is(new Timestamp(100)));
   }
 
   @Test
   public void shouldHandleAllNullColumns(){
-    assertThat(udf.greatest((Integer) null, null, null), is(nullValue()));
-    assertThat(udf.greatest((Double) null, null, null), is(nullValue()));
-    assertThat(udf.greatest((Long) null, null, null), is(nullValue()));
-    assertThat(udf.greatest((BigDecimal) null, null, null), is(nullValue()));
-    assertThat(udf.greatest((String) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Integer) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Double) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Long) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((BigDecimal) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((String) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((ByteBuffer) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Date) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Time) null, null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Timestamp) null, null, null), is(nullValue()));
   }
 
   @Test
   public void shouldHandleNullArrays(){
-    assertThat(udf.greatest((Integer) null, null), is(nullValue()));
-    assertThat(udf.greatest((Double) null, null), is(nullValue()));
-    assertThat(udf.greatest((Long) null, null), is(nullValue()));
-    assertThat(udf.greatest((BigDecimal) null, null), is(nullValue()));
-    assertThat(udf.greatest((String) null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Integer) null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Double) null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((Long) null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((BigDecimal) null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest((String) null, null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (ByteBuffer) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Date) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Time) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Timestamp) null), is(nullValue()));
   }
 
   @Test
   public void shouldHandleSomeNullColumns(){
-    assertThat(udf.greatest(null, 27, null, 39, -49, -11, 68, 32, null, 101), is(101));
-    assertThat(udf.greatest(null, null, 39D, -49.01, -11.98, 68.1, .32, null, 101D), is(101D));
-    assertThat(udf.greatest(null, 272038202439L, null, 39L, -4923740932490L, -11L, 68L, 32L, null, 101L), is(272038202439L));
-    assertThat(udf.greatest(null, new BigDecimal("27"), null, new BigDecimal("-49")), is(new BigDecimal("27")));
-    assertThat(udf.greatest(null, "apple", null, "banana", "kumquat", "aardvark", null), is("kumquat"));
+    assertThat(greatestUDF.greatest(null, 27, null, 39, -49, -11, 68, 32, null, 101), is(101));
+    assertThat(greatestUDF.greatest(null, null, 39D, -49.01, -11.98, 68.1, .32, null, 101D), is(101D));
+    assertThat(greatestUDF.greatest(null, 272038202439L, null, 39L, -4923740932490L, -11L, 68L, 32L, null, 101L), is(272038202439L));
+    assertThat(greatestUDF.greatest(null, new BigDecimal("27"), null, new BigDecimal("-49")), is(new BigDecimal("27")));
+    assertThat(greatestUDF.greatest(null, "apple", null, "banana", "kumquat", "aardvark", null), is("kumquat"));
+    assertThat(greatestUDF.greatest(null, toBytes("apple"), null, toBytes("banana"), toBytes("kumquat"), toBytes("aardvark"), null), is(toBytes("kumquat")));
+    assertThat(greatestUDF.greatest(null, new Date(10), null, new Date(0), new Date(-5), new Date(100), null, new Date(2)), is(new Date(100)));
+    assertThat(greatestUDF.greatest(null, new Time(10), null, new Time(0), new Time(-5), new Time(100), null, new Time(2)), is(new Time(100)));
+    assertThat(greatestUDF.greatest(null, new Timestamp(10), null, new Timestamp(0), new Timestamp(-5), new Timestamp(100), null, new Timestamp(2)), is(new Timestamp(100)));
+  }
+
+  private ByteBuffer toBytes(final String val) {
+    return toBytesUDF.toBytes(val, BytesUtils.Encoding.ASCII.toString());
   }
 
 }

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/GreatestTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/GreatestTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,7 +41,7 @@ public class GreatestTest {
   }
 
   @Test
-  public void shouldWorkWithoutImplicitCasting(){
+  public void shouldWorkWithoutImplicitCasting() {
     assertThat(greatestUDF.greatest(0, 1, -1, 2, -2), is(2));
     assertThat(greatestUDF.greatest(0L, 1L, -1L, 2L, -2L), is(2L));
     assertThat(greatestUDF.greatest(0D, .1, -.1, .2, -.2), is(.2));
@@ -40,7 +54,7 @@ public class GreatestTest {
   }
 
   @Test
-  public void shouldHandleAllNullColumns(){
+  public void shouldHandleAllNullColumns() {
     assertThat(greatestUDF.greatest((Integer) null, null, null), is(nullValue()));
     assertThat(greatestUDF.greatest((Double) null, null, null), is(nullValue()));
     assertThat(greatestUDF.greatest((Long) null, null, null), is(nullValue()));
@@ -53,7 +67,7 @@ public class GreatestTest {
   }
 
   @Test
-  public void shouldHandleNullArrays(){
+  public void shouldHandleNullArrays() {
     assertThat(greatestUDF.greatest(null, (Integer[]) null), is(nullValue()));
     assertThat(greatestUDF.greatest(null, (Double[]) null), is(nullValue()));
     assertThat(greatestUDF.greatest(null, (Long[]) null), is(nullValue()));
@@ -66,7 +80,7 @@ public class GreatestTest {
   }
 
   @Test
-  public void shouldHandleSomeNullColumns(){
+  public void shouldHandleSomeNullColumns() {
     assertThat(greatestUDF.greatest(null, 27, null, 39, -49, -11, 68, 32, null, 101), is(101));
     assertThat(greatestUDF.greatest(null, null, 39D, -49.01, -11.98, 68.1, .32, null, 101D), is(101D));
     assertThat(greatestUDF.greatest(null, 272038202439L, null, 39L, -4923740932490L, -11L, 68L, 32L, null, 101L), is(272038202439L));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/GreatestTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/GreatestTest.java
@@ -54,15 +54,15 @@ public class GreatestTest {
 
   @Test
   public void shouldHandleNullArrays(){
-    assertThat(greatestUDF.greatest((Integer) null, null), is(nullValue()));
-    assertThat(greatestUDF.greatest((Double) null, null), is(nullValue()));
-    assertThat(greatestUDF.greatest((Long) null, null), is(nullValue()));
-    assertThat(greatestUDF.greatest((BigDecimal) null, null), is(nullValue()));
-    assertThat(greatestUDF.greatest((String) null, null), is(nullValue()));
-    assertThat(greatestUDF.greatest(null, (ByteBuffer) null), is(nullValue()));
-    assertThat(greatestUDF.greatest(null, (Date) null), is(nullValue()));
-    assertThat(greatestUDF.greatest(null, (Time) null), is(nullValue()));
-    assertThat(greatestUDF.greatest(null, (Timestamp) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Integer[]) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Double[]) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Long[]) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (BigDecimal[]) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (String[]) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (ByteBuffer[]) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Date[]) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Time[]) null), is(nullValue()));
+    assertThat(greatestUDF.greatest(null, (Timestamp[]) null), is(nullValue()));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/LeastTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/LeastTest.java
@@ -54,15 +54,15 @@ public class LeastTest {
   
   @Test
   public void shouldHandleNullArrays(){
-    assertThat(leastUDF.least(null, (Integer) null), is(nullValue()));
-    assertThat(leastUDF.least(null, (Double) null), is(nullValue()));
-    assertThat(leastUDF.least(null, (Long) null), is(nullValue()));
-    assertThat(leastUDF.least(null, (BigDecimal) null), is(nullValue()));
-    assertThat(leastUDF.least(null, (String) null), is(nullValue()));
-    assertThat(leastUDF.least(null, (ByteBuffer) null), is(nullValue()));
-    assertThat(leastUDF.least(null, (Date) null), is(nullValue()));
-    assertThat(leastUDF.least(null, (Time) null), is(nullValue()));
-    assertThat(leastUDF.least(null, (Timestamp) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Integer[]) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Double[]) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Long[]) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (BigDecimal[]) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (String[]) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (ByteBuffer[]) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Date[]) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Time[]) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Timestamp[]) null), is(nullValue()));
   }
 
   @Test

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/LeastTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/LeastTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.math;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,7 +67,7 @@ public class LeastTest {
   }
   
   @Test
-  public void shouldHandleNullArrays(){
+  public void shouldHandleNullArrays() {
     assertThat(leastUDF.least(null, (Integer[]) null), is(nullValue()));
     assertThat(leastUDF.least(null, (Double[]) null), is(nullValue()));
     assertThat(leastUDF.least(null, (Long[]) null), is(nullValue()));

--- a/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/LeastTest.java
+++ b/ksqldb-engine/src/test/java/io/confluent/ksql/function/udf/math/LeastTest.java
@@ -5,52 +5,81 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+
+import io.confluent.ksql.function.udf.string.ToBytes;
+import io.confluent.ksql.util.BytesUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 public class LeastTest {
 
-  private Least udf;
+  private Least leastUDF;
+  private ToBytes toBytesUDF;
 
   @Before
   public void setUp() {
-    udf = new Least();
+    leastUDF = new Least();
+    toBytesUDF = new ToBytes();
   }
 
   @Test
   public void shouldWorkWithoutImplicitCasting() {
-    assertThat(udf.least(0, 1, -1, 2, -2), is(-2));
-    assertThat(udf.least(0L, 1L, -1L, 2L, -2L), is(-2L));
-    assertThat(udf.least(0D, .1, -.1, .2, -.2), is(-.2));
-    assertThat(udf.least(new BigDecimal("0"), new BigDecimal(".1"), new BigDecimal("-.1"), new BigDecimal(".2"), new BigDecimal("-.2")), is(new BigDecimal("-.2")));
-    assertThat(udf.least("apple", "banana", "aardvark"), is("aardvark"));
+    assertThat(leastUDF.least(0, 1, -1, 2, -2), is(-2));
+    assertThat(leastUDF.least(0L, 1L, -1L, 2L, -2L), is(-2L));
+    assertThat(leastUDF.least(0D, .1, -.1, .2, -.2), is(-.2));
+    assertThat(leastUDF.least(new BigDecimal("0"), new BigDecimal(".1"), new BigDecimal("-.1"), new BigDecimal(".2"), new BigDecimal("-.2")), is(new BigDecimal("-.2")));
+    assertThat(leastUDF.least("apple", "banana", "aardvark"), is("aardvark"));
+    assertThat(leastUDF.least(toBytes("apple"), toBytes("banana"), toBytes("aardvark")), is(toBytes("aardvark")));
+    assertThat(leastUDF.least(new Date(10), new Date(0), new Date(-5), new Date(100), new Date(2)), is(new Date(-5)));
+    assertThat(leastUDF.least(new Time(10), new Time(0), new Time(-5), new Time(100), new Time(2)), is(new Time(-5)));
+    assertThat(leastUDF.least(new Timestamp(10), new Timestamp(0), new Timestamp(-5), new Timestamp(100), new Timestamp(2)), is(new Timestamp(-5)));
   }
 
   @Test
   public void shouldHandleAllNullColumns() {
-    assertThat(udf.least((Integer) null, null, null), is(nullValue()));
-    assertThat(udf.least((Double) null, null, null), is(nullValue()));
-    assertThat(udf.least((Long) null, null, null), is(nullValue()));
-    assertThat(udf.least((BigDecimal) null, null, null), is(nullValue()));
-    assertThat(udf.least((String) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((Integer) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((Double) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((Long) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((BigDecimal) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((String) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((ByteBuffer) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((Date) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((Time) null, null, null), is(nullValue()));
+    assertThat(leastUDF.least((Timestamp) null, null, null), is(nullValue()));
   }
   
   @Test
   public void shouldHandleNullArrays(){
-    assertThat(udf.least(null, (Integer) null), is(nullValue()));
-    assertThat(udf.least(null, (Double) null), is(nullValue()));
-    assertThat(udf.least(null, (Long) null), is(nullValue()));
-    assertThat(udf.least(null, (BigDecimal) null), is(nullValue()));
-    assertThat(udf.least(null, (String) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Integer) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Double) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Long) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (BigDecimal) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (String) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (ByteBuffer) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Date) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Time) null), is(nullValue()));
+    assertThat(leastUDF.least(null, (Timestamp) null), is(nullValue()));
   }
 
   @Test
   public void shouldHandleSomeNullColumns() {
-    assertThat(udf.least(null, 27, null, 39, -49, -11, 68, 32, null, 101), is(-49));
-    assertThat(udf.least(null, null, 39d, -49.01, -11.98, 68.1, .32, null, 101d), is(-49.01));
-    assertThat(udf.least(null, 272038202439L, null, 39L, -4923740932490L, -11L, 68L, 32L, null, 101L), is(-4923740932490L));
-    assertThat(udf.least(null, new BigDecimal("27"), null, new BigDecimal("-49")), is(new BigDecimal("-49")));
-    assertThat(udf.least(null, "apple", null, "banana", "kumquat", "aardvark", null), is("aardvark"));
+    assertThat(leastUDF.least(null, 27, null, 39, -49, -11, 68, 32, null, 101), is(-49));
+    assertThat(leastUDF.least(null, null, 39d, -49.01, -11.98, 68.1, .32, null, 101d), is(-49.01));
+    assertThat(leastUDF.least(null, 272038202439L, null, 39L, -4923740932490L, -11L, 68L, 32L, null, 101L), is(-4923740932490L));
+    assertThat(leastUDF.least(null, new BigDecimal("27"), null, new BigDecimal("-49")), is(new BigDecimal("-49")));
+    assertThat(leastUDF.least(null, "apple", null, "banana", "kumquat", "aardvark", null), is("aardvark"));
+    assertThat(leastUDF.least(null, toBytes("apple"), null, toBytes("banana"), toBytes("kumquat"), toBytes("aardvark"), null), is(toBytes("aardvark")));
+    assertThat(leastUDF.least(null, new Date(10), null, new Date(0), new Date(-5), new Date(100), null, new Date(2)), is(new Date(-5)));
+    assertThat(leastUDF.least(null, new Time(10), null, new Time(0), new Time(-5), new Time(100), null, new Time(2)), is(new Time(-5)));
+    assertThat(leastUDF.least(null, new Timestamp(10), null, new Timestamp(0), new Timestamp(-5), new Timestamp(100), null, new Timestamp(2)), is(new Timestamp(-5)));
+  }
+
+  private ByteBuffer toBytes(final String val) {
+    return toBytesUDF.toBytes(val, BytesUtils.Encoding.ASCII.toString());
   }
 
 }

--- a/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/NullSafe.java
+++ b/ksqldb-execution/src/main/java/io/confluent/ksql/execution/codegen/helpers/NullSafe.java
@@ -75,8 +75,8 @@ public final class NullSafe {
       final String mapperCode,
       final Class<?> returnType
   ) {
-    return "(" + returnType.getSimpleName() + ")" + NullSafe.class.getSimpleName()
-        + ".apply(" + inputCode + "," + mapperCode + ")";
+    return "((" + returnType.getSimpleName() + ")" + NullSafe.class.getSimpleName()
+        + ".apply(" + inputCode + "," + mapperCode + "))";
   }
 
   /**

--- a/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksqldb-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.codegen.CodeGenTestUtil.Evaluator;
 import io.confluent.ksql.execution.codegen.helpers.CastEvaluator;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
@@ -64,6 +65,7 @@ import io.confluent.ksql.execution.expression.tree.IntervalUnit;
 import io.confluent.ksql.execution.expression.tree.LambdaFunctionCall;
 import io.confluent.ksql.execution.expression.tree.LambdaVariable;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
+import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.expression.tree.QualifiedColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
@@ -627,6 +629,20 @@ public class SqlToJavaVisitorTest {
         "COL8", SqlTypes.decimal(2, 1), SqlTypes.DOUBLE, ksqlConfig);
     assertThat(java, containsString(doubleCast));
   }
+
+    @Test
+    public void shouldGenerateCastExpressionsWhichAreComparable() {
+        // Given:
+        final Expression cast = new Cast(new StringLiteral("2020-01-01"), new io.confluent.ksql.execution.expression.tree.Type(SqlTypes.DATE));
+        final ComparisonExpression exp = new ComparisonExpression(Type.GREATER_THAN_OR_EQUAL, cast, cast);
+
+        // When:
+        final String java = sqlToJavaVisitor.process(exp);
+
+        // Then:
+        final Evaluator evaluator = CodeGenTestUtil.cookCode(java, Boolean.class);
+        evaluator.evaluate(Collections.emptyList());
+    }
 
   @Test
   public void shouldGenerateCorrectCodeForDecimalSubtract() {
@@ -1298,24 +1314,24 @@ public class SqlToJavaVisitorTest {
     // Then
     assertThat(
         javaExpression, equalTo(
-            "(((Double) nested_0.evaluate(COL4, (Double)NullSafe.apply(0,new Function() {\n"
+            "(((Double) nested_0.evaluate(COL4, ((Double)NullSafe.apply(0,new Function() {\n"
                 + " @Override\n"
                 + " public Object apply(Object arg1) {\n"
                 + "   final Integer val = (Integer) arg1;\n"
                 + "   return val.doubleValue();\n"
                 + " }\n"
-                + "}), new BiFunction() {\n"
+                + "})), new BiFunction() {\n"
                 + " @Override\n"
                 + " public Object apply(Object arg1, Object arg2) {\n"
                 + "   final Double A = (Double) arg1;\n"
                 + "   final Integer B = (Integer) arg2;\n"
-                + "   return (((Double) nested_1.evaluate(COL4, (Double)NullSafe.apply(0,new Function() {\n"
+                + "   return (((Double) nested_1.evaluate(COL4, ((Double)NullSafe.apply(0,new Function() {\n"
                 + " @Override\n"
                 + " public Object apply(Object arg1) {\n"
                 + "   final Integer val = (Integer) arg1;\n"
                 + "   return val.doubleValue();\n"
                 + " }\n"
-                + "}), new BiFunction() {\n"
+                + "})), new BiFunction() {\n"
                 + " @Override\n"
                 + " public Object apply(Object arg1, Object arg2) {\n"
                 + "   final Double Q = (Double) arg1;\n"

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_bytes/7.3.0_1655238066340/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_bytes/7.3.0_1655238066340/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, S1 BYTES, S2 BYTES, S3 BYTES, S4 BYTES) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `S1` BYTES, `S2` BYTES, `S3` BYTES, `S4` BYTES",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  GREATEST(INPUT.S1, INPUT.S2, INPUT.S3, INPUT.S4, null, null, TO_BYTES('hello', 'ascii')) HIGHEST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `HIGHEST` BYTES",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` BIGINT KEY, `S1` BYTES, `S2` BYTES, `S3` BYTES, `S4` BYTES",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "GREATEST(S1, S2, S3, S4, null, null, TO_BYTES('hello', 'ascii')) AS HIGHEST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_bytes/7.3.0_1655238066340/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_bytes/7.3.0_1655238066340/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655238066340,
+  "path" : "query-validation-tests/greatest.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `S1` BYTES, `S2` BYTES, `S3` BYTES, `S4` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `HIGHEST` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "test greatest with bytes",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 1,
+      "value" : {
+        "S1" : "YXBwbGU=",
+        "S2" : "YmFuYW5h",
+        "S3" : "YWFyZGF2YXJr",
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 2,
+      "value" : {
+        "S1" : null,
+        "S2" : null,
+        "S3" : null,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 3,
+      "value" : {
+        "S1" : "IQ==",
+        "S2" : "emVicmE=",
+        "S3" : "YWFyZGF2YXJr",
+        "S4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "HIGHEST" : "aGVsbG8="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "HIGHEST" : "aGVsbG8="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "HIGHEST" : "emVicmE="
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, S1 BYTES, S2 BYTES, S3 BYTES, S4 BYTES) WITH (kafka_topic='input_topic',value_format='json');", "CREATE STREAM OUTPUT AS SELECT ID, GREATEST(S1, S2, S3, S4, null, null, TO_BYTES('hello', 'ascii')) AS HIGHEST FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `S1` BYTES, `S2` BYTES, `S3` BYTES, `S4` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `HIGHEST` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_bytes/7.3.0_1655238066340/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_bytes/7.3.0_1655238066340/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_dates/7.3.0_1655238066415/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_dates/7.3.0_1655238066415/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, S1 DATE, S2 DATE, S3 DATE, S4 DATE) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `S1` DATE, `S2` DATE, `S3` DATE, `S4` DATE",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  GREATEST(INPUT.S1, INPUT.S2, INPUT.S3, INPUT.S4, null, null, '2022-06-14') HIGHEST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `HIGHEST` DATE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` BIGINT KEY, `S1` DATE, `S2` DATE, `S3` DATE, `S4` DATE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "GREATEST(S1, S2, S3, S4, null, null, '2022-06-14') AS HIGHEST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_dates/7.3.0_1655238066415/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_dates/7.3.0_1655238066415/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655238066415,
+  "path" : "query-validation-tests/greatest.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `S1` DATE, `S2` DATE, `S3` DATE, `S4` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `HIGHEST` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "test greatest with dates",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 1,
+      "value" : {
+        "S1" : 19071,
+        "S2" : 18824,
+        "S3" : -5883,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 2,
+      "value" : {
+        "S1" : null,
+        "S2" : null,
+        "S3" : null,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 3,
+      "value" : {
+        "S1" : 19158,
+        "S2" : 19187,
+        "S3" : -92,
+        "S4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "HIGHEST" : 19157
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "HIGHEST" : 19157
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "HIGHEST" : 19187
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, S1 DATE, S2 DATE, S3 DATE, S4 DATE) WITH (kafka_topic='input_topic',value_format='json');", "CREATE STREAM OUTPUT AS SELECT ID, GREATEST(S1, S2, S3, S4, null, null, '2022-06-14') AS HIGHEST FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `S1` DATE, `S2` DATE, `S3` DATE, `S4` DATE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `HIGHEST` DATE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_dates/7.3.0_1655238066415/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_dates/7.3.0_1655238066415/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_times/7.3.0_1655238066481/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_times/7.3.0_1655238066481/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIME, S2 TIME, S3 TIME, S4 TIME) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `S1` TIME, `S2` TIME, `S3` TIME, `S4` TIME",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  GREATEST(INPUT.S1, INPUT.S2, INPUT.S3, INPUT.S4, null, null, '09:16:00') HIGHEST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `HIGHEST` TIME",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` BIGINT KEY, `S1` TIME, `S2` TIME, `S3` TIME, `S4` TIME",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "GREATEST(S1, S2, S3, S4, null, null, '09:16:00') AS HIGHEST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_times/7.3.0_1655238066481/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_times/7.3.0_1655238066481/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655238066481,
+  "path" : "query-validation-tests/greatest.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `S1` TIME, `S2` TIME, `S3` TIME, `S4` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `HIGHEST` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "test greatest with times",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 1,
+      "value" : {
+        "S1" : 33359999,
+        "S2" : 23361230,
+        "S3" : 10,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 2,
+      "value" : {
+        "S1" : null,
+        "S2" : null,
+        "S3" : null,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 3,
+      "value" : {
+        "S1" : 32560000,
+        "S2" : 33370000,
+        "S3" : 33360001,
+        "S4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "HIGHEST" : 33360000
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "HIGHEST" : 33360000
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "HIGHEST" : 33370000
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIME, S2 TIME, S3 TIME, S4 TIME) WITH (kafka_topic='input_topic',value_format='json');", "CREATE STREAM OUTPUT AS SELECT ID, GREATEST(S1, S2, S3, S4, null, null, '09:16:00') AS HIGHEST FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `S1` TIME, `S2` TIME, `S3` TIME, `S4` TIME",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `HIGHEST` TIME",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_times/7.3.0_1655238066481/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_times/7.3.0_1655238066481/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_timestamps/7.3.0_1655238066518/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_timestamps/7.3.0_1655238066518/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIMESTAMP, S2 TIMESTAMP, S3 TIMESTAMP, S4 TIMESTAMP) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `S1` TIMESTAMP, `S2` TIMESTAMP, `S3` TIMESTAMP, `S4` TIMESTAMP",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  GREATEST(INPUT.S1, INPUT.S2, INPUT.S3, INPUT.S4, null, null, '2022-06-14') HIGHEST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `HIGHEST` TIMESTAMP",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` BIGINT KEY, `S1` TIMESTAMP, `S2` TIMESTAMP, `S3` TIMESTAMP, `S4` TIMESTAMP",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "GREATEST(S1, S2, S3, S4, null, null, '2022-06-14') AS HIGHEST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_timestamps/7.3.0_1655238066518/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_timestamps/7.3.0_1655238066518/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655238066518,
+  "path" : "query-validation-tests/greatest.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `S1` TIMESTAMP, `S2` TIMESTAMP, `S3` TIMESTAMP, `S4` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `HIGHEST` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "test greatest with timestamps",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 1,
+      "value" : {
+        "S1" : 1647734400000,
+        "S2" : 1626393600000,
+        "S3" : -508291200000,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 2,
+      "value" : {
+        "S1" : null,
+        "S2" : null,
+        "S3" : null,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 3,
+      "value" : {
+        "S1" : 1655251200000,
+        "S2" : 1657756800000,
+        "S3" : -7948800000,
+        "S4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "HIGHEST" : 1655164800000
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "HIGHEST" : 1655164800000
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "HIGHEST" : 1657756800000
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIMESTAMP, S2 TIMESTAMP, S3 TIMESTAMP, S4 TIMESTAMP) WITH (kafka_topic='input_topic',value_format='json');", "CREATE STREAM OUTPUT AS SELECT ID, GREATEST(S1, S2, S3, S4, null, null, '2022-06-14') AS HIGHEST FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `S1` TIMESTAMP, `S2` TIMESTAMP, `S3` TIMESTAMP, `S4` TIMESTAMP",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `HIGHEST` TIMESTAMP",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_timestamps/7.3.0_1655238066518/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/greatest_-_test_greatest_with_timestamps/7.3.0_1655238066518/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_bytes/7.3.0_1655238590139/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_bytes/7.3.0_1655238590139/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, S1 BYTES, S2 BYTES, S3 BYTES, S4 BYTES) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `S1` BYTES, `S2` BYTES, `S3` BYTES, `S4` BYTES",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  LEAST(INPUT.S1, INPUT.S2, INPUT.S3, INPUT.S4, null, null, TO_BYTES('hello', 'ascii')) LOWEST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `LOWEST` BYTES",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` BIGINT KEY, `S1` BYTES, `S2` BYTES, `S3` BYTES, `S4` BYTES",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "LEAST(S1, S2, S3, S4, null, null, TO_BYTES('hello', 'ascii')) AS LOWEST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_bytes/7.3.0_1655238590139/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_bytes/7.3.0_1655238590139/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655238590139,
+  "path" : "query-validation-tests/least.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `S1` BYTES, `S2` BYTES, `S3` BYTES, `S4` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `LOWEST` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "test least with bytes",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 1,
+      "value" : {
+        "S1" : "YXBwbGU=",
+        "S2" : "YmFuYW5h",
+        "S3" : "YWFyZGF2YXJr",
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 2,
+      "value" : {
+        "S1" : null,
+        "S2" : null,
+        "S3" : null,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 3,
+      "value" : {
+        "S1" : "IQ==",
+        "S2" : "emVicmE=",
+        "S3" : "YWFyZGF2YXJr",
+        "S4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "LOWEST" : "YWFyZGF2YXJr"
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "LOWEST" : "aGVsbG8="
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "LOWEST" : "IQ=="
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, S1 BYTES, S2 BYTES, S3 BYTES, S4 BYTES) WITH (kafka_topic='input_topic',value_format='json');", "CREATE STREAM OUTPUT AS SELECT ID, LEAST(S1, S2, S3, S4, null, null, TO_BYTES('hello', 'ascii')) AS LOWEST FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `S1` BYTES, `S2` BYTES, `S3` BYTES, `S4` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `LOWEST` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_bytes/7.3.0_1655238590139/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_bytes/7.3.0_1655238590139/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_dates/7.3.0_1655238590162/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_dates/7.3.0_1655238590162/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, S1 DATE, S2 DATE, S3 DATE, S4 DATE) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `S1` DATE, `S2` DATE, `S3` DATE, `S4` DATE",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  LEAST(INPUT.S1, INPUT.S2, INPUT.S3, INPUT.S4, null, null, '2022-06-14') LOWEST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `LOWEST` DATE",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` BIGINT KEY, `S1` DATE, `S2` DATE, `S3` DATE, `S4` DATE",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "LEAST(S1, S2, S3, S4, null, null, '2022-06-14') AS LOWEST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_dates/7.3.0_1655238590162/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_dates/7.3.0_1655238590162/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655238590162,
+  "path" : "query-validation-tests/least.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `S1` DATE, `S2` DATE, `S3` DATE, `S4` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `LOWEST` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "test least with dates",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 1,
+      "value" : {
+        "S1" : 19071,
+        "S2" : 18824,
+        "S3" : -5883,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 2,
+      "value" : {
+        "S1" : null,
+        "S2" : null,
+        "S3" : null,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 3,
+      "value" : {
+        "S1" : 19158,
+        "S2" : 19187,
+        "S3" : -92,
+        "S4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "LOWEST" : -5883
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "LOWEST" : 19157
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "LOWEST" : -92
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, S1 DATE, S2 DATE, S3 DATE, S4 DATE) WITH (kafka_topic='input_topic',value_format='json');", "CREATE STREAM OUTPUT AS SELECT ID, LEAST(S1, S2, S3, S4, null, null, '2022-06-14') AS LOWEST FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `S1` DATE, `S2` DATE, `S3` DATE, `S4` DATE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `LOWEST` DATE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_dates/7.3.0_1655238590162/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_dates/7.3.0_1655238590162/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_times/7.3.0_1655238590195/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_times/7.3.0_1655238590195/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIME, S2 TIME, S3 TIME, S4 TIME) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `S1` TIME, `S2` TIME, `S3` TIME, `S4` TIME",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  LEAST(INPUT.S1, INPUT.S2, INPUT.S3, INPUT.S4, null, null, '09:16:00') LOWEST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `LOWEST` TIME",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` BIGINT KEY, `S1` TIME, `S2` TIME, `S3` TIME, `S4` TIME",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "LEAST(S1, S2, S3, S4, null, null, '09:16:00') AS LOWEST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_times/7.3.0_1655238590195/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_times/7.3.0_1655238590195/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655238590195,
+  "path" : "query-validation-tests/least.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `S1` TIME, `S2` TIME, `S3` TIME, `S4` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `LOWEST` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "test least with times",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 1,
+      "value" : {
+        "S1" : 33359999,
+        "S2" : 23361230,
+        "S3" : 10,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 2,
+      "value" : {
+        "S1" : null,
+        "S2" : null,
+        "S3" : null,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 3,
+      "value" : {
+        "S1" : 32560000,
+        "S2" : 33370000,
+        "S3" : 33360001,
+        "S4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "LOWEST" : 10
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "LOWEST" : 33360000
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "LOWEST" : 32560000
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIME, S2 TIME, S3 TIME, S4 TIME) WITH (kafka_topic='input_topic',value_format='json');", "CREATE STREAM OUTPUT AS SELECT ID, LEAST(S1, S2, S3, S4, null, null, '09:16:00') AS LOWEST FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `S1` TIME, `S2` TIME, `S3` TIME, `S4` TIME",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `LOWEST` TIME",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_times/7.3.0_1655238590195/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_times/7.3.0_1655238590195/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_timestamps/7.3.0_1655238590234/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_timestamps/7.3.0_1655238590234/plan.json
@@ -1,0 +1,205 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIMESTAMP, S2 TIMESTAMP, S3 TIMESTAMP, S4 TIMESTAMP) WITH (KAFKA_TOPIC='input_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='JSON');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "INPUT",
+      "schema" : "`ID` BIGINT KEY, `S1` TIMESTAMP, `S2` TIMESTAMP, `S3` TIMESTAMP, `S4` TIMESTAMP",
+      "timestampColumn" : null,
+      "topicName" : "input_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM OUTPUT AS SELECT\n  INPUT.ID ID,\n  LEAST(INPUT.S1, INPUT.S2, INPUT.S3, INPUT.S4, null, null, '2022-06-14') LOWEST\nFROM INPUT INPUT\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "OUTPUT",
+      "schema" : "`ID` BIGINT KEY, `LOWEST` TIMESTAMP",
+      "timestampColumn" : null,
+      "topicName" : "OUTPUT",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "JSON",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "INPUT" ],
+      "sink" : "OUTPUT",
+      "physicalPlan" : {
+        "@type" : "streamSinkV1",
+        "properties" : {
+          "queryContext" : "OUTPUT"
+        },
+        "source" : {
+          "@type" : "streamSelectV1",
+          "properties" : {
+            "queryContext" : "Project"
+          },
+          "source" : {
+            "@type" : "streamSourceV1",
+            "properties" : {
+              "queryContext" : "KsqlTopic/Source"
+            },
+            "topicName" : "input_topic",
+            "formats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "JSON",
+                "properties" : { }
+              }
+            },
+            "timestampColumn" : null,
+            "sourceSchema" : "`ID` BIGINT KEY, `S1` TIMESTAMP, `S2` TIMESTAMP, `S3` TIMESTAMP, `S4` TIMESTAMP",
+            "pseudoColumnVersion" : 1
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectedKeys" : null,
+          "selectExpressions" : [ "LEAST(S1, S2, S3, S4, null, null, '2022-06-14') AS LOWEST" ]
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "JSON",
+            "properties" : { }
+          }
+        },
+        "topicName" : "OUTPUT",
+        "timestampColumn" : null
+      },
+      "queryId" : "CSAS_OUTPUT_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_timestamps/7.3.0_1655238590234/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_timestamps/7.3.0_1655238590234/spec.json
@@ -1,0 +1,131 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655238590234,
+  "path" : "query-validation-tests/least.json",
+  "schemas" : {
+    "CSAS_OUTPUT_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `S1` TIMESTAMP, `S2` TIMESTAMP, `S3` TIMESTAMP, `S4` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    },
+    "CSAS_OUTPUT_0.OUTPUT" : {
+      "schema" : "`ID` BIGINT KEY, `LOWEST` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "JSON"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "test least with timestamps",
+    "inputs" : [ {
+      "topic" : "input_topic",
+      "key" : 1,
+      "value" : {
+        "S1" : 1647734400000,
+        "S2" : 1626393600000,
+        "S3" : -508291200000,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 2,
+      "value" : {
+        "S1" : null,
+        "S2" : null,
+        "S3" : null,
+        "S4" : null
+      }
+    }, {
+      "topic" : "input_topic",
+      "key" : 3,
+      "value" : {
+        "S1" : 1655251200000,
+        "S2" : 1657756800000,
+        "S3" : -7948800000,
+        "S4" : null
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "OUTPUT",
+      "key" : 1,
+      "value" : {
+        "LOWEST" : -508291200000
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 2,
+      "value" : {
+        "LOWEST" : 1655164800000
+      }
+    }, {
+      "topic" : "OUTPUT",
+      "key" : 3,
+      "value" : {
+        "LOWEST" : -7948800000
+      }
+    } ],
+    "topics" : [ {
+      "name" : "OUTPUT",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "input_topic",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIMESTAMP, S2 TIMESTAMP, S3 TIMESTAMP, S4 TIMESTAMP) WITH (kafka_topic='input_topic',value_format='json');", "CREATE STREAM OUTPUT AS SELECT ID, LEAST(S1, S2, S3, S4, null, null, '2022-06-14') AS LOWEST FROM INPUT;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "INPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `S1` TIMESTAMP, `S2` TIMESTAMP, `S3` TIMESTAMP, `S4` TIMESTAMP",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "OUTPUT",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `LOWEST` TIMESTAMP",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "JSON",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "input_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        }, {
+          "name" : "OUTPUT",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "JSON"
+          },
+          "partitions" : 4
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_timestamps/7.3.0_1655238590234/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/least_-_test_least_with_timestamps/7.3.0_1655238590234/topology
@@ -1,0 +1,13 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [input_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Project
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Project (stores: [])
+      --> KSTREAM-SINK-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Sink: KSTREAM-SINK-0000000003 (topic: OUTPUT)
+      <-- Project
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_bytes/7.3.0_1655222498255/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_bytes/7.3.0_1655222498255/plan.json
@@ -1,0 +1,257 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE BYTES) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BYTES",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  TOPKDISTINCT(TEST.VALUE, 3) TOPK\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<BYTES>",
+      "timestampColumn" : null,
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BYTES",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "3 AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "AVRO",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "TOPKDISTINCT(VALUE, 3)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS TOPK" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "AVRO",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          }
+        },
+        "topicName" : "S2",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_S2_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_bytes/7.3.0_1655222498255/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_bytes/7.3.0_1655222498255/spec.json
@@ -1,0 +1,264 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655222498255,
+  "path" : "query-validation-tests/topk-distinct.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` BYTES, `KSQL_AGG_VARIABLE_0` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BYTES",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<BYTES>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` BYTES, `KSQL_INTERNAL_COL_2` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "topk distinct bytes",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : "Qg=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : "Rg=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : "Rw=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : "QQ=="
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : "Rg=="
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ "Qg==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ "Rg==", "Qg==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ "Rw==", "Rg==", "Qg==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ "Rw==", "Rg==", "Qg==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ "Rw==", "Rg==", "Qg==" ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ "Rw==", "Rg==", "Qg==" ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "KsqlDataSourceSchema",
+        "namespace" : "io.confluent.ksql.avro_schemas",
+        "fields" : [ {
+          "name" : "NAME",
+          "type" : [ "null", "string" ],
+          "default" : null
+        }, {
+          "name" : "VALUE",
+          "type" : [ "null", "bytes" ],
+          "default" : null
+        } ],
+        "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bytes) WITH (kafka_topic='test_topic',value_format='AVRO');", "CREATE TABLE S2 as SELECT ID, topkdistinct(value, 3) as topk FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<BYTES>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` BYTES",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "ID",
+              "type" : [ "null", "long" ],
+              "default" : null
+            }, {
+              "name" : "VALUE",
+              "type" : [ "null", "bytes" ],
+              "default" : null
+            }, {
+              "name" : "KSQL_AGG_VARIABLE_0",
+              "type" : [ "null", {
+                "type" : "array",
+                "items" : [ "null", "bytes" ]
+              } ],
+              "default" : null
+            } ]
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "NAME",
+              "type" : [ "null", "string" ],
+              "default" : null
+            }, {
+              "name" : "VALUE",
+              "type" : [ "null", "bytes" ],
+              "default" : null
+            } ],
+            "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+          }
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "TOPK",
+              "type" : [ "null", {
+                "type" : "array",
+                "items" : [ "null", "bytes" ]
+              } ],
+              "default" : null
+            } ]
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_bytes/7.3.0_1655222498255/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_bytes/7.3.0_1655222498255/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_date/7.3.0_1655222499229/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_date/7.3.0_1655222499229/plan.json
@@ -1,0 +1,257 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE DATE) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` DATE",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  TOPKDISTINCT(TEST.VALUE, 3) TOPK\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<DATE>",
+      "timestampColumn" : null,
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` DATE",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "3 AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "AVRO",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "TOPKDISTINCT(VALUE, 3)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS TOPK" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "AVRO",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          }
+        },
+        "topicName" : "S2",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_S2_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_date/7.3.0_1655222499229/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_date/7.3.0_1655222499229/spec.json
@@ -1,0 +1,283 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655222499229,
+  "path" : "query-validation-tests/topk-distinct.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` DATE, `KSQL_AGG_VARIABLE_0` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` DATE",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<DATE>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` DATE, `KSQL_INTERNAL_COL_2` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "topk distinct date",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 100
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 99
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : -7
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 100
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "KsqlDataSourceSchema",
+        "namespace" : "io.confluent.ksql.avro_schemas",
+        "fields" : [ {
+          "name" : "NAME",
+          "type" : [ "null", "string" ],
+          "default" : null
+        }, {
+          "name" : "VALUE",
+          "type" : [ "null", {
+            "type" : "int",
+            "connect.version" : 1,
+            "connect.name" : "org.apache.kafka.connect.data.Date",
+            "logicalType" : "date"
+          } ],
+          "default" : null
+        } ],
+        "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE date) WITH (kafka_topic='test_topic',value_format='AVRO');", "CREATE TABLE S2 as SELECT ID, topkdistinct(value, 3) as topk FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<DATE>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` DATE",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "ID",
+              "type" : [ "null", "long" ],
+              "default" : null
+            }, {
+              "name" : "VALUE",
+              "type" : [ "null", {
+                "type" : "int",
+                "logicalType" : "date"
+              } ],
+              "default" : null
+            }, {
+              "name" : "KSQL_AGG_VARIABLE_0",
+              "type" : [ "null", {
+                "type" : "array",
+                "items" : [ "null", {
+                  "type" : "int",
+                  "logicalType" : "date"
+                } ]
+              } ],
+              "default" : null
+            } ]
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "NAME",
+              "type" : [ "null", "string" ],
+              "default" : null
+            }, {
+              "name" : "VALUE",
+              "type" : [ "null", {
+                "type" : "int",
+                "connect.version" : 1,
+                "connect.name" : "org.apache.kafka.connect.data.Date",
+                "logicalType" : "date"
+              } ],
+              "default" : null
+            } ],
+            "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+          }
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "TOPK",
+              "type" : [ "null", {
+                "type" : "array",
+                "items" : [ "null", {
+                  "type" : "int",
+                  "logicalType" : "date"
+                } ]
+              } ],
+              "default" : null
+            } ]
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_date/7.3.0_1655222499229/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_date/7.3.0_1655222499229/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_time/7.3.0_1655222500243/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_time/7.3.0_1655222500243/plan.json
@@ -1,0 +1,257 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE TIME) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` TIME",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  TOPKDISTINCT(TEST.VALUE, 3) TOPK\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<TIME>",
+      "timestampColumn" : null,
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` TIME",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "3 AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "AVRO",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "TOPKDISTINCT(VALUE, 3)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS TOPK" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "AVRO",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          }
+        },
+        "topicName" : "S2",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_S2_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_time/7.3.0_1655222500243/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_time/7.3.0_1655222500243/spec.json
@@ -1,0 +1,283 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655222500243,
+  "path" : "query-validation-tests/topk-distinct.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` TIME, `KSQL_AGG_VARIABLE_0` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` TIME",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<TIME>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` TIME, `KSQL_INTERNAL_COL_2` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "topk distinct time",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 100
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 99
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 7
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 100
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 7 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 7 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "KsqlDataSourceSchema",
+        "namespace" : "io.confluent.ksql.avro_schemas",
+        "fields" : [ {
+          "name" : "NAME",
+          "type" : [ "null", "string" ],
+          "default" : null
+        }, {
+          "name" : "VALUE",
+          "type" : [ "null", {
+            "type" : "int",
+            "connect.version" : 1,
+            "connect.name" : "org.apache.kafka.connect.data.Time",
+            "logicalType" : "time-millis"
+          } ],
+          "default" : null
+        } ],
+        "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE time) WITH (kafka_topic='test_topic',value_format='AVRO');", "CREATE TABLE S2 as SELECT ID, topkdistinct(value, 3) as topk FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<TIME>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` TIME",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "ID",
+              "type" : [ "null", "long" ],
+              "default" : null
+            }, {
+              "name" : "VALUE",
+              "type" : [ "null", {
+                "type" : "int",
+                "logicalType" : "time-millis"
+              } ],
+              "default" : null
+            }, {
+              "name" : "KSQL_AGG_VARIABLE_0",
+              "type" : [ "null", {
+                "type" : "array",
+                "items" : [ "null", {
+                  "type" : "int",
+                  "logicalType" : "time-millis"
+                } ]
+              } ],
+              "default" : null
+            } ]
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "NAME",
+              "type" : [ "null", "string" ],
+              "default" : null
+            }, {
+              "name" : "VALUE",
+              "type" : [ "null", {
+                "type" : "int",
+                "connect.version" : 1,
+                "connect.name" : "org.apache.kafka.connect.data.Time",
+                "logicalType" : "time-millis"
+              } ],
+              "default" : null
+            } ],
+            "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+          }
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "TOPK",
+              "type" : [ "null", {
+                "type" : "array",
+                "items" : [ "null", {
+                  "type" : "int",
+                  "logicalType" : "time-millis"
+                } ]
+              } ],
+              "default" : null
+            } ]
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_time/7.3.0_1655222500243/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_time/7.3.0_1655222500243/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_timestamp/7.3.0_1655222501246/plan.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_timestamp/7.3.0_1655222501246/plan.json
@@ -1,0 +1,257 @@
+{
+  "plan" : [ {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE STREAM TEST (ID BIGINT KEY, NAME STRING, VALUE TIMESTAMP) WITH (KAFKA_TOPIC='test_topic', KEY_FORMAT='KAFKA', VALUE_FORMAT='AVRO');",
+    "ddlCommand" : {
+      "@type" : "createStreamV1",
+      "sourceName" : "TEST",
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` TIMESTAMP",
+      "timestampColumn" : null,
+      "topicName" : "test_topic",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : null
+  }, {
+    "@type" : "ksqlPlanV1",
+    "statementText" : "CREATE TABLE S2 AS SELECT\n  TEST.ID ID,\n  TOPKDISTINCT(TEST.VALUE, 3) TOPK\nFROM TEST TEST\nGROUP BY TEST.ID\nEMIT CHANGES",
+    "ddlCommand" : {
+      "@type" : "createTableV1",
+      "sourceName" : "S2",
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<TIMESTAMP>",
+      "timestampColumn" : null,
+      "topicName" : "S2",
+      "formats" : {
+        "keyFormat" : {
+          "format" : "KAFKA",
+          "properties" : { }
+        },
+        "valueFormat" : {
+          "format" : "AVRO",
+          "properties" : { }
+        }
+      },
+      "windowInfo" : null,
+      "orReplace" : false,
+      "isSource" : false
+    },
+    "queryPlan" : {
+      "sources" : [ "TEST" ],
+      "sink" : "S2",
+      "physicalPlan" : {
+        "@type" : "tableSinkV1",
+        "properties" : {
+          "queryContext" : "S2"
+        },
+        "source" : {
+          "@type" : "tableSelectV1",
+          "properties" : {
+            "queryContext" : "Aggregate/Project"
+          },
+          "source" : {
+            "@type" : "streamAggregateV1",
+            "properties" : {
+              "queryContext" : "Aggregate/Aggregate"
+            },
+            "source" : {
+              "@type" : "streamGroupByKeyV1",
+              "properties" : {
+                "queryContext" : "Aggregate/GroupBy"
+              },
+              "source" : {
+                "@type" : "streamSelectV1",
+                "properties" : {
+                  "queryContext" : "Aggregate/Prepare"
+                },
+                "source" : {
+                  "@type" : "streamSourceV1",
+                  "properties" : {
+                    "queryContext" : "KsqlTopic/Source"
+                  },
+                  "topicName" : "test_topic",
+                  "formats" : {
+                    "keyFormat" : {
+                      "format" : "KAFKA",
+                      "properties" : { }
+                    },
+                    "valueFormat" : {
+                      "format" : "AVRO",
+                      "properties" : { }
+                    }
+                  },
+                  "timestampColumn" : null,
+                  "sourceSchema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` TIMESTAMP",
+                  "pseudoColumnVersion" : 1
+                },
+                "keyColumnNames" : [ "ID" ],
+                "selectedKeys" : null,
+                "selectExpressions" : [ "ID AS ID", "VALUE AS VALUE", "3 AS KSQL_INTERNAL_COL_2" ]
+              },
+              "internalFormats" : {
+                "keyFormat" : {
+                  "format" : "KAFKA",
+                  "properties" : { }
+                },
+                "valueFormat" : {
+                  "format" : "AVRO",
+                  "properties" : { }
+                }
+              }
+            },
+            "internalFormats" : {
+              "keyFormat" : {
+                "format" : "KAFKA",
+                "properties" : { }
+              },
+              "valueFormat" : {
+                "format" : "AVRO",
+                "properties" : { }
+              }
+            },
+            "nonAggregateColumns" : [ "ID", "VALUE" ],
+            "aggregationFunctions" : [ "TOPKDISTINCT(VALUE, 3)" ]
+          },
+          "keyColumnNames" : [ "ID" ],
+          "selectExpressions" : [ "KSQL_AGG_VARIABLE_0 AS TOPK" ],
+          "internalFormats" : {
+            "keyFormat" : {
+              "format" : "KAFKA",
+              "properties" : { }
+            },
+            "valueFormat" : {
+              "format" : "AVRO",
+              "properties" : { }
+            }
+          }
+        },
+        "formats" : {
+          "keyFormat" : {
+            "format" : "KAFKA",
+            "properties" : { }
+          },
+          "valueFormat" : {
+            "format" : "AVRO",
+            "properties" : { }
+          }
+        },
+        "topicName" : "S2",
+        "timestampColumn" : null
+      },
+      "queryId" : "CTAS_S2_0",
+      "runtimeId" : null
+    }
+  } ],
+  "configs" : {
+    "ksql.extension.dir" : "ext",
+    "ksql.streams.cache.max.bytes.buffering" : "0",
+    "metric.reporters" : "",
+    "ksql.query.status.running.threshold.seconds" : "300",
+    "ksql.connect.basic.auth.credentials.reload" : "false",
+    "ksql.output.topic.name.prefix" : "",
+    "ksql.query.pull.stream.enabled" : "true",
+    "ksql.query.push.v2.interpreter.enabled" : "true",
+    "ksql.queryanonymizer.logs_enabled" : "true",
+    "ksql.variable.substitution.enable" : "true",
+    "ksql.streams.shutdown.timeout.ms" : "300000",
+    "ksql.query.pull.max.allowed.offset.lag" : "9223372036854775807",
+    "ksql.query.pull.max.qps" : "2147483647",
+    "ksql.access.validator.enable" : "auto",
+    "ksql.streams.bootstrap.servers" : "localhost:0",
+    "ksql.query.pull.metrics.enabled" : "true",
+    "ksql.metrics.extension" : null,
+    "ksql.query.push.v2.alos.enabled" : "true",
+    "ksql.query.push.v2.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.query.pull.range.scan.enabled" : "true",
+    "ksql.transient.query.cleanup.service.initial.delay.seconds" : "600",
+    "ksql.hidden.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.lambdas.enabled" : "true",
+    "ksql.source.table.materialization.enabled" : "true",
+    "ksql.query.pull.max.hourly.bandwidth.megabytes" : "2147483647",
+    "ksql.sink.window.change.log.additional.retention" : "1000000",
+    "ksql.query.persistent.active.limit" : "2147483647",
+    "ksql.persistence.wrap.single.values" : null,
+    "ksql.query.transient.max.bytes.buffering.total" : "-1",
+    "ksql.connect.basic.auth.credentials.source" : "NONE",
+    "ksql.schema.registry.url" : "schema_registry.url:0",
+    "ksql.properties.overrides.denylist" : "",
+    "ksql.service.id" : "some.ksql.service.id",
+    "ksql.query.push.v2.max.catchup.consumers" : "5",
+    "ksql.assert.topic.default.timeout.ms" : "1000",
+    "ksql.query.push.v2.enabled" : "false",
+    "ksql.transient.query.cleanup.service.enable" : "true",
+    "ksql.query.push.v2.metrics.enabled" : "true",
+    "ksql.rowpartition.rowoffset.enabled" : "true",
+    "ksql.streams.commit.interval.ms" : "2000",
+    "ksql.query.pull.table.scan.enabled" : "true",
+    "ksql.streams.auto.commit.interval.ms" : "0",
+    "ksql.streams.topology.optimization" : "all",
+    "ksql.endpoint.migrate.query" : "true",
+    "ksql.query.push.v2.registry.installed" : "false",
+    "ksql.streams.num.stream.threads" : "4",
+    "ksql.metrics.tags.custom" : "",
+    "ksql.query.push.v2.catchup.consumer.msg.window" : "50",
+    "ksql.runtime.feature.shared.enabled" : "false",
+    "ksql.udf.collect.metrics" : "false",
+    "ksql.new.query.planner.enabled" : "false",
+    "ksql.connect.request.headers.plugin" : null,
+    "ksql.security.extension.class" : null,
+    "ksql.transient.prefix" : "transient_",
+    "ksql.headers.columns.enabled" : "true",
+    "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+    "ksql.connect.request.timeout.ms" : "5000",
+    "ksql.query.pull.enable.standby.reads" : "false",
+    "ksql.persistence.default.format.key" : "KAFKA",
+    "ksql.query.persistent.max.bytes.buffering.total" : "-1",
+    "ksql.query.error.max.queue.size" : "10",
+    "ksql.query.cleanup.shutdown.timeout.ms" : "30000",
+    "ksql.internal.topic.min.insync.replicas" : "1",
+    "ksql.internal.topic.replicas" : "1",
+    "ksql.insert.into.values.enabled" : "true",
+    "ksql.queryanonymizer.cluster_namespace" : null,
+    "ksql.create.or.replace.enabled" : "true",
+    "ksql.shared.runtimes.count" : "2",
+    "ksql.cast.strings.preserve.nulls" : "true",
+    "ksql.authorization.cache.max.entries" : "10000",
+    "ksql.pull.queries.enable" : "true",
+    "ksql.transient.query.cleanup.service.period.seconds" : "600",
+    "ksql.suppress.enabled" : "false",
+    "ksql.readonly.topics" : "_confluent.*,__confluent.*,_schemas,__consumer_offsets,__transaction_state,connect-configs,connect-offsets,connect-status,connect-statuses",
+    "ksql.connect.basic.auth.credentials.file" : "",
+    "ksql.authorization.cache.expiry.time.secs" : "30",
+    "ksql.query.retry.backoff.initial.ms" : "15000",
+    "ksql.query.pull.max.concurrent.requests" : "2147483647",
+    "ksql.streams.auto.offset.reset" : "earliest",
+    "ksql.connect.url" : "http://localhost:8083",
+    "ksql.query.push.v2.new.latest.delay.ms" : "5000",
+    "ksql.query.push.v2.latest.reset.age.ms" : "30000",
+    "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+    "ksql.query.pull.interpreter.enabled" : "true",
+    "ksql.assert.schema.default.timeout.ms" : "1000",
+    "ksql.query.pull.limit.clause.enabled" : "true",
+    "ksql.query.pull.router.thread.pool.size" : "50",
+    "ksql.query.push.v2.continuation.tokens.enabled" : "false",
+    "ksql.query.retry.backoff.max.ms" : "900000",
+    "ksql.timestamp.throw.on.invalid" : "false",
+    "ksql.persistence.default.format.value" : null,
+    "ksql.udfs.enabled" : "true",
+    "ksql.udf.enable.security.manager" : "true",
+    "ksql.connect.worker.config" : "",
+    "ksql.nested.error.set.null" : "true",
+    "ksql.query.pull.thread.pool.size" : "50",
+    "ksql.persistent.prefix" : "query_",
+    "ksql.metastore.backup.location" : "",
+    "ksql.error.classifier.regex" : "",
+    "ksql.suppress.buffer.size.bytes" : "-1"
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_timestamp/7.3.0_1655222501246/spec.json
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_timestamp/7.3.0_1655222501246/spec.json
@@ -1,0 +1,283 @@
+{
+  "version" : "7.3.0",
+  "timestamp" : 1655222501246,
+  "path" : "query-validation-tests/topk-distinct.json",
+  "schemas" : {
+    "CTAS_S2_0.Aggregate.Aggregate.Materialize" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` TIMESTAMP, `KSQL_AGG_VARIABLE_0` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.Aggregate.Project" : {
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.KsqlTopic.Source" : {
+      "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` TIMESTAMP",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.S2" : {
+      "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<TIMESTAMP>",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    },
+    "CTAS_S2_0.Aggregate.GroupBy" : {
+      "schema" : "`ID` BIGINT KEY, `ID` BIGINT, `VALUE` TIMESTAMP, `KSQL_INTERNAL_COL_2` INTEGER",
+      "keyFormat" : {
+        "format" : "KAFKA"
+      },
+      "valueFormat" : {
+        "format" : "AVRO"
+      }
+    }
+  },
+  "testCase" : {
+    "name" : "topk distinct timestamp",
+    "inputs" : [ {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 0
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 100
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 99
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : null
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : -7
+      }
+    }, {
+      "topic" : "test_topic",
+      "key" : 0,
+      "value" : {
+        "NAME" : "zero",
+        "VALUE" : 100
+      }
+    } ],
+    "outputs" : [ {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    }, {
+      "topic" : "S2",
+      "key" : 0,
+      "value" : {
+        "TOPK" : [ 100, 99, 0 ]
+      }
+    } ],
+    "topics" : [ {
+      "name" : "test_topic",
+      "valueSchema" : {
+        "type" : "record",
+        "name" : "KsqlDataSourceSchema",
+        "namespace" : "io.confluent.ksql.avro_schemas",
+        "fields" : [ {
+          "name" : "NAME",
+          "type" : [ "null", "string" ],
+          "default" : null
+        }, {
+          "name" : "VALUE",
+          "type" : [ "null", {
+            "type" : "long",
+            "connect.version" : 1,
+            "connect.name" : "org.apache.kafka.connect.data.Timestamp",
+            "logicalType" : "timestamp-millis"
+          } ],
+          "default" : null
+        } ],
+        "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+      },
+      "valueFormat" : "AVRO",
+      "replicas" : 1,
+      "numPartitions" : 4
+    }, {
+      "name" : "S2",
+      "replicas" : 1,
+      "numPartitions" : 4
+    } ],
+    "statements" : [ "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE timestamp) WITH (kafka_topic='test_topic',value_format='AVRO');", "CREATE TABLE S2 as SELECT ID, topkdistinct(value, 3) as topk FROM test group by id;" ],
+    "post" : {
+      "sources" : [ {
+        "name" : "S2",
+        "type" : "TABLE",
+        "schema" : "`ID` BIGINT KEY, `TOPK` ARRAY<TIMESTAMP>",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      }, {
+        "name" : "TEST",
+        "type" : "STREAM",
+        "schema" : "`ID` BIGINT KEY, `NAME` STRING, `VALUE` TIMESTAMP",
+        "keyFormat" : {
+          "format" : "KAFKA"
+        },
+        "valueFormat" : "AVRO",
+        "keyFeatures" : [ ],
+        "valueFeatures" : [ ],
+        "isSource" : false
+      } ],
+      "topics" : {
+        "topics" : [ {
+          "name" : "_confluent-ksql-some.ksql.service.idquery_CTAS_S2_0-Aggregate-Aggregate-Materialize-changelog",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "ID",
+              "type" : [ "null", "long" ],
+              "default" : null
+            }, {
+              "name" : "VALUE",
+              "type" : [ "null", {
+                "type" : "long",
+                "logicalType" : "timestamp-millis"
+              } ],
+              "default" : null
+            }, {
+              "name" : "KSQL_AGG_VARIABLE_0",
+              "type" : [ "null", {
+                "type" : "array",
+                "items" : [ "null", {
+                  "type" : "long",
+                  "logicalType" : "timestamp-millis"
+                } ]
+              } ],
+              "default" : null
+            } ]
+          }
+        }, {
+          "name" : "test_topic",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "NAME",
+              "type" : [ "null", "string" ],
+              "default" : null
+            }, {
+              "name" : "VALUE",
+              "type" : [ "null", {
+                "type" : "long",
+                "connect.version" : 1,
+                "connect.name" : "org.apache.kafka.connect.data.Timestamp",
+                "logicalType" : "timestamp-millis"
+              } ],
+              "default" : null
+            } ],
+            "connect.name" : "io.confluent.ksql.avro_schemas.KsqlDataSourceSchema"
+          }
+        }, {
+          "name" : "S2",
+          "keyFormat" : {
+            "format" : "KAFKA"
+          },
+          "valueFormat" : {
+            "format" : "AVRO"
+          },
+          "partitions" : 4,
+          "valueSchema" : {
+            "type" : "record",
+            "name" : "KsqlDataSourceSchema",
+            "namespace" : "io.confluent.ksql.avro_schemas",
+            "fields" : [ {
+              "name" : "TOPK",
+              "type" : [ "null", {
+                "type" : "array",
+                "items" : [ "null", {
+                  "type" : "long",
+                  "logicalType" : "timestamp-millis"
+                } ]
+              } ],
+              "default" : null
+            } ]
+          }
+        } ]
+      }
+    }
+  }
+}

--- a/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_timestamp/7.3.0_1655222501246/topology
+++ b/ksqldb-functional-tests/src/test/resources/historical_plans/topk-distinct_-_topk_distinct_timestamp/7.3.0_1655222501246/topology
@@ -1,0 +1,25 @@
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [test_topic])
+      --> KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000001 (stores: [])
+      --> Aggregate-Prepare
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: Aggregate-Prepare (stores: [])
+      --> KSTREAM-AGGREGATE-0000000003
+      <-- KSTREAM-TRANSFORMVALUES-0000000001
+    Processor: KSTREAM-AGGREGATE-0000000003 (stores: [Aggregate-Aggregate-Materialize])
+      --> Aggregate-Aggregate-ToOutputSchema
+      <-- Aggregate-Prepare
+    Processor: Aggregate-Aggregate-ToOutputSchema (stores: [])
+      --> Aggregate-Project
+      <-- KSTREAM-AGGREGATE-0000000003
+    Processor: Aggregate-Project (stores: [])
+      --> KTABLE-TOSTREAM-0000000006
+      <-- Aggregate-Aggregate-ToOutputSchema
+    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])
+      --> KSTREAM-SINK-0000000007
+      <-- Aggregate-Project
+    Sink: KSTREAM-SINK-0000000007 (topic: S2)
+      <-- KTABLE-TOSTREAM-0000000006
+

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/greatest.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/greatest.json
@@ -197,6 +197,74 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Function 'greatest' does not accept parameters ()."
       }
+    },
+    {
+      "name": "test greatest with bytes",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, S1 BYTES, S2 BYTES, S3 BYTES, S4 BYTES) WITH (kafka_topic='input_topic',value_format='json');",
+        "CREATE STREAM OUTPUT AS SELECT ID, GREATEST(S1, S2, S3, S4, null, null, TO_BYTES('hello', 'ascii')) AS HIGHEST FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": {"S1": "YXBwbGU=", "S2": "YmFuYW5h", "S3": "YWFyZGF2YXJr",  "S4": null}},
+        {"topic": "input_topic", "key": 2, "value": {"S1": null, "S2": null, "S3": null,  "S4": null}},
+        {"topic": "input_topic", "key": 3, "value": {"S1": "IQ==", "S2": "emVicmE=", "S3": "YWFyZGF2YXJr",  "S4": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"HIGHEST": "aGVsbG8="}},
+        {"topic": "OUTPUT", "key": 2, "value": {"HIGHEST": "aGVsbG8="}},
+        {"topic": "OUTPUT", "key": 3, "value": {"HIGHEST": "emVicmE="}}
+      ]
+    },
+    {
+      "name": "test greatest with dates",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, S1 DATE, S2 DATE, S3 DATE, S4 DATE) WITH (kafka_topic='input_topic',value_format='json');",
+        "CREATE STREAM OUTPUT AS SELECT ID, GREATEST(S1, S2, S3, S4, null, null, '2022-06-14') AS HIGHEST FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": {"S1": 19071, "S2": 18824, "S3": -5883,  "S4": null}},
+        {"topic": "input_topic", "key": 2, "value": {"S1": null, "S2": null, "S3": null,  "S4": null}},
+        {"topic": "input_topic", "key": 3, "value": {"S1": 19158, "S2": 19187, "S3": -92,  "S4": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"HIGHEST": 19157}},
+        {"topic": "OUTPUT", "key": 2, "value": {"HIGHEST": 19157}},
+        {"topic": "OUTPUT", "key": 3, "value": {"HIGHEST": 19187}}
+      ]
+    },
+    {
+      "name": "test greatest with times",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIME, S2 TIME, S3 TIME, S4 TIME) WITH (kafka_topic='input_topic',value_format='json');",
+        "CREATE STREAM OUTPUT AS SELECT ID, GREATEST(S1, S2, S3, S4, null, null, '09:16:00') AS HIGHEST FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": {"S1": 33359999, "S2": 23361230, "S3": 10,  "S4": null}},
+        {"topic": "input_topic", "key": 2, "value": {"S1": null, "S2": null, "S3": null,  "S4": null}},
+        {"topic": "input_topic", "key": 3, "value": {"S1": 32560000, "S2": 33370000, "S3": 33360001,  "S4": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"HIGHEST": 33360000}},
+        {"topic": "OUTPUT", "key": 2, "value": {"HIGHEST": 33360000}},
+        {"topic": "OUTPUT", "key": 3, "value": {"HIGHEST": 33370000}}
+      ]
+    },
+    {
+      "name": "test greatest with timestamps",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIMESTAMP, S2 TIMESTAMP, S3 TIMESTAMP, S4 TIMESTAMP) WITH (kafka_topic='input_topic',value_format='json');",
+        "CREATE STREAM OUTPUT AS SELECT ID, GREATEST(S1, S2, S3, S4, null, null, '2022-06-14') AS HIGHEST FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": {"S1": 1647734400000, "S2": 1626393600000, "S3": -508291200000,  "S4": null}},
+        {"topic": "input_topic", "key": 2, "value": {"S1": null, "S2": null, "S3": null,  "S4": null}},
+        {"topic": "input_topic", "key": 3, "value": {"S1": 1655251200000, "S2": 1657756800000, "S3": -7948800000,  "S4": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"HIGHEST": 1655164800000}},
+        {"topic": "OUTPUT", "key": 2, "value": {"HIGHEST": 1655164800000}},
+        {"topic": "OUTPUT", "key": 3, "value": {"HIGHEST": 1657756800000}}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/least.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/least.json
@@ -192,6 +192,74 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Function 'least' does not accept parameters ()."
       }
+    },
+    {
+      "name": "test least with bytes",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, S1 BYTES, S2 BYTES, S3 BYTES, S4 BYTES) WITH (kafka_topic='input_topic',value_format='json');",
+        "CREATE STREAM OUTPUT AS SELECT ID, LEAST(S1, S2, S3, S4, null, null, TO_BYTES('hello', 'ascii')) AS LOWEST FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": {"S1": "YXBwbGU=", "S2": "YmFuYW5h", "S3": "YWFyZGF2YXJr",  "S4": null}},
+        {"topic": "input_topic", "key": 2, "value": {"S1": null, "S2": null, "S3": null,  "S4": null}},
+        {"topic": "input_topic", "key": 3, "value": {"S1": "IQ==", "S2": "emVicmE=", "S3": "YWFyZGF2YXJr",  "S4": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"LOWEST": "YWFyZGF2YXJr"}},
+        {"topic": "OUTPUT", "key": 2, "value": {"LOWEST": "aGVsbG8="}},
+        {"topic": "OUTPUT", "key": 3, "value": {"LOWEST": "IQ=="}}
+      ]
+    },
+    {
+      "name": "test least with dates",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, S1 DATE, S2 DATE, S3 DATE, S4 DATE) WITH (kafka_topic='input_topic',value_format='json');",
+        "CREATE STREAM OUTPUT AS SELECT ID, LEAST(S1, S2, S3, S4, null, null, '2022-06-14') AS LOWEST FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": {"S1": 19071, "S2": 18824, "S3": -5883,  "S4": null}},
+        {"topic": "input_topic", "key": 2, "value": {"S1": null, "S2": null, "S3": null,  "S4": null}},
+        {"topic": "input_topic", "key": 3, "value": {"S1": 19158, "S2": 19187, "S3": -92,  "S4": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"LOWEST": -5883}},
+        {"topic": "OUTPUT", "key": 2, "value": {"LOWEST": 19157}},
+        {"topic": "OUTPUT", "key": 3, "value": {"LOWEST": -92}}
+      ]
+    },
+    {
+      "name": "test least with times",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIME, S2 TIME, S3 TIME, S4 TIME) WITH (kafka_topic='input_topic',value_format='json');",
+        "CREATE STREAM OUTPUT AS SELECT ID, LEAST(S1, S2, S3, S4, null, null, '09:16:00') AS LOWEST FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": {"S1": 33359999, "S2": 23361230, "S3": 10,  "S4": null}},
+        {"topic": "input_topic", "key": 2, "value": {"S1": null, "S2": null, "S3": null,  "S4": null}},
+        {"topic": "input_topic", "key": 3, "value": {"S1": 32560000, "S2": 33370000, "S3": 33360001,  "S4": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"LOWEST": 10}},
+        {"topic": "OUTPUT", "key": 2, "value": {"LOWEST": 33360000}},
+        {"topic": "OUTPUT", "key": 3, "value": {"LOWEST": 32560000}}
+      ]
+    },
+    {
+      "name": "test least with timestamps",
+      "statements": [
+        "CREATE STREAM INPUT (ID BIGINT KEY, S1 TIMESTAMP, S2 TIMESTAMP, S3 TIMESTAMP, S4 TIMESTAMP) WITH (kafka_topic='input_topic',value_format='json');",
+        "CREATE STREAM OUTPUT AS SELECT ID, LEAST(S1, S2, S3, S4, null, null, '2022-06-14') AS LOWEST FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": {"S1": 1647734400000, "S2": 1626393600000, "S3": -508291200000,  "S4": null}},
+        {"topic": "input_topic", "key": 2, "value": {"S1": null, "S2": null, "S3": null,  "S4": null}},
+        {"topic": "input_topic", "key": 3, "value": {"S1": 1655251200000, "S2": 1657756800000, "S3": -7948800000,  "S4": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"LOWEST": -508291200000}},
+        {"topic": "OUTPUT", "key": 2, "value": {"LOWEST": 1655164800000}},
+        {"topic": "OUTPUT", "key": 3, "value": {"LOWEST": -7948800000}}
+      ]
     }
   ]
 }

--- a/ksqldb-functional-tests/src/test/resources/query-validation-tests/topk-distinct.json
+++ b/ksqldb-functional-tests/src/test/resources/query-validation-tests/topk-distinct.json
@@ -93,6 +93,98 @@
         {"topic": "S2", "key": 0, "value": {"TOPK":["9.8","8.9","7.8"]}},
         {"topic": "S2", "key": 0, "value": {"TOPK":["9.9","9.8","8.9"]}}
       ]
+    },
+    {
+      "name": "topk distinct bytes",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE bytes) WITH (kafka_topic='test_topic',value_format='AVRO');",
+        "CREATE TABLE S2 as SELECT ID, topkdistinct(value, 3) as topk FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE":"Qg=="}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": "Rg=="}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": "Rw=="}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": null}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": "QQ=="}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": "Rg=="}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"TOPK":["Qg=="]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":["Rg==","Qg=="]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":["Rw==","Rg==","Qg=="]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":["Rw==","Rg==","Qg=="]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":["Rw==","Rg==","Qg=="]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":["Rw==","Rg==","Qg=="]}}
+      ]
+    },
+    {
+      "name": "topk distinct date",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE date) WITH (kafka_topic='test_topic',value_format='AVRO');",
+        "CREATE TABLE S2 as SELECT ID, topkdistinct(value, 3) as topk FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE":0}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 100}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 99}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": null}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": -7}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 100}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"TOPK":[0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}}
+      ]
+    },
+    {
+      "name": "topk distinct time",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE time) WITH (kafka_topic='test_topic',value_format='AVRO');",
+        "CREATE TABLE S2 as SELECT ID, topkdistinct(value, 3) as topk FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE":0}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 100}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 99}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": null}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 7}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 100}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"TOPK":[0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,7]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,7]}}
+      ]
+    },
+    {
+      "name": "topk distinct timestamp",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT KEY, NAME varchar, VALUE timestamp) WITH (kafka_topic='test_topic',value_format='AVRO');",
+        "CREATE TABLE S2 as SELECT ID, topkdistinct(value, 3) as topk FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE":0}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 100}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 99}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": null}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": -7}},
+        {"topic": "test_topic", "key": 0, "value": {"NAME": "zero", "VALUE": 100}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"TOPK":[0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}},
+        {"topic": "S2", "key": 0, "value": {"TOPK":[100,99,0]}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 
- Resolves #9125.
- Added support for the BYTES, DATE, TIME, and TIMESTAMP types to TopKDistinct.
- Added support for the BYTES, DATE, TIME, and TIMESTAMP types to Greatest.
- Added support for the BYTES, DATE, TIME, and TIMESTAMP types to Least.
- Fixed an issue in the unit tests for Greatest and Least where an array with a null element was being tested instead of the intended null array. This also resolves some compiler warnings.

### Testing done 
Added unit tests and QTT tests for the new supported types.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

