### PR TITLE
fix: fix the interval check in RocksDBMetricCollectorTest

### DIFF
--- a/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/metrics/RocksDBMetricsCollector.java
+++ b/ksqldb-streams/src/main/java/io/confluent/ksql/execution/streams/metrics/RocksDBMetricsCollector.java
@@ -257,10 +257,12 @@ public class RocksDBMetricsCollector implements MetricsReporter {
 
     boolean check() {
       final Instant now = clock.get();
-      return Objects.equals(last.accumulateAndGet(
+      final Instant previous = last.getAndAccumulate(
           now,
           (l, n) -> n.isAfter(l.plusSeconds(intervalSeconds)) ? n : l
-      ), now);
+      );
+      // Return true if the call to getAndAccumulate changed the value
+      return last.get().isAfter(previous);
     }
   }
 

--- a/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/metrics/RocksDBMetricsCollectorTest.java
+++ b/ksqldb-streams/src/test/java/io/confluent/ksql/execution/streams/metrics/RocksDBMetricsCollectorTest.java
@@ -235,6 +235,18 @@ public class RocksDBMetricsCollectorTest {
   }
 
   @Test
+  public void shouldComputeIntervalChangeCorrectlyInSameInstant() {
+    // Given:
+    final Instant now = Instant.now();
+    when(clock.get()).thenReturn(now, now);
+    final Interval interval = new Interval(UPDATE_INTERVAL, clock);
+
+    // When/Then:
+    assertThat(interval.check(), is(true));
+    assertThat(interval.check(), is(false));
+  }
+
+  @Test
   public void shouldNotUpdateIfWithinInterval() {
     // Given:
     final RocksDBMetricsCollector collector = new RocksDBMetricsCollector();


### PR DESCRIPTION
fix the interval check in RocksDBMetricCollectorTest. Previously
it would return true if called multiple times in the same millisecond.
Now it only returns true if the instant actually changes