### PR TITLE
fix: change group name and extend CumulativeSum in ThroughputMetricsReporter

### DIFF
--- a/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
+++ b/ksqldb-engine/src/main/java/io/confluent/ksql/internal/ThroughputMetricsReporter.java
@@ -41,7 +41,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -263,7 +262,7 @@ public class ThroughputMetricsReporter implements MetricsReporter {
     }
 
     @Override
-    public double measure(MetricConfig var1, long var2) {
+    public double measure(final MetricConfig metricConfig, final long now) {
       return throughputTotalMetrics
         .values()
          .stream()


### PR DESCRIPTION
This PR contains two fixes:
1. changes the group name for ksql's per-query topic-level metrics to `ksql-query-throughput-metrics` so that we can distinguish them from the Streams metrics they are derived from
2. have the `ThroughputTotalMetric` extend the Kafka metrics class `CumulativeSum` so that the ce-kafka metrics reporter we integrate with will know to compute the diff and only forward the throughput deltas (see [here](https://github.com/confluentinc/ce-kafka/blob/6bb7cd13e0c7ca01474c3f04f4e081bdf42d2448/ce-metrics/src/main/java/io/confluent/telemetry/collector/KafkaMetricsCollector.java#L171)). This is a bit of a hack but it's necessary to ensure that the downstream metrics processing will accumulate the totals correctly.